### PR TITLE
Various fixes for hexchat

### DIFF
--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -2880,7 +2880,9 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					req->socktype(), req->protocol(),
 					req->flags() & SOCK_NONBLOCK);
 			}else{
-				throw std::runtime_error("posix: Handle unknown protocol families");
+				std::cout << "posix: SOCKET: Handle unknown protocols families, this is: " << req->domain() << std::endl;
+				co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+				continue;
 			}
 
 			auto fd = self->fileContext()->attachFile(file,

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -886,6 +886,51 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 					helix_ng::sendBuffer(ser.data(), ser.size())
 				);
 				HEL_CHECK(send_resp.error());
+			} else if(res.error() == Error::hostUnreachable) {
+				resp.set_error(managarm::fs::Errors::HOST_UNREACHABLE);
+
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size())
+				);
+				HEL_CHECK(send_resp.error());
+			} else if(res.error() == Error::accessDenied) {
+				resp.set_error(managarm::fs::Errors::ACCESS_DENIED);
+
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size())
+				);
+				HEL_CHECK(send_resp.error());
+			} else if(res.error() == Error::netUnreachable) {
+				resp.set_error(managarm::fs::Errors::NETWORK_UNREACHABLE);
+
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size())
+				);
+				HEL_CHECK(send_resp.error());
+			} else if(res.error() == Error::destAddrRequired) {
+				resp.set_error(managarm::fs::Errors::DESTINATION_ADDRESS_REQUIRED);
+
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size())
+				);
+				HEL_CHECK(send_resp.error());
+			} else if(res.error() == Error::addressNotAvailable) {
+				resp.set_error(managarm::fs::Errors::ADDRESS_NOT_AVAILABLE);
+
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size())
+				);
+				HEL_CHECK(send_resp.error());
 			} else {
 				std::cout << "Unknown error from sendMsg()" << std::endl;
 				co_return;


### PR DESCRIPTION
This PR adds various fixes in order to run `hexchat` on Managarm. For now, this consist of better error handling in `sendMsg` and handling unknown address families gracefully in the socket request. I fully expect more to come and as such, this PR is a draft.

The mlibc counterpart to this PR is managarm/mlibc#273