### PR TITLE
posix: Create /dev/shm and mount a tmpfs to it

### DIFF
--- a/posix/init/src/stage1.cpp
+++ b/posix/init/src/stage1.cpp
@@ -96,6 +96,10 @@ int main() {
 		throw std::runtime_error("mkdir() failed");
 	if(mount("", "/realfs/dev/pts", "devpts", 0, ""))
 		throw std::runtime_error("mount() failed");
+	if(mkdir("/dev/shm", 1777)) // Seems to be the same as linux
+		throw std::runtime_error("mkdir() failed");
+	if(mount("", "/realfs/dev/shm", "tmpfs", 0, ""))
+		throw std::runtime_error("mount() failed");
 
 	if(chroot("/realfs"))
 		throw std::runtime_error("chroot() failed");


### PR DESCRIPTION
This allows functions like `shm_open()` to work, a requirement for `gtk+-3`.