### PR TITLE
Ensure allocator globals are always placed in .bss

### DIFF
--- a/kernel/thor/generic/core.cpp
+++ b/kernel/thor/generic/core.cpp
@@ -222,18 +222,18 @@ void KernelVirtualAlloc::output_trace(void *buffer, size_t size) {
 	allocLog->enqueue(buffer, size);
 }
 
-frg::manual_box<PhysicalChunkAllocator> physicalAllocator;
+constinit frg::manual_box<PhysicalChunkAllocator> physicalAllocator = {};
 
-frg::manual_box<KernelVirtualAlloc> kernelVirtualAlloc;
+constinit frg::manual_box<KernelVirtualAlloc> kernelVirtualAlloc = {};
 
-frg::manual_box<
+constinit frg::manual_box<
 	frg::slab_pool<
 		KernelVirtualAlloc,
 		IrqSpinlock
 	>
-> kernelHeap;
+> kernelHeap = {};
 
-frg::manual_box<KernelAlloc> kernelAlloc;
+constinit frg::manual_box<KernelAlloc> kernelAlloc = {};
 
 // --------------------------------------------------------
 // CpuData

--- a/kernel/thor/generic/thor-internal/kernel_heap.hpp
+++ b/kernel/thor/generic/thor-internal/kernel_heap.hpp
@@ -68,16 +68,16 @@ public:
 
 using KernelAlloc = frg::slab_allocator<KernelVirtualAlloc, IrqSpinlock>;
 
-extern frg::manual_box<KernelVirtualAlloc> kernelVirtualAlloc;
+extern constinit frg::manual_box<KernelVirtualAlloc> kernelVirtualAlloc;
 
-extern frg::manual_box<
+extern constinit frg::manual_box<
 	frg::slab_pool<
 		KernelVirtualAlloc,
 		IrqSpinlock
 	>
 > kernelHeap;
 
-extern frg::manual_box<KernelAlloc> kernelAlloc;
+extern constinit frg::manual_box<KernelAlloc> kernelAlloc;
 
 struct Allocator {
 	void *allocate(size_t size) {

--- a/kernel/thor/generic/thor-internal/physical.hpp
+++ b/kernel/thor/generic/thor-internal/physical.hpp
@@ -63,6 +63,6 @@ private:
 	std::atomic<size_t> _freePages{0};
 };
 
-extern frg::manual_box<PhysicalChunkAllocator> physicalAllocator;
+extern constinit frg::manual_box<PhysicalChunkAllocator> physicalAllocator;
 
 } // namespace thor


### PR DESCRIPTION
Those globals are used during early initialization *before* global constructors are called.