### PR TITLE
docs: Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Programs supported on managarm include [Weston](https://gitlab.freedesktop.org/w
 
 While this repository contains managarm's kernel, its drivers and other core functionality,
 it is not enough to build a full managarm distribution. Instead, we refer to the
-[bootstrap-managarm](https://github.com/managarm/bootstrap-managarm) repository for build instructions.
+[Managarm Handbook](https://docs.managarm.org/handbook/building.html) for build instructions.

--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -44,10 +44,6 @@ mkdir build
       src_mount: /var/bootstrap-managarm/src
       build_mount: /var/bootstrap-managarm/build
       allow_containerless: true
-
-    general:
-      cargo:
-        config_toml: '../src/extrafiles/config.toml'
     ```
     This `bootstrap-site.yml` will instruct our build system to invoke the build scripts within your container image.
 

--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -144,5 +144,5 @@ xbstrap run make-image qemu
 # Check their help messages for more information.
 ../src/managarm/tools/gen-initrd.py
 ../src/scripts/update-image.py
-../src/scripts/run-qemu
+../src/scripts/vm-util.py qemu
 ```

--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -12,22 +12,21 @@ provided [Dockerfile](https://github.com/managarm/bootstrap-managarm/blob/master
 Make sure that you have atleast 20 - 30 GiB of free disk space.
 
 #### Preperations
-First and foremost we will create a directory (`$MANAGARM_DIR`) which will be
-used for storing the source and build directories.
+First, create a directory which will be used for storing the
+source and build directories. Here we use `~/managarm`, but it can be any directory.
 
 ```sh
-export MANAGARM_DIR="$HOME/managarm" # In this example we are using $HOME/managarm, but it can be any directory
-mkdir -p "$MANAGARM_DIR" && cd "$MANAGARM_DIR"
+mkdir ~/managarm && cd ~/managarm
 ```
 
 The `xbstrap` build system is required on the host (whether you build in a container or not). `xbstrap` can be installed via pip3: `pip3 install xbstrap`.
 You also need `git`, `subversion` and `mercurial` on the host (whether you build in a container or not). Install these via your package manager.
 
 Clone this repository into a `src` directory and create a `build` directory:
-    ```bash
-    git clone https://github.com/managarm/bootstrap-managarm.git src
-    mkdir build
-    ```
+```bash
+git clone https://github.com/managarm/bootstrap-managarm.git src
+mkdir build
+```
 
 #### Creating Docker image and container
 > Note: this step is not needed if you don't want to use a Docker container, if so skip to the next paragraph.
@@ -122,7 +121,8 @@ define_options:
 
 When invoking the script directly, selecting the method can be done with the `--mount-using` argument.
 
-Furthermore, all methods require `rsync` installed on the host as well.
+For all methods, the `image_create.sh` and `make-image` invocations shown below require the following programs to be installed:
+`rsync`, `losetup`, `sfdisk`, `mkfs.ext2`, `mkfs.vfat`. Refer to [image_create](https://github.com/qookei/image_create#requirements) for more details on this.
 
 Hence, running the following commands in the build directory
 should produce a working image and launch it using QEMU:
@@ -134,11 +134,15 @@ should produce a working image and launch it using QEMU:
 # Copy the system onto it.
 xbstrap run make-image
 
+# Launch the image using QEMU.
+xbstrap run qemu
+
+# Or as a one-liner:
+xbstrap run make-image qemu
+
 # Alternatively, you can call the necessary scripts manually:
 # Check their help messages for more information.
 ../src/managarm/tools/gen-initrd.py
 ../src/scripts/update-image.py
-
-# To launch the image using QEMU, you can run:
 ../src/scripts/run-qemu
 ```

--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -11,7 +11,7 @@ provided [Dockerfile](https://github.com/managarm/bootstrap-managarm/blob/master
 
 Make sure that you have atleast 20 - 30 GiB of free disk space.
 
-#### Preperations
+#### Preparations
 First, create a directory which will be used for storing the
 source and build directories. Here we use `~/managarm`, but it can be any directory.
 
@@ -39,11 +39,15 @@ mkdir build
 3.  Create a `bootstrap-site.yml` file inside the `build` directory containing:
     ```yml
     container:
-        runtime: docker
-        image: managarm-buildenv
-        src_mount: /var/bootstrap-managarm/src
-        build_mount: /var/bootstrap-managarm/build
-        allow_containerless: true
+      runtime: docker
+      image: managarm-buildenv
+      src_mount: /var/bootstrap-managarm/src
+      build_mount: /var/bootstrap-managarm/build
+      allow_containerless: true
+
+    general:
+      cargo:
+        config_toml: '../src/extrafiles/config.toml'
     ```
     This `bootstrap-site.yml` will instruct our build system to invoke the build scripts within your container image.
 


### PR DESCRIPTION
Fixes a few issues in the build instructions, and points the `README.md` to the handbook.
