### PR TITLE
Refactored some FsNode operations

### DIFF
--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -75,7 +75,8 @@ async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id
 	while(true) {
 		size_t s = path.find('/', k);
 		if(s == std::string::npos) {
-			co_await node->mkdev(path.substr(k), type, id);
+			auto result = co_await node->mkdev(path.substr(k), type, id);
+			assert(result);
 			break;
 		}else{
 			assert(s > k);

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -80,7 +80,9 @@ async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id
 		}else{
 			assert(s > k);
 			std::shared_ptr<FsLink> link;
-			link = co_await node->getLink(path.substr(k, s - k));
+			auto linkResult = co_await node->getLink(path.substr(k, s - k));
+			assert(linkResult);
+			link = linkResult.value();
 			// TODO: Check for errors from mkdir().
 			if(!link)
 				link = std::get<std::shared_ptr<FsLink>>(

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -45,8 +45,8 @@ std::shared_ptr<UnixDevice> UnixDeviceRegistry::get(DeviceId id) {
 	return *it;
 }
 
-FutureMaybe<SharedFilePtr> openDevice(VfsType type, DeviceId id,
-		std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> openDevice(VfsType type,
+		DeviceId id, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	if(type == VfsType::charDevice) {
 		auto device = charRegistry.get(id);

--- a/posix/subsystem/src/device.hpp
+++ b/posix/subsystem/src/device.hpp
@@ -73,8 +73,8 @@ private:
 extern UnixDeviceRegistry charRegistry;
 extern UnixDeviceRegistry blockRegistry;
 
-FutureMaybe<smarter::shared_ptr<File, FileHandle>> openDevice(VfsType type, DeviceId id,
-		std::shared_ptr<MountView> mont, std::shared_ptr<FsLink> link,
+async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
+openDevice(VfsType type, DeviceId id, std::shared_ptr<MountView> mont, std::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags);
 
 // --------------------------------------------------------

--- a/posix/subsystem/src/exec.cpp
+++ b/posix/subsystem/src/exec.cpp
@@ -138,7 +138,9 @@ execute(ViewPath root, ViewPath workdir,
 		std::vector<std::string> args, std::vector<std::string> env,
 		std::shared_ptr<VmContext> vmContext, helix::BorrowedDescriptor universe,
 		HelHandle mbusHandle) {
-	auto execFile = co_await open(root, workdir, path);
+	auto execFileResult = co_await open(root, workdir, path);
+	assert(execFileResult);
+	auto execFile = execFileResult.value();
 	if(!execFile)
 		co_return Error::noSuchFile;
 
@@ -190,7 +192,9 @@ execute(ViewPath root, ViewPath workdir,
 
 		// Linux looks up the interpreter in the current working directory.
 		std::string interpreterPath{beginPath, endPath};
-		auto interpreterFile = co_await open(root, workdir, interpreterPath);
+		auto interpreterFileResult = co_await open(root, workdir, interpreterPath);
+		assert(interpreterFileResult);
+		auto interpreterFile = interpreterFileResult.value();
 		if(!interpreterFile)
 			co_return Error::noSuchFile;
 
@@ -209,7 +213,9 @@ execute(ViewPath root, ViewPath workdir,
 	auto binaryInfo = FRG_CO_TRY(co_await load(binaryFile, vmContext.get(), 0));
 
 	// TODO: Should we really look up the dynamic linker in the current working dir?
-	auto ldsoFile = co_await open(root, workdir, "/lib/ld-init.so");
+	auto ldsoFileResult = co_await open(root, workdir, "/lib/ld-init.so");
+	assert(ldsoFileResult);
+	auto ldsoFile = ldsoFileResult.value();
 	assert(ldsoFile);
 	auto ldsoInfo = FRG_CO_TRY(co_await load(ldsoFile, vmContext.get(), 0x40000000));
 

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -495,7 +495,7 @@ private:
 		}
 	}
 
-	FutureMaybe<std::shared_ptr<FsLink>> link(std::string name,
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> link(std::string name,
 			std::shared_ptr<FsNode> target) override {
 		helix::Offer offer;
 		helix::SendBuffer send_req;

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -35,7 +35,7 @@ private:
 };
 
 struct Node : FsNode {
-	async::result<FileStats> getStats() override {
+	async::result<frg::expected<Error, FileStats>> getStats() override {
 		helix::Offer offer;
 		helix::SendBuffer send_req;
 		helix::RecvInline recv_resp;

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -537,7 +537,7 @@ private:
 		}
 	}
 
-	FutureMaybe<void> unlink(std::string name) override {
+	async::result<frg::expected<Error>> unlink(std::string name) override {
 		helix::Offer offer;
 		helix::SendBuffer send_req;
 		helix::RecvInline recv_resp;

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -446,7 +446,7 @@ private:
 		}
 	}
 
-	FutureMaybe<std::shared_ptr<FsLink>> mkdev(std::string name, VfsType type, DeviceId id) override {
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkdev(std::string name, VfsType type, DeviceId id) override {
 		(void)name;
 		(void)type;
 		(void)id;

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -454,7 +454,7 @@ private:
 		__builtin_unreachable();
 	}
 
-	FutureMaybe<std::shared_ptr<FsLink>>
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
 			getLink(std::string name) override {
 		helix::Offer offer;
 		helix::SendBuffer send_req;

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -214,7 +214,7 @@ private:
 		return VfsType::regular;
 	}
 
-	FutureMaybe<SharedFilePtr>
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		// Regular files do not support O_NONBLOCK.
@@ -585,7 +585,7 @@ private:
 		co_return {};
 	}
 
-	FutureMaybe<SharedFilePtr>
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		// Regular files do not support O_NONBLOCK.

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -559,6 +559,7 @@ private:
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
+		co_return {};
 	}
 
 	async::result<frg::expected<Error>> rmdir(std::string name) override {

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -14,7 +14,7 @@ VfsType FsNode::getType() {
 	throw std::runtime_error("getType() is not implemented for this FsNode");
 }
 
-FutureMaybe<FileStats> FsNode::getStats() {
+async::result<frg::expected<Error, FileStats>> FsNode::getStats() {
 	throw std::runtime_error("getStats() is not implemented for this FsNode");
 }
 

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -77,7 +77,7 @@ async::result<frg::expected<Error>> FsNode::rmdir(std::string) {
 	co_return Error::illegalOperationTarget;
 }
 
-FutureMaybe<smarter::shared_ptr<File, FileHandle>>
+async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 FsNode::open(std::shared_ptr<MountView>, std::shared_ptr<FsLink>, SemanticFlags) {
 	throw std::runtime_error("open() is not implemented for this FsNode");
 }

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -68,7 +68,7 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::mkfifo(std:
 }
 
 
-FutureMaybe<void> FsNode::unlink(std::string) {
+async::result<frg::expected<Error>> FsNode::unlink(std::string) {
 	throw std::runtime_error("unlink() is not implemented for this FsNode");
 }
 

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -53,13 +53,13 @@ FsNode::mkdir(std::string) {
 	co_return Error::illegalOperationTarget;
 }
 
-FutureMaybe<std::variant<Error, std::shared_ptr<FsLink>>>
+async::result<std::variant<Error, std::shared_ptr<FsLink>>>
 FsNode::symlink(std::string, std::string) {
 	std::cout << "posix: symlink() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-FutureMaybe<std::shared_ptr<FsLink>> FsNode::mkdev(std::string, VfsType, DeviceId) {
+async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::mkdev(std::string, VfsType, DeviceId) {
 	throw std::runtime_error("mkdev() is not implemented for this FsNode");
 }
 

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -63,7 +63,7 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::mkdev(std::
 	throw std::runtime_error("mkdev() is not implemented for this FsNode");
 }
 
-FutureMaybe<std::shared_ptr<FsLink>> FsNode::mkfifo(std::string, mode_t) {
+async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::mkfifo(std::string, mode_t) {
 	throw std::runtime_error("mkfifo() is not implemented for this FsNode");
 }
 

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -43,7 +43,7 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::getLink(std
 	throw std::runtime_error("getLink() is not implemented for this FsNode");
 }
 
-FutureMaybe<std::shared_ptr<FsLink>> FsNode::link(std::string, std::shared_ptr<FsNode>) {
+async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::link(std::string, std::shared_ptr<FsNode>) {
 	throw std::runtime_error("link() is not implemented for this FsNode");
 }
 

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -39,7 +39,7 @@ void FsNode::removeObserver(FsObserver *observer) {
 	_observers.erase(it);
 }
 
-FutureMaybe<std::shared_ptr<FsLink>> FsNode::getLink(std::string) {
+async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::getLink(std::string) {
 	throw std::runtime_error("getLink() is not implemented for this FsNode");
 }
 

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -138,7 +138,7 @@ public:
 	symlink(std::string name, std::string path);
 
 	//! Creates a new device file (directories only).
-	virtual FutureMaybe<std::shared_ptr<FsLink>> mkdev(std::string name,
+	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkdev(std::string name,
 			VfsType type, DeviceId id);
 
 	virtual FutureMaybe<std::shared_ptr<FsLink>> mkfifo(std::string name, mode_t mode);

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -143,7 +143,7 @@ public:
 
 	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkfifo(std::string name, mode_t mode);
 
-	virtual FutureMaybe<void> unlink(std::string name);
+	virtual async::result<frg::expected<Error>> unlink(std::string name);
 
 	virtual async::result<frg::expected<Error>> rmdir(std::string name);
 

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -123,7 +123,7 @@ public:
 	virtual void removeObserver(FsObserver *observer);
 
 	//! Resolves a file in a directory (directories only).
-	virtual FutureMaybe<std::shared_ptr<FsLink>> getLink(std::string name);
+	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name);
 
 	//! Links an existing node to this directory (directories only).
 	virtual FutureMaybe<std::shared_ptr<FsLink>> link(std::string name,

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -112,7 +112,7 @@ public:
 	virtual VfsType getType();
 
 	// TODO: This should be async.
-	virtual FutureMaybe<FileStats> getStats();
+	virtual async::result<frg::expected<Error, FileStats>> getStats();
 
 	// For directories only: Returns a pointer to the link
 	// that links this directory from its parent.
@@ -217,7 +217,7 @@ private:
 			return node->fileType_;
 		}
 
-		async::result<FileStats> getStats() override {
+		async::result<frg::expected<Error, FileStats>> getStats() override {
 			auto node = frg::container_of(this, &SpecialLink::embeddedNode_);
 			FileStats stats{};
 			// TODO: Allocate an inode number.

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -141,7 +141,7 @@ public:
 	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkdev(std::string name,
 			VfsType type, DeviceId id);
 
-	virtual FutureMaybe<std::shared_ptr<FsLink>> mkfifo(std::string name, mode_t mode);
+	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkfifo(std::string name, mode_t mode);
 
 	virtual FutureMaybe<void> unlink(std::string name);
 

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -149,7 +149,7 @@ public:
 
 	//! Opens the file (regular files only).
 	// TODO: Move this to the link instead of the inode?
-	virtual FutureMaybe<smarter::shared_ptr<File, FileHandle>>
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags);
 

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -126,7 +126,7 @@ public:
 	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name);
 
 	//! Links an existing node to this directory (directories only).
-	virtual FutureMaybe<std::shared_ptr<FsLink>> link(std::string name,
+	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> link(std::string name,
 			std::shared_ptr<FsNode> target);
 
 	//! Creates a new directory (directories only).

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1493,7 +1493,9 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				continue;
 			}
 
-			auto stats = co_await target_link->getTarget()->getStats();
+			auto statsResult = co_await target_link->getTarget()->getStats();
+			assert(statsResult);
+			auto stats = statsResult.value();
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1249,7 +1249,8 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				continue;
 			}
 
-			co_await parent->mkfifo(resolver.nextComponent(), req.mode());
+			auto result = co_await parent->mkfifo(resolver.nextComponent(), req.mode());
+			assert(result);
 
 			co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 		}else if(req.request_type() == managarm::posix::CntReqType::LINKAT) {
@@ -1325,7 +1326,8 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			auto target = resolver.currentLink()->getTarget();
 			auto directory = new_resolver.currentLink()->getTarget();
 			assert(target->superblock() == directory->superblock()); // Hard links across mount points are not allowed, return EXDEV
-			co_await directory->link(new_resolver.nextComponent(), target);
+			auto result = co_await directory->link(new_resolver.nextComponent(), target);
+			assert(result);
 
 			resp.set_error(managarm::posix::Errors::SUCCESS);
 
@@ -2216,7 +2218,8 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				HEL_CHECK(send_resp.error());
 			} else {
 				auto owner = target_link->getOwner();
-				co_await owner->unlink(target_link->getName());
+				auto result = co_await owner->unlink(target_link->getName());
+				assert(result);
 
 				managarm::posix::SvrResponse resp;
 				resp.set_error(managarm::posix::Errors::SUCCESS);
@@ -2247,7 +2250,8 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				continue;
 			} else {
 				auto owner = target_link->getOwner();
-				co_await owner->rmdir(target_link->getName());
+				auto result = co_await owner->rmdir(target_link->getName());
+				assert(result);
 
 				managarm::posix::SvrResponse resp;
 				resp.set_error(managarm::posix::Errors::SUCCESS);

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1791,7 +1791,9 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					// Due to races, link() can fail here.
 					// TODO: Implement a version of link() that eithers links the new node
 					// or returns the current node without failing.
-					auto link = co_await directory->link(resolver.nextComponent(), node);
+					auto linkResult = co_await directory->link(resolver.nextComponent(), node);
+					assert(linkResult);
+					auto link = linkResult.value();
 					file = co_await node->open(resolver.currentView(), std::move(link),
 							semantic_flags);
 					assert(file);
@@ -1922,7 +1924,9 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					// Due to races, link() can fail here.
 					// TODO: Implement a version of link() that eithers links the new node
 					// or returns the current node without failing.
-					auto link = co_await directory->link(resolver.nextComponent(), node);
+					auto linkResult = co_await directory->link(resolver.nextComponent(), node);
+					assert(linkResult);
+					auto link = linkResult.value();
 					file = co_await node->open(resolver.currentView(), std::move(link),
 							semantic_flags);
 					assert(file);

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1170,7 +1170,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			assert(resolver.currentLink());
 
 			auto parent = resolver.currentLink()->getTarget();
-			if(co_await parent->getLink(resolver.nextComponent())) {
+			auto existsResult = co_await parent->getLink(resolver.nextComponent());
+			assert(existsResult);
+			auto exists = existsResult.value();
+			if(exists) {
 				resp.set_error(managarm::posix::Errors::ALREADY_EXISTS);
 
 				auto ser = resp.SerializeAsString();
@@ -1762,7 +1765,9 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					std::cout << "posix: Creating file " << req.path() << std::endl;
 
 				auto directory = resolver.currentLink()->getTarget();
-				auto tail = co_await directory->getLink(resolver.nextComponent());
+				auto tailResult = co_await directory->getLink(resolver.nextComponent());
+				assert(tailResult);
+				auto tail = tailResult.value();
 				if(tail) {
 					if(req.flags() & managarm::posix::OpenFlags::OF_EXCLUSIVE) {
 						resp.set_error(managarm::posix::Errors::ALREADY_EXISTS);
@@ -1891,7 +1896,9 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					std::cout << "posix: Creating file " << req.path() << std::endl;
 
 				auto directory = resolver.currentLink()->getTarget();
-				auto tail = co_await directory->getLink(resolver.nextComponent());
+				auto tailResult = co_await directory->getLink(resolver.nextComponent());
+				assert(tailResult);
+				auto tail = tailResult.value();
 				if(tail) {
 					if(req.flags() & managarm::posix::OpenFlags::OF_EXCLUSIVE) {
 						resp.set_error(managarm::posix::Errors::ALREADY_EXISTS);

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1250,7 +1250,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			}
 
 			auto result = co_await parent->mkfifo(resolver.nextComponent(), req.mode());
-			assert(result);
+			if(!result) {
+				std::cout << "posix: Unexpected failure from mkfifo()" << std::endl;
+				co_return;
+			}
 
 			co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 		}else if(req.request_type() == managarm::posix::CntReqType::LINKAT) {
@@ -1327,7 +1330,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			auto directory = new_resolver.currentLink()->getTarget();
 			assert(target->superblock() == directory->superblock()); // Hard links across mount points are not allowed, return EXDEV
 			auto result = co_await directory->link(new_resolver.nextComponent(), target);
-			assert(result);
+			if(!result) {
+				std::cout << "posix: Unexpected failure from link()" << std::endl;
+				co_return;
+			}
 
 			resp.set_error(managarm::posix::Errors::SUCCESS);
 
@@ -2219,7 +2225,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			} else {
 				auto owner = target_link->getOwner();
 				auto result = co_await owner->unlink(target_link->getName());
-				assert(result);
+				if(!result) {
+					std::cout << "posix: Unexpected failure from unlink()" << std::endl;
+					co_return;
+				}
 
 				managarm::posix::SvrResponse resp;
 				resp.set_error(managarm::posix::Errors::SUCCESS);
@@ -2251,7 +2260,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			} else {
 				auto owner = target_link->getOwner();
 				auto result = co_await owner->rmdir(target_link->getName());
-				assert(result);
+				if(!result) {
+					std::cout << "posix: Unexpected failure from rmdir()" << std::endl;
+					co_return;
+				}
 
 				managarm::posix::SvrResponse resp;
 				resp.set_error(managarm::posix::Errors::SUCCESS);

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1780,9 +1780,11 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 						HEL_CHECK(send_resp.error());
 						continue;
 					}else{
-						file = co_await tail->getTarget()->open(
-								resolver.currentView(), std::move(tail),
-								semantic_flags);
+						auto fileResult = co_await tail->getTarget()->open(
+											resolver.currentView(), std::move(tail),
+											semantic_flags);
+						assert(fileResult);
+						file = fileResult.value();
 						assert(file);
 					}
 				}else{
@@ -1794,8 +1796,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					auto linkResult = co_await directory->link(resolver.nextComponent(), node);
 					assert(linkResult);
 					auto link = linkResult.value();
-					file = co_await node->open(resolver.currentView(), std::move(link),
-							semantic_flags);
+					auto fileResult = co_await node->open(resolver.currentView(), std::move(link),
+										semantic_flags);
+					assert(fileResult);
+					file = fileResult.value();
 					assert(file);
 				}
 			}else{
@@ -1803,8 +1807,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 				if(resolver.currentLink()) {
 					auto target = resolver.currentLink()->getTarget();
-					file = co_await target->open(resolver.currentView(), resolver.currentLink(),
-							semantic_flags);
+					auto fileResult = co_await target->open(resolver.currentView(), resolver.currentLink(),
+										semantic_flags);
+					assert(fileResult);
+					file = fileResult.value();
 				}
 			}
 
@@ -1913,9 +1919,11 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 						HEL_CHECK(send_resp.error());
 						continue;
 					}else{
-						file = co_await tail->getTarget()->open(
-								resolver.currentView(), std::move(tail),
-								semantic_flags);
+						auto fileResult = co_await tail->getTarget()->open(
+											resolver.currentView(), std::move(tail),
+											semantic_flags);
+						assert(fileResult);
+						file = fileResult.value();
 						assert(file);
 					}
 				}else{
@@ -1927,8 +1935,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					auto linkResult = co_await directory->link(resolver.nextComponent(), node);
 					assert(linkResult);
 					auto link = linkResult.value();
-					file = co_await node->open(resolver.currentView(), std::move(link),
-							semantic_flags);
+					auto fileResult = co_await node->open(resolver.currentView(), std::move(link),
+										semantic_flags);
+					assert(fileResult);
+					file = fileResult.value();
 					assert(file);
 				}
 			}else{
@@ -1936,8 +1946,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 				if(resolver.currentLink()) {
 					auto target = resolver.currentLink()->getTarget();
-					file = co_await target->open(resolver.currentView(), resolver.currentLink(),
-							semantic_flags);
+					auto fileResult = co_await target->open(resolver.currentView(), resolver.currentLink(),
+										semantic_flags);
+					assert(fileResult);
+					file = fileResult.value();
 				}
 			}
 

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -243,7 +243,7 @@ DirectoryNode::open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> li
 	co_return File::constructHandle(std::move(file));
 }
 
-FutureMaybe<std::shared_ptr<FsLink>> DirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, std::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -174,7 +174,7 @@ async::result<frg::expected<Error, FileStats>> RegularNode::getStats() {
 	co_return stats;
 }
 
-FutureMaybe<SharedFilePtr>
+async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 RegularNode::open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	assert(!(semantic_flags & ~(semanticRead | semanticWrite)));
@@ -232,7 +232,7 @@ std::shared_ptr<FsLink> DirectoryNode::treeLink() {
 	return _treeLink ? _treeLink->shared_from_this() : nullptr;
 }
 
-FutureMaybe<SharedFilePtr>
+async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 DirectoryNode::open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	assert(!(semantic_flags & ~(semanticRead | semanticWrite)));

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -154,7 +154,7 @@ VfsType RegularNode::getType() {
 	return VfsType::regular;
 }
 
-FutureMaybe<FileStats> RegularNode::getStats() {
+async::result<frg::expected<Error, FileStats>> RegularNode::getStats() {
 	// TODO: Store a file creation time.
 	auto now = clk::getRealtime();
 
@@ -222,7 +222,7 @@ VfsType DirectoryNode::getType() {
 	return VfsType::directory;
 }
 
-FutureMaybe<FileStats> DirectoryNode::getStats() {
+async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 	std::cout << "\e[31mposix: Fix procfs Directory::getStats()\e[39m" << std::endl;
 	co_return FileStats{};
 }

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -95,7 +95,7 @@ struct RegularNode : FsNode, std::enable_shared_from_this<RegularNode> {
 	virtual ~RegularNode() = default;
 
 	VfsType getType() override;
-	FutureMaybe<FileStats> getStats() override;
+	async::result<frg::expected<Error, FileStats>> getStats() override;
 	FutureMaybe<smarter::shared_ptr<File, FileHandle>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
@@ -117,7 +117,7 @@ struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode>
 	std::shared_ptr<Link> directMkdir(std::string name);
 
 	VfsType getType() override;
-	FutureMaybe<FileStats> getStats() override;
+	async::result<frg::expected<Error, FileStats>> getStats() override;
 	std::shared_ptr<FsLink> treeLink() override;
 
 	FutureMaybe<smarter::shared_ptr<File, FileHandle>>

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -96,7 +96,7 @@ struct RegularNode : FsNode, std::enable_shared_from_this<RegularNode> {
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
-	FutureMaybe<smarter::shared_ptr<File, FileHandle>>
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 
@@ -120,7 +120,7 @@ struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode>
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	std::shared_ptr<FsLink> treeLink() override;
 
-	FutureMaybe<smarter::shared_ptr<File, FileHandle>>
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override;

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -123,7 +123,7 @@ struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode>
 	FutureMaybe<smarter::shared_ptr<File, FileHandle>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	FutureMaybe<std::shared_ptr<FsLink>> getLink(std::string name) override;
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override;
 
 private:
 	Link *_treeLink;

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -255,7 +255,7 @@ public:
 		return _type;
 	}
 
-	FutureMaybe<FileStats> getStats() override {
+	async::result<frg::expected<Error, FileStats>> getStats() override {
 		std::cout << "\e[31mposix: Fix pts DeviceNode::getStats()\e[39m" << std::endl;
 		co_return FileStats{};
 	}
@@ -288,7 +288,7 @@ public:
 		_entries.insert(std::move(link));
 	}
 
-	FutureMaybe<FileStats> getStats() override {
+	async::result<frg::expected<Error, FileStats>> getStats() override {
 		std::cout << "\e[31mposix: Fix pts RootNode::getStats()\e[39m" << std::endl;
 		co_return FileStats{};
 	}

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -293,7 +293,7 @@ public:
 		co_return FileStats{};
 	}
 
-	FutureMaybe<std::shared_ptr<FsLink>>
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
 	getLink(std::string name) override {
 		auto it = _entries.find(name);
 		if(it != _entries.end())

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -264,7 +264,7 @@ public:
 		return _id;
 	}
 
-	FutureMaybe<SharedFilePtr> open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		return openDevice(_type, _id, std::move(mount), std::move(link), semantic_flags);
 	}

--- a/posix/subsystem/src/sysfs.cpp
+++ b/posix/subsystem/src/sysfs.cpp
@@ -310,7 +310,7 @@ FutureMaybe<SharedFilePtr> DirectoryNode::open(std::shared_ptr<MountView> mount,
 	co_return File::constructHandle(std::move(file));
 }
 
-FutureMaybe<std::shared_ptr<FsLink>> DirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, std::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;

--- a/posix/subsystem/src/sysfs.cpp
+++ b/posix/subsystem/src/sysfs.cpp
@@ -170,7 +170,7 @@ VfsType AttributeNode::getType() {
 	return VfsType::regular;
 }
 
-FutureMaybe<FileStats> AttributeNode::getStats() {
+async::result<frg::expected<Error, FileStats>> AttributeNode::getStats() {
 	// TODO: Store a file creation time.
 	auto now = clk::getRealtime();
 	
@@ -211,7 +211,7 @@ VfsType SymlinkNode::getType() {
 	return VfsType::symlink;
 }
 
-FutureMaybe<FileStats> SymlinkNode::getStats() {
+async::result<frg::expected<Error, FileStats>> SymlinkNode::getStats() {
 	std::cout << "\e[31mposix: Fix sysfs SymlinkNode::getStats()\e[39m" << std::endl;
 	co_return FileStats{};
 }
@@ -290,7 +290,7 @@ VfsType DirectoryNode::getType() {
 	return VfsType::directory;
 }
 
-FutureMaybe<FileStats> DirectoryNode::getStats() {
+async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 	std::cout << "\e[31mposix: Fix sysfs Directory::getStats()\e[39m" << std::endl;
 	co_return FileStats{};
 }

--- a/posix/subsystem/src/sysfs.cpp
+++ b/posix/subsystem/src/sysfs.cpp
@@ -190,8 +190,8 @@ async::result<frg::expected<Error, FileStats>> AttributeNode::getStats() {
 	co_return stats;
 }
 
-FutureMaybe<SharedFilePtr> AttributeNode::open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
-		SemanticFlags semantic_flags) {
+async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> AttributeNode::open(std::shared_ptr<MountView> mount,
+		std::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
 	assert(!(semantic_flags & ~(semanticRead | semanticWrite)));
 
 	auto file = smarter::make_shared<AttributeFile>(std::move(mount), std::move(link));
@@ -300,8 +300,8 @@ std::shared_ptr<FsLink> DirectoryNode::treeLink() {
 	return _treeLink ? _treeLink->shared_from_this() : nullptr;
 }
 
-FutureMaybe<SharedFilePtr> DirectoryNode::open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
-		SemanticFlags semantic_flags) {
+async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> DirectoryNode::open(std::shared_ptr<MountView> mount,
+		std::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
 	assert(!(semantic_flags & ~(semanticRead | semanticWrite)));
 
 	auto file = smarter::make_shared<DirectoryFile>(std::move(mount), std::move(link));

--- a/posix/subsystem/src/sysfs.hpp
+++ b/posix/subsystem/src/sysfs.hpp
@@ -98,7 +98,7 @@ struct AttributeNode final : FsNode, std::enable_shared_from_this<AttributeNode>
 	AttributeNode(Object *object, Attribute *attr);
 
 	VfsType getType() override;
-	FutureMaybe<FileStats> getStats() override;
+	async::result<frg::expected<Error, FileStats>> getStats() override;
 	FutureMaybe<smarter::shared_ptr<File, FileHandle>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
@@ -112,7 +112,7 @@ struct SymlinkNode final : FsNode, std::enable_shared_from_this<SymlinkNode> {
 	SymlinkNode(std::weak_ptr<Object> target);
 
 	VfsType getType() override;
-	FutureMaybe<FileStats> getStats() override;
+	async::result<frg::expected<Error, FileStats>> getStats() override;
 	expected<std::string> readSymlink(FsLink *link) override;
 
 private:
@@ -131,7 +131,7 @@ struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode>
 	std::shared_ptr<Link> directMkdir(std::string name);
 
 	VfsType getType() override;
-	FutureMaybe<FileStats> getStats() override;
+	async::result<frg::expected<Error, FileStats>> getStats() override;
 	std::shared_ptr<FsLink> treeLink() override;
 
 	FutureMaybe<smarter::shared_ptr<File, FileHandle>>

--- a/posix/subsystem/src/sysfs.hpp
+++ b/posix/subsystem/src/sysfs.hpp
@@ -137,7 +137,7 @@ struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode>
 	FutureMaybe<smarter::shared_ptr<File, FileHandle>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	FutureMaybe<std::shared_ptr<FsLink>> getLink(std::string name) override;
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override;
 
 private:
 	Link *_treeLink;

--- a/posix/subsystem/src/sysfs.hpp
+++ b/posix/subsystem/src/sysfs.hpp
@@ -99,7 +99,7 @@ struct AttributeNode final : FsNode, std::enable_shared_from_this<AttributeNode>
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
-	FutureMaybe<smarter::shared_ptr<File, FileHandle>>
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 
@@ -134,7 +134,7 @@ struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode>
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	std::shared_ptr<FsLink> treeLink() override;
 
-	FutureMaybe<smarter::shared_ptr<File, FileHandle>>
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override;

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -29,7 +29,7 @@ protected:
 	~Node() = default;
 
 public:
-	FutureMaybe<FileStats> getStats() override {
+	async::result<frg::expected<Error, FileStats>> getStats() override {
 		std::cout << "\e[31mposix: Fix tmpfs getStats()\e[39m" << std::endl;
 		FileStats stats{};
 		stats.inodeNumber = _inodeNumber;
@@ -408,7 +408,7 @@ struct MemoryNode final : Node {
 		co_return File::constructHandle(std::move(file));
 	}
 
-	FutureMaybe<FileStats> getStats() override {
+	async::result<frg::expected<Error, FileStats>> getStats() override {
 		std::cout << "\e[31mposix: Fix tmpfs getStats() in MemoryNode\e[39m" << std::endl;
 		FileStats stats{};
 		stats.inodeNumber = inodeNumber();

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -279,7 +279,7 @@ private:
 	}
 
 
-	FutureMaybe<std::shared_ptr<FsLink>> getLink(std::string name) override {
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override {
 		auto it = _entries.find(name);
 		if(it != _entries.end())
 			co_return *it;

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -286,7 +286,7 @@ private:
 		co_return nullptr; // TODO: Return an error code.
 	}
 
-	FutureMaybe<std::shared_ptr<FsLink>> link(std::string name,
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> link(std::string name,
 			std::shared_ptr<FsNode> target) override {
 		assert(_entries.find(name) == _entries.end());
 		auto link = std::make_shared<Link>(shared_from_this(), std::move(name), std::move(target));

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -303,7 +303,7 @@ private:
 	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkdev(std::string name,
 			VfsType type, DeviceId id) override;
 
-	async::result<std::shared_ptr<FsLink>> mkfifo(std::string name, mode_t mode) override;
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkfifo(std::string name, mode_t mode) override;
 
 	FutureMaybe<void> unlink(std::string name) override {
 		auto it = _entries.find(name);
@@ -690,7 +690,7 @@ DirectoryNode::mkdev(std::string name, VfsType type, DeviceId id) {
 	co_return link;
 }
 
-async::result<std::shared_ptr<FsLink>>
+async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
 DirectoryNode::mkfifo(std::string name, mode_t mode) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = std::make_shared<FifoNode>(static_cast<Superblock *>(superblock()), mode);

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -300,7 +300,7 @@ private:
 	async::result<std::variant<Error, std::shared_ptr<FsLink>>>
 	symlink(std::string name, std::string path) override;
 
-	async::result<std::shared_ptr<FsLink>> mkdev(std::string name,
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkdev(std::string name,
 			VfsType type, DeviceId id) override;
 
 	async::result<std::shared_ptr<FsLink>> mkfifo(std::string name, mode_t mode) override;
@@ -680,7 +680,7 @@ DirectoryNode::symlink(std::string name, std::string path) {
 	co_return link;
 }
 
-async::result<std::shared_ptr<FsLink>>
+async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
 DirectoryNode::mkdev(std::string name, VfsType type, DeviceId id) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = std::make_shared<DeviceNode>(static_cast<Superblock *>(superblock()),

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -305,13 +305,13 @@ private:
 
 	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkfifo(std::string name, mode_t mode) override;
 
-	FutureMaybe<void> unlink(std::string name) override {
+	async::result<frg::expected<Error>> unlink(std::string name) override {
 		auto it = _entries.find(name);
 		assert(it != _entries.end());
 		_entries.erase(it);
 
 		notifyObservers(FsObserver::deleteEvent, name, 0);
-		co_return;
+		co_return {};
 	}
 
 public:

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -137,8 +137,8 @@ private:
 		return _id;
 	}
 
-	FutureMaybe<SharedFilePtr> open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
-			SemanticFlags semantic_flags) override {
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> open(std::shared_ptr<MountView> mount,
+			std::shared_ptr<FsLink> link, SemanticFlags semantic_flags) override {
 		return openDevice(_type, _id, std::move(mount), std::move(link), semantic_flags);
 	}
 
@@ -164,8 +164,8 @@ private:
 		return VfsType::fifo;
 	}
 
-	FutureMaybe<SharedFilePtr> open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
-			SemanticFlags semantic_flags) override {
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> open(std::shared_ptr<MountView> mount,
+			std::shared_ptr<FsLink> link, SemanticFlags semantic_flags) override {
 		co_return co_await fifo::openNamedChannel(mount, link, this, semantic_flags);
 	}
 
@@ -267,7 +267,7 @@ private:
 		return _treeLink;
 	}
 
-	FutureMaybe<SharedFilePtr>
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		assert(!(semantic_flags & ~(semanticRead | semanticWrite)));
@@ -330,7 +330,7 @@ private:
 		return VfsType::regular;
 	}
 
-	FutureMaybe<SharedFilePtr>
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		assert(!(semantic_flags & ~(semanticRead | semanticWrite)));
@@ -398,7 +398,7 @@ struct MemoryNode final : Node {
 		return VfsType::regular;
 	}
 
-	FutureMaybe<SharedFilePtr>
+	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		assert(!(semantic_flags & ~(semanticRead | semanticWrite | semanticNonBlock)));

--- a/posix/subsystem/src/un-socket.cpp
+++ b/posix/subsystem/src/un-socket.cpp
@@ -294,7 +294,8 @@ public:
 
 		auto superblock = resolver.currentLink()->getTarget()->superblock();
 		auto node = co_await superblock->createSocket();
-		co_await resolver.currentLink()->getTarget()->link(resolver.nextComponent(), node);
+		auto result = co_await resolver.currentLink()->getTarget()->link(resolver.nextComponent(), node);
+		assert(result);
 
 		// Associate the current socket with the node.
 		auto res = globalBindMap.insert({std::weak_ptr<FsNode>{node}, this});

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -236,7 +236,9 @@ async::result<void> PathResolver::resolve(ResolveFlags flags) {
 				_currentPath = ViewPath{_currentPath.first, owner->treeLink()};
 			}
 		}else{
-			auto child = co_await _currentPath.second->getTarget()->getLink(std::move(name));
+			auto childResult = co_await _currentPath.second->getTarget()->getLink(std::move(name));
+			assert(childResult);
+			auto child = childResult.value();
 
 			if(!child) {
 				// TODO: Return an error code.

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -119,7 +119,8 @@ async::result<void> populateRootView() {
 
 				auto file_path = "/" + item.second + "/" + resp.path();
 				auto node = tmp_fs::createMemoryNode(std::move(file_path));
-				co_await item.first->link(resp.path(), node);
+				auto result = co_await item.first->link(resp.path(), node);
+				assert(result);
 			}
 		}
 	}

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -295,8 +295,9 @@ FutureMaybe<ViewPath> resolve(ViewPath root, ViewPath workdir,
 	co_return ViewPath(resolver.currentView(), resolver.currentLink());
 }
 
-FutureMaybe<SharedFilePtr> open(ViewPath root, ViewPath workdir,
-		std::string name, ResolveFlags resolve_flags, SemanticFlags semantic_flags) {
+async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> open(ViewPath root,
+		ViewPath workdir, std::string name, ResolveFlags resolve_flags,
+		SemanticFlags semantic_flags) {
 	ViewPath current = co_await resolve(std::move(root), std::move(workdir),
 			std::move(name), resolve_flags);
 	if(!current.second)

--- a/posix/subsystem/src/vfs.hpp
+++ b/posix/subsystem/src/vfs.hpp
@@ -96,7 +96,8 @@ ViewPath rootPath();
 FutureMaybe<ViewPath> resolve(ViewPath root, ViewPath workdir,
 		std::string name, ResolveFlags flags = 0);
 
-FutureMaybe<smarter::shared_ptr<File, FileHandle>> open(ViewPath root, ViewPath workdir,
-		std::string name, ResolveFlags resolve_flags = 0, SemanticFlags semantic_flags = 0);
+async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> open(ViewPath root,
+		ViewPath workdir, std::string name, ResolveFlags resolve_flags = 0,
+		SemanticFlags semantic_flags = 0);
 
 #endif // POSIX_SUBSYSTEM_VFS_HPP


### PR DESCRIPTION
As requested on Discord, I have started refactoring some `FsNode` operations to use `frg::expected`. For now, I assume that nothing will throw errors, but this assumption may be wrong.
I have tested the changes and they seem to work, as in managarm boots into weston, although I fully expect there to be bugs and/or issues in this pr.