### PR TITLE
thor: Use cursors to implement VirtualOperations on x86

### DIFF
--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -82,8 +82,8 @@ frg::expected<Error> VirtualOperations::remapPresentPages(VirtualAddr va, Memory
 	return {};
 }
 
-frg::expected<Error> VirtualOperations::faultPage(VirtualAddr va,
-		MemoryView *view, uintptr_t offset, PageFlags flags) {
+frg::expected<Error> VirtualOperations::faultPage(VirtualAddr va, MemoryView *view,
+		uintptr_t offset, PageFlags flags) {
 	auto physicalRange = view->peekRange(offset & ~(kPageSize - 1));
 	if(physicalRange.get<0>() == PhysicalAddr(-1))
 		return Error::fault;


### PR DESCRIPTION
This PR improves performance of common paging operations, see the commit message of the second commit.

The first commit optimizes large shootdowns by reloading CR3 instead of calling `invlpg` hundreds of times. This also gives a considerable speedup when unmapping pages.