### PR TITLE
posix: Various additions to tmpfs

### DIFF
--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -18,8 +18,8 @@ struct Superblock final : FsSuperblock {
 	FutureMaybe<std::shared_ptr<FsNode>> createRegular() override;
 	FutureMaybe<std::shared_ptr<FsNode>> createSocket() override;
 
-	async::result<std::shared_ptr<FsLink>> rename(FsLink *source,
-			FsNode *directory, std::string name) override;
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+			rename(FsLink *source, FsNode *directory, std::string name) override;
 
 	std::shared_ptr<Node> internalizeStructural(uint64_t id, helix::UniqueLane lane);
 	std::shared_ptr<Node> internalizeStructural(Node *owner, std::string name,
@@ -810,8 +810,8 @@ FutureMaybe<std::shared_ptr<FsNode>> Superblock::createSocket() {
 	throw std::runtime_error("extern_fs: createSocket() is not supported");
 }
 
-async::result<std::shared_ptr<FsLink>> Superblock::rename(FsLink *source,
-		FsNode *directory, std::string name) {
+async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+		Superblock::rename(FsLink *source, FsNode *directory, std::string name) {
 
 	managarm::fs::CntRequest req;
 	req.set_req_type(managarm::fs::CntReqType::RENAME);

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -62,8 +62,8 @@ public:
 	virtual FutureMaybe<std::shared_ptr<FsNode>> createRegular() = 0;
 	virtual FutureMaybe<std::shared_ptr<FsNode>> createSocket() = 0;
 
-	virtual async::result<std::shared_ptr<FsLink>> rename(FsLink *source,
-			FsNode *directory, std::string name) = 0;
+	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+			rename(FsLink *source, FsNode *directory, std::string name) = 0;
 };
 
 // ----------------------------------------------------------------------------

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1536,8 +1536,9 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			auto superblock = resolver.currentLink()->getTarget()->superblock();
 			auto directory = new_resolver.currentLink()->getTarget();
 			assert(superblock == directory->superblock());
-			co_await superblock->rename(resolver.currentLink().get(),
+			auto result = co_await superblock->rename(resolver.currentLink().get(),
 					directory.get(), new_resolver.nextComponent());
+			assert(result);
 
 			co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 		}else if(preamble.id() == managarm::posix::FstatAtRequest::message_id) {

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -1538,7 +1538,11 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			assert(superblock == directory->superblock());
 			auto result = co_await superblock->rename(resolver.currentLink().get(),
 					directory.get(), new_resolver.nextComponent());
-			assert(result);
+			if(!result) {
+				assert(result.error() == Error::alreadyExists);
+				co_await sendErrorResponse(managarm::posix::Errors::ALREADY_EXISTS);
+				continue;
+			}
 
 			co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 		}else if(preamble.id() == managarm::posix::FstatAtRequest::message_id) {

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -237,6 +237,8 @@ public:
 
 	explicit DirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link);
 
+	async::result<frg::expected<Error, off_t>> seek(off_t delta, VfsSeek whence) override;
+
 	void handleClose() override;
 
 	FutureMaybe<ReadEntriesResult> readEntries() override;
@@ -315,6 +317,15 @@ private:
 	}
 
 	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mksocket(std::string name) override;
+
+	async::result<frg::expected<Error>> rmdir(std::string name) override {
+		auto result = co_await unlink(name);
+		if(!result) {
+			std::cout << "tmpfs: Unexpected failure from unlink()" << std::endl;
+			co_return {};
+		}
+		co_return {};
+	}
 
 public:
 	DirectoryNode(Superblock *superblock);

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -262,7 +262,7 @@ struct DirectoryNode final : Node, std::enable_shared_from_this<DirectoryNode> {
 
 private:
 	VfsType getType() override {
-  		return VfsType::directory;
+		return VfsType::directory;
 	}
 
 	std::shared_ptr<FsLink> treeLink() override {
@@ -478,16 +478,15 @@ struct Superblock final : FsSuperblock {
 		co_return std::move(node);
 	}
 
-	async::result<std::shared_ptr<FsLink>> rename(FsLink *src_fs_link,
+	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> rename(FsLink *src_fs_link,
 			FsNode *dest_fs_dir, std::string dest_name) override {
 		auto src_link = static_cast<Link *>(src_fs_link);
 		auto dest_dir = static_cast<DirectoryNode *>(dest_fs_dir);
 
 		auto src_dir = static_cast<DirectoryNode *>(src_link->getOwner().get());
 		auto it = src_dir->_entries.find(src_link->getName());
-		// TODO: This should really return an error, frg::expected style.
 		if(it == src_dir->_entries.end() || it->get() != src_link)
-			co_return nullptr;
+			co_return Error:alreadyExists;
 
 		// Unlink an existing link if such a link exists.
 		if(auto dest_it = dest_dir->_entries.find(dest_name);


### PR DESCRIPTION
This PR aims to implement `seek` and `rmdir` for the tmpfs `DirectoryNode` and `DirectoryFile`.
Python uses `rmdir()` and `rewinddir()` on directories in `/tmp` when running `python3 get-pip.py`, this PR implements the required functionality.
Furthermore, this PR changes various assertions in tmpfs to proper error returns. As such, this PR closes #217 