### PR TITLE
posix: Implement pipe2 with O_NONBLOCK

### DIFF
--- a/posix/subsystem/src/fifo.cpp
+++ b/posix/subsystem/src/fifo.cpp
@@ -291,10 +291,10 @@ openNamedChannel(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 	}
 }
 
-std::array<smarter::shared_ptr<File, FileHandle>, 2> createPair() {
+std::array<smarter::shared_ptr<File, FileHandle>, 2> createPair(bool nonBlock) {
 	auto link = SpecialLink::makeSpecialLink(VfsType::fifo, 0777);
 	auto channel = std::make_shared<Channel>();
-	auto r_file = smarter::make_shared<ReaderFile>(nullptr, link);
+	auto r_file = smarter::make_shared<ReaderFile>(nullptr, link, nonBlock);
 	auto w_file = smarter::make_shared<WriterFile>(nullptr, link);
 	r_file->setupWeakFile(r_file);
 	w_file->setupWeakFile(w_file);

--- a/posix/subsystem/src/fifo.hpp
+++ b/posix/subsystem/src/fifo.hpp
@@ -9,7 +9,7 @@ void unlinkNamedChannel(FsNode *node);
 async::result<smarter::shared_ptr<File, FileHandle>>
 openNamedChannel(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, FsNode *node, SemanticFlags flags);
 
-std::array<smarter::shared_ptr<File, FileHandle>, 2> createPair();
+std::array<smarter::shared_ptr<File, FileHandle>, 2> createPair(bool nonBlock);
 
 } // namespace fifo
 

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -2441,13 +2441,14 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			assert(!(req.flags() & ~(O_CLOEXEC | O_NONBLOCK)));
 
+			bool nonBlock = false;
+
 			if(req.flags() & O_NONBLOCK)
-				std::cout << "\e[31mposix: pipe2(O_NONBLOCK)"
-						" is not implemented correctly\e[39m" << std::endl;
+				nonBlock = true;
 
 			helix::SendBuffer send_resp;
 
-			auto pair = fifo::createPair();
+			auto pair = fifo::createPair(nonBlock);
 			auto r_fd = self->fileContext()->attachFile(std::get<0>(pair),
 					req.flags() & O_CLOEXEC);
 			auto w_fd = self->fileContext()->attachFile(std::get<1>(pair),


### PR DESCRIPTION
This PR should get rid of the message `posix: pipe2(O_NONBLOCK) is not implemented correctly` which is shown on boot.