### PR TITLE
Various fixes for gcc 10

### DIFF
--- a/drivers/uart/src/main.cpp
+++ b/drivers/uart/src/main.cpp
@@ -223,7 +223,7 @@ async::detached handleIrqs() {
 async::result<protocols::fs::ReadResult>
 read(void *, const char *, void *buffer, size_t length) {
 	if(!length)
-		co_return 0;
+		co_return size_t{0};
 
 	ReadRequest req{buffer, length};
 	recvRequests.push_back(req);

--- a/kernel/eir/arch/arm/meson.build
+++ b/kernel/eir/arch/arm/meson.build
@@ -1,6 +1,6 @@
 eir_sources = [files('load64.S', 'arch.cpp', 'fault.S', 'fault.cpp'), eir_generic_sources]
 eir_includes += include_directories('.')
-eir_cpp_args += ['-mgeneral-regs-only', '-mno-unaligned-access', '-DCXXSHIM_INTEGRATE_GCC']
+eir_cpp_args += ['-mgeneral-regs-only', '-mno-unaligned-access']
 eir_c_args += ['-mgeneral-regs-only', '-mno-unaligned-access']
 
 subdir('raspi4')

--- a/kernel/eir/arch/x86/meson.build
+++ b/kernel/eir/arch/x86/meson.build
@@ -8,7 +8,7 @@ eir32_sources = [
 	eir_generic_sources,
 	eir_x86_sources]
 eir32_c_args = [eir_c_args, '-m32']
-eir32_cpp_args = [eir_cpp_args, '-m32', '-DCXXSHIM_INTEGRATE_GCC']
+eir32_cpp_args = [eir_cpp_args, '-m32']
 eir32_link_args = [eir_link_args, '-m32', '-Wl,-T,' + meson.current_source_dir() + '/generic32_link.x']
 eir32_dependencies = eir_dependencies
 eir32_extra_objects = [meson.current_source_dir() + '/libgcc.a']
@@ -19,7 +19,7 @@ eir64_sources = [
 	eir_generic_sources,
 	eir_x86_sources]
 eir64_c_args = eir_c_args
-eir64_cpp_args = [eir_cpp_args, '-DCXXSHIM_INTEGRATE_GCC']
+eir64_cpp_args = eir_cpp_args
 eir64_link_args_without_link_script = [eir_link_args, '-Wl,-z,max-page-size=0x1000']
 eir64_link_args = ['-Wl,-T,' + meson.current_source_dir() + '/generic64_link.x', eir64_link_args_without_link_script]
 eir64_dependencies = eir_dependencies

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -2,8 +2,7 @@ libsmarter = subproject('libsmarter').get_variable('libsmarter_dep')
 link_args = [ '-nostdlib' ]
 
 args = [ 
-	'-DCXXSHIM_INTEGRATE_GCC', 
-	'-DLIBASYNC_CUSTOM_PLATFORM', 
+	'-DLIBASYNC_CUSTOM_PLATFORM',
 	'-DLIBASYNC_FORCE_USE_EXPERIMENTAL',
 	'-fno-threadsafe-statics'
 ]


### PR DESCRIPTION
This PR is the Managarm counterpart of managarm/bootstrap-managarm#100 and fixes several issues identified under gcc 10.3. This PR is blocked on everything in managarm/bootstrap-managarm#100, with exception of this and the mlibc PR. This PR can only be merged if the mlibc PR and the bootstrap PR are also ready to be merged in order to avoid build failures.

After this PR, managarm/bootstrap-managarm#100 should be merged