### PR TITLE
netserver: Various bug fixes

### DIFF
--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -83,6 +83,7 @@ namespace stdio {
 
 				managarm::fs::SvrResponse<KernelAlloc> resp(*kernelAlloc);
 				resp.set_error(managarm::fs::Errors::SUCCESS);
+				resp.set_size(dataBuffer.size());
 
 				frg::string<KernelAlloc> ser(*kernelAlloc);
 				resp.SerializeToString(&ser);

--- a/posix/subsystem/src/epoll.cpp
+++ b/posix/subsystem/src/epoll.cpp
@@ -136,12 +136,14 @@ public:
 		return Error::success;
 	}
 
-	void modifyItem(File *file, int mask, uint64_t cookie) {
+	Error modifyItem(File *file, int mask, uint64_t cookie) {
 		if(logEpoll)
 			std::cout << "posix.epoll \e[1;34m" << structName() << "\e[0m: Modifying item \e[1;34m"
 					<< file->structName() << "\e[0m. New mask is " << mask << std::endl;
 		auto it = _fileMap.find(file);
-		assert(it != _fileMap.end());
+		if(it == _fileMap.end()) {
+			return Error::noSuchFile;
+		}
 		auto item = it->second;
 		assert(item->state & stateActive);
 
@@ -159,12 +161,14 @@ public:
 		}
 	}
 
-	void deleteItem(File *file) {
+	Error deleteItem(File *file) {
 		if(logEpoll)
 			std::cout << "posix.epoll \e[1;34m" << structName() << "\e[0m: Deleting item \e[1;34m"
 					<< file->structName() << "\e[0m" << std::endl;
 		auto it = _fileMap.find(file);
-		assert(it != _fileMap.end());
+		if(it == _fileMap.end()) {
+			return Error::noSuchFile;
+		}
 		auto item = it->second;
 		assert(item->state & stateActive);
 

--- a/posix/subsystem/src/epoll.hpp
+++ b/posix/subsystem/src/epoll.hpp
@@ -8,10 +8,10 @@ namespace epoll {
 
 smarter::shared_ptr<File, FileHandle> createFile();
 
-void addItem(File *epfile, Process *process, smarter::shared_ptr<File> file,
+Error addItem(File *epfile, Process *process, smarter::shared_ptr<File> file,
 		int flags, uint64_t cookie);
-void modifyItem(File *epfile, File *file, int flags, uint64_t cookie);
-void deleteItem(File *epfile, File *file, int flags);
+Error modifyItem(File *epfile, File *file, int flags, uint64_t cookie);
+Error deleteItem(File *epfile, File *file, int flags);
 
 async::result<size_t> wait(File *epfile, struct epoll_event *events,
 		size_t max_events, async::cancellation_token cancellation = {});

--- a/posix/subsystem/src/exec.cpp
+++ b/posix/subsystem/src/exec.cpp
@@ -280,6 +280,8 @@ execute(ViewPath root, ViewPath workdir,
 		static_cast<uintptr_t>(mbusHandle),
 		AT_EXECFN,
 		execfn,
+		AT_SECURE,
+		0,
 		AT_NULL,
 		0
 	});

--- a/posix/subsystem/src/file.cpp
+++ b/posix/subsystem/src/file.cpp
@@ -177,7 +177,7 @@ File::ptRecvMsg(void *object, const char *creds, uint32_t flags,
 			max_ctrl_len);
 }
 
-async::result<protocols::fs::SendResult>
+async::result<frg::expected<protocols::fs::Error, size_t>>
 File::ptSendMsg(void *object, const char *creds, uint32_t flags,
 		void *data, size_t len,
 		void *addr, size_t addr_len,
@@ -264,7 +264,7 @@ File::recvMsg(Process *, uint32_t, void *, size_t,
 	throw std::runtime_error("posix: Object has no File::recvMsg()");
 }
 
-async::result<protocols::fs::SendResult>
+async::result<frg::expected<protocols::fs::Error, size_t>>
 File::sendMsg(Process *, uint32_t,
 		const void *, size_t,
 		const void *, size_t,

--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -153,7 +153,7 @@ public:
 			void *addr, size_t addr_len,
 			size_t max_ctrl_len);
 
-	static async::result<protocols::fs::SendResult>
+	static async::result<frg::expected<protocols::fs::Error, size_t>>
 	ptSendMsg(void *object, const char *creds, uint32_t flags,
 			void *data, size_t len,
 			void *addr, size_t addr_len,
@@ -272,7 +272,7 @@ public:
 			void *data, size_t max_length,
 			void *addr_ptr, size_t max_addr_length, size_t max_ctrl_length);
 
-	virtual async::result<protocols::fs::SendResult>
+	virtual async::result<frg::expected<protocols::fs::Error, size_t>>
 		sendMsg(Process *process, uint32_t flags,
 			const void *data, size_t max_length,
 			const void *addr_ptr, size_t addr_length,

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -2897,6 +2897,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					co_await sendErrorResponse(managarm::posix::Errors::ALREADY_EXISTS);
 					continue;
 				}
+				assert(ret == Error::success);
 			}
 
 			struct epoll_event events[16];
@@ -2973,6 +2974,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				co_await sendErrorResponse(managarm::posix::Errors::ALREADY_EXISTS);
 				continue;
 			}
+			assert(ret == Error::success);
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);
@@ -2998,6 +3000,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				co_await sendErrorResponse(managarm::posix::Errors::FILE_NOT_FOUND);
 				continue;
 			}
+			assert(ret == Error::success);
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);
@@ -3026,6 +3029,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				co_await sendErrorResponse(managarm::posix::Errors::FILE_NOT_FOUND);
 				continue;
 			}
+			assert(ret == Error::success);
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -2891,8 +2891,12 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				assert(file && "Illegal FD for EPOLL_ADD item");
 				auto locked = file->weakFile().lock();
 				assert(locked);
-				epoll::addItem(epfile.get(), self.get(), std::move(locked),
+				Error ret = epoll::addItem(epfile.get(), self.get(), std::move(locked),
 						req.events(i), i);
+				if(ret == Error::alreadyExists) {
+					co_await sendErrorResponse(managarm::posix::Errors::ALREADY_EXISTS);
+					continue;
+				}
 			}
 
 			struct epoll_event events[16];
@@ -2963,8 +2967,12 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			auto locked = file->weakFile().lock();
 			assert(locked);
-			epoll::addItem(epfile.get(), self.get(), std::move(locked),
+			Error ret = epoll::addItem(epfile.get(), self.get(), std::move(locked),
 					req.flags(), req.cookie());
+			if(ret == Error::alreadyExists) {
+				co_await sendErrorResponse(managarm::posix::Errors::ALREADY_EXISTS);
+				continue;
+			}
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);
@@ -2985,7 +2993,11 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			assert(epfile && "Illegal FD for EPOLL_MODIFY");
 			assert(file && "Illegal FD for EPOLL_MODIFY item");
 
-			epoll::modifyItem(epfile.get(), file.get(), req.flags(), req.cookie());
+			Error ret = epoll::modifyItem(epfile.get(), file.get(), req.flags(), req.cookie());
+			if(ret == Error::noSuchFile) {
+				co_await sendErrorResponse(managarm::posix::Errors::FILE_NOT_FOUND);
+				continue;
+			}
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);
@@ -3009,7 +3021,11 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				continue;
 			}
 
-			epoll::deleteItem(epfile.get(), file.get(), req.flags());
+			Error ret = epoll::deleteItem(epfile.get(), file.get(), req.flags());
+			if(ret == Error::noSuchFile) {
+				co_await sendErrorResponse(managarm::posix::Errors::FILE_NOT_FOUND);
+				continue;
+			}
 
 			managarm::posix::SvrResponse resp;
 			resp.set_error(managarm::posix::Errors::SUCCESS);

--- a/posix/subsystem/src/nl-socket.cpp
+++ b/posix/subsystem/src/nl-socket.cpp
@@ -140,7 +140,7 @@ public:
 		co_return RecvResult { RecvData { size, sizeof(struct sockaddr_nl), ctrl.buffer() } };
 	}
 	
-	async::result<protocols::fs::SendResult>
+	async::result<frg::expected<protocols::fs::Error, size_t>>
 	sendMsg(Process *process, uint32_t flags,
 			const void *data, size_t max_length,
 			const void *addr_ptr, size_t addr_length,
@@ -231,7 +231,7 @@ private:
 // ----------------------------------------------------------------------------
 
 
-async::result<protocols::fs::SendResult>
+async::result<frg::expected<protocols::fs::Error, size_t>>
 OpenFile::sendMsg(Process *process, uint32_t flags, const void *data, size_t max_length,
 		const void *addr_ptr, size_t addr_length,
 		std::vector<smarter::shared_ptr<File, FileHandle>> files) {

--- a/posix/subsystem/src/un-socket.cpp
+++ b/posix/subsystem/src/un-socket.cpp
@@ -205,14 +205,14 @@ public:
 		co_return protocols::fs::RecvResult { protocols::fs::RecvData { chunk, 0, ctrl.buffer() } };
 	}
 
-	async::result<protocols::fs::SendResult>
+	async::result<frg::expected<protocols::fs::Error, size_t>>
 	sendMsg(Process *process, uint32_t flags, const void *data, size_t max_length,
 			const void *, size_t,
 			std::vector<smarter::shared_ptr<File, FileHandle>> files) override {
 		assert(!(flags & ~(MSG_DONTWAIT)));
 
 		if(_currentState == State::remoteShutDown)
-			co_return protocols::fs::SendResult { protocols::fs::Error::brokenPipe };
+			co_return protocols::fs::Error::brokenPipe;
 
 		if(_currentState != State::connected)
 			co_return protocols::fs::Error::notConnected;
@@ -232,7 +232,7 @@ public:
 		_remote->_inSeq = ++_remote->_currentSeq;
 		_remote->_statusBell.ring();
 
-		co_return protocols::fs::SendResult { max_length };
+		co_return max_length;
 	}
 
 	async::result<int> getOption(int option) override {

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -177,7 +177,7 @@ struct FileOperations {
 	async::result<RecvResult> (*recvMsg)(void *object, const char *creds,
 			uint32_t flags, void *data, size_t len,
 			void *addr_buf, size_t addr_size, size_t max_ctrl_len);
-	async::result<SendResult> (*sendMsg)(void *object, const char *creds,
+	async::result<frg::expected<protocols::fs::Error, size_t>> (*sendMsg)(void *object, const char *creds,
 			uint32_t flags, void *data, size_t len,
 			void *addr_buf, size_t addr_size,
 			std::vector<uint32_t> fds);

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -260,6 +260,7 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 			}
 		}else{
 			resp.set_error(managarm::fs::Errors::SUCCESS);
+			resp.set_size(res.value());
 
 			auto ser = resp.SerializeAsString();
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -254,6 +254,15 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 					helix_ng::sendBuffer(ser.data(), ser.size())
 				);
 				HEL_CHECK(send_resp.error());
+			} else if(res.error() == Error::wouldBlock) {
+				resp.set_error(managarm::fs::Errors::WOULD_BLOCK);
+
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size())
+				);
+				HEL_CHECK(send_resp.error());
 			} else {
 				std::cout << "Unknown error from write()" << std::endl;
 				co_return;

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -247,26 +247,18 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 		if(!res) {
 			if(res.error() == Error::noSpaceLeft) {
 				resp.set_error(managarm::fs::Errors::NO_SPACE_LEFT);
-
-				auto ser = resp.SerializeAsString();
-				auto [send_resp] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBuffer(ser.data(), ser.size())
-				);
-				HEL_CHECK(send_resp.error());
 			} else if(res.error() == Error::wouldBlock) {
 				resp.set_error(managarm::fs::Errors::WOULD_BLOCK);
-
-				auto ser = resp.SerializeAsString();
-				auto [send_resp] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBuffer(ser.data(), ser.size())
-				);
-				HEL_CHECK(send_resp.error());
 			} else {
 				std::cout << "Unknown error from write()" << std::endl;
 				co_return;
-			}
+			}	
+			auto ser = resp.SerializeAsString();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBuffer(ser.data(), ser.size())
+			);
+			HEL_CHECK(send_resp.error());
 		}else{
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 			resp.set_size(res.value());

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -820,7 +820,7 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 
 		std::vector<uint32_t> files(req.fds().cbegin(), req.fds().cend());
 
-		auto result_or_error = co_await file_ops->sendMsg(file.get(),
+		auto res = co_await file_ops->sendMsg(file.get(),
 				extract_creds.credentials(), req.flags(),
 				buffer.data(), recv_data.actualLength(),
 				recv_addr.data(), recv_addr.length(),
@@ -828,21 +828,24 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 
 		managarm::fs::SvrResponse resp;
 
-		auto error = std::get_if<Error>(&result_or_error);
-		if(error) {
-			resp.set_error(static_cast<managarm::fs::Errors>(*error));
+		if(!res) {
+			if(res.error() == Error::wouldBlock) {
+				resp.set_error(managarm::fs::Errors::WOULD_BLOCK);
 
-			auto ser = resp.SerializeAsString();
-			auto [send_resp] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::sendBuffer(ser.data(), ser.size())
-			);
-			HEL_CHECK(send_resp.error());
-			co_return;
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size())
+				);
+				HEL_CHECK(send_resp.error());
+			} else {
+				std::cout << "Unknown error from sendMsg()" << std::endl;
+				co_return;
+			}
 		}
 
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-		resp.set_size(std::get<size_t>(result_or_error));
+		resp.set_size(res.value());
 
 		auto ser = resp.SerializeAsString();
 		auto [send_resp] = co_await helix_ng::exchangeMsgs(

--- a/servers/netserver/src/ip/ip4.cpp
+++ b/servers/netserver/src/ip/ip4.cpp
@@ -126,7 +126,7 @@ struct Ip4Socket {
 		co_return RecvData { copy_size, sizeof(addr), {} };
 	}
 
-	static async::result<SendResult> sendmsg(void *obj,
+	static async::result<frg::expected<protocols::fs::Error, size_t>> sendmsg(void *obj,
 			const char *creds, uint32_t flags,
 			void *data, size_t len,
 			void *addr_ptr, size_t addr_size,
@@ -163,7 +163,7 @@ private:
 	async::doorbell bell;
 };
 
-async::result<SendResult> Ip4Socket::sendmsg(void *obj,
+async::result<frg::expected<protocols::fs::Error, size_t>> Ip4Socket::sendmsg(void *obj,
 		const char *creds, uint32_t flags,
 		void *data, size_t len,
 		void *addr_ptr, size_t addr_size,

--- a/servers/netserver/src/ip/tcp4.cpp
+++ b/servers/netserver/src/ip/tcp4.cpp
@@ -701,7 +701,7 @@ void Tcp4::feedDatagram(smarter::shared_ptr<const Ip4Packet> packet) {
 		std::cout << "netserver: Received TCP packet at port " << tcp.header.destPort.load()
 				<< " (" << tcp.payload().size() << " bytes)" << std::endl;
 
-	auto it = binds.lower_bound({ 0, packet });
+	auto it = binds.lower_bound({ 0, tcp.header.destPort.load() });
 	for (; it != binds.end() && it->first.port == tcp.header.destPort.load(); it++) {
 		auto existingEp = it->first;
 		if (existingEp.ipAddress == tcp.packet->header.destination

--- a/servers/netserver/src/ip/tcp4.cpp
+++ b/servers/netserver/src/ip/tcp4.cpp
@@ -277,8 +277,7 @@ struct Tcp4Socket {
 
 	static async::result<frg::expected<protocols::fs::Error, size_t>> write(void *object, const char *creds,
 			const void *data, size_t size) {
-		co_await sendMsg(object, creds, 0, const_cast<void *>(data), size, nullptr, 0, {});
-		co_return size;
+		co_return co_await sendMsg(object, creds, 0, const_cast<void *>(data), size, nullptr, 0, {});
 	}
 
 	static async::result<protocols::fs::RecvResult> recvMsg(void *object,
@@ -321,7 +320,7 @@ struct Tcp4Socket {
 		co_return protocols::fs::RecvData{progress, sizeof(struct sockaddr_in), {}};
 	}
 
-	static async::result<protocols::fs::SendResult> sendMsg(void *object,
+	static async::result<frg::expected<protocols::fs::Error, size_t>> sendMsg(void *object,
 			const char *creds, uint32_t flags,
 			void *data, size_t size,
 			void *addrPtr, size_t addrSize,

--- a/servers/netserver/src/ip/tcp4.cpp
+++ b/servers/netserver/src/ip/tcp4.cpp
@@ -183,7 +183,7 @@ protocols::fs::Error checkAddress(const void *addrPtr, size_t addrLength, TcpEnd
 
 struct Tcp4Socket {
 	Tcp4Socket(Tcp4 *parent, bool nonBlock)
-	: parent_(parent), nonBlock_{nonBlock}, recvRing_{4}, sendRing_{4} {}
+	: parent_(parent), nonBlock_{nonBlock}, recvRing_{14}, sendRing_{14} {}
 
 	~Tcp4Socket() {
 		parent_->unbind(localEp_);
@@ -590,7 +590,7 @@ async::result<void> Tcp4Socket::flushOutPackets_() {
 				.destPort = remoteEp_.port,
 				.seqNumber = localFlushedSn_,
 				.ackNumber = remoteKnownSn_,
-				.window = recvRing_.spaceForEnqueue(),
+				.window = std::min(recvRing_.spaceForEnqueue(), size_t{0xFFFF}),
 				.checksum = 0,
 				.urgentPointer = 0
 			};

--- a/servers/netserver/src/ip/tcp4.cpp
+++ b/servers/netserver/src/ip/tcp4.cpp
@@ -105,6 +105,7 @@ static std::mt19937 globalPrng;
 } // namespace
 
 struct TcpHeader {
+	static constexpr arch::field<uint16_t, bool> finFlag{0, 1};
 	static constexpr arch::field<uint16_t, bool> synFlag{1, 1};
 	static constexpr arch::field<uint16_t, bool> ackFlag{4, 1};
 	static constexpr arch::field<uint16_t, unsigned int> headerWords{12, 4};
@@ -367,12 +368,16 @@ struct Tcp4Socket {
 			edges |= EPOLLIN;
 		if(self->outSeq_ > pastSeq)
 			edges |= EPOLLOUT;
+		if(self->hupSeq_ > pastSeq)
+			edges |= EPOLLHUP;
 
 		int active = 0;
 		if(self->recvRing_.availableToDequeue())
 			active |= EPOLLIN;
 		if(self->sendRing_.spaceForEnqueue())
 			active |= EPOLLOUT;
+		if(self->remoteClosed_)
+			active |= EPOLLHUP;
 
 		co_return protocols::fs::PollResult{
 			self->currentSeq_,
@@ -451,6 +456,7 @@ private:
 	smarter::weak_ptr<Tcp4Socket> holder_;
 
 	ConnectState connectState_ = ConnectState::none;
+	bool remoteClosed_ = false;
 
 	// Out-SN corresponding to the front of sendRing_.
 	uint32_t localSettledSn_ = 0;
@@ -477,6 +483,7 @@ private:
 	uint64_t currentSeq_ = 1;
 	uint64_t inSeq_ = 1;
 	uint64_t outSeq_ = 0;
+	uint64_t hupSeq_ = 1;
 	async::doorbell pollEvent_;
 };
 
@@ -649,23 +656,38 @@ void Tcp4Socket::handleInPacket_(TcpPacket packet) {
 		++localSettledSn_;
 		localWindowSn_ = localSettledSn_ + packet.header.window.load();
 		remoteAckedSn_ = packet.header.seqNumber.load();
-		remoteKnownSn_ = packet.header.seqNumber.load() + 1;
+		remoteKnownSn_ = packet.header.seqNumber.load() + 1; // SYN counts as one byte.
 		connectState_ = ConnectState::connected;
 		flushEvent_.ring();
 		settleEvent_.ring();
 	}else if(connectState_ == ConnectState::connected) {
 		if(packet.header.seqNumber.load() == remoteKnownSn_) {
+			bool gotUpdate = false;
+
 			auto payload = packet.payload();
 			size_t chunk = std::min(payload.size(), recvRing_.spaceForEnqueue());
 			if(chunk) {
 				recvRing_.enqueue(payload.data(), chunk);
-				inSeq_ = ++currentSeq_;
 				remoteKnownSn_ += chunk;
 				if(announcedWindow_ < chunk) {
 					announcedWindow_ = 0;
 				}else{
 					announcedWindow_ -= chunk;
 				}
+
+				inSeq_ = ++currentSeq_;
+				gotUpdate = true;
+			}
+
+			if(packet.header.flags.load() & TcpHeader::finFlag) {
+				++remoteKnownSn_; // FIN counts as one byte.
+				remoteClosed_ = true;
+
+				hupSeq_ = ++currentSeq_;
+				gotUpdate = true;
+			}
+
+			if(gotUpdate) {
 				inEvent_.ring();
 				flushEvent_.ring();
 				pollEvent_.ring();

--- a/servers/netserver/src/ip/udp4.cpp
+++ b/servers/netserver/src/ip/udp4.cpp
@@ -238,7 +238,7 @@ struct Udp4Socket {
 		co_return RecvData { copy_size, sizeof(addr), {} };
 	}
 
-	static async::result<SendResult> sendmsg(void *obj,
+	static async::result<frg::expected<protocols::fs::Error, size_t>> sendmsg(void *obj,
 			const char *creds, uint32_t flags,
 			void *data, size_t len,
 			void *addr_ptr, size_t addr_size,

--- a/servers/netserver/src/ip/udp4.cpp
+++ b/servers/netserver/src/ip/udp4.cpp
@@ -384,7 +384,7 @@ void Udp4::feedDatagram(smarter::shared_ptr<const Ip4Packet> packet) {
 
 	std::cout << "received udp datagram to port " << udp.header.dst << std::endl;
 
-	auto i = binds.lower_bound({ 0, packet });
+	auto i = binds.lower_bound({ 0, udp.header.dst });
 	for (; i != binds.end() && i->first.port == udp.header.dst; i++) {
 		auto ep = i->first;
 		if (ep.addr == udp.packet->header.destination

--- a/servers/netserver/src/ip/udp4.cpp
+++ b/servers/netserver/src/ip/udp4.cpp
@@ -314,7 +314,7 @@ struct Udp4Socket {
 			<< std::setw(8) << header.src << std::endl
 			<< std::setw(8) << header.dst << std::endl
 			<< std::setw(8) << header.len << std::endl
-			<< std::setw(8) << header.chk << std::endl;
+			<< std::setw(8) << header.chk << std::endl << std::dec;
 
 		if (header.chk == 0) {
 			header.chk = ~header.chk;


### PR DESCRIPTION
This PR originally held various bugfixes for the netstack. During bug hunting, the need to refactor the sendMsg code to handle partial writes (and as such also add this to the write code) came up. Furthermore, this PR fixes a formatting error, fixes 2 critical bugs in the TCP and UDP stack, adds additional error returns in several places and adds code to handle (but not yet send) FIN TCP packets.

This PR possibly fixes #208
After this PR, managarm/mlibc#242 should be merged 