### PR TITLE
thor: Fix several non-virtual-dtor warnings

### DIFF
--- a/kernel/thor/generic/thor-internal/irq.hpp
+++ b/kernel/thor/generic/thor-internal/irq.hpp
@@ -307,6 +307,9 @@ private:
 			&AwaitIrqNode::_queueNode
 		>
 	> _waitQueue;
+
+protected:
+	~IrqObject() = default;
 };
 
 struct GenericIrqObject final : IrqObject {

--- a/kernel/thor/system/pci/dmalog.cpp
+++ b/kernel/thor/system/pci/dmalog.cpp
@@ -27,7 +27,7 @@ constexpr arch::bit_register<uint32_t> isrRegister{0x10};
 constexpr arch::field<uint32_t, bool> isrOutStatus{0, 1};
 constexpr arch::field<uint32_t, bool> isrInStatus{1, 1};
 
-struct DmalogDevice : KernelIoChannel {
+struct DmalogDevice final : KernelIoChannel {
 	static constexpr size_t ringSize = kPageSize;
 
 	DmalogDevice(frg::string<KernelAlloc> tag, frg::string<KernelAlloc> descriptiveTag,


### PR DESCRIPTION
Should be merged before #319 to minimize the amount of warnings given.