### PR TITLE
Implemented chmod

### DIFF
--- a/drivers/libblockfs/src/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2fs.cpp
@@ -263,7 +263,7 @@ async::result<std::optional<DirEntry>> Inode::mkdir(std::string name) {
 	co_return co_await link(name, dir_node->number, kTypeDirectory);
 }
 
-async::result<int> Inode::chmod(int mode) {
+async::result<protocols::fs::Error> Inode::chmod(int mode) {
 	co_await readyJump.async_wait();
 
 	diskInode()->mode = (diskInode()->mode & 0xFFFFF000) | mode;
@@ -273,7 +273,7 @@ async::result<int> Inode::chmod(int mode) {
 			diskMapping.get(), fs.inodeSize);
 	HEL_CHECK(syncInode.error());
 
-	co_return 0;
+	co_return protocols::fs::Error::none;
 }
 
 // --------------------------------------------------------
@@ -614,7 +614,6 @@ async::detached FileSystem::initiateInode(std::shared_ptr<Inode> inode) {
 
 	// filter out the file type from the mode
 	// TODO: ext2fs stores a 32-bit mode
-	inode->diskInode()->mode = disk_inode->mode & 0x0FFF;
 
 	inode->numLinks = disk_inode->linksCount;
 	// TODO: support large uid / gids

--- a/drivers/libblockfs/src/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2fs.hpp
@@ -191,6 +191,7 @@ struct Inode : std::enable_shared_from_this<Inode> {
 	async::result<std::optional<DirEntry>> link(std::string name, int64_t ino, blockfs::FileType type);
 	async::result<void> unlink(std::string name);
 	async::result<std::optional<DirEntry>> mkdir(std::string name);
+	async::result<int> chmod(int mode, int64_t ino);
 
 	FileSystem &fs;
 

--- a/drivers/libblockfs/src/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2fs.hpp
@@ -191,7 +191,7 @@ struct Inode : std::enable_shared_from_this<Inode> {
 	async::result<std::optional<DirEntry>> link(std::string name, int64_t ino, blockfs::FileType type);
 	async::result<void> unlink(std::string name);
 	async::result<std::optional<DirEntry>> mkdir(std::string name);
-	async::result<int> chmod(int mode, int64_t ino);
+	async::result<int> chmod(int mode);
 
 	FileSystem &fs;
 
@@ -230,7 +230,6 @@ struct Inode : std::enable_shared_from_this<Inode> {
 	FileData fileData; // block references / small symlink data
 
 	int numLinks; // number of links to this file
-	uint32_t mode; // POSIX file mode
 	int uid, gid;
 	struct timespec accessTime;
 	struct timespec dataModifyTime;

--- a/drivers/libblockfs/src/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2fs.hpp
@@ -191,7 +191,7 @@ struct Inode : std::enable_shared_from_this<Inode> {
 	async::result<std::optional<DirEntry>> link(std::string name, int64_t ino, blockfs::FileType type);
 	async::result<void> unlink(std::string name);
 	async::result<std::optional<DirEntry>> mkdir(std::string name);
-	async::result<int> chmod(int mode);
+	async::result<protocols::fs::Error> chmod(int mode);
 
 	FileSystem &fs;
 

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -319,7 +319,7 @@ mkdir(std::shared_ptr<void> object, std::string name) {
 	co_return protocols::fs::MkdirResult{fs->accessInode(entry->inode), entry->inode};
 }
 
-async::result<int> chmod(std::shared_ptr<void> object, int mode) {
+async::result<protocols::fs::Error> chmod(std::shared_ptr<void> object, int mode) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
 	auto result = co_await self->chmod(mode);
 

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -274,7 +274,7 @@ getStats(std::shared_ptr<void> object) {
 	protocols::fs::FileStats stats;
 	stats.linkCount = self->numLinks;
 	stats.fileSize = self->fileSize();
-	stats.mode = self->mode;
+	stats.mode = self->diskInode()->mode;
 	stats.uid = self->uid;
 	stats.gid = self->gid;
 	stats.accessTime = self->accessTime;
@@ -319,6 +319,13 @@ mkdir(std::shared_ptr<void> object, std::string name) {
 	co_return protocols::fs::MkdirResult{fs->accessInode(entry->inode), entry->inode};
 }
 
+async::result<int> chmod(std::shared_ptr<void> object, int mode, int64_t ino) {
+	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
+	auto result = co_await self->chmod(mode, ino);
+
+	co_return result;
+}
+
 constexpr protocols::fs::NodeOperations nodeOperations{
 	&getStats,
 	&getLink,
@@ -326,7 +333,8 @@ constexpr protocols::fs::NodeOperations nodeOperations{
 	&unlink,
 	&open,
 	&readSymlink,
-	&mkdir
+	&mkdir,
+	&chmod
 };
 
 } // anonymous namespace

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -274,7 +274,7 @@ getStats(std::shared_ptr<void> object) {
 	protocols::fs::FileStats stats;
 	stats.linkCount = self->numLinks;
 	stats.fileSize = self->fileSize();
-	stats.mode = self->diskInode()->mode;
+	stats.mode = self->diskInode()->mode & 0xFFF;
 	stats.uid = self->uid;
 	stats.gid = self->gid;
 	stats.accessTime = self->accessTime;
@@ -319,9 +319,9 @@ mkdir(std::shared_ptr<void> object, std::string name) {
 	co_return protocols::fs::MkdirResult{fs->accessInode(entry->inode), entry->inode};
 }
 
-async::result<int> chmod(std::shared_ptr<void> object, int mode, int64_t ino) {
+async::result<int> chmod(std::shared_ptr<void> object, int mode) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
-	auto result = co_await self->chmod(mode, ino);
+	auto result = co_await self->chmod(mode);
 
 	co_return result;
 }

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -90,7 +90,7 @@ thor_sources = files(
 trampoline = custom_target('trampoline',
 	command: c_compiler.cmd_array() + ['-o', '@OUTPUT@',
 		'-nostdlib', '-Wl,-Ttext,0', '-Wl,--oformat,binary',
-		'@INPUT@'],
+		'@INPUT@'] + meson.get_cross_property('cpp_args'),
 	input: 'extra-src/trampoline.S',
 	output: 'trampoline.bin')
 

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -74,7 +74,7 @@ struct Node : FsNode {
 		co_return stats;
 	}
 
-	async::result<int> chmod(int mode) override {
+	async::result<Error> chmod(int mode) override {
 		helix::Offer offer;
 		helix::SendBuffer send_req;
 		helix::RecvInline recv_resp;
@@ -82,7 +82,6 @@ struct Node : FsNode {
 		managarm::fs::CntRequest req;
 		req.set_req_type(managarm::fs::CntReqType::NODE_CHMOD);
 		req.set_mode(mode);
-		req.set_fd(getInode());
 
 		auto ser = req.SerializeAsString();
 		auto &&transmit = helix::submitAsync(getLane(), helix::Dispatcher::global(),
@@ -98,7 +97,7 @@ struct Node : FsNode {
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 
-		co_return 0;
+		co_return Error::success;
 	}
 
 public:

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -83,8 +83,8 @@ DeviceId FsNode::readDevice() {
 	throw std::runtime_error("readDevice() is not implemented for this FsNode");
 }
 
-async::result<int> FsNode::chmod(int mode) {
-	throw std::runtime_error("chmod() is not implemented for this FsNode");
+async::result<Error> FsNode::chmod(int mode) {
+	co_return Error::accessDenied;
 }
 
 void FsNode::notifyObservers(uint32_t events, const std::string &name, uint32_t cookie) {

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -83,6 +83,10 @@ DeviceId FsNode::readDevice() {
 	throw std::runtime_error("readDevice() is not implemented for this FsNode");
 }
 
+async::result<int> FsNode::chmod(int mode) {
+	throw std::runtime_error("chmod() is not implemented for this FsNode");
+}
+
 void FsNode::notifyObservers(uint32_t events, const std::string &name, uint32_t cookie) {
 	assert(_defaultOps & defaultSupportsObservers);
 	for(const auto &[borrowed, observer] : _observers) {

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -84,6 +84,7 @@ DeviceId FsNode::readDevice() {
 }
 
 async::result<Error> FsNode::chmod(int mode) {
+	std::cout << "\e[31m" "posix: chmod() is not implemented for this FsNode" "\e[39m" << std::endl;
 	co_return Error::accessDenied;
 }
 

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -155,7 +155,7 @@ public:
 	virtual DeviceId readDevice();
 
 	// Changes permissions on a node
-	virtual async::result<int> chmod(int mode);
+	virtual async::result<Error> chmod(int mode);
 
 protected:
 	void notifyObservers(uint32_t inotifyEvents, const std::string &name, uint32_t cookie);

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -154,6 +154,9 @@ public:
 	//! Read the major/minor device number (devices only).
 	virtual DeviceId readDevice();
 
+	// Changes permissions on a node
+	virtual async::result<int> chmod(int mode);
+
 protected:
 	void notifyObservers(uint32_t inotifyEvents, const std::string &name, uint32_t cookie);
 

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1481,6 +1481,68 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					helix::action(&send_resp, ser.data(), ser.size()));
 			co_await transmit.async_wait();
 			HEL_CHECK(send_resp.error());
+		}else if(req.request_type() == managarm::posix::CntReqType::FCHMODAT) {
+			if(logRequests)
+				std::cout << "posix: FCHMODAT request" << std::endl;
+
+			helix::SendBuffer send_resp;
+
+			ViewPath relative_to;
+			smarter::shared_ptr<File, FileHandle> file;
+			std::shared_ptr<FsLink> target_link;
+
+			if(req.fd() == AT_FDCWD) {
+				relative_to = self->fsContext()->getWorkingDirectory();
+			} else {
+				file = self->fileContext()->getFile(req.fd());
+
+				if (!file) {
+					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					continue;
+				}
+
+				relative_to = {file->associatedMount(), file->associatedLink()};
+			}
+
+			if(req.flags()) {
+				if(req.flags() & AT_SYMLINK_NOFOLLOW) {
+					co_await sendErrorResponse(managarm::posix::Errors::NOT_SUPPORTED);
+					continue;
+				} else if(req.flags() & AT_EMPTY_PATH) {
+					// Allowed, managarm extension
+				} else {
+					co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+					continue;
+				}
+			}
+
+			if(req.flags() & AT_EMPTY_PATH) {
+				target_link = file->associatedLink();
+			} else {
+				PathResolver resolver;
+				resolver.setup(self->fsContext()->getRoot(),
+					relative_to, req.path());
+
+				co_await resolver.resolve();
+
+				target_link = resolver.currentLink();
+			}
+
+			if (!target_link) {
+				co_await sendErrorResponse(managarm::posix::Errors::FILE_NOT_FOUND);
+				continue;
+			}
+
+			co_await target_link->getTarget()->chmod(req.mode());
+
+			managarm::posix::SvrResponse resp;
+			resp.set_error(managarm::posix::Errors::SUCCESS);
+
+			auto ser = resp.SerializeAsString();
+			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+					helix::action(&send_resp, ser.data(), ser.size()));
+			co_await transmit.async_wait();
+			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::READLINK) {
 			if(logRequests || logPaths)
 				std::cout << "posix: READLINK path: " << req.path() << std::endl;

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -78,10 +78,10 @@ public:
 		return _ctime;
 	}
 
-	async::result<int> chmod(int mode) override {
+	async::result<Error> chmod(int mode) override {
 		// Unimplemented
 		std::cout << "posix: Fix chmod on tmpfs" << std::endl;
-		co_return 0;
+		co_return Error::accessDenied;
 	}
 
 private:

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -78,6 +78,12 @@ public:
 		return _ctime;
 	}
 
+	async::result<int> chmod(int mode) override {
+		// Unimplemented
+		std::cout << "posix: Fix chmod on tmpfs" << std::endl;
+		co_return 0;
+	}
+
 private:
 	int64_t _inodeNumber;
 	int _numLinks = 0;

--- a/protocols/fs/fs.proto
+++ b/protocols/fs/fs.proto
@@ -106,6 +106,8 @@ enum CntReqType {
 	RENAME = 36;
 
 	PT_PREAD = 37;
+
+	NODE_CHMOD = 38;
 }
 
 message Rect {
@@ -206,6 +208,8 @@ message CntRequest {
 	optional int32 input_clock = 41;
 
 	optional int64 offset = 58;
+
+	optional int32 mode = 60;
 }
 
 message SvrResponse {

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -199,6 +199,8 @@ struct NodeOperations {
 	async::result<std::string> (*readSymlink)(std::shared_ptr<void> object);
 
 	async::result<MkdirResult> (*mkdir)(std::shared_ptr<void> object, std::string name);
+
+	async::result<int> (*chmod)(std::shared_ptr<void> object, int mode, int64_t ino);
 };
 
 async::result<void>

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -200,7 +200,7 @@ struct NodeOperations {
 
 	async::result<MkdirResult> (*mkdir)(std::shared_ptr<void> object, std::string name);
 
-	async::result<int> (*chmod)(std::shared_ptr<void> object, int mode, int64_t ino);
+	async::result<int> (*chmod)(std::shared_ptr<void> object, int mode);
 };
 
 async::result<void>

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -200,7 +200,7 @@ struct NodeOperations {
 
 	async::result<MkdirResult> (*mkdir)(std::shared_ptr<void> object, std::string name);
 
-	async::result<int> (*chmod)(std::shared_ptr<void> object, int mode);
+	async::result<Error> (*chmod)(std::shared_ptr<void> object, int mode);
 };
 
 async::result<void>

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -786,6 +786,18 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_link.error());
+		}else if(req.req_type() == managarm::fs::CntReqType::NODE_CHMOD) {
+			co_await node_ops->chmod(node, req.mode(), req.fd());
+
+			managarm::fs::SvrResponse resp;
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+
+			auto ser = resp.SerializeAsString();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBuffer(ser.data(), ser.size())
+			);
+			HEL_CHECK(send_resp.error());
 		}else{
 			throw std::runtime_error("libfs_protocol: Unexpected request type in serveNode");
 		}

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -787,7 +787,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_link.error());
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_CHMOD) {
-			co_await node_ops->chmod(node, req.mode(), req.fd());
+			co_await node_ops->chmod(node, req.mode());
 
 			managarm::fs::SvrResponse resp;
 			resp.set_error(managarm::fs::Errors::SUCCESS);

--- a/protocols/posix/posix.proto
+++ b/protocols/posix/posix.proto
@@ -17,6 +17,7 @@ enum Errors {
 	BAD_FD = 8;
 	WOULD_BLOCK = 10;
 	BROKEN_PIPE = 11;
+	NOT_SUPPORTED = 12;
 }
 
 enum CntReqType {
@@ -105,6 +106,7 @@ enum CntReqType {
 	GET_EGID = 72;
 	SET_GID = 73;
 	SET_EGID = 74;
+	FCHMODAT = 75;
 };
 
 enum OpenMode {


### PR DESCRIPTION
This PR implements a `FCHMODAT` request in posix, allowing the libc functions `chmod()`, `fchmod()` and `fchmodat()` to function.