### PR TITLE
Added more docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,21 +4,24 @@
 
 - [Getting Started](getting-started/index.md)
     - [Trying Out](getting-started/trying-out.md)
-    - [Contributing](getting-started/contributing.md)
-    - [Support](getting-started/supported.md)
+    - [Supported Hardware and Software](getting-started/supported/index.md)
+        - [Temporary Package Index](getting-started/supported/package_index.md)
+
 
 - [Building](building.md)
 
 - [Design](design/index.md)
     - [Components](design/index.md)
         - [managarm](design/index.md)
-        - [hel and helix](design/index.md)
-        - [thor and eir](design/index.md)
-        - [frigg](design/index.md)
-        - [libasync](design/index.md)
-        
+        - [hel and helix](design/hel/index.md)
+        - [thor and eir](design/thoreir/index.md)
+        - [frigg](design/frigg/index.md)
+        - [libasync](design/libasync/index.md)
+        - [mbus](design/mbus/index.md)
+        - [bragi](design/bragi/index.md)
 
-- [Contribting](contributing/contributing.md)
+
+- [Contributing](contributing/contributing.md)
     - [Communication](contributing/communication.md)
     - [Direct Contributions](contributing/direct/direct.md)
         - [Fields](contributing/direct/direct.md)

--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -1,7 +1,110 @@
 # Building Managarm
 
-> This section of the Guide is Work-In-Progress. Please come back later for more information.
+This guide shows how to build a managarm distribution from source utilising the [bootstrap-managarm](https://github.com/managarm/bootstrap-managarm) patches and build scripts.
 
-The repository at [https://github.com/managarm/managarm](https://github.com/managarm/managarm) contains managarm's kernel, drivers and other core functionality.
+## Building a managarm distribution from source
 
-For information on how to build Managarm please refer to the [bootstrap-managarm](https://github.com/managarm/bootstrap-managarm) repository for build instructions.
+### Build environment
+To make sure that all build environments work properly, it is recommended to
+setup a build environment with [Docker](https://www.docker.com/) using the
+provided [Dockerfile](https://github.com/managarm/bootstrap-managarm/blob/master/docker/Dockerfile).
+
+Make sure that you have atleast 20 - 30 GiB of free disk space.
+
+#### Preperations
+First and foremost we will create a directory (`$MANAGARM_DIR`) which will be
+used for storing the source and build directories.
+
+```sh
+export MANAGARM_DIR="$HOME/managarm" # In this example we are using $HOME/managarm, but it can be any directory
+mkdir -p "$MANAGARM_DIR" && cd "$MANAGARM_DIR"
+```
+
+Then clone this directoy into a `src` directory:
+```sh
+git clone https://github.com/managarm/bootstrap-managarm.git src
+```
+
+#### Creating Docker image and container
+> Note: this step is not needed if you don't want to use a Docker container, if so skip to the next paragraph.
+1. Install Docker (duh) and make sure it is working properly by running `docker run hello-world` and making sure the output shows:
+```
+Hello from Docker!
+This message shows that your installation appears to be working correctly.
+```
+2. Creae a Docker image from the provided Dockerfile:
+```sh
+docker build -t managarm_buildenv src/docker
+```
+3. Start a container:
+```sh
+docker run -v $(realpath "$MANAGARM_DIR"):/home/managarm_buildenv/managarm -it managarm_buildenv
+```
+
+You are now running a `bash` shell within a Docker container with all the build
+dependencies already installed. Inside the home directory (`ls`) there shiuld be
+a `managarm` directory shared with the host containing a `src` directory (this repo).
+If this is not the case go back and make sure you followed the steps properly.
+
+Switch to the `managarm` directory:
+```sh
+cd managarm
+```
+Now proceed to the Building paragraph.
+
+#### Installing dependecies manually
+> Note: if you created a Docker image in the previous step, skip this paragraph.
+1.  Certain programs are required to build managarm;
+    here we list the corresponding Debian packages:
+    `build-essential`, `pkg-config`, `autopoint`, `bison`, `curl`, `flex`, `gettext`, `git`, `gperf`, `help2man`, `m4`, `mercurial`, `ninja-build`, `python3-mako`, `python3-protobuf`, `python3-yaml`, `texinfo`, `unzip`, `wget`, `xsltproc`, `xz-utils`, `libexpat1-dev`, `rsync`, `python3-pip`, `python3-libxml2`, `netpbm`, `itstool`, `zlib1g-dev`, `libgmp-dev`, `libmpfr-dev`, `libmpc-dev`.
+1.  `meson` is required. There is a Debian package, but as of Debian Stretch, a newer version is required.
+    Install it from pip: `pip3 install meson`.
+1.  The [xbstrap](https://github.com/managarm/xbstrap) tool is required to build managarm. Install it from pip: `pip3 install xbstrap`.
+
+### Building
+1. Create and change into a `build` directory
+```sh
+mkdir build && cd build
+```
+2. Initialize the build directory with
+```sh
+xbstrap init ../src
+```
+3. Start the build using
+```sh
+xbstrap install --all
+```
+Note that this command can take **multiple hours**, depending on your machine.
+
+### Creating Images
+> Note: if using a Docker container the following command are meant to be ran **outside** the Docker container, in the `build` directory on the host. Adding to the aforementioned commands, one would `exit` from the container once the build finishes, enter the `build` directory, and proceed as follows.
+
+After managarm's packages have been built, building a HDD image of the system is straightforward. The [`image_create.sh`](https://gitlab.com/qookei/image_create) script can be used tp create an empty HDD imsage.
+
+Download the `image_create.sh` script and mark it executable:
+```sh
+wget 'https://gitlab.com/qookei/image_create/raw/master/image_create.sh'
+chmod +x image_create.sh
+```
+
+This repository contains a `mkimage` script to copy the system onto the image. Note that `mkimage` requires `libguestfs` and `rsync` to be able to create an image without requiring root access and synchronise it.
+
+After installing `libguestfs` it might be necessary to run the following:
+```sh
+sudo install -d /usr/lib/guestfs
+sudo update-libguestfs-appliance
+```
+
+Hence, running the following commands in the build directory should produce a working image and launch it using [QEMU](https://qemu.org/):
+```sh
+# Copy some files (e.g., the timezone configuration) from the host to system-root/.
+# It is sufficient to run this once.
+../src/scripts/prepare-sysroot
+
+# Create a HDD image file called 'image' and copy the system onto it.
+./image_create.sh image 4GiB ext2 gpt
+../src/scripts/mkimage
+
+# To launch the image using QEMU, you can run:
+../src/scripts/run-qemu
+```

--- a/docs/src/contributing/contributing.md
+++ b/docs/src/contributing/contributing.md
@@ -1,3 +1,5 @@
 # Contributing
 
 This section of the Managarm documentation helps you on contributing to Managarm.
+
+> This section of the Guide is Work-In-Progress. Please come back later for more information.

--- a/docs/src/design/bragi/index.md
+++ b/docs/src/design/bragi/index.md
@@ -1,0 +1,60 @@
+# bragi
+
+> This part of the Handbook if Work-In-Progress.
+
+bragi is the future interface definition language for use in managarm.
+
+The code for bragi can be found at [https://github.com/managarm/bragi](https://github.com/managarm/bragi).
+
+## Requirements
+bragi requires `python3` and `lark-parser`.
+
+## Sample code
+```
+enum enum1 {
+	foo = 1,
+	bar,
+	baz
+}
+
+message msg1 1 {
+head(256):
+	byte[64] bab;
+	byte[64] bib;
+
+tail:
+	optional tag(13) byte[3] bub = [1,2,3];
+	optional byte[] beb = [7];
+	string bob = "test";
+}
+
+message msg2 2 {
+head(128):
+	optional byte[64] bab;
+	int32 bib = 2345;
+
+tail:
+	byte[4] bub = [1,2,3];
+	byte beb = 7;
+	byte bhb = 7;
+	string bob = "test";
+}
+
+message msg3 3 {head(13): byte foo = 3;}
+
+message msg4 4 {
+head(64):
+	uint64 foo;
+	byte[16] arr;
+tail:
+	int32 baz;
+	uint32[] bif;
+}
+```
+
+### Compile the sample code
+To compile the `sample.idl` sample code run:
+```sh
+python setup.py install
+bragi
+```

--- a/docs/src/design/frigg/index.md
+++ b/docs/src/design/frigg/index.md
@@ -1,0 +1,7 @@
+# frigg
+
+> This part of the handbook is Work-In-Progress.
+
+frigg is a lightweight utility library for system programming written in C++.
+
+The code for frigg can found at [https://github.com/managarm/frigg](https://github.com/managarm/frigg).

--- a/docs/src/design/hel/index.md
+++ b/docs/src/design/hel/index.md
@@ -1,0 +1,9 @@
+# Hel and Helix
+
+> This part of the Handbook if Work-In-Progress.
+
+Hel and Helix is the syscall API for Managarm.
+Hel is the C API and Helix is C++ wrapper for some parts of Hel.
+
+## Doxygen Generated API Reference
+The generated Documentation for `managarm/hel` can be found at [https://docs.managarm.org/](https://docs.managarm.org/)

--- a/docs/src/design/libasync/index.md
+++ b/docs/src/design/libasync/index.md
@@ -1,0 +1,5 @@
+# libasync
+
+> This part of the handbook is Work-In-Progress.
+
+The code for libasync can be found at [https://github.com/managarm/libasync](https://github.com/managarm/libasync).

--- a/docs/src/design/mbus/index.md
+++ b/docs/src/design/mbus/index.md
@@ -1,0 +1,5 @@
+# mbus
+
+> This part of the Handbook if Work-In-Progress.
+
+mbus is the managarm message bus system.

--- a/docs/src/design/thoreir/index.md
+++ b/docs/src/design/thoreir/index.md
@@ -1,0 +1,9 @@
+# thor and eir
+
+> This part of the handbook is Work-In-Progress.
+
+thor and eir are the kernel of managarm.
+
+eir is the platform-dependant part of managarm's kernel which hands over control to thor after setup.
+
+The code for thor and eir can found at [https://github.com/managarm/managarm/tree/master/kernel](https://github.com/managarm/managarm/tree/master/kernel).

--- a/docs/src/getting-started/contributing.md
+++ b/docs/src/getting-started/contributing.md
@@ -1,3 +1,0 @@
-# Contributing to Managarm
-
-> This section of the Guide is Work-In-Progress. Please come back later for more information.

--- a/docs/src/getting-started/supported/index.md
+++ b/docs/src/getting-started/supported/index.md
@@ -3,6 +3,8 @@
 ## Software
 Programs supported on managarm include [Weston](https://gitlab.freedesktop.org/wayland/weston/) (the Wayland reference compositor), [kmscon](https://www.freedesktop.org/wiki/Software/kmscon/) (a system console), GNU coreutils, bash, nano and others.
 
+We are looking into building a managarm package index in the future.
+
 ## Hardware
 #### General
 - USB (UHCI, EHCI)

--- a/docs/src/getting-started/supported/package_index.md
+++ b/docs/src/getting-started/supported/package_index.md
@@ -1,0 +1,36 @@
+# Temporary package index
+
+> This part of the handbook is Work-In-Progress.
+
+- automake
+- bash
+- binutils
+- cairo
+- coreutils
+- eudev
+- gcc
+- glib
+- kernel-libc
+- kmscon
+- libdrm
+- libexpat
+- libressl
+- libtool
+- libxkbcommon
+- llvm
+- make
+- mesa
+- ncurses
+- pcre
+- perl-cross
+- protobuf
+- python
+- runit
+- sdl2
+- socat
+- sysklogd
+- tyr-quake
+- wayland
+- weston
+- xbps
+- zlib


### PR DESCRIPTION
## Stuff added to the docs
- Building managarm guide using the `bootstrap-managarm` guide
- Short docs for hel, thor/eir, libasync, mbus, frigg, bragi, libasync.
- Added a list of packages that we have patched to work on managarm.