### PR TITLE
Several non-blocking related fixes in POSIX and netserver

### DIFF
--- a/servers/netserver/src/ip/tcp4.cpp
+++ b/servers/netserver/src/ip/tcp4.cpp
@@ -379,12 +379,35 @@ struct Tcp4Socket {
 		};
 	}
 
+	static async::result<void> setFileFlags(void *object, int flags) {
+		auto self = static_cast<Tcp4Socket *>(object);
+		std::cout << "posix: setFileFlags on tcp socket only supports O_NONBLOCK" << std::endl;
+		if(flags & ~O_NONBLOCK) {
+			std::cout << "posix: setFileFlags on tcp socket called with unknown flags" << std::endl;
+			co_return;
+		}
+		if(flags & O_NONBLOCK)
+			self->nonBlock_ = true;
+		else
+			self->nonBlock_ = false;
+		co_return;
+	}
+
+	static async::result<int> getFileFlags(void *object) {
+		auto self = static_cast<Tcp4Socket *>(object);
+		if(self->nonBlock_)
+			co_return O_NONBLOCK;
+		co_return 0;
+	}
+
 	constexpr static protocols::fs::FileOperations ops {
 		.read = &read,
 		.write = &write,
 		.poll = &poll,
 		.bind = &bind,
 		.connect = &connect,
+		.getFileFlags = &getFileFlags,
+		.setFileFlags = &setFileFlags,
 		.recvMsg = &recvMsg,
 		.sendMsg = &sendMsg,
 	};


### PR DESCRIPTION
This PR adds the ability to a FIFO pipe reader side to be non-blocking and implements `getFileFlags()` and `setFileFlags()` for a FIFO pipe reader side and tcp sockets. For the tcp sockets, this is a partial implementation, only working for `O_NONBLOCK`