### PR TITLE
posix: Neofetch fixes

### DIFF
--- a/posix/subsystem/src/exec.cpp
+++ b/posix/subsystem/src/exec.cpp
@@ -241,9 +241,9 @@ execute(ViewPath root, ViewPath workdir,
 
 		if(!args.empty()) // Handle exec() without arguments.
 			args.erase(args.begin());
+		args.insert(args.begin(), path);
 		if(beginArg != endArg)
 			args.insert(args.begin(), std::string{beginArg, endArg});
-		args.insert(args.begin(), path);
 		args.insert(args.begin(), interpreterPath);
 		path = std::move(interpreterPath);
 		execFile = std::move(interpreterFile);

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -2266,7 +2266,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			if(req->flags() & managarm::posix::OpenFlags::OF_TRUNC) {
 				auto result = co_await file->truncate(0);
-				assert(result);
+				assert(result || result.error() == protocols::fs::Error::illegalOperationTarget);
 			}
 			int fd = self->fileContext()->attachFile(file,
 					req->flags() & managarm::posix::OpenFlags::OF_CLOEXEC);


### PR DESCRIPTION
- posix/exec: Fix order of arguments in shebang
- posix: Ignore illegal truncate targets
