### PR TITLE
posix: Implement utimensat

### DIFF
--- a/drivers/libblockfs/src/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2fs.cpp
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <algorithm>
 #include <iostream>
+#include <bits/posix/stat.h>
 
 #include <async/result.hpp>
 #include <helix/ipc.hpp>
@@ -299,6 +300,31 @@ async::result<protocols::fs::Error> Inode::chmod(int mode) {
 	co_return protocols::fs::Error::none;
 }
 
+async::result<protocols::fs::Error> Inode::utimensat(uint64_t sec, uint64_t nsec) {
+	std::cout << "\e[31m" "ext2fs: utimensat() only supports setting atime and mtime to current time" "\e[39m" << std::endl;
+	
+	co_await readyJump.async_wait();
+
+	if(sec != UTIME_NOW || nsec != UTIME_NOW) {
+		// TODO: Properly implement it, also respect atime and mtime
+		std::cout << "\e[31m" "ext2fs: utimensat() unsupported mode called" "\e[39m" << std::endl;
+		co_return protocols::fs::Error::none;
+	}
+
+	struct timespec time;
+	// TODO: Move to CLOCK_REALTIME when supported
+	clock_gettime(CLOCK_MONOTONIC, &time);
+	diskInode()->atime = time.tv_sec;
+	diskInode()->mtime = time.tv_sec;
+
+	auto syncInode = co_await helix_ng::synchronizeSpace(
+			helix::BorrowedDescriptor{kHelNullHandle},
+			diskMapping.get(), fs.inodeSize);
+	HEL_CHECK(syncInode.error());
+
+	co_return protocols::fs::Error::none;
+}
+
 // --------------------------------------------------------
 // FileSystem
 // --------------------------------------------------------
@@ -531,6 +557,12 @@ async::result<std::shared_ptr<Inode>> FileSystem::createRegular() {
 	memset(disk_inode, 0, inodeSize);
 	disk_inode->mode = EXT2_S_IFREG;
 	disk_inode->generation = generation + 1;
+	struct timespec time;
+	// TODO: Move to CLOCK_REALTIME when supported
+	clock_gettime(CLOCK_MONOTONIC, &time);
+	disk_inode->atime = time.tv_sec;
+	disk_inode->ctime = time.tv_sec;
+	disk_inode->mtime = time.tv_sec;
 
 	co_return accessInode(ino);
 }
@@ -560,6 +592,12 @@ async::result<std::shared_ptr<Inode>> FileSystem::createDirectory() {
 	disk_inode->mode = EXT2_S_IFDIR;
 	disk_inode->generation = generation + 1;
 	disk_inode->size = blockSize;
+	struct timespec time;
+	// TODO: Move to CLOCK_REALTIME when supported
+	clock_gettime(CLOCK_MONOTONIC, &time);
+	disk_inode->atime = time.tv_sec;
+	disk_inode->ctime = time.tv_sec;
+	disk_inode->mtime = time.tv_sec;
 
 	co_return accessInode(ino);
 }
@@ -588,6 +626,12 @@ async::result<std::shared_ptr<Inode>> FileSystem::createSymlink() {
 	memset(disk_inode, 0, inodeSize);
 	disk_inode->mode = EXT2_S_IFLNK;
 	disk_inode->generation = generation + 1;
+	struct timespec time;
+	// TODO: Move to CLOCK_REALTIME when supported
+	clock_gettime(CLOCK_MONOTONIC, &time);
+	disk_inode->atime = time.tv_sec;
+	disk_inode->ctime = time.tv_sec;
+	disk_inode->mtime = time.tv_sec;
 
 	co_return accessInode(ino);
 }

--- a/drivers/libblockfs/src/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2fs.cpp
@@ -300,14 +300,14 @@ async::result<protocols::fs::Error> Inode::chmod(int mode) {
 	co_return protocols::fs::Error::none;
 }
 
-async::result<protocols::fs::Error> Inode::utimensat(uint64_t sec, uint64_t nsec) {
+async::result<protocols::fs::Error> Inode::utimensat(uint64_t atime_sec, uint64_t atime_nsec, uint64_t mtime_sec, uint64_t mtime_nsec) {
 	std::cout << "\e[31m" "ext2fs: utimensat() only supports setting atime and mtime to current time" "\e[39m" << std::endl;
 	
 	co_await readyJump.async_wait();
 
-	if(sec != UTIME_NOW || nsec != UTIME_NOW) {
-		// TODO: Properly implement it, also respect atime and mtime
-		std::cout << "\e[31m" "ext2fs: utimensat() unsupported mode called" "\e[39m" << std::endl;
+	if(atime_sec != UTIME_NOW || atime_nsec != UTIME_NOW || mtime_sec != UTIME_NOW || mtime_nsec != UTIME_NOW) {
+		// TODO: Properly implement setting the time to arbitrary values
+		std::cout << "\e[31m" "ext2fs: utimensat() unsupported mode called (not UTIME_NOW for all fields)" "\e[39m" << std::endl;
 		co_return protocols::fs::Error::none;
 	}
 
@@ -708,12 +708,6 @@ async::detached FileSystem::initiateInode(std::shared_ptr<Inode> inode) {
 	// TODO: support large uid / gids
 	inode->uid = disk_inode->uid;
 	inode->gid = disk_inode->gid;
-	inode->accessTime.tv_sec = disk_inode->atime;
-	inode->accessTime.tv_nsec = 0;
-	inode->dataModifyTime.tv_sec = disk_inode->mtime;
-	inode->dataModifyTime.tv_nsec = 0;
-	inode->anyChangeTime.tv_sec = disk_inode->ctime;
-	inode->anyChangeTime.tv_nsec = 0;
 
 	// Allocate a page cache for the file.
 	auto cache_size = (inode->fileSize() + 0xFFF) & ~size_t(0xFFF);

--- a/drivers/libblockfs/src/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2fs.hpp
@@ -193,7 +193,7 @@ struct Inode : std::enable_shared_from_this<Inode> {
 	async::result<std::optional<DirEntry>> mkdir(std::string name);
 	async::result<std::optional<DirEntry>> symlink(std::string name, std::string target);
 	async::result<protocols::fs::Error> chmod(int mode);
-	async::result<protocols::fs::Error> utimensat(uint64_t sec, uint64_t nsec);
+	async::result<protocols::fs::Error> utimensat(uint64_t atime_sec, uint64_t atime_nsec, uint64_t mtime_sec, uint64_t mtime_nsec);
 
 	FileSystem &fs;
 
@@ -232,9 +232,6 @@ struct Inode : std::enable_shared_from_this<Inode> {
 
 	int numLinks; // number of links to this file
 	int uid, gid;
-	struct timespec accessTime;
-	struct timespec dataModifyTime;
-	struct timespec anyChangeTime;
 	FlockManager flockManager;
 };
 

--- a/drivers/libblockfs/src/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2fs.hpp
@@ -193,6 +193,7 @@ struct Inode : std::enable_shared_from_this<Inode> {
 	async::result<std::optional<DirEntry>> mkdir(std::string name);
 	async::result<std::optional<DirEntry>> symlink(std::string name, std::string target);
 	async::result<protocols::fs::Error> chmod(int mode);
+	async::result<protocols::fs::Error> utimensat(uint64_t sec, uint64_t nsec);
 
 	FileSystem &fs;
 

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -277,9 +277,9 @@ getStats(std::shared_ptr<void> object) {
 	stats.mode = self->diskInode()->mode & 0xFFF;
 	stats.uid = self->uid;
 	stats.gid = self->gid;
-	stats.accessTime = self->accessTime;
-	stats.dataModifyTime = self->dataModifyTime;
-	stats.anyChangeTime = self->anyChangeTime;
+	stats.accessTime.tv_sec = self->diskInode()->atime;
+	stats.dataModifyTime.tv_sec = self->diskInode()->mtime;;
+	stats.anyChangeTime.tv_sec = self->diskInode()->ctime;
 
 	co_return stats;
 }
@@ -288,11 +288,22 @@ async::result<protocols::fs::OpenResult>
 open(std::shared_ptr<void> object) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
 	auto file = smarter::make_shared<ext2fs::OpenFile>(self);
+	co_await self->readyJump.async_wait();
 
 	helix::UniqueLane local_ctrl, remote_ctrl;
 	helix::UniqueLane local_pt, remote_pt;
 	std::tie(local_ctrl, remote_ctrl) = helix::createStream();
 	std::tie(local_pt, remote_pt) = helix::createStream();
+	struct timespec time;
+	// Use CLOCK_REALTIME when available
+	clock_gettime(CLOCK_MONOTONIC, &time);
+	self->diskInode()->atime = time.tv_sec;
+
+	auto syncInode = co_await helix_ng::synchronizeSpace(
+			helix::BorrowedDescriptor{kHelNullHandle},
+			self->diskMapping.get(), self->fs.inodeSize);
+	HEL_CHECK(syncInode.error());
+
 	serve(file, std::move(local_ctrl), std::move(local_pt));
 
 	co_return protocols::fs::OpenResult{std::move(remote_ctrl), std::move(remote_pt)};
@@ -338,6 +349,13 @@ async::result<protocols::fs::Error> chmod(std::shared_ptr<void> object, int mode
 	co_return result;
 }
 
+async::result<protocols::fs::Error> utimensat(std::shared_ptr<void> object, uint64_t sec, uint64_t nsec) {
+	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
+	auto result = co_await self->utimensat(sec, nsec);
+
+	co_return result;
+}
+
 constexpr protocols::fs::NodeOperations nodeOperations{
 	.getStats = &getStats,
 	.getLink = &getLink,
@@ -347,7 +365,8 @@ constexpr protocols::fs::NodeOperations nodeOperations{
 	.readSymlink = &readSymlink,
 	.mkdir = &mkdir,
 	.symlink = &symlink,
-	.chmod = &chmod
+	.chmod = &chmod,
+	.utimensat = &utimensat
 };
 
 } // anonymous namespace

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -349,9 +349,9 @@ async::result<protocols::fs::Error> chmod(std::shared_ptr<void> object, int mode
 	co_return result;
 }
 
-async::result<protocols::fs::Error> utimensat(std::shared_ptr<void> object, uint64_t sec, uint64_t nsec) {
+async::result<protocols::fs::Error> utimensat(std::shared_ptr<void> object, uint64_t atime_sec, uint64_t atime_nsec, uint64_t mtime_sec, uint64_t mtime_nsec) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
-	auto result = co_await self->utimensat(sec, nsec);
+	auto result = co_await self->utimensat(atime_sec, atime_nsec, mtime_sec, mtime_nsec);
 
 	co_return result;
 }

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -98,6 +98,32 @@ struct Node : FsNode {
 		co_return Error::success;
 	}
 
+	async::result<Error> utimensat(uint64_t sec, uint64_t nsec) override {
+		managarm::fs::CntRequest req;
+		req.set_req_type(managarm::fs::CntReqType::NODE_UTIMENSAT);
+		req.set_sec(sec);
+		req.set_nsec(nsec);
+
+		auto ser = req.SerializeAsString();
+		auto [offer, send_req, recv_resp] = co_await helix_ng::exchangeMsgs(
+			getLane(),
+			helix_ng::offer(
+				helix_ng::sendBuffer(ser.data(), ser.size()),
+				helix_ng::recvInline()
+			)
+		);
+		HEL_CHECK(offer.error());
+		HEL_CHECK(send_req.error());
+		HEL_CHECK(recv_resp.error());
+
+		managarm::fs::SvrResponse resp;
+		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		assert(resp.error() == managarm::fs::Errors::SUCCESS);
+
+		co_return Error::success;
+	}
+
+
 public:
 	Node(uint64_t inode, helix::UniqueLane lane, Superblock *sb = nullptr)
 	: FsNode{sb}, _inode{inode}, _lane{std::move(lane)} { }

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -98,11 +98,13 @@ struct Node : FsNode {
 		co_return Error::success;
 	}
 
-	async::result<Error> utimensat(uint64_t sec, uint64_t nsec) override {
+	async::result<Error> utimensat(uint64_t atime_sec, uint64_t atime_nsec, uint64_t mtime_sec, uint64_t mtime_nsec) override {
 		managarm::fs::CntRequest req;
 		req.set_req_type(managarm::fs::CntReqType::NODE_UTIMENSAT);
-		req.set_sec(sec);
-		req.set_nsec(nsec);
+		req.set_atime_sec(atime_sec);
+		req.set_atime_nsec(atime_nsec);
+		req.set_mtime_sec(mtime_sec);
+		req.set_mtime_nsec(mtime_nsec);
 
 		auto ser = req.SerializeAsString();
 		auto [offer, send_req, recv_resp] = co_await helix_ng::exchangeMsgs(

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -95,7 +95,7 @@ async::result<Error> FsNode::chmod(int mode) {
 	co_return Error::accessDenied;
 }
 
-async::result<Error> FsNode::utimensat(uint64_t sec, uint64_t nsec) {
+async::result<Error> FsNode::utimensat(uint64_t atime_sec, uint64_t atime_nsec, uint64_t mtime_sec, uint64_t mtime_nsec) {
 	std::cout << "\e[31m" "posix: utimensat() is not implemented for this FsNode" "\e[39m" << std::endl;
 	co_return Error::accessDenied;
 }

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -95,6 +95,11 @@ async::result<Error> FsNode::chmod(int mode) {
 	co_return Error::accessDenied;
 }
 
+async::result<Error> FsNode::utimensat(uint64_t sec, uint64_t nsec) {
+	std::cout << "\e[31m" "posix: utimensat() is not implemented for this FsNode" "\e[39m" << std::endl;
+	co_return Error::accessDenied;
+}
+
 void FsNode::notifyObservers(uint32_t events, const std::string &name, uint32_t cookie) {
 	assert(_defaultOps & defaultSupportsObservers);
 	for(const auto &[borrowed, observer] : _observers) {

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -163,6 +163,9 @@ public:
 	// Changes permissions on a node
 	virtual async::result<Error> chmod(int mode);
 
+	// Changes timestamps on a node
+	virtual async::result<Error> utimensat(uint64_t sec, uint64_t nsec);
+
 protected:
 	void notifyObservers(uint32_t inotifyEvents, const std::string &name, uint32_t cookie);
 

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -164,7 +164,7 @@ public:
 	virtual async::result<Error> chmod(int mode);
 
 	// Changes timestamps on a node
-	virtual async::result<Error> utimensat(uint64_t sec, uint64_t nsec);
+	virtual async::result<Error> utimensat(uint64_t atime_sec, uint64_t atime_nsec, uint64_t mtime_sec, uint64_t mtime_nsec);
 
 protected:
 	void notifyObservers(uint32_t inotifyEvents, const std::string &name, uint32_t cookie);

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1626,10 +1626,8 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				}
 
 				if(req.flags() & AT_SYMLINK_NOFOLLOW) {
-					std::cout << "posix: AT_SYMLINK_FOLLOW is unimplemented for linkat" << std::endl;
+					std::cout << "posix: AT_SYMLINK_FOLLOW is unimplemented for utimensat" << std::endl;
 				}
-
-				std::cout << "posix: UTIMENSAT called with: " << req.tv_sec() << " secs and " << req.tv_nsec() << " nsecs" << std::endl;
 
 				if(req.fd() == AT_FDCWD) {
 					relativeTo = self->fsContext()->getWorkingDirectory();
@@ -1652,7 +1650,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				target = resolver.currentLink()->getTarget();
 			}
 
-			co_await target->utimensat(req.tv_sec(), req.tv_nsec());
+			co_await target->utimensat(req.atime_sec(), req.atime_nsec(), req.mtime_sec(), req.mtime_nsec());
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1609,6 +1609,60 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
+		}else if(req.request_type() == managarm::posix::CntReqType::UTIMENSAT) {
+			if(logRequests || logPaths)
+				std::cout << "posix: UTIMENSAT " << req.path() << std::endl;
+
+			ViewPath relativeTo;
+			smarter::shared_ptr<File, FileHandle> file;
+			std::shared_ptr<FsNode> target = nullptr;
+
+			if(!req.path().size()) {
+				target = self->fileContext()->getFile(req.fd())->associatedLink()->getTarget();
+			} else {
+				if(req.flags() & ~AT_SYMLINK_NOFOLLOW) {
+					co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+					continue;
+				}
+
+				if(req.flags() & AT_SYMLINK_NOFOLLOW) {
+					std::cout << "posix: AT_SYMLINK_FOLLOW is unimplemented for linkat" << std::endl;
+				}
+
+				std::cout << "posix: UTIMENSAT called with: " << req.tv_sec() << " secs and " << req.tv_nsec() << " nsecs" << std::endl;
+
+				if(req.fd() == AT_FDCWD) {
+					relativeTo = self->fsContext()->getWorkingDirectory();
+				} else {
+					file = self->fileContext()->getFile(req.fd());
+					if (!file) {
+						co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+						continue;
+					}
+
+					relativeTo = {file->associatedMount(), file->associatedLink()};
+				}
+
+				PathResolver resolver;
+				resolver.setup(self->fsContext()->getRoot(),
+						relativeTo, req.path());
+				co_await resolver.resolve(resolvePrefix);
+				assert(resolver.currentLink());
+
+				target = resolver.currentLink()->getTarget();
+			}
+
+			co_await target->utimensat(req.tv_sec(), req.tv_nsec());
+
+			managarm::posix::SvrResponse resp;
+			resp.set_error(managarm::posix::Errors::SUCCESS);
+
+			auto ser = resp.SerializeAsString();
+			auto [sendResp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBuffer(ser.data(), ser.size())
+			);
+			HEL_CHECK(sendResp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::READLINK) {
 			if(logRequests || logPaths)
 				std::cout << "posix: READLINK path: " << req.path() << std::endl;

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -84,8 +84,8 @@ public:
 		co_return Error::success;
 	}
 
-	async::result<Error> utimensat(uint64_t sec, uint64_t nsec) override {
-		if(sec != UTIME_NOW || nsec != UTIME_NOW) {
+	async::result<Error> utimensat(uint64_t atime_sec, uint64_t atime_nsec, uint64_t mtime_sec, uint64_t mtime_nsec) override {
+		if(atime_sec != UTIME_NOW || atime_nsec != UTIME_NOW || mtime_sec != UTIME_NOW || mtime_nsec != UTIME_NOW) {
 			std::cout << "\e[31m" "tmp_fs: utimensat() only supports setting atime and mtime to current time" "\e[39m" << std::endl;
 			co_return Error::success;
 		}

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -9,6 +9,7 @@
 #include "device.hpp"
 #include "tmp_fs.hpp"
 #include "fifo.hpp"
+#include <bits/posix/stat.h>
 
 // TODO: Remove dependency on those functions.
 #include "extern_fs.hpp"
@@ -79,9 +80,23 @@ public:
 	}
 
 	async::result<Error> chmod(int mode) override {
-		// Unimplemented
-		std::cout << "posix: Fix chmod on tmpfs" << std::endl;
-		co_return Error::accessDenied;
+		_mode = (_mode & 0xFFFFF000) | mode;
+		co_return Error::success;
+	}
+
+	async::result<Error> utimensat(uint64_t sec, uint64_t nsec) override {
+		if(sec != UTIME_NOW || nsec != UTIME_NOW) {
+			std::cout << "\e[31m" "tmp_fs: utimensat() only supports setting atime and mtime to current time" "\e[39m" << std::endl;
+			co_return Error::success;
+		}
+		struct timespec time;
+		// TODO: Move to CLOCK_REALTIME when supported
+		clock_gettime(CLOCK_MONOTONIC, &time);
+		_atime.tv_sec = time.tv_sec;
+		_atime.tv_nsec = time.tv_nsec;
+		_mtime.tv_sec = time.tv_sec;
+		_mtime.tv_nsec = time.tv_nsec;
+		co_return Error::success;
 	}
 
 private:

--- a/protocols/fs/fs.proto
+++ b/protocols/fs/fs.proto
@@ -223,8 +223,10 @@ message CntRequest {
 	optional int32 mode = 60;
 
 	// used by utimensat
-	optional uint64 sec = 63;
-	optional uint64 nsec = 64;
+	optional uint64 atime_sec = 63;
+	optional uint64 atime_nsec = 64;
+	optional uint64 mtime_sec = 65;
+	optional uint64 mtime_nsec = 66;
 }
 
 message SvrResponse {

--- a/protocols/fs/fs.proto
+++ b/protocols/fs/fs.proto
@@ -114,6 +114,7 @@ enum CntReqType {
 	NODE_CHMOD = 38;
 
 	NODE_RMDIR = 40;
+	NODE_UTIMENSAT = 41;
 }
 
 message Rect {
@@ -220,6 +221,10 @@ message CntRequest {
 	optional int64 offset = 58;
 
 	optional int32 mode = 60;
+
+	// used by utimensat
+	optional uint64 sec = 63;
+	optional uint64 nsec = 64;
 }
 
 message SvrResponse {

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -206,7 +206,7 @@ struct NodeOperations {
 
 	async::result<Error> (*chmod)(std::shared_ptr<void> object, int mode);
 
-	async::result<Error> (*utimensat)(std::shared_ptr<void> object, uint64_t sec, uint64_t nsec);
+	async::result<Error> (*utimensat)(std::shared_ptr<void> object, uint64_t atime_sec, uint64_t atime_nsec, uint64_t mtime_sec, uint64_t mtime_nsec);
 };
 
 async::result<void>

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -205,6 +205,8 @@ struct NodeOperations {
 			std::string path);
 
 	async::result<Error> (*chmod)(std::shared_ptr<void> object, int mode);
+
+	async::result<Error> (*utimensat)(std::shared_ptr<void> object, uint64_t sec, uint64_t nsec);
 };
 
 async::result<void>

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -857,7 +857,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 			);
 			HEL_CHECK(send_resp.error());
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_UTIMENSAT) {
-			co_await node_ops->utimensat(node, req.sec(), req.nsec());
+			co_await node_ops->utimensat(node, req.atime_sec(), req.atime_nsec(), req.mtime_sec(), req.mtime_nsec());
 
 			managarm::fs::SvrResponse resp;
 			resp.set_error(managarm::fs::Errors::SUCCESS);

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -856,6 +856,18 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
+		}else if(req.req_type() == managarm::fs::CntReqType::NODE_UTIMENSAT) {
+			co_await node_ops->utimensat(node, req.sec(), req.nsec());
+
+			managarm::fs::SvrResponse resp;
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+
+			auto ser = resp.SerializeAsString();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBuffer(ser.data(), ser.size())
+			);
+			HEL_CHECK(send_resp.error());
 		}else{
 			throw std::runtime_error("libfs_protocol: Unexpected request type in serveNode");
 		}

--- a/protocols/posix/posix.proto
+++ b/protocols/posix/posix.proto
@@ -22,7 +22,6 @@ enum Errors {
 
 enum CntReqType {
 	INIT = 7;
-	GET_TID = 29;
 	GET_PID = 17;
 	FORK = 8;
 	EXEC = 1;
@@ -223,8 +222,10 @@ message CntRequest {
 	optional int64 uid = 41;
 
 	// used by utimensat
-	optional uint64 tv_sec = 44;
-	optional uint64 tv_nsec = 45;
+	optional uint64 atime_sec = 44;
+	optional uint64 atime_nsec = 45;
+	optional uint64 mtime_sec = 46;
+	optional uint64 mtime_nsec = 47;
 }
 
 message SvrResponse {

--- a/protocols/posix/posix.proto
+++ b/protocols/posix/posix.proto
@@ -112,6 +112,7 @@ enum CntReqType {
 	SET_EGID = 74;
 	FCHMODAT = 75;
 	RMDIR = 77;
+	UTIMENSAT = 78;
 };
 
 enum OpenMode {
@@ -220,6 +221,10 @@ message CntRequest {
 
 	// used by {GET/SET}UID
 	optional int64 uid = 41;
+
+	// used by utimensat
+	optional uint64 tv_sec = 44;
+	optional uint64 tv_nsec = 45;
 }
 
 message SvrResponse {


### PR DESCRIPTION
This PR implements the file system operation `utimensat` for `ext2fs` and `tmpfs`, adds an `chmod` file system operation for `tmpfs` and updates the access times on open for files on a `ext2` file system.

This PR is blocked on inclusion of managarm/mlibc#100