### PR TITLE
posix: Implement get/set uid/euid/gid/egid

### DIFF
--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -40,7 +40,9 @@ enum class Error {
 
 	brokenPipe,
 
-	illegalArguments
+	illegalArguments,
+
+	accessDenied
 };
 
 // TODO: Rename this enum as is not part of the VFS.

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -641,6 +641,78 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					helix::action(&send_resp, ser.data(), ser.size()));
 			co_await transmit.async_wait();
 			HEL_CHECK(send_resp.error());
+		}else if(req.request_type() == managarm::posix::CntReqType::GET_GID) {
+			if(logRequests)
+				std::cout << "posix: GET_GID" << std::endl;
+
+			helix::SendBuffer send_resp;
+
+			managarm::posix::SvrResponse resp;
+			resp.set_error(managarm::posix::Errors::SUCCESS);
+			resp.set_uid(self->gid());
+
+			auto ser = resp.SerializeAsString();
+			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+					helix::action(&send_resp, ser.data(), ser.size()));
+			co_await transmit.async_wait();
+			HEL_CHECK(send_resp.error());
+		}else if(req.request_type() == managarm::posix::CntReqType::GET_EGID) {
+			if(logRequests)
+				std::cout << "posix: GET_EGID" << std::endl;
+
+			helix::SendBuffer send_resp;
+
+			managarm::posix::SvrResponse resp;
+			resp.set_error(managarm::posix::Errors::SUCCESS);
+			resp.set_uid(self->egid());
+
+			auto ser = resp.SerializeAsString();
+			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+					helix::action(&send_resp, ser.data(), ser.size()));
+			co_await transmit.async_wait();
+			HEL_CHECK(send_resp.error());
+		}else if(req.request_type() == managarm::posix::CntReqType::SET_GID) {
+			if(logRequests)
+				std::cout << "posix: SET_GID" << std::endl;
+
+			helix::SendBuffer send_resp;
+
+			managarm::posix::SvrResponse resp;
+			Error err = self->setGid(req.uid());
+			if(err == Error::accessDenied) {
+				resp.set_error(managarm::posix::Errors::ACCESS_DENIED);
+			} else if(err == Error::illegalArguments) {
+				resp.set_error(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+			} else {
+				resp.set_error(managarm::posix::Errors::SUCCESS);
+			}
+
+			auto ser = resp.SerializeAsString();
+			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+					helix::action(&send_resp, ser.data(), ser.size()));
+			co_await transmit.async_wait();
+			HEL_CHECK(send_resp.error());
+		}else if(req.request_type() == managarm::posix::CntReqType::SET_EGID) {
+			if(logRequests)
+				std::cout << "posix: SET_EGID" << std::endl;
+
+			helix::SendBuffer send_resp;
+
+			managarm::posix::SvrResponse resp;
+			Error err = self->setEgid(req.uid());
+			if(err == Error::accessDenied) {
+				resp.set_error(managarm::posix::Errors::ACCESS_DENIED);
+			} else if(err == Error::illegalArguments) {
+				resp.set_error(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+			} else {
+				resp.set_error(managarm::posix::Errors::SUCCESS);
+			}
+
+			auto ser = resp.SerializeAsString();
+			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+					helix::action(&send_resp, ser.data(), ser.size()));
+			co_await transmit.async_wait();
+			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::WAIT) {
 			if(logRequests)
 				std::cout << "posix: WAIT" << std::endl;

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -569,6 +569,39 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					helix::action(&send_resp, ser.data(), ser.size()));
 			co_await transmit.async_wait();
 			HEL_CHECK(send_resp.error());
+		}else if(req.request_type() == managarm::posix::CntReqType::GET_UID) {
+			if(logRequests)
+				std::cout << "posix: GET_UID" << std::endl;
+
+			helix::SendBuffer send_resp;
+
+			managarm::posix::SvrResponse resp;
+			resp.set_error(managarm::posix::Errors::SUCCESS);
+			resp.set_uid(self->uid());
+
+			auto ser = resp.SerializeAsString();
+			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+					helix::action(&send_resp, ser.data(), ser.size()));
+			co_await transmit.async_wait();
+			HEL_CHECK(send_resp.error());
+		}else if(req.request_type() == managarm::posix::CntReqType::SET_UID) {
+			if(logRequests)
+				std::cout << "posix: SET_UID" << std::endl;
+
+			helix::SendBuffer send_resp;
+
+			managarm::posix::SvrResponse resp;
+			if(!self->setUid(req.uid())) {
+				resp.set_error(managarm::posix::Errors::SUCCESS);
+			} else {
+				resp.set_error(managarm::posix::Errors::ACCESS_DENIED);
+			}
+
+			auto ser = resp.SerializeAsString();
+			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+					helix::action(&send_resp, ser.data(), ser.size()));
+			co_await transmit.async_wait();
+			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::WAIT) {
 			if(logRequests)
 				std::cout << "posix: WAIT" << std::endl;

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -632,7 +632,7 @@ std::shared_ptr<Process> Process::findProcess(ProcessId pid) {
 }
 
 Process::Process(Process *parent)
-: _parent{parent}, _pid{0}, _clientPosixLane{kHelNullHandle}, _clientFileTable{nullptr},
+: _parent{parent}, _pid{0}, /*_uid{0},*/ _clientPosixLane{kHelNullHandle}, _clientFileTable{nullptr},
 		_notifyType{NotifyType::null} { }
 
 Process::~Process() {
@@ -697,6 +697,7 @@ async::result<std::shared_ptr<Process>> Process::init(std::string path) {
 
 	assert(globalPidMap.find(1) == globalPidMap.end());
 	process->_pid = 1;
+	process->_uid = 0;
 	globalPidMap.insert({1, process.get()});
 
 	// TODO: Do not pass an empty argument vector?
@@ -757,6 +758,7 @@ std::shared_ptr<Process> Process::fork(std::shared_ptr<Process> original) {
 	ProcessId pid = nextPid++;
 	assert(globalPidMap.find(pid) == globalPidMap.end());
 	process->_pid = pid;
+	process->_uid = original->_uid;
 	original->_children.push_back(process);
 	globalPidMap.insert({pid, process.get()});
 
@@ -806,6 +808,7 @@ std::shared_ptr<Process> Process::clone(std::shared_ptr<Process> original, void 
 	ProcessId pid = nextPid++;
 	assert(globalPidMap.find(pid) == globalPidMap.end());
 	process->_pid = pid;
+	process->_uid = original->_uid;
 	original->_children.push_back(process);
 	globalPidMap.insert({pid, process.get()});
 

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -699,6 +699,8 @@ async::result<std::shared_ptr<Process>> Process::init(std::string path) {
 	process->_pid = 1;
 	process->_uid = 0;
 	process->_euid = 0;
+	process->_gid = 0;
+	process->_egid = 0;
 	globalPidMap.insert({1, process.get()});
 
 	// TODO: Do not pass an empty argument vector?
@@ -761,6 +763,8 @@ std::shared_ptr<Process> Process::fork(std::shared_ptr<Process> original) {
 	process->_pid = pid;
 	process->_uid = original->_uid;
 	process->_euid = original->_euid;
+	process->_gid = original->_gid;
+	process->_egid = original->_egid;
 	original->_children.push_back(process);
 	globalPidMap.insert({pid, process.get()});
 
@@ -812,6 +816,8 @@ std::shared_ptr<Process> Process::clone(std::shared_ptr<Process> original, void 
 	process->_pid = pid;
 	process->_uid = original->_uid;
 	process->_euid = original->_euid;
+	process->_gid = original->_gid;
+	process->_egid = original->_egid;
 	original->_children.push_back(process);
 	globalPidMap.insert({pid, process.get()});
 

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -632,7 +632,7 @@ std::shared_ptr<Process> Process::findProcess(ProcessId pid) {
 }
 
 Process::Process(Process *parent)
-: _parent{parent}, _pid{0}, /*_uid{0},*/ _clientPosixLane{kHelNullHandle}, _clientFileTable{nullptr},
+: _parent{parent}, _pid{0}, _clientPosixLane{kHelNullHandle}, _clientFileTable{nullptr},
 		_notifyType{NotifyType::null} { }
 
 Process::~Process() {
@@ -698,6 +698,7 @@ async::result<std::shared_ptr<Process>> Process::init(std::string path) {
 	assert(globalPidMap.find(1) == globalPidMap.end());
 	process->_pid = 1;
 	process->_uid = 0;
+	process->_euid = 0;
 	globalPidMap.insert({1, process.get()});
 
 	// TODO: Do not pass an empty argument vector?
@@ -759,6 +760,7 @@ std::shared_ptr<Process> Process::fork(std::shared_ptr<Process> original) {
 	assert(globalPidMap.find(pid) == globalPidMap.end());
 	process->_pid = pid;
 	process->_uid = original->_uid;
+	process->_euid = original->_euid;
 	original->_children.push_back(process);
 	globalPidMap.insert({pid, process.get()});
 
@@ -809,6 +811,7 @@ std::shared_ptr<Process> Process::clone(std::shared_ptr<Process> original, void 
 	assert(globalPidMap.find(pid) == globalPidMap.end());
 	process->_pid = pid;
 	process->_uid = original->_uid;
+	process->_euid = original->_euid;
 	original->_children.push_back(process);
 	globalPidMap.insert({pid, process.get()});
 

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -341,6 +341,18 @@ public:
 	 	return _pid;
 	}
 
+	int setUid(int uid) {
+		if(uid == _uid || _uid == 0) {
+			_uid = uid;
+			return 0;
+		}
+		return -1;
+	}
+
+	int uid() {
+		return _uid;
+	}
+
 	std::shared_ptr<Generation> currentGeneration() {
 		return _currentGeneration;
 	}
@@ -393,6 +405,7 @@ private:
 	Process *_parent;
 
 	int _pid;
+	int _uid;
 	std::shared_ptr<Generation> _currentGeneration;
 	std::string _path;
 	std::shared_ptr<VmContext> _vmContext;

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -341,16 +341,38 @@ public:
 	 	return _pid;
 	}
 
-	int setUid(int uid) {
-		if(uid == _uid || _uid == 0) {
-			_uid = uid;
-			return 0;
+	Error setUid(int uid) {
+		if(uid < 0) {
+			return Error::illegalArguments;
 		}
-		return -1;
+		if(_uid == 0 || _euid == 0) {
+			_uid = uid;
+			_euid = uid;
+			return Error::success;
+		} else if(uid == _uid) {
+			_uid = uid;
+			return Error::success;
+		}
+		return Error::accessDenied;
 	}
 
 	int uid() {
 		return _uid;
+	}
+
+	Error setEuid(int euid) {
+		if(euid < 0) {
+			return Error::illegalArguments;
+		}
+		if(_uid == 0 || _euid == 0 || euid == _uid) {
+			_euid = euid;
+			return Error::success;
+		}
+		return Error::accessDenied;
+	}
+
+	int euid() {
+		return _euid;
 	}
 
 	std::shared_ptr<Generation> currentGeneration() {
@@ -406,6 +428,7 @@ private:
 
 	int _pid;
 	int _uid;
+	int _euid;
 	std::shared_ptr<Generation> _currentGeneration;
 	std::string _path;
 	std::shared_ptr<VmContext> _vmContext;

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -375,6 +375,40 @@ public:
 		return _euid;
 	}
 
+	Error setGid(int gid) {
+		if(gid < 0) {
+			return Error::illegalArguments;
+		}
+		if(_gid == 0 || _egid == 0) {
+			_gid = gid;
+			_egid = gid;
+			return Error::success;
+		} else if(gid == _gid) {
+			_egid = gid;
+			return Error::success;
+		}
+		return Error::accessDenied;
+	}
+
+	int gid() {
+		return _gid;
+	}
+
+	Error setEgid(int egid) {
+		if(egid < 0) {
+			return Error::illegalArguments;
+		}
+		if(_gid == 0 || _egid == 0 || _gid == egid || _egid == egid) {
+			_egid = egid;
+			return Error::success;
+		}
+		return Error::accessDenied;
+	}
+
+	int egid() {
+		return _egid;
+	}
+
 	std::shared_ptr<Generation> currentGeneration() {
 		return _currentGeneration;
 	}
@@ -429,6 +463,8 @@ private:
 	int _pid;
 	int _uid;
 	int _euid;
+	int _gid;
+	int _egid;
 	std::shared_ptr<Generation> _currentGeneration;
 	std::string _path;
 	std::shared_ptr<VmContext> _vmContext;

--- a/protocols/posix/posix.proto
+++ b/protocols/posix/posix.proto
@@ -99,6 +99,8 @@ enum CntReqType {
 	LINKAT = 66;
 	GET_UID = 67;
 	SET_UID = 68;
+	GET_EUID = 69;
+	SET_EUID = 70;
 };
 
 enum OpenMode {

--- a/protocols/posix/posix.proto
+++ b/protocols/posix/posix.proto
@@ -101,6 +101,10 @@ enum CntReqType {
 	SET_UID = 68;
 	GET_EUID = 69;
 	SET_EUID = 70;
+	GET_GID = 71;
+	GET_EGID = 72;
+	SET_GID = 73;
+	SET_EGID = 74;
 };
 
 enum OpenMode {

--- a/protocols/posix/posix.proto
+++ b/protocols/posix/posix.proto
@@ -97,6 +97,8 @@ enum CntReqType {
 
 	MKFIFOAT = 65;
 	LINKAT = 66;
+	GET_UID = 67;
+	SET_UID = 68;
 };
 
 enum OpenMode {
@@ -200,6 +202,9 @@ message CntRequest {
 
 	// used by EVENTFD
 	optional uint32 initval = 39;
+
+	// used by {GET/SET}UID
+	optional int64 uid = 41;
 }
 
 message SvrResponse {


### PR DESCRIPTION
This PR implements get and set for user-id and related friends.
So far, the following has been implemented in at least a basic form

- `getuid()`
- `setuid()`, needs more work, as we do not check against effective user-id and friends. This should now be fixed and more POSIX compliant
- `geteuid()`
- `seteuid()`
- `getgid()`
- `setgid()`, doesn't exactly match linux in behaviour, probably `setgid` bit or `CAP_SETGID` capability.
- `getegid()`
- `setegid()`, doesn't exactly match linux in behaviour, probably `setgid` bit or `CAP_SETGID` capability.