### PR TITLE
Init: enable xwayland

### DIFF
--- a/posix/init/src/stage2.cpp
+++ b/posix/init/src/stage2.cpp
@@ -142,8 +142,8 @@ int main() {
 				throw std::runtime_error("mkdir() failed");
 			if(mkdir("/tmp/.X11-unix", 1777))
 				throw std::runtime_error("mkdir() failed");
-			execl("/usr/bin/weston", "weston", nullptr);
-			//execl("/usr/bin/weston", "weston", "--xwayland", nullptr);
+			//execl("/usr/bin/weston", "weston", nullptr);
+			execl("/usr/bin/weston", "weston", "--xwayland", nullptr);
 			//execl("/usr/bin/weston", "weston", "--use-pixman", nullptr);
 		}else{
 			std::cout << "init: init does not know how to launch " << launch << std::endl;


### PR DESCRIPTION
With the runtime issues fixed, we can enable Xwayland by default