### PR TITLE
posix: Add /dev/random and /dev/urandom devices

### DIFF
--- a/posix/subsystem/meson.build
+++ b/posix/subsystem/meson.build
@@ -6,6 +6,8 @@ src = [
 	'src/devices/full.cpp',
 	'src/devices/helout.cpp',
 	'src/devices/null.cpp',
+	'src/devices/random.cpp',
+	'src/devices/urandom.cpp',
 	'src/devices/zero.cpp',
 	'src/drvcore.cpp',
 	'src/epoll.cpp',

--- a/posix/subsystem/src/devices/random.cpp
+++ b/posix/subsystem/src/devices/random.cpp
@@ -1,0 +1,77 @@
+#include <string.h>
+#include <sys/random.h>
+
+#include "../common.hpp"
+#include "random.hpp"
+
+#include <experimental/coroutine>
+
+namespace {
+
+struct RandomFile final : File {
+private:
+	async::result<frg::expected<Error, size_t>>
+	readSome(Process *, void *data, size_t length) override {
+		auto p = reinterpret_cast<char *>(data);
+		size_t n = 0;
+		while(n < length) {
+			size_t chunk;
+			HEL_CHECK(helGetRandomBytes(p + n, length - n, &chunk));
+			n+= chunk;
+		}
+
+		co_return n;
+	}
+
+	async::result<frg::expected<Error, size_t>> writeAll(Process *, const void *, size_t length) override {
+		co_return length;
+	}
+
+	async::result<frg::expected<Error, off_t>> seek(off_t, VfsSeek) override {
+		co_return 0;
+	}
+
+	helix::BorrowedDescriptor getPassthroughLane() override {
+		return _passthrough;
+	}
+
+	helix::UniqueLane _passthrough;
+	async::cancellation_event _cancelServe;
+
+public:
+	static void serve(smarter::shared_ptr<RandomFile> file) {
+		helix::UniqueLane lane;
+		std::tie(lane, file->_passthrough) = helix::createStream();
+		async::detach(protocols::fs::servePassthrough(std::move(lane),
+				file, &fileOperations, file->_cancelServe));
+	}
+
+	RandomFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	: File{StructName::get("random-file"), std::move(mount), std::move(link)} { }
+};
+
+struct RandomDevice final : UnixDevice {
+	RandomDevice()
+	: UnixDevice(VfsType::charDevice) {
+		assignId({1, 8});
+	}
+	
+	std::string nodePath() override {
+		return "random";
+	}
+	
+	FutureMaybe<SharedFilePtr> open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+			SemanticFlags semantic_flags) override {
+		assert(!(semantic_flags & ~(semanticRead | semanticWrite)));
+		auto file = smarter::make_shared<RandomFile>(std::move(mount), std::move(link));
+		file->setupWeakFile(file);
+		RandomFile::serve(file);
+		co_return File::constructHandle(std::move(file));
+	}
+};
+
+} // anonymous namespace
+
+std::shared_ptr<UnixDevice> createRandomDevice() {
+	return std::make_shared<RandomDevice>();
+}

--- a/posix/subsystem/src/devices/random.hpp
+++ b/posix/subsystem/src/devices/random.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "../device.hpp"
+
+std::shared_ptr<UnixDevice> createRandomDevice();
+

--- a/posix/subsystem/src/devices/urandom.cpp
+++ b/posix/subsystem/src/devices/urandom.cpp
@@ -1,0 +1,77 @@
+#include <string.h>
+#include <sys/random.h>
+
+#include "../common.hpp"
+#include "urandom.hpp"
+
+#include <experimental/coroutine>
+
+namespace {
+
+struct UrandomFile final : File {
+private:
+	async::result<frg::expected<Error, size_t>>
+	readSome(Process *, void *data, size_t length) override {
+		auto p = reinterpret_cast<char *>(data);
+		size_t n = 0;
+		while(n < length) {
+			size_t chunk;
+			HEL_CHECK(helGetRandomBytes(p + n, length - n, &chunk));
+			n+= chunk;
+		}
+
+		co_return n;
+	}
+
+	async::result<frg::expected<Error, size_t>> writeAll(Process *, const void *, size_t length) override {
+		co_return length;
+	}
+
+	async::result<frg::expected<Error, off_t>> seek(off_t, VfsSeek) override {
+		co_return 0;
+	}
+
+	helix::BorrowedDescriptor getPassthroughLane() override {
+		return _passthrough;
+	}
+
+	helix::UniqueLane _passthrough;
+	async::cancellation_event _cancelServe;
+
+public:
+	static void serve(smarter::shared_ptr<UrandomFile> file) {
+		helix::UniqueLane lane;
+		std::tie(lane, file->_passthrough) = helix::createStream();
+		async::detach(protocols::fs::servePassthrough(std::move(lane),
+				file, &fileOperations, file->_cancelServe));
+	}
+
+	UrandomFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	: File{StructName::get("urandom-file"), std::move(mount), std::move(link)} { }
+};
+
+struct UrandomDevice final : UnixDevice {
+	UrandomDevice()
+	: UnixDevice(VfsType::charDevice) {
+		assignId({1, 9});
+	}
+	
+	std::string nodePath() override {
+		return "urandom";
+	}
+	
+	FutureMaybe<SharedFilePtr> open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+			SemanticFlags semantic_flags) override {
+		assert(!(semantic_flags & ~(semanticRead | semanticWrite)));
+		auto file = smarter::make_shared<UrandomFile>(std::move(mount), std::move(link));
+		file->setupWeakFile(file);
+		UrandomFile::serve(file);
+		co_return File::constructHandle(std::move(file));
+	}
+};
+
+} // anonymous namespace
+
+std::shared_ptr<UnixDevice> createUrandomDevice() {
+	return std::make_shared<UrandomDevice>();
+}

--- a/posix/subsystem/src/devices/urandom.hpp
+++ b/posix/subsystem/src/devices/urandom.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "../device.hpp"
+
+std::shared_ptr<UnixDevice> createUrandomDevice();
+

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -34,6 +34,8 @@
 #include "devices/full.hpp"
 #include "devices/helout.hpp"
 #include "devices/null.hpp"
+#include "devices/random.hpp"
+#include "devices/urandom.hpp"
 #include "devices/zero.hpp"
 #include "fifo.hpp"
 #include "gdbserver.hpp"
@@ -3783,6 +3785,8 @@ int main() {
 		charRegistry.install(pts::createMasterDevice());
 		charRegistry.install(createNullDevice());
 		charRegistry.install(createFullDevice());
+		charRegistry.install(createRandomDevice());
+		charRegistry.install(createUrandomDevice());
 		charRegistry.install(createZeroDevice());
 		block_subsystem::run();
 		drm_subsystem::run();


### PR DESCRIPTION
This PR adds the necessary code for `/dev/random` and `/dev/urandom` based devices, and makes the `/dev/random` and `/dev/urandom` device nodes, thus providing userspace with a commonly available source of randomness.

This PR fixes #169 