### PR TITLE
posix: Fix unused parameter warning

### DIFF
--- a/posix/subsystem/src/subsystem/block.cpp
+++ b/posix/subsystem/src/subsystem/block.cpp
@@ -59,7 +59,7 @@ async::detached run() {
 	});
 
 	auto handler = mbus::ObserverHandler{}
-	.withAttach([] (mbus::Entity entity, mbus::Properties properties) {
+	.withAttach([] (mbus::Entity entity, mbus::Properties) {
 		constexpr const char *alphabet = "abcdefghijklmnopqrstuvwxyz";
 
 		auto id = entity.getId();


### PR DESCRIPTION
Should be merged before #319 to minimize the amount of warnings given.