### PR TITLE
docs: Rework building and image creation instructions

### DIFF
--- a/docs/src/building/index.md
+++ b/docs/src/building/index.md
@@ -79,7 +79,7 @@ source and build directories. Here we use `~/managarm`, but it can be any direct
 	> Note: **this only works if you build in a container** (though this is untested with Docker). Containerless builds must do a full build from source (see below).
 
 	```bash
-	xbstrap pull-pack --deps-of <meta-package> # e.g xbstrap pull-pack --deps-of base
+	xbstrap pull-pack --deps-of <meta-package> mlibc mlibc-headers # e.g xbstrap pull-pack --deps-of base mlibc mlibc-headers
 	xbstrap install --deps-of <meta-package>
 
 	# The following two commands fetch managarm and mlibc (plus their required tools) to enable local development:

--- a/docs/src/building/index.md
+++ b/docs/src/building/index.md
@@ -91,62 +91,40 @@ source and build directories. Here we use `~/managarm`, but it can be any direct
 	Note that this can take multiple hours, depending on your machine.
 
 ### Creating Images
-> Note: if using a Docker container the following command are meant to be ran **outside** the Docker container, in the `build` directory on the host. Adding to the aforementioned commands, one would `exit` from the container once the build finishes, enter the `build` directory, and proceed as follows.
+After managarm's packages have been built, building a HDD image of the system is straightforward. 
 
-After managarm's packages have been built, building a HDD image of the system
-is straightforward. The [image_create.sh](https://github.com/qookei/image_create) script
-can be used to create an empty HDD image.
-
-Download the `image_create.sh` script and mark it executable:
-```bash
-wget 'https://raw.githubusercontent.com/qookei/image_create/master/image_create.sh'
-chmod +x image_create.sh
-```
-
-This repository contains an `update-image.py` script to mount the image and copy the system onto it.
-
-This script can use 3 different methods to copy files onto the image:
-1. **Using libguestfs** (the default method). We recommend this when root access is not possible or desirable. However, it is much slower than method 2 and requires some setup on the host (see below).
-1. **Using a classic loopback and mount** (requires root privileges). We recommend this when root access is acceptable because it is the fastest method and most guaranteed to work.
-1. **Via Docker container** (only works with the Docker build method). This is handy in case the user is in the `docker` group since it does not require additional root authentication. We discourage this because it uses `docker run --privileged` (which is not safer than giving root access) and [currently has some bugs](https://github.com/managarm/bootstrap-managarm/issues/103).
-
-Going with method 1 will require `libguestfs` to be installed on the host.
-After installing `libguestfs` it might be necessary to run the following:
-```bash
-sudo install -d /usr/lib/guestfs
-sudo update-libguestfs-appliance
-```
-
-If you're using xbstrap to invoke the script, selecting the desired method can be done by adding the following to the `bootstrap-site.yml` file:
-```
-define_options:
-    mount-using: 'loopback' # or guestfs/docker
-```
-
-When invoking the script directly, selecting the method can be done with the `--mount-using` argument.
-
-For all methods, the `image_create.sh` and `make-image` invocations shown below require the following programs to be installed:
+For all methods, the image creation and updation commands shown below require the following programs to be installed on the host:
 `rsync`, `losetup`, `sfdisk`, `mkfs.ext2`, `mkfs.vfat`. Refer to [image_create](https://github.com/qookei/image_create#requirements) for more details on this.
 
-Hence, running the following commands in the build directory
-should produce a working image and launch it using QEMU:
-```bash
-# Create a HDD image file called 'image'.
-# Check "./image_create.sh -h" for more options.
-./image_create.sh -o image -s 4GiB -t ext2 -p gpt -l limine -be
+1.  Decide what method you want to use to copy files to the image:
+	1. **Using libguestfs** (the default method). We recommend this when root access is not possible or desirable. However, it is much slower than method 2 and requires some setup on the host (see below).
+	1. **Using a classic loopback and mount** (requires root privileges). We recommend this when root access is acceptable because it is the fastest method and most guaranteed to work.
+	1. **Via Docker container** (only works with the Docker build method). This is handy in case the user is in the `docker` group since it does not require additional root authentication. We discourage this because it uses `docker run --privileged` (which is not safer than giving root access) and [currently has some bugs](https://github.com/managarm/bootstrap-managarm/issues/103).
 
-# Copy the system onto it.
-xbstrap run make-image
+	Going with method 1 will require `libguestfs` to be installed on the host.
+	After installing `libguestfs` it might be necessary to run the following:
+	```bash
+	sudo install -d /usr/lib/guestfs
+	sudo update-libguestfs-appliance
+	```
+1.  Add the following to `build/bootstrap-site.yml`, depending on what mount method you have chosen:
+	```yaml
+	define_options:
+	  mount-using: 'loopback' # or guestfs/docker
+	```
+1.  Create the image:
+	```bash
+	xbstrap run initialize-empty-image
+	```
+1.  Copy the system onto it:
+	```bash
+	xbstrap run make-image
+	```
+1.  Launch the image using QEMU:
+	```bash
+	xbstrap run qemu # Note that you can combine the last two operations: xbstrap run make-image qemu
+	```
 
-# Launch the image using QEMU.
-xbstrap run qemu
-
-# Or as a one-liner:
-xbstrap run make-image qemu
-
-# Alternatively, you can call the necessary scripts manually:
-# Check their help messages for more information.
-../src/managarm/tools/gen-initrd.py
-../src/scripts/update-image.py
-../src/scripts/vm-util.py qemu
-```
+Alternatively, you can call the necessary scripts manually (check their help messages for more information):
+* `../src/managarm/tools/gen-initrd.py` and `../src/scripts/update-image.py` for copying the files onto the image (the mount method can be selected with the `--mount-using` argument)
+* `../src/scripts/vm-util.py qemu` for launching QEMU

--- a/docs/src/building/index.md
+++ b/docs/src/building/index.md
@@ -102,7 +102,7 @@ For all methods, the image creation and updation commands shown below require th
 	1. **Via Docker container** (only works with the Docker build method). This is handy in case the user is in the `docker` group since it does not require additional root authentication. We discourage this because it uses `docker run --privileged` (which is not safer than giving root access) and [currently has some bugs](https://github.com/managarm/bootstrap-managarm/issues/103).
 
 	Going with method 1 will require `libguestfs` to be installed on the host.
-	After installing `libguestfs` it might be necessary to run the following:
+	After installing `libguestfs`, if you encounter errors while making the image it might be necessary to run the following:
 	```bash
 	sudo install -d /usr/lib/guestfs
 	sudo update-libguestfs-appliance

--- a/docs/src/building/with-docker.md
+++ b/docs/src/building/with-docker.md
@@ -5,6 +5,7 @@ This section explains how to build Managarm in a Docker environment.
 > Note: we recommend using `cbuildrt` instead of Docker as it is faster, requires less privileges and is better tested
 (we use `cbuildrt` on our continuous integration build server, so breakages are more noticeable).
 
+1.  Complete the [Preparations](index.md#preparations) section.
 1.  Install [Docker](https://docs.docker.com/get-docker/).
 1.  Build a Docker image from the provided Dockerfile:
     ```bash

--- a/docs/src/building/without-containers.md
+++ b/docs/src/building/without-containers.md
@@ -8,7 +8,8 @@ to use pre-built tools from our build server rather than compiling everything fr
 > 
 > Be aware that not only missing dependencies can impact the build process: some ports might incorrectly detect optional dependencies from the host operating system. Since it is infeasible to test all possible combinations of host packages, support for building outside of containers is not a priority of the project.
 
-1.  Certain programs are required to build managarm; To get a list of the corresponding Debian packages we refer you to the [Dockerfile](https://github.com/managarm/bootstrap-managarm/blob/master/docker/Dockerfile).
+1.  Complete the [Preparations](index.md#preparations) section.
+1.  Certain programs are required to build managarm; to get a list of the corresponding Debian packages we refer you to the [Dockerfile](https://github.com/managarm/bootstrap-managarm/blob/master/docker/Dockerfile).
 1.  `meson` is required. There is a Debian package, but as of Debian Stretch, a newer version is required.
     Install it from pip:
 	```bash


### PR DESCRIPTION
This PR changes the following:
- add instructions for installing pre-built packages
- rework image creation section

[Rendered](https://github.com/managarm/managarm/blob/e2b3bb538e846a727b349a3a1ba6f71bc90bae1c/docs/src/building/index.md)