### PR TITLE
Fixes for gcc 11

### DIFF
--- a/drivers/block/ahci/src/controller.cpp
+++ b/drivers/block/ahci/src/controller.cpp
@@ -1,3 +1,5 @@
+#include <bit> // For std::popcount
+
 #include <inttypes.h>
 
 #include <helix/timer.hpp>

--- a/kernel/thor/generic/fiber.cpp
+++ b/kernel/thor/generic/fiber.cpp
@@ -101,7 +101,7 @@ void KernelFiber::invoke() {
 	restoreExecutor(&_executor);
 }
 
-void KernelFiber::handlePreemption(IrqImageAccessor image) {
+void KernelFiber::handlePreemption(IrqImageAccessor) {
 	// Do nothing (do not preempt fibers for now).
 }
 

--- a/kernel/thor/generic/schedule.cpp
+++ b/kernel/thor/generic/schedule.cpp
@@ -19,7 +19,7 @@ namespace {
 	// Minimum length of a preemption time slice in ns.
 	constexpr int64_t sliceGranularity = 10'000'000;
 
-	struct IdleTask : ScheduleEntity {
+	struct IdleTask final : ScheduleEntity {
 		IdleTask()
 		: ScheduleEntity{ScheduleType::idle} { }
 

--- a/servers/netserver/src/ip/arp.hpp
+++ b/servers/netserver/src/ip/arp.hpp
@@ -3,6 +3,7 @@
 #include <async/recurring-event.hpp>
 #include <netserver/nic.hpp>
 #include <map>
+#include <optional>
 
 struct Neighbours {
 	static constexpr uint64_t staleTimeMs = 30'000;


### PR DESCRIPTION
This PR fixes 2 warnings and addresses 2 build failures when building with gcc 11. This will be followed up with a PR in bootstrap actually merging gcc 11 into master.

This PR complements managarm/frigg#10