### PR TITLE
posix: Fix a bug and implement RMDIR

### DIFF
--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -533,6 +533,30 @@ private:
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 	}
 
+	async::result<Error> rmdir(std::string name) override {
+		managarm::fs::CntRequest req;
+		req.set_req_type(managarm::fs::CntReqType::NODE_RMDIR);
+		req.set_path(name);
+
+		auto ser = req.SerializeAsString();
+		auto [offer, send_req, recv_resp] = co_await helix_ng::exchangeMsgs(
+			getLane(),
+			helix_ng::offer(
+				helix_ng::sendBuffer(ser.data(), ser.size()),
+				helix_ng::recvInline()
+			)
+		);
+		HEL_CHECK(offer.error());
+		HEL_CHECK(send_req.error());
+		HEL_CHECK(recv_resp.error());
+
+		managarm::fs::SvrResponse resp;
+		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		assert(resp.error() == managarm::fs::Errors::SUCCESS);
+
+		co_return Error::success;
+	}
+
 	FutureMaybe<SharedFilePtr>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -72,6 +72,11 @@ FutureMaybe<void> FsNode::unlink(std::string) {
 	throw std::runtime_error("unlink() is not implemented for this FsNode");
 }
 
+async::result<Error> FsNode::rmdir(std::string) {
+	std::cout << "posix: rmdir() is not implemented for this FsNode" << std::endl;
+	co_return Error::illegalOperationTarget;
+}
+
 FutureMaybe<smarter::shared_ptr<File, FileHandle>>
 FsNode::open(std::shared_ptr<MountView>, std::shared_ptr<FsLink>, SemanticFlags) {
 	throw std::runtime_error("open() is not implemented for this FsNode");

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -145,6 +145,8 @@ public:
 
 	virtual FutureMaybe<void> unlink(std::string name);
 
+	virtual async::result<Error> rmdir(std::string name);
+
 	//! Opens the file (regular files only).
 	// TODO: Move this to the link instead of the inode?
 	virtual FutureMaybe<smarter::shared_ptr<File, FileHandle>>

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1239,7 +1239,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			helix::SendBuffer send_resp;
 			managarm::posix::SvrResponse resp;
 
-			if(!(req.flags() & ~(AT_EMPTY_PATH | AT_SYMLINK_FOLLOW))) {
+			if(!(req.flags() & (AT_EMPTY_PATH | AT_SYMLINK_FOLLOW))) {
 				co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
 				continue;
 			}

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1239,7 +1239,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			helix::SendBuffer send_resp;
 			managarm::posix::SvrResponse resp;
 
-			if(!(req.flags() & (AT_EMPTY_PATH | AT_SYMLINK_FOLLOW))) {
+			if(req.flags() & ~(AT_EMPTY_PATH | AT_SYMLINK_FOLLOW)) {
 				co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
 				continue;
 			}

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -2153,7 +2153,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				continue;
 			} else {
 				auto owner = target_link->getOwner();
-				co_await owner->unlink(target_link->getName());
+				co_await owner->rmdir(target_link->getName());
 
 				managarm::posix::SvrResponse resp;
 				resp.set_error(managarm::posix::Errors::SUCCESS);

--- a/protocols/fs/fs.proto
+++ b/protocols/fs/fs.proto
@@ -112,6 +112,8 @@ enum CntReqType {
 	PT_PREAD = 37;
 
 	NODE_CHMOD = 38;
+
+	NODE_RMDIR = 40;
 }
 
 message Rect {

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -801,6 +801,19 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
+		}else if(req.req_type() == managarm::fs::CntReqType::NODE_RMDIR) {
+			// TODO: This should probably be it's own operation, for now, let it be
+			co_await node_ops->unlink(node, req.path());
+
+			managarm::fs::SvrResponse resp;
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+
+			auto ser = resp.SerializeAsString();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBuffer(ser.data(), ser.size())
+			);
+			HEL_CHECK(send_resp.error());
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_OPEN) {
 			auto result = co_await node_ops->open(node);
 

--- a/protocols/posix/posix.proto
+++ b/protocols/posix/posix.proto
@@ -110,6 +110,7 @@ enum CntReqType {
 	SET_GID = 73;
 	SET_EGID = 74;
 	FCHMODAT = 75;
+	RMDIR = 77;
 };
 
 enum OpenMode {


### PR DESCRIPTION
We should return ILLEGAL_ARGUMENTS when flags is more then the two specified, not when either of those is declared.