### PR TITLE
ext2: Fix link counts

### DIFF
--- a/drivers/libblockfs/src/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2fs.cpp
@@ -737,7 +737,6 @@ async::detached FileSystem::initiateInode(std::shared_ptr<Inode> inode) {
 		abort();
 	}
 
-	inode->numLinks = disk_inode->linksCount;
 	// TODO: support large uid / gids
 	inode->uid = disk_inode->uid;
 	inode->gid = disk_inode->gid;

--- a/drivers/libblockfs/src/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2fs.hpp
@@ -231,7 +231,6 @@ struct Inode : std::enable_shared_from_this<Inode> {
 
 	FileType fileType;
 
-	int numLinks; // number of links to this file
 	int uid, gid;
 	FlockManager flockManager;
 

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -290,7 +290,7 @@ getStats(std::shared_ptr<void> object) {
 	co_await self->readyJump.async_wait();
 
 	protocols::fs::FileStats stats;
-	stats.linkCount = self->numLinks;
+	stats.linkCount = self->diskInode()->linksCount;
 	stats.fileSize = self->fileSize();
 	stats.mode = self->diskInode()->mode & 0xFFF;
 	stats.uid = self->uid;

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -2087,7 +2087,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			auto file = self->fileContext()->getFile(req->fd());
 			if(!file) {
-				co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+				co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 				continue;
 			}
 


### PR DESCRIPTION
This PR addresses several small bugs regarding error handling in the code for `isatty()` and link counts in the ext2 driver.