### PR TITLE
posix: Implement ioctl(FIOCLEX)

### DIFF
--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -2668,6 +2668,22 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
 					helix_ng::sendBuffer(ser.data(), ser.size()));
 			HEL_CHECK(send_resp.error());
+		}else if(req.request_type() == managarm::posix::CntReqType::IOCLEX) {
+			if(logRequests)
+				std::cout << "posix: FIOCLEX" << std::endl;
+
+			if(self->fileContext()->setDescriptor(req.fd(), true) != Error::success) {
+				co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
+				continue;
+			}
+
+			managarm::posix::SvrResponse resp;
+			resp.set_error(managarm::posix::Errors::SUCCESS);
+
+			auto ser = resp.SerializeAsString();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size()));
+			HEL_CHECK(send_resp.error());
 		}else if(req.request_type() == managarm::posix::CntReqType::SIG_ACTION) {
 			if(logRequests)
 				std::cout << "posix: SIG_ACTION" << std::endl;

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -51,6 +51,7 @@ consts CntReqType uint32 {
 	GETCWD = 59,
 	FD_GET_FLAGS = 44,
 	FD_SET_FLAGS = 45,
+	IOCLEX = 48,
 	GET_RESOURCE_USAGE = 57,
 
 	// Session and process group calls.

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -51,7 +51,6 @@ consts CntReqType uint32 {
 	GETCWD = 59,
 	FD_GET_FLAGS = 44,
 	FD_SET_FLAGS = 45,
-	IOCLEX = 48,
 	GET_RESOURCE_USAGE = 57,
 
 	// Session and process group calls.
@@ -474,4 +473,9 @@ head(128):
 message GetSidRequest 82 {
 head(128):
 	int64 pid;
+}
+
+message IoctlFioclexRequest 83 {
+head(128):
+	int32 fd;	
 }


### PR DESCRIPTION
This PR adds a new request type in `bragi` and `posix` to support `ioctl(FIOCLEX)`. This is used by Rust's `std` to set the `CLOEXEC` flag on file descriptors.

mlibc supported is added in managarm/mlibc#259.