### PR TITLE
build: Enable several warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -67,13 +67,6 @@ if not build_kernel and not build_drivers and not build_tools
 	subdir_done()
 endif
 
-# It would be nice to fix these at some point in the future, but it will be a ton of work.
-add_project_arguments(
-	'-Wno-unused-parameter',
-	'-Wno-missing-field-initializers',
-	'-Wno-non-virtual-dtor',
-	language : 'cpp')
-
 # declare constants that subdirs are going to use
 c = meson.get_compiler('cpp')
 cxx = meson.get_compiler('cpp')


### PR DESCRIPTION
This PR is basically the culmination of work done in PR #287 and #288, and enables the warnings the PRs mentioned fixed. There might be a few more cases that produce warnings now in code introduced after the merging of #287 and #288, or in the aarch64 port, as I did not build that. If that turns out to be the case, a follow-up PR will fix those warnings.