### PR TITLE
Various fixes for gdbserver

### DIFF
--- a/drivers/uart/src/main.cpp
+++ b/drivers/uart/src/main.cpp
@@ -61,7 +61,7 @@ void completeRecvs() {
 
 	while(!recvRequests.empty() && !recvBuffer.empty()) {
 		auto req = &recvRequests.front();
-	
+
 		size_t chunk = std::min(req->maxLength, recvBuffer.size());
 		assert(chunk);
 		for(size_t i = 0; i < chunk; i++) {
@@ -170,7 +170,7 @@ async::detached handleIrqs() {
 		sequence = await.sequence();
 		if(logIrqs)
 			std::cout << "uart: IRQ fired." << std::endl;
-		
+
 		// The 8250's status register always reports the reason for one IRQ at a time.
 		// Drain IRQs until the IRQ status register does not report any IRQs anymore.
 		while(true) {
@@ -219,7 +219,7 @@ async::detached handleIrqs() {
 		HEL_CHECK(helAcknowledgeIrq(irq.getHandle(), kHelAckAcknowledge, sequence));
 	}
 }
-	
+
 async::result<protocols::fs::ReadResult>
 read(void *, const char *, void *buffer, size_t length) {
 	if(!length)
@@ -270,7 +270,7 @@ async::detached serveTerminal(helix::UniqueLane lane) {
 		);
 		HEL_CHECK(accept.error());
 		HEL_CHECK(recv_req.error());
-		
+
 		auto conversation = accept.descriptor();
 
 		managarm::fs::CntRequest req;
@@ -296,14 +296,14 @@ async::detached serveTerminal(helix::UniqueLane lane) {
 		}
 	}
 }
-	
+
 async::detached runTerminal() {
 	// Create an mbus object for the partition.
 	auto root = co_await mbus::Instance::global().getRoot();
-	
+
 	mbus::Properties descriptor{
-		{"unix.devtype", mbus::StringItem{"block"}},
-		{"unix.devname", mbus::StringItem{"ttyS0"}}
+		{"generic.devtype", mbus::StringItem{"block"}},
+		{"generic.devname", mbus::StringItem{"ttyS0"}}
 	};
 
 	auto handler = mbus::ObjectHandler{}
@@ -332,14 +332,14 @@ int main() {
 	HelHandle handle;
 	HEL_CHECK(helAccessIo(ports, 8, &handle));
 	HEL_CHECK(helEnableIo(handle));
-	
+
 	base = arch::global_io.subspace(COM1);
 
 	// Perform general initialization.
 	base.store(uart_register::fifoControl,
 			fifo_control::fifoEnable(FifoCtrl::enable)
 			| fifo_control::fifoIrqLvl(FifoCtrl::triggerLvl14));
-	
+
 	// Wait for the FIFO to become empty.
 	while(!(base.load(uart_register::lineStatus) & line_status::txReady))
 		; // Busy spin for now.
@@ -368,7 +368,6 @@ int main() {
 	}
 
 	async::run_forever(helix::globalQueue()->run_token(), helix::currentDispatcher);
-	
+
 	return 0;
 }
-

--- a/posix/subsystem/meson.build
+++ b/posix/subsystem/meson.build
@@ -29,6 +29,7 @@ src = [
 	'src/signalfd.cpp',
 	'src/subsystem/block.cpp',
 	'src/subsystem/drm.cpp',
+	'src/subsystem/generic.cpp',
 	'src/subsystem/input.cpp',
 	'src/subsystem/pci.cpp',
 	'src/sysfs.cpp',

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -45,6 +45,7 @@
 #include "signalfd.hpp"
 #include "subsystem/block.hpp"
 #include "subsystem/drm.hpp"
+#include "subsystem/generic.hpp"
 #include "subsystem/input.hpp"
 #include "subsystem/pci.hpp"
 #include "sysfs.hpp"
@@ -3790,6 +3791,7 @@ int main() {
 		charRegistry.install(createZeroDevice());
 		block_subsystem::run();
 		drm_subsystem::run();
+		generic_subsystem::run();
 		input_subsystem::run();
 		pci_subsystem::run();
 

--- a/posix/subsystem/src/subsystem/generic.cpp
+++ b/posix/subsystem/src/subsystem/generic.cpp
@@ -1,0 +1,92 @@
+#include <string.h>
+#include <iostream>
+
+#include <protocols/mbus/client.hpp>
+
+#include "../common.hpp"
+#include "../device.hpp"
+#include "../util.hpp"
+#include "../vfs.hpp"
+
+namespace generic_subsystem {
+
+namespace {
+
+id_allocator<uint32_t> minorAllocator;
+
+struct Subsystem {
+	Subsystem() {
+		minorAllocator.use_range(0);
+	}
+} subsystem;
+
+struct Device final : UnixDevice {
+	Device(VfsType type, std::string name, helix::UniqueLane lane)
+	: UnixDevice{type},
+			_name{std::move(name)}, _lane{std::move(lane)} { }
+
+	std::string nodePath() override {
+		return _name;
+	}
+	
+	FutureMaybe<smarter::shared_ptr<File, FileHandle>>
+	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+			SemanticFlags semantic_flags) override {
+		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
+	}
+
+	FutureMaybe<std::shared_ptr<FsLink>> mount() override {
+		return mountExternalDevice(_lane);
+	}
+
+private:
+	std::string _name;
+	helix::UniqueLane _lane;
+};
+
+} // anonymous namepsace
+
+async::detached run() {
+	auto root = co_await mbus::Instance::global().getRoot();
+
+	auto blockFilter = mbus::Conjunction({
+		mbus::EqualsFilter("generic.devtype", "block")
+	});
+
+	auto charFilter = mbus::Conjunction({
+		mbus::EqualsFilter("generic.devtype", "char")
+	});
+	
+	auto blockHandler = mbus::ObserverHandler{}
+	.withAttach([] (mbus::Entity entity, mbus::Properties properties) -> async::detached {
+		std::cout << "POSIX: Installing block device "
+				<< std::get<mbus::StringItem>(properties.at("generic.devname")).value << std::endl;
+
+		auto lane = helix::UniqueLane(co_await entity.bind());
+		auto device = std::make_shared<Device>(VfsType::blockDevice,
+				std::get<mbus::StringItem>(properties.at("generic.devname")).value,
+				std::move(lane));
+		// We use 240 here, the major for block devices local and experimental use and allocate minors sequentially.
+		device->assignId({240, minorAllocator.allocate()});
+		blockRegistry.install(device);
+	});
+
+	auto charHandler = mbus::ObserverHandler{}
+	.withAttach([] (mbus::Entity entity, mbus::Properties properties) -> async::detached {
+		std::cout << "POSIX: Installing char device "
+				<< std::get<mbus::StringItem>(properties.at("generic.devname")).value << std::endl;
+
+		auto lane = helix::UniqueLane(co_await entity.bind());
+		auto device = std::make_shared<Device>(VfsType::charDevice,
+				std::get<mbus::StringItem>(properties.at("generic.devname")).value,
+				std::move(lane));
+		// We use 234 here, the major for char devices dynamic allocation and allocate minors sequentially.
+		device->assignId({234, minorAllocator.allocate()});
+		charRegistry.install(device);
+	});
+
+	co_await root.linkObserver(std::move(blockFilter), std::move(blockHandler));
+	co_await root.linkObserver(std::move(charFilter), std::move(charHandler));
+}
+
+} // namespace generic_subsystem

--- a/posix/subsystem/src/subsystem/generic.hpp
+++ b/posix/subsystem/src/subsystem/generic.hpp
@@ -1,0 +1,12 @@
+#ifndef POSIX_SUBSYSTEM_GENERIC_SYSTEM_HPP
+#define POSIX_SUBSYSTEM_GENERIC_SYSTEM_HPP
+
+#include <async/result.hpp>
+
+namespace generic_subsystem {
+
+async::detached run();
+
+} // namespace generic_subsystem
+
+#endif // POSIX_SUBSYSTEM_GENERIC_SYSTEM_HPP


### PR DESCRIPTION
This PR fixes various issues with gdbserver, including not being able to use `/dev/ttyS0`. A new subsystem was added that will register `/dev/ttyS0`, I am however unsure about the major numbers used. While the numbers I've chosen now seem to be used by Linux for dynamic allocation, I did see a different number for `/dev/ttyS0`, this might need to be checked.