### PR TITLE
Various updates to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ While the managarm user space API supports many Linux APIs (e.g. epoll, timerfd,
 managarm does not share any source code (or binaries) with the Linux kernel.
 
 **Official Discord server:** https://discord.gg/7WB6Ur3. This is our primary real-time communication channel.
-**Official IRC channel:** `#managarm` on `irc.freenode.net`
+
+**Official IRC channel:** `#managarm` on `irc.libera.chat`, our former channel on freenode is no longer in use.
 
 ## Features
 
@@ -51,7 +52,7 @@ Programs supported on managarm include [Weston](https://gitlab.freedesktop.org/w
 **General** USB (UHCI, EHCI)\
 **Graphics** Generic VBE graphics, Intel G45, virtio GPU, Bochs VBE interface, VMWare SVGA\
 **Input** USB human interface devices, PS/2 keyboard and mouse\
-**Storage** USB mass storage devices, AHCI, ATA, virtio block
+**Storage** USB mass storage devices, NVMe, AHCI, ATA, virtio block
 
 ## Building managarm
 

--- a/docs/src/contributing/overview.md
+++ b/docs/src/contributing/overview.md
@@ -11,7 +11,7 @@ Most of our communication happens on our Discord at [https://discord.gg/7WB6Ur3]
 Some of our communication takes place on GitHub at [https://github.com/managarm/managarm](https://github.com/managarm/managarm).
 
 ### IRC
-We also have an IRC channel `#managarm` on `chat.freenode.net`
+We also have an IRC channel `#managarm` on `irc.libera.chat`, please keep in mind that our former channel found on freenode is no longer in use.
 
 
 <!-- omit in toc -->

--- a/docs/src/getting-started/supported/index.md
+++ b/docs/src/getting-started/supported/index.md
@@ -10,7 +10,7 @@ A list of packages is available on our [repo](https://ci.managarm.org/project/ma
 - General: USB (UHCI, EHCI, XHCI)
 - Graphics: Generic VBE graphics, Intel G45
 - Input: USB human interface devices, PS/2 keyboard and mouse
-- Storage: USB mass storage devices, AHCI, ATA
+- Storage: USB mass storage devices, NVMe, AHCI, ATA
 
 ### Virtual Hardware
 Includes all of the hardware listed above


### PR DESCRIPTION
This PR changes our IRC location to libera.chat and adds NVMe to the list of supported hardware in both the handbook and the readme.