### PR TITLE
posix: Convert requests to bragi

### DIFF
--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -662,20 +662,26 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			} else {
 				co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 			}
-		}else if(req.request_type() == managarm::posix::CntReqType::GET_EUID) {
+		}else if(preamble.id() == managarm::posix::GetEuidRequest::message_id) {
+			auto req = bragi::parse_head_only<managarm::posix::GetEuidRequest>(recv_head);
+
+			if (!req) {
+				std::cout << "posix: Rejecting request due to decoding failure" << std::endl;
+				break;
+			}
+
 			if(logRequests)
 				std::cout << "posix: GET_EUID" << std::endl;
-
-			helix::SendBuffer send_resp;
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);
 			resp.set_uid(self->euid());
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-					helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+				);
+
 			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::SET_EUID) {
 			if(logRequests)

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -702,20 +702,26 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			} else {
 				co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 			}
-		}else if(req.request_type() == managarm::posix::CntReqType::GET_GID) {
+		}else if(preamble.id() == managarm::posix::GetGidRequest::message_id) {
+			auto req = bragi::parse_head_only<managarm::posix::GetGidRequest>(recv_head);
+
+			if (!req) {
+				std::cout << "posix: Rejecting request due to decoding failure" << std::endl;
+				break;
+			}
+
 			if(logRequests)
 				std::cout << "posix: GET_GID" << std::endl;
-
-			helix::SendBuffer send_resp;
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);
 			resp.set_uid(self->gid());
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-					helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+				);
+
 			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::GET_EGID) {
 			if(logRequests)

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -683,27 +683,25 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				);
 
 			HEL_CHECK(send_resp.error());
-		}else if(req.request_type() == managarm::posix::CntReqType::SET_EUID) {
+		}else if(preamble.id() == managarm::posix::SetEuidRequest::message_id) {
+			auto req = bragi::parse_head_only<managarm::posix::SetEuidRequest>(recv_head);
+
+			if (!req) {
+				std::cout << "posix: Rejecting request due to decoding failure" << std::endl;
+				break;
+			}
+
 			if(logRequests)
 				std::cout << "posix: SET_EUID" << std::endl;
 
-			helix::SendBuffer send_resp;
-
-			managarm::posix::SvrResponse resp;
-			Error err = self->setEuid(req.uid());
+			Error err = self->setEuid(req->uid());
 			if(err == Error::accessDenied) {
-				resp.set_error(managarm::posix::Errors::ACCESS_DENIED);
+				co_await sendErrorResponse(managarm::posix::Errors::ACCESS_DENIED);
 			} else if(err == Error::illegalArguments) {
-				resp.set_error(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+				co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
 			} else {
-				resp.set_error(managarm::posix::Errors::SUCCESS);
+				co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 			}
-
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-					helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
-			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::GET_GID) {
 			if(logRequests)
 				std::cout << "posix: GET_GID" << std::endl;

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -2815,31 +2815,38 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				);
 
 			HEL_CHECK(send_resp.error());
-		}else if(req.request_type() == managarm::posix::CntReqType::EVENTFD_CREATE) {
+		}else if(preamble.id() == managarm::posix::EventfdCreateRequest::message_id) {
+			auto req = bragi::parse_head_only<managarm::posix::EventfdCreateRequest>(recv_head);
+
+			if (!req) {
+				std::cout << "posix: Rejecting request due to decoding failure" << std::endl;
+				break;
+			}
+
 			if(logRequests)
 				std::cout << "posix: EVENTFD_CREATE" << std::endl;
 
-			helix::SendBuffer send_resp;
 			managarm::posix::SvrResponse resp;
 
-			if (req.flags() & ~(managarm::posix::OpenFlags::OF_CLOEXEC | managarm::posix::OpenFlags::OF_NONBLOCK)) {
+			if (req->flags() & ~(managarm::posix::OpenFlags::OF_CLOEXEC | managarm::posix::OpenFlags::OF_NONBLOCK)) {
 				std::cout << "posix: invalid flag specified (EFD_SEMAPHORE?)" << std::endl;
-				std::cout << "posix: flags specified: " << req.flags() << std::endl;
+				std::cout << "posix: flags specified: " << req->flags() << std::endl;
 				resp.set_error(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
 			} else {
 
-				auto file = eventfd::createFile(req.initval(), req.flags() & managarm::posix::OpenFlags::OF_NONBLOCK);
+				auto file = eventfd::createFile(req->initval(), req->flags() & managarm::posix::OpenFlags::OF_NONBLOCK);
 				auto fd = self->fileContext()->attachFile(file,
-						req.flags() & managarm::posix::OpenFlags::OF_CLOEXEC);
+						req->flags() & managarm::posix::OpenFlags::OF_CLOEXEC);
 
 				resp.set_error(managarm::posix::Errors::SUCCESS);
 				resp.set_fd(fd);
 			}
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-					helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+				);
+
 			HEL_CHECK(send_resp.error());
 		}else{
 			std::cout << "posix: Illegal request" << std::endl;

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -763,27 +763,25 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			} else {
 				co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 			}
-		}else if(req.request_type() == managarm::posix::CntReqType::SET_EGID) {
+		}else if(preamble.id() == managarm::posix::SetEgidRequest::message_id) {
+			auto req = bragi::parse_head_only<managarm::posix::SetEgidRequest>(recv_head);
+
+			if (!req) {
+				std::cout << "posix: Rejecting request due to decoding failure" << std::endl;
+				break;
+			}
+
 			if(logRequests)
 				std::cout << "posix: SET_EGID" << std::endl;
 
-			helix::SendBuffer send_resp;
-
-			managarm::posix::SvrResponse resp;
-			Error err = self->setEgid(req.uid());
+			Error err = self->setEgid(req->uid());
 			if(err == Error::accessDenied) {
-				resp.set_error(managarm::posix::Errors::ACCESS_DENIED);
+				co_await sendErrorResponse(managarm::posix::Errors::ACCESS_DENIED);
 			} else if(err == Error::illegalArguments) {
-				resp.set_error(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+				co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
 			} else {
-				resp.set_error(managarm::posix::Errors::SUCCESS);
+				co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 			}
-
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-					helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
-			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::WAIT) {
 			if(logRequests)
 				std::cout << "posix: WAIT" << std::endl;

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -744,27 +744,25 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				);
 
 			HEL_CHECK(send_resp.error());
-		}else if(req.request_type() == managarm::posix::CntReqType::SET_GID) {
+		}else if(preamble.id() == managarm::posix::SetGidRequest::message_id) {
+			auto req = bragi::parse_head_only<managarm::posix::SetGidRequest>(recv_head);
+
+			if (!req) {
+				std::cout << "posix: Rejecting request due to decoding failure" << std::endl;
+				break;
+			}
+
 			if(logRequests)
 				std::cout << "posix: SET_GID" << std::endl;
 
-			helix::SendBuffer send_resp;
-
-			managarm::posix::SvrResponse resp;
-			Error err = self->setGid(req.uid());
+			Error err = self->setGid(req->uid());
 			if(err == Error::accessDenied) {
-				resp.set_error(managarm::posix::Errors::ACCESS_DENIED);
+				co_await sendErrorResponse(managarm::posix::Errors::ACCESS_DENIED);
 			} else if(err == Error::illegalArguments) {
-				resp.set_error(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+				co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
 			} else {
-				resp.set_error(managarm::posix::Errors::SUCCESS);
+				co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 			}
-
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-					helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
-			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::SET_EGID) {
 			if(logRequests)
 				std::cout << "posix: SET_EGID" << std::endl;

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -643,27 +643,25 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				);
 
 			HEL_CHECK(send_resp.error());
-		}else if(req.request_type() == managarm::posix::CntReqType::SET_UID) {
+		}else if(preamble.id() == managarm::posix::SetUidRequest::message_id) {
+			auto req = bragi::parse_head_only<managarm::posix::SetUidRequest>(recv_head);
+
+			if (!req) {
+				std::cout << "posix: Rejecting request due to decoding failure" << std::endl;
+				break;
+			}
+
 			if(logRequests)
 				std::cout << "posix: SET_UID" << std::endl;
 
-			helix::SendBuffer send_resp;
-
-			managarm::posix::SvrResponse resp;
-			Error err = self->setUid(req.uid());
+			Error err = self->setUid(req->uid());
 			if(err == Error::accessDenied) {
-				resp.set_error(managarm::posix::Errors::ACCESS_DENIED);
+				co_await sendErrorResponse(managarm::posix::Errors::ACCESS_DENIED);
 			} else if(err == Error::illegalArguments) {
-				resp.set_error(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+				co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
 			} else {
-				resp.set_error(managarm::posix::Errors::SUCCESS);
+				co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 			}
-
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-					helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
-			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::GET_EUID) {
 			if(logRequests)
 				std::cout << "posix: GET_EUID" << std::endl;

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -622,20 +622,26 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					helix::action(&send_resp, ser.data(), ser.size()));
 			co_await transmit.async_wait();
 			HEL_CHECK(send_resp.error());
-		}else if(req.request_type() == managarm::posix::CntReqType::GET_UID) {
+		}else if(preamble.id() == managarm::posix::GetUidRequest::message_id) {
+			auto req = bragi::parse_head_only<managarm::posix::GetUidRequest>(recv_head);
+
+			if (!req) {
+				std::cout << "posix: Rejecting request due to decoding failure" << std::endl;
+				break;
+			}
+
 			if(logRequests)
 				std::cout << "posix: GET_UID" << std::endl;
-
-			helix::SendBuffer send_resp;
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);
 			resp.set_uid(self->uid());
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-					helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+				);
+
 			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::SET_UID) {
 			if(logRequests)

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1240,14 +1240,25 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				co_await transmit.async_wait();
 				HEL_CHECK(send_resp.error());
 			}
-		}else if(req.request_type() == managarm::posix::CntReqType::MKFIFOAT) {
+		}else if(preamble.id() == managarm::posix::MkfifoAtRequest::message_id) {
+			std::vector<std::byte> tail(preamble.tail_size());
+			auto [recv_tail] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::recvBuffer(tail.data(), tail.size())
+				);
+			HEL_CHECK(recv_tail.error());
+
+			auto req = bragi::parse_head_tail<managarm::posix::MkfifoAtRequest>(recv_head, tail);
+
+			if (!req) {
+				std::cout << "posix: Rejecting request due to decoding failure" << std::endl;
+				break;
+			}
+
 			if(logRequests || logPaths)
-				std::cout << "posix: MKFIFOAT " << req.fd() << " " << req.path() << std::endl;
+				std::cout << "posix: MKFIFOAT " << req->fd() << " " << req->path() << std::endl;
 
-			helix::SendBuffer send_resp;
-			managarm::posix::SvrResponse resp;
-
-			if (!req.path().size()) {
+			if (!req->path().size()) {
 				co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
 				continue;
 			}
@@ -1256,10 +1267,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			smarter::shared_ptr<File, FileHandle> file;
 			std::shared_ptr<FsLink> target_link;
 
-			if (req.fd() == AT_FDCWD) {
+			if (req->fd() == AT_FDCWD) {
 				relative_to = self->fsContext()->getWorkingDirectory();
 			} else {
-				file = self->fileContext()->getFile(req.fd());
+				file = self->fileContext()->getFile(req->fd());
 
 				if (!file) {
 					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
@@ -1271,7 +1282,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			PathResolver resolver;
 			resolver.setup(self->fsContext()->getRoot(),
-					relative_to, req.path());
+					relative_to, req->path());
 			co_await resolver.resolve(resolvePrefix);
 
 			if (!resolver.currentLink()) {
@@ -1285,7 +1296,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				continue;
 			}
 
-			auto result = co_await parent->mkfifo(resolver.nextComponent(), req.mode());
+			auto result = co_await parent->mkfifo(resolver.nextComponent(), req->mode());
 			if(!result) {
 				std::cout << "posix: Unexpected failure from mkfifo()" << std::endl;
 				co_return;

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -373,3 +373,11 @@ head(128):
 tail:
 	string path;
 }
+
+message MkfifoAtRequest 14 {
+head(128):
+	int32 fd;
+	int32 mode;
+tail:
+	string path;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -345,3 +345,8 @@ head(128):
 message GetEuidRequest 6 {
 head(128):
 }
+
+message SetEuidRequest 7 {
+head(128):
+	uint64 uid;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -413,3 +413,9 @@ head(128):
 tail:
 	string path;
 }
+
+message RmdirRequest 18 {
+head(128):
+tail:
+	string path;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -357,3 +357,11 @@ message SetEgidRequest 11 {
 head(128):
 	uint64 uid;
 }
+
+message UnlinkAtRequest 12 {
+head(128):
+	int32 fd;
+	int32 flags;
+tail:
+	string path;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -75,15 +75,8 @@ consts CntReqType uint32 {
 	TIMERFD_CREATE = 33,
 	TIMERFD_SETTIME = 36,
 
-	// inotify()-specific calls
-	INOTIFY_CREATE = 48,
-	INOTIFY_DELETE = 50,
-
 	HELFD_ATTACH = 10,
-	HELFD_CLONE = 11,
-
-	// eventfd()-specific calls
-	EVENTFD_CREATE = 60
+	HELFD_CLONE = 11
 }
 
 consts OpenMode uint32 {
@@ -186,9 +179,6 @@ head(128):
 		tag(21) uint64 interval_nanos;
 
 		tag(33) uint64 sigset;
-
-		// used by EVENTFD
-		tag(39) uint32 initval;
 	}
 }
 
@@ -413,5 +403,11 @@ tail:
 
 message InotifyCreateRequest 48 {
 head(128):
+	int32 flags;
+}
+
+message EventfdCreateRequest 60 {
+head(128):
+	uint32 initval;
 	int32 flags;
 }

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -332,3 +332,7 @@ tail:
 	string path;
 	string target_path;
 }
+
+message GetUidRequest 4 {
+head(128):
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -411,3 +411,11 @@ head(128):
 	uint32 initval;
 	int32 flags;
 }
+
+message SocketRequest 35 {
+head(128):
+	int32 flags;
+	int32 domain;
+	int32 socktype;
+	int32 protocol;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -365,3 +365,11 @@ head(128):
 tail:
 	string path;
 }
+
+message FstatAtRequest 13 {
+head(128):
+	int32 fd;
+	int32 flags;
+tail:
+	string path;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -341,3 +341,7 @@ message SetUidRequest 5 {
 head(128):
 	uint64 uid;
 }
+
+message GetEuidRequest 6 {
+head(128):
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -39,12 +39,10 @@ consts CntReqType uint32 {
 	SEEK_ABS = 13,
 	SEEK_REL = 14,
 	SEEK_EOF = 15,
-	CLOSE = 5,
 	DUP = 34,
 	DUP2 = 6,
 	TTY_NAME = 18,
 	GETCWD = 59,
-	OPENAT = 64,
 	FD_GET_FLAGS = 44,
 	FD_SET_FLAGS = 45,
 	GET_RESOURCE_USAGE = 57,
@@ -307,43 +305,43 @@ tail:
 	string target_path;
 }
 
-message GetUidRequest 4 {
+message GetUidRequest 67 {
 head(128):
 }
 
-message SetUidRequest 5 {
-head(128):
-	uint64 uid;
-}
-
-message GetEuidRequest 6 {
-head(128):
-}
-
-message SetEuidRequest 7 {
+message SetUidRequest 68 {
 head(128):
 	uint64 uid;
 }
 
-message GetGidRequest 8 {
+message GetEuidRequest 69 {
 head(128):
 }
 
-message GetEgidRequest 9 {
-head(128):
-}
-
-message SetGidRequest 10 {
+message SetEuidRequest 70 {
 head(128):
 	uint64 uid;
 }
 
-message SetEgidRequest 11 {
+message GetGidRequest 71 {
+head(128):
+}
+
+message GetEgidRequest 72 {
+head(128):
+}
+
+message SetGidRequest 73 {
 head(128):
 	uint64 uid;
 }
 
-message UnlinkAtRequest 12 {
+message SetEgidRequest 74 {
+head(128):
+	uint64 uid;
+}
+
+message UnlinkAtRequest 40 {
 head(128):
 	int32 fd;
 	int32 flags;
@@ -351,7 +349,7 @@ tail:
 	string path;
 }
 
-message FstatAtRequest 13 {
+message FstatAtRequest 63 {
 head(128):
 	int32 fd;
 	int32 flags;
@@ -359,7 +357,7 @@ tail:
 	string path;
 }
 
-message MkfifoAtRequest 14 {
+message MkfifoAtRequest 65 {
 head(128):
 	int32 fd;
 	int32 mode;
@@ -367,7 +365,7 @@ tail:
 	string path;
 }
 
-message LinkAtRequest 15 {
+message LinkAtRequest 66 {
 head(128):
 	int32 fd;
 	int32 newfd;
@@ -377,7 +375,7 @@ tail:
 	string target_path;
 }
 
-message FchmodAtRequest 16 {
+message FchmodAtRequest 75 {
 head(128):
 	int32 fd;
 	int32 flags;
@@ -386,7 +384,7 @@ tail:
 	string path;
 }
 
-message UtimensAtRequest 17 {
+message UtimensAtRequest 78 {
 head(128):
 	int32 fd;
 	int32 flags;
@@ -399,13 +397,13 @@ tail:
 	string path;
 }
 
-message RmdirRequest 18 {
+message RmdirRequest 77 {
 head(128):
 tail:
 	string path;
 }
 
-message InotifyAddRequest 19 {
+message InotifyAddRequest 49 {
 head(128):
 	int32 fd;
 	int32 flags;

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -33,20 +33,18 @@ consts CntReqType uint32 {
 	ACCESSAT = 20,
 	MKDIRAT = 46,
 	SYMLINKAT = 47,
-	RENAMEAT = 51,
-	FSTATAT = 63,
 	READLINK = 31,
 	READ = 3,
 	WRITE = 4,
 	SEEK_ABS = 13,
 	SEEK_REL = 14,
 	SEEK_EOF = 15,
-	MMAP = 16,
+	CLOSE = 5,
 	DUP = 34,
 	DUP2 = 6,
 	TTY_NAME = 18,
 	GETCWD = 59,
-	UNLINKAT = 40,
+	OPENAT = 64,
 	FD_GET_FLAGS = 44,
 	FD_SET_FLAGS = 45,
 	GET_RESOURCE_USAGE = 57,
@@ -81,20 +79,13 @@ consts CntReqType uint32 {
 
 	// inotify()-specific calls
 	INOTIFY_CREATE = 48,
-	INOTIFY_ADD = 49,
 	INOTIFY_DELETE = 50,
 
 	HELFD_ATTACH = 10,
 	HELFD_CLONE = 11,
 
 	// eventfd()-specific calls
-	EVENTFD_CREATE = 60,
-
-	MKFIFOAT = 65,
-	LINKAT = 66,
-	FCHMODAT = 75,
-	RMDIR = 77,
-	UTIMENSAT = 78
+	EVENTFD_CREATE = 60
 }
 
 consts OpenMode uint32 {
@@ -200,12 +191,6 @@ head(128):
 
 		// used by EVENTFD
 		tag(39) uint32 initval;
-
-		// used by utimensat
-		tag(44) uint64 atime_sec;
-		tag(45) uint64 atime_nsec;
-		tag(46) uint64 mtime_sec;
-		tag(47) uint64 mtime_nsec;
 	}
 }
 
@@ -416,6 +401,14 @@ tail:
 
 message RmdirRequest 18 {
 head(128):
+tail:
+	string path;
+}
+
+message InotifyAddRequest 19 {
+head(128):
+	int32 fd;
+	int32 flags;
 tail:
 	string path;
 }

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -410,3 +410,8 @@ head(128):
 tail:
 	string path;
 }
+
+message InotifyCreateRequest 48 {
+head(128):
+	int32 flags;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -57,8 +57,6 @@ consts CntReqType uint32 {
 	PIPE_CREATE = 52,
 
 	// Socket-specific calls.
-	SOCKET = 35,
-	SOCKPAIR = 25,
 	ACCEPT = 19,
 
 	// epoll-specific calls.
@@ -152,11 +150,6 @@ head(128):
 		tag(30) uint64 sig_mask;
 		tag(31) uint64 sig_handler;
 		tag(32) uint64 sig_restorer;
-
-		// used by socket functions
-		tag(14) int32 domain;
-		tag(15) int32 socktype;
-		tag(16) int32 protocol;
 
 		tag(26) uint64 addr_size;
 		tag(27) uint64 ctrl_size;
@@ -413,6 +406,14 @@ head(128):
 }
 
 message SocketRequest 35 {
+head(128):
+	int32 flags;
+	int32 domain;
+	int32 socktype;
+	int32 protocol;
+}
+
+message SockpairRequest 25 {
 head(128):
 	int32 flags;
 	int32 domain;

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -391,3 +391,12 @@ tail:
 	string path;
 	string target_path;
 }
+
+message FchmodAtRequest 16 {
+head(128):
+	int32 fd;
+	int32 flags;
+	int32 mode;
+tail:
+	string path;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -354,3 +354,7 @@ head(128):
 message GetGidRequest 8 {
 head(128):
 }
+
+message GetEgidRequest 9 {
+head(128):
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -350,3 +350,7 @@ message SetEuidRequest 7 {
 head(128):
 	uint64 uid;
 }
+
+message GetGidRequest 8 {
+head(128):
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -358,3 +358,8 @@ head(128):
 message GetEgidRequest 9 {
 head(128):
 }
+
+message SetGidRequest 10 {
+head(128):
+	uint64 uid;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -381,3 +381,13 @@ head(128):
 tail:
 	string path;
 }
+
+message LinkAtRequest 15 {
+head(128):
+	int32 fd;
+	int32 newfd;
+	int32 flags;
+tail:
+	string path;
+	string target_path;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -56,9 +56,6 @@ consts CntReqType uint32 {
 	// FIFO- and pipe-specific calls.
 	PIPE_CREATE = 52,
 
-	// Socket-specific calls.
-	ACCEPT = 19,
-
 	// epoll-specific calls.
 	EPOLL_CALL = 54,
 	EPOLL_CREATE = 28,
@@ -419,4 +416,9 @@ head(128):
 	int32 domain;
 	int32 socktype;
 	int32 protocol;
+}
+
+message AcceptRequest 19 {
+head(128):
+	int32 fd;
 }

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -92,14 +92,6 @@ consts CntReqType uint32 {
 
 	MKFIFOAT = 65,
 	LINKAT = 66,
-	GET_UID = 67,
-	SET_UID = 68,
-	GET_EUID = 69,
-	SET_EUID = 70,
-	GET_GID = 71,
-	GET_EGID = 72,
-	SET_GID = 73,
-	SET_EGID = 74,
 	FCHMODAT = 75,
 	RMDIR = 77,
 	UTIMENSAT = 78
@@ -208,9 +200,6 @@ head(128):
 
 		// used by EVENTFD
 		tag(39) uint32 initval;
-
-		// used by {GET/SET}UID
-		tag(41) int64 uid;
 
 		// used by utimensat
 		tag(44) uint64 atime_sec;
@@ -360,6 +349,11 @@ head(128):
 }
 
 message SetGidRequest 10 {
+head(128):
+	uint64 uid;
+}
+
+message SetEgidRequest 11 {
 head(128):
 	uint64 uid;
 }

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -400,3 +400,16 @@ head(128):
 tail:
 	string path;
 }
+
+message UtimensAtRequest 17 {
+head(128):
+	int32 fd;
+	int32 flags;
+	int32 mode;
+	uint64 atimeSec;
+	uint64 atimeNsec;
+	uint64 mtimeSec;
+	uint64 mtimeNsec;
+tail:
+	string path;
+}

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -336,3 +336,8 @@ tail:
 message GetUidRequest 4 {
 head(128):
 }
+
+message SetUidRequest 5 {
+head(128):
+	uint64 uid;
+}


### PR DESCRIPTION
As discussed on Discord, this PR converts the following requests to bragi:

- `GET_UID`
- `SET_UID`
- `GET_EUID`
- `SET_EUID`
- `GET_GID`
- `SET_GID`
- `GET_EGID`
- `SET_EGID`
- `UNLINKAT`
- `FSTATAT`
- `MKFIFOAT`
- `LINKAT`
- `FCHMODAT`
- `UTIMENSAT`
- `RMDIR`
- `INOTIFY_ADD`

This batch should be done