### PR TITLE
Implement atomic modesetting in DRM

### DIFF
--- a/core/drm/include/core/drm/core.hpp
+++ b/core/drm/include/core/drm/core.hpp
@@ -380,27 +380,18 @@ struct CrtcState {
 
 	std::weak_ptr<Crtc> crtc(void);
 
-	std::shared_ptr<Blob> mode();
-	void mode(std::shared_ptr<Blob> mode);
-
-	bool active();
-	void active(bool active);
-
-	bool mode_changed();
-
-private:
 	std::weak_ptr<Crtc> _crtc;
-	bool _active;
+	bool active;
 
-	bool _planesChanged;
-	bool _modeChanged;
-	bool _activeChanged;
-	bool _connectorsChanged;
-	uint32_t _planeMask;
-	uint32_t _connectorMask;
-	uint32_t _encoderMask;
+	bool planesChanged;
+	bool modeChanged;
+	bool activeChanged;
+	bool connectorsChanged;
+	uint32_t planeMask;
+	uint32_t connectorMask;
+	uint32_t encoderMask;
 
-	std::shared_ptr<Blob> _mode;
+	std::shared_ptr<Blob> mode;
 };
 
 struct Crtc : ModeObject {
@@ -452,20 +443,12 @@ private:
 };
 
 struct ConnectorState {
-	ConnectorState(std::weak_ptr<Connector> connector) : _connector(connector) {};
+	ConnectorState(std::weak_ptr<Connector> connector) : connector(connector) {};
 
-	std::shared_ptr<Connector> connector();
-	std::shared_ptr<Crtc> crtc();
-	void crtc(std::shared_ptr<Crtc> crtc);
-	std::shared_ptr<Encoder> encoder();
-	uint32_t dpms();
-	void dpms(uint32_t val);
-
-private:
-	std::shared_ptr<Connector> _connector;
-	std::shared_ptr<Crtc> _crtc;
-	std::shared_ptr<Encoder> _encoder;
-	uint32_t _dpms;
+	std::shared_ptr<Connector> connector;
+	std::shared_ptr<Crtc> crtc;
+	std::shared_ptr<Encoder> encoder;
+	uint32_t dpms;
 };
 
 /**
@@ -560,45 +543,21 @@ private:
 };
 
 struct PlaneState {
-	PlaneState(std::weak_ptr<Plane> plane) : _plane(plane) {};
-
-	std::shared_ptr<Plane> plane(void);
+	PlaneState(std::weak_ptr<Plane> plane) : plane(plane) {};
 
 	Plane::PlaneType type(void);
 
-	void crtc_w(uint32_t value);
-	uint32_t crtc_w();
-	void crtc_h(uint32_t value);
-	uint32_t crtc_h();
-	void crtc_x(uint32_t value);
-	uint32_t crtc_x();
-	void crtc_y(uint32_t value);
-	uint32_t crtc_y();
-	void src_w(uint32_t value);
-	uint32_t src_w();
-	void src_h(uint32_t value);
-	uint32_t src_h();
-	void src_x(uint32_t value);
-	uint32_t src_x();
-	void src_y(uint32_t value);
-	uint32_t src_y();
-	void crtc(std::shared_ptr<Crtc> value);
-	std::shared_ptr<Crtc> crtc();
-	void fb_id(std::shared_ptr<FrameBuffer>);
-	std::shared_ptr<FrameBuffer> fb_id();
-
-private:
-	std::shared_ptr<Plane> _plane;
-	std::shared_ptr<Crtc> _crtc;
-	std::shared_ptr<FrameBuffer> _fb;
-	int32_t _crtcX;
-	int32_t _crtcY;
-	uint32_t _crtcW;
-	uint32_t _crtcH;
-	uint32_t _srcX;
-	uint32_t _srcY;
-	uint32_t _srcW;
-	uint32_t _srcH;
+	std::shared_ptr<Plane> plane;
+	std::shared_ptr<Crtc> crtc;
+	std::shared_ptr<FrameBuffer> fb;
+	int32_t crtc_x;
+	int32_t crtc_y;
+	uint32_t crtc_w;
+	uint32_t crtc_h;
+	uint32_t src_x;
+	uint32_t src_y;
+	uint32_t src_w;
+	uint32_t src_h;
 };
 
 /**

--- a/core/drm/include/core/drm/core.hpp
+++ b/core/drm/include/core/drm/core.hpp
@@ -418,10 +418,6 @@ public:
 	std::shared_ptr<drm_core::CrtcState> drm_state();
 	void set_drm_state(std::shared_ptr<drm_core::CrtcState> new_state);
 
-	std::shared_ptr<Blob> currentMode();
-	[[deprecated("This is ignored on updated drivers, use atomic state instead.")]]
-	void setCurrentMode(std::shared_ptr<Blob> mode);
-
 	std::vector<drm_core::Assignment> getAssignments(std::shared_ptr<Device> dev);
 
 	int index;

--- a/core/drm/include/core/drm/core.hpp
+++ b/core/drm/include/core/drm/core.hpp
@@ -109,12 +109,12 @@ struct Property {
 	uint32_t flags();
 	PropertyType propertyType();
 	std::string name();
-	void add_enum_info(uint64_t value, std::string name);
-	const std::unordered_map<uint64_t, std::string>& enum_info();
+	void addEnumInfo(uint64_t value, std::string name);
+	const std::unordered_map<uint64_t, std::string>& enumInfo();
 
 	virtual void writeToState(const Assignment assignment, std::unique_ptr<drm_core::AtomicState> &state);
 	virtual uint32_t intFromState(std::shared_ptr<ModeObject> obj);
-	virtual std::shared_ptr<ModeObject> modeobjFromState(std::shared_ptr<ModeObject> obj);
+	virtual std::shared_ptr<ModeObject> modeObjFromState(std::shared_ptr<ModeObject> obj);
 
 private:
 	PropertyId _id;
@@ -208,7 +208,7 @@ private:
 	std::unordered_map<uint32_t, ModeObject *> _objects;
 	std::unordered_map<uint32_t, std::shared_ptr<Blob>> _blobs;
 
-	id_allocator<uint32_t> _blob_id_allocator;
+	id_allocator<uint32_t> _blobIdAllocator;
 
 	/**
 	 * Holds (property_id, property) pairs for this device.
@@ -244,7 +244,6 @@ public:
 
 	void registerProperty(std::shared_ptr<drm_core::Property> p);
 	std::shared_ptr<drm_core::Property> getProperty(uint32_t id);
-	const std::unordered_map<uint32_t, std::shared_ptr<drm_core::Property>>& getProperties();
 
 	Property *srcWProperty();
 	Property *srcHProperty();
@@ -311,6 +310,7 @@ private:
 
 	// BufferObjects associated with this file.
 	std::unordered_map<uint32_t, std::shared_ptr<BufferObject>> _buffers;
+	// id allocator for mapping BufferObjects
 	id_allocator<uint32_t> _allocator;
 
 	// Event queuing structures.
@@ -415,8 +415,8 @@ public:
 	virtual Plane *primaryPlane() = 0;
 	virtual Plane *cursorPlane();
 
-	std::shared_ptr<drm_core::CrtcState> drm_state();
-	void set_drm_state(std::shared_ptr<drm_core::CrtcState> new_state);
+	std::shared_ptr<drm_core::CrtcState> drmState();
+	void setDrmState(std::shared_ptr<drm_core::CrtcState> new_state);
 
 	std::vector<drm_core::Assignment> getAssignments(std::shared_ptr<Device> dev);
 
@@ -497,8 +497,8 @@ struct Connector : ModeObject {
 	void setConnectorType(uint32_t type);
 	uint32_t connectorType();
 
-	std::shared_ptr<drm_core::ConnectorState> drm_state();
-	void set_drm_state(std::shared_ptr<drm_core::ConnectorState> new_state);
+	std::shared_ptr<drm_core::ConnectorState> drmState();
+	void setDrmState(std::shared_ptr<drm_core::ConnectorState> new_state);
 
 	std::vector<drm_core::Assignment> getAssignments(std::shared_ptr<Device> dev);
 
@@ -549,8 +549,8 @@ struct Plane : ModeObject {
 	void setupPossibleCrtcs(std::vector<Crtc *> crtcs);
 	const std::vector<Crtc *> &getPossibleCrtcs();
 
-	std::shared_ptr<drm_core::PlaneState> drm_state();
-	void set_drm_state(std::shared_ptr<drm_core::PlaneState> new_state);
+	std::shared_ptr<drm_core::PlaneState> drmState();
+	void setDrmState(std::shared_ptr<drm_core::PlaneState> new_state);
 
 private:
 	PlaneType _type;
@@ -617,15 +617,15 @@ struct AtomicState {
 private:
 	Device *_device;
 
-	std::unordered_map<uint32_t, std::shared_ptr<CrtcState>> _crtc_states;
-	std::unordered_map<uint32_t, std::shared_ptr<PlaneState>> _plane_states;
-	std::unordered_map<uint32_t, std::shared_ptr<ConnectorState>> _connector_states;
+	std::unordered_map<uint32_t, std::shared_ptr<CrtcState>> _crtcStates;
+	std::unordered_map<uint32_t, std::shared_ptr<PlaneState>> _planeStates;
+	std::unordered_map<uint32_t, std::shared_ptr<ConnectorState>> _connectorStates;
 };
 
 struct Assignment {
-	static Assignment with_int(std::shared_ptr<ModeObject>, Property *property, uint64_t val);
-	static Assignment with_modeobj(std::shared_ptr<ModeObject>, Property *property, std::shared_ptr<ModeObject>);
-	static Assignment with_blob(std::shared_ptr<ModeObject>, Property *property, std::shared_ptr<Blob>);
+	static Assignment withInt(std::shared_ptr<ModeObject>, Property *property, uint64_t val);
+	static Assignment withModeObj(std::shared_ptr<ModeObject>, Property *property, std::shared_ptr<ModeObject>);
+	static Assignment withBlob(std::shared_ptr<ModeObject>, Property *property, std::shared_ptr<Blob>);
 
 	std::shared_ptr<ModeObject> object;
 	Property *property;

--- a/core/drm/src/core.cpp
+++ b/core/drm/src/core.cpp
@@ -28,28 +28,28 @@
 drm_core::Device::Device() {
 	struct SrcWProperty : drm_core::Property {
 		SrcWProperty()
-		: drm_core::Property{drm_core::IntPropertyType{}} { }
+		: drm_core::Property{srcW, drm_core::IntPropertyType{}, "SRC_W"} { }
 
 		bool validate(const Assignment&) override {
 			return true;
 		};
 	};
-	_srcWProperty = std::make_shared<SrcWProperty>();
-	
+	registerProperty(_srcWProperty = std::make_shared<SrcWProperty>());
+
 	struct SrcHProperty : drm_core::Property {
 		SrcHProperty()
-		: drm_core::Property{drm_core::IntPropertyType{}} { }
+		: drm_core::Property{srcH, drm_core::IntPropertyType{}, "SRC_H"} { }
 
 		bool validate(const Assignment&) override {
 			return true;
 		};
 	};
-	_srcHProperty = std::make_shared<SrcHProperty>();
+	registerProperty(_srcHProperty = std::make_shared<SrcHProperty>());
 
 	struct FbIdProperty : drm_core::Property {
 		FbIdProperty()
-		: drm_core::Property{drm_core::ObjectPropertyType{}} { }
-		
+		: drm_core::Property{fbId, drm_core::ObjectPropertyType{}, "FB_ID"} { }
+
 		bool validate(const Assignment& assignment) override {
 			if(!assignment.objectValue)
 				return true;
@@ -60,19 +60,20 @@ drm_core::Device::Device() {
 			return false;
 		};
 	};
-	_fbIdProperty = std::make_shared<FbIdProperty>();
+	registerProperty(_fbIdProperty = std::make_shared<FbIdProperty>());
 
 	struct ModeIdProperty : drm_core::Property {
 		ModeIdProperty()
-		: drm_core::Property{drm_core::BlobPropertyType{}} { }
+		: drm_core::Property{modeId, drm_core::BlobPropertyType{}, "MODE_ID"} { }
 
 		bool validate(const Assignment& assignment) override {
-			if(!assignment.blobValue)
+			if(!assignment.blobValue) {
 				return true;
+			}
 
 			if(assignment.blobValue->size() != sizeof(drm_mode_modeinfo))
 				return false;
-			
+
 			drm_mode_modeinfo mode_info;
 			memcpy(&mode_info, assignment.blobValue->data(), sizeof(drm_mode_modeinfo));
 			if(mode_info.hdisplay > mode_info.hsync_start)
@@ -92,29 +93,113 @@ drm_core::Device::Device() {
 			return true;
 		};
 	};
-	_modeIdProperty = std::make_shared<ModeIdProperty>();
+	registerProperty(_modeIdProperty = std::make_shared<ModeIdProperty>());
 
 	struct CrtcXProperty : drm_core::Property {
 		CrtcXProperty()
-		: drm_core::Property{drm_core::IntPropertyType{}} { }
+		: drm_core::Property{crtcX, drm_core::IntPropertyType{}, "CRTC_X"} { }
 
 		bool validate(const Assignment&) override {
 			return true;
 		};
 	};
-	_crtcXProperty = std::make_shared<CrtcXProperty>();
-	
+	registerProperty(_crtcXProperty = std::make_shared<CrtcXProperty>());
+
 	struct CrtcYProperty : drm_core::Property {
 		CrtcYProperty()
-		: drm_core::Property{drm_core::IntPropertyType{}} { }
+		: drm_core::Property{crtcY, drm_core::IntPropertyType{}, "CRTC_Y"} { }
 
 		bool validate(const Assignment&) override {
 			return true;
 		};
 	};
-	_crtcYProperty = std::make_shared<CrtcYProperty>();
+	registerProperty(_crtcYProperty = std::make_shared<CrtcYProperty>());
 
+	struct PlaneTypeProperty : drm_core::Property {
+		PlaneTypeProperty()
+		: drm_core::Property{planeType, drm_core::EnumPropertyType{}, "type"} {
+			add_enum_info(0, "Overlay");
+			add_enum_info(1, "Primary");
+			add_enum_info(2, "Cursor");
+		}
 
+		bool validate(const Assignment& assignment) override {
+			auto plane = assignment.object->asPlane();
+			assert(plane);
+			return (static_cast<uint64_t>(plane->type()) == assignment.intValue);
+		}
+	};
+	registerProperty(_planeTypeProperty = std::make_shared<PlaneTypeProperty>());
+
+	struct DpmsProperty : drm_core::Property {
+		DpmsProperty()
+		: drm_core::Property{dpms, drm_core::IntPropertyType{}, "DPMS"} { }
+
+		bool validate(const Assignment& assignment) override {
+			return (assignment.intValue < 4);
+		}
+	};
+	registerProperty(_dpmsProperty = std::make_shared<DpmsProperty>());
+
+	struct CrtcIdProperty : drm_core::Property {
+		CrtcIdProperty()
+		: drm_core::Property{crtcId, drm_core::ObjectPropertyType{}, "CRTC_ID"} { }
+
+		bool validate(const Assignment&) override {
+			return true;
+		};
+	};
+	registerProperty(_crtcIdProperty = std::make_shared<CrtcIdProperty>());
+
+	struct ActiveProperty : drm_core::Property {
+		ActiveProperty()
+		: drm_core::Property{active, drm_core::IntPropertyType{}, "ACTIVE"} { }
+
+		bool validate(const Assignment&) override {
+			return true;
+		};
+	};
+	registerProperty(_activeProperty = std::make_shared<ActiveProperty>());
+
+	struct SrcXProperty : drm_core::Property {
+		SrcXProperty()
+		: drm_core::Property{srcX, drm_core::IntPropertyType{}, "SRC_X"} { }
+
+		bool validate(const Assignment&) override {
+			return true;
+		};
+	};
+	registerProperty(_srcXProperty = std::make_shared<SrcXProperty>());
+
+	struct SrcYProperty : drm_core::Property {
+		SrcYProperty()
+		: drm_core::Property{srcY, drm_core::IntPropertyType{}, "SRC_Y"} { }
+
+		bool validate(const Assignment&) override {
+			return true;
+		};
+	};
+	registerProperty(_srcYProperty = std::make_shared<SrcYProperty>());
+
+	struct CrtcWProperty : drm_core::Property {
+		CrtcWProperty()
+		: drm_core::Property{crtcW, drm_core::IntPropertyType{}, "CRTC_W"} { }
+
+		bool validate(const Assignment&) override {
+			return true;
+		};
+	};
+	registerProperty(_crtcWProperty = std::make_shared<CrtcWProperty>());
+
+	struct CrtcHProperty : drm_core::Property {
+		CrtcHProperty()
+		: drm_core::Property{crtcH, drm_core::IntPropertyType{}, "CRTC_H"} { }
+
+		bool validate(const Assignment&) override {
+			return true;
+		};
+	};
+	registerProperty(_crtcHProperty = std::make_shared<CrtcHProperty>());
 }
 
 void drm_core::Device::setupCrtc(drm_core::Crtc *crtc) {
@@ -154,11 +239,34 @@ std::shared_ptr<drm_core::ModeObject> drm_core::Device::findObject(uint32_t id) 
 	return it->second->sharedModeObject();
 }
 
+uint32_t drm_core::Device::registerBlob(std::shared_ptr<drm_core::Blob> blob) {
+	uint32_t id = _blob_id_allocator.allocate();
+	_blobs.insert({id, blob});
+
+	return id;
+}
+
+bool drm_core::Device::deleteBlob(uint32_t id) {
+	if(_blobs.contains(id)) {
+		_blobs.erase(id);
+		return true;
+	}
+
+	return false;
+}
+
+std::shared_ptr<drm_core::Blob> drm_core::Device::findBlob(uint32_t id) {
+	auto it = _blobs.find(id);
+	if(it == _blobs.end())
+		return nullptr;
+	return it->second;
+}
+
 uint64_t drm_core::Device::installMapping(drm_core::BufferObject *bo) {
 	assert(bo->getSize() < (UINT64_C(1) << 32));
 	return static_cast<uint64_t>(_memorySlotAllocator.allocate()) << 32;
 }
-	
+
 void drm_core::Device::setupMinDimensions(uint32_t width, uint32_t height) {
 	_minWidth = width;
 	_minHeight = height;
@@ -184,7 +292,7 @@ uint32_t drm_core::Device::getMinHeight() {
 uint32_t drm_core::Device::getMaxHeight() {
 	return _maxHeight;
 }
-	
+
 drm_core::Property *drm_core::Device::srcWProperty() {
 	return _srcWProperty.get();
 }
@@ -208,7 +316,57 @@ drm_core::Property *drm_core::Device::crtcXProperty() {
 drm_core::Property *drm_core::Device::crtcYProperty() {
 	return _crtcYProperty.get();
 }
-	
+
+drm_core::Property *drm_core::Device::planeTypeProperty() {
+	return _planeTypeProperty.get();
+}
+
+drm_core::Property *drm_core::Device::dpmsProperty() {
+	return _dpmsProperty.get();
+}
+
+drm_core::Property *drm_core::Device::crtcIdProperty() {
+	return _crtcIdProperty.get();
+}
+
+drm_core::Property *drm_core::Device::activeProperty() {
+	return _activeProperty.get();
+}
+
+drm_core::Property *drm_core::Device::srcXProperty() {
+	return _srcXProperty.get();
+}
+
+drm_core::Property *drm_core::Device::srcYProperty() {
+	return _srcYProperty.get();
+}
+
+drm_core::Property *drm_core::Device::crtcWProperty() {
+	return _crtcWProperty.get();
+}
+
+drm_core::Property *drm_core::Device::crtcHProperty() {
+	return _crtcHProperty.get();
+}
+
+void drm_core::Device::registerProperty(std::shared_ptr<drm_core::Property> p) {
+	_properties.insert({p->id(), p});
+}
+
+std::shared_ptr<drm_core::Property> drm_core::Device::getProperty(uint32_t id) {
+	auto it = _properties.find(id);
+
+	if(it == _properties.end()) {
+		return nullptr;
+	}
+
+	return it->second;
+}
+
+const std::unordered_map<uint32_t, std::shared_ptr<drm_core::Property>>& drm_core::Device::getProperties() {
+	return _properties;
+}
+
 // ----------------------------------------------------------------
 // Property
 // ----------------------------------------------------------------
@@ -217,8 +375,29 @@ bool drm_core::Property::validate(const Assignment&) {
 	return true;
 }
 
+drm_core::PropertyId drm_core::Property::id() {
+	return _id;
+}
+
+uint32_t drm_core::Property::flags() {
+	return _flags;
+}
+
 drm_core::PropertyType drm_core::Property::propertyType() {
 	return _propertyType;
+}
+
+std::string drm_core::Property::name() {
+	return _name;
+}
+
+void drm_core::Property::add_enum_info(uint64_t value, std::string name) {
+	assert(std::holds_alternative<EnumPropertyType>(_propertyType));
+	_enum_info.insert({value, name});
+}
+
+const std::unordered_map<uint64_t, std::string>& drm_core::Property::enum_info() {
+	return _enum_info;
 }
 
 // ----------------------------------------------------------------
@@ -250,27 +429,27 @@ drm_core::Crtc *drm_core::Encoder::currentCrtc() {
 void drm_core::Encoder::setCurrentCrtc(drm_core::Crtc *crtc) {
 	_currentCrtc = crtc;
 }
-	
+
 void drm_core::Encoder::setupEncoderType(uint32_t type) {
 	_encoderType = type;
 }
-	
+
 uint32_t drm_core::Encoder::getEncoderType() {
 	return _encoderType;
 }
-	
+
 void drm_core::Encoder::setupPossibleCrtcs(std::vector<drm_core::Crtc *> crtcs) {
 	_possibleCrtcs = crtcs;
 }
-	
+
 const std::vector<drm_core::Crtc *> &drm_core::Encoder::getPossibleCrtcs() {
 	return _possibleCrtcs;
 }
-	
+
 void drm_core::Encoder::setupPossibleClones(std::vector<drm_core::Encoder *> clones) {
 	_possibleClones = clones;
 }
-	
+
 const std::vector<drm_core::Encoder *> &drm_core::Encoder::getPossibleClones() {
 	return _possibleClones;
 }
@@ -281,6 +460,10 @@ const std::vector<drm_core::Encoder *> &drm_core::Encoder::getPossibleClones() {
 
 uint32_t drm_core::ModeObject::id() {
 	return _id;
+}
+
+drm_core::ObjectType drm_core::ModeObject::type() {
+	return _type;
 }
 
 drm_core::Encoder *drm_core::ModeObject::asEncoder() {
@@ -333,7 +516,7 @@ drm_core::Crtc::Crtc(uint32_t id)
 std::shared_ptr<drm_core::Blob> drm_core::Crtc::currentMode() {
 	return _curMode;
 }
-	
+
 void drm_core::Crtc::setCurrentMode(std::shared_ptr<drm_core::Blob> mode) {
 	_curMode = mode;
 }
@@ -354,8 +537,28 @@ drm_core::FrameBuffer::FrameBuffer(uint32_t id)
 // Plane
 // ----------------------------------------------------------------
 
-drm_core::Plane::Plane(uint32_t id)
-	:drm_core::ModeObject { ObjectType::plane, id } {
+drm_core::Plane::Plane(uint32_t id, PlaneType type)
+	:drm_core::ModeObject { ObjectType::plane, id }, _type(type) {
+}
+
+drm_core::Plane::PlaneType drm_core::Plane::type() {
+	return _type;
+}
+
+void drm_core::Plane::setCurrentFrameBuffer(drm_core::FrameBuffer *fb) {
+	_fb = fb;
+}
+
+drm_core::FrameBuffer *drm_core::Plane::getFrameBuffer() {
+	return _fb;
+}
+
+void drm_core::Plane::setupPossibleCrtcs(std::vector<drm_core::Crtc *> crtcs) {
+	_possibleCrtcs = crtcs;
+}
+
+const std::vector<drm_core::Crtc *> &drm_core::Plane::getPossibleCrtcs() {
+	return _possibleCrtcs;
 }
 
 // ----------------------------------------------------------------
@@ -375,15 +578,15 @@ const std::vector<drm_mode_modeinfo> &drm_core::Connector::modeList() {
 void drm_core::Connector::setModeList(std::vector<drm_mode_modeinfo> mode_list) {
 	_modeList = mode_list;
 }
-	
+
 void drm_core::Connector::setCurrentStatus(uint32_t status) {
 	_currentStatus = status;
 }
-	
+
 void drm_core::Connector::setCurrentEncoder(drm_core::Encoder *encoder) {
 	_currentEncoder = encoder;
 }
-	
+
 drm_core::Encoder *drm_core::Connector::currentEncoder() {
 	return _currentEncoder;
 }
@@ -391,7 +594,7 @@ drm_core::Encoder *drm_core::Connector::currentEncoder() {
 uint32_t drm_core::Connector::getCurrentStatus() {
 	return _currentStatus;
 }
-	
+
 void drm_core::Connector::setupPossibleEncoders(std::vector<drm_core::Encoder *> encoders) {
 	_possibleEncoders = encoders;
 }
@@ -399,7 +602,7 @@ void drm_core::Connector::setupPossibleEncoders(std::vector<drm_core::Encoder *>
 const std::vector<drm_core::Encoder *> &drm_core::Connector::getPossibleEncoders() {
 	return _possibleEncoders;
 }
-	
+
 void drm_core::Connector::setupPhysicalDimensions(uint32_t width, uint32_t height) {
 	_physicalWidth = width;
 	_physicalHeight = height;
@@ -421,6 +624,10 @@ uint32_t drm_core::Connector::getSubpixel() {
 	return _subpixel;
 }
 
+void drm_core::Connector::setConnectorType(uint32_t type) {
+	_connectorType = type;
+}
+
 uint32_t drm_core::Connector::connectorType() {
 	return _connectorType;
 }
@@ -432,7 +639,7 @@ uint32_t drm_core::Connector::connectorType() {
 size_t drm_core::Blob::size() {
 	return _data.size();
 }
-	
+
 const void *drm_core::Blob::data() {
 	return _data.data();
 }
@@ -457,7 +664,7 @@ void drm_core::File::setBlocking(bool blocking) {
 void drm_core::File::attachFrameBuffer(std::shared_ptr<drm_core::FrameBuffer> frame_buffer) {
 	_frameBuffers.push_back(frame_buffer);
 }
-	
+
 void drm_core::File::detachFrameBuffer(drm_core::FrameBuffer *frame_buffer) {
 	auto it = std::find_if(_frameBuffers.begin(), _frameBuffers.end(),
 			([&](std::shared_ptr<drm_core::FrameBuffer> fb) {
@@ -466,11 +673,11 @@ void drm_core::File::detachFrameBuffer(drm_core::FrameBuffer *frame_buffer) {
 	assert(it != _frameBuffers.end());
 	_frameBuffers.erase(it);
 }
-	
+
 const std::vector<std::shared_ptr<drm_core::FrameBuffer>> &drm_core::File::getFrameBuffers() {
 	return _frameBuffers;
 }
-	
+
 uint32_t drm_core::File::createHandle(std::shared_ptr<BufferObject> bo) {
 	auto handle = _allocator.allocate();
 	_buffers.insert({handle, bo});
@@ -482,7 +689,7 @@ uint32_t drm_core::File::createHandle(std::shared_ptr<BufferObject> bo) {
 
 	return handle;
 }
-	
+
 drm_core::BufferObject *drm_core::File::resolveHandle(uint32_t handle) {
 	auto it = _buffers.find(handle);
 	if(it == _buffers.end())
@@ -519,12 +726,13 @@ drm_core::File::read(void *object, const char *,
 	out.base.type = DRM_EVENT_FLIP_COMPLETE;
 	out.base.length = sizeof(drm_event_vblank);
 	out.user_data = ev->cookie;
+	out.crtc_id = ev->crtcId;
 	out.tv_sec = ev->timestamp / 1000000000;
 	out.tv_usec = (ev->timestamp % 1000000000) / 1000;
 
 	assert(length >= sizeof(drm_event_vblank));
 	memcpy(buffer, &out, sizeof(drm_event_vblank));
-	
+
 	self->_pendingEvents.pop_front();
 	if(self->_pendingEvents.empty())
 		self->_statusPage.update(self->_eventSequence, 0);
@@ -871,8 +1079,8 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		assert(valid);
 		config->commit();
 
-		self->_retirePageFlip(std::move(config), req.drm_cookie());
-			
+		self->_retirePageFlip(std::move(config), req.drm_cookie(), crtc->id());
+
 		resp.set_error(managarm::fs::Errors::SUCCESS);
 
 		auto ser = resp.SerializeAsString();
@@ -1047,11 +1255,12 @@ drm_core::File::pollStatus(void *object) {
 
 async::detached
 drm_core::File::_retirePageFlip(std::unique_ptr<drm_core::Configuration> config,
-			uint64_t cookie) {
+			uint64_t cookie, uint32_t crtc_id) {
 	co_await config->waitForCompletion();
 
 	Event event;
 	event.cookie = cookie;
+	event.crtcId = crtc_id;
 	postEvent(event);
 }
 

--- a/core/drm/src/core.cpp
+++ b/core/drm/src/core.cpp
@@ -41,7 +41,7 @@ drm_core::Device::Device() {
 		uint32_t intFromState(std::shared_ptr<ModeObject> obj) override {
 			auto plane = obj->asPlane();
 			assert(plane);
-			return plane->drm_state()->src_w();
+			return plane->drmState()->src_w();
 		}
 	};
 	registerProperty(_srcWProperty = std::make_shared<SrcWProperty>());
@@ -61,7 +61,7 @@ drm_core::Device::Device() {
 		uint32_t intFromState(std::shared_ptr<ModeObject> obj) override {
 			auto plane = obj->asPlane();
 			assert(plane);
-			return plane->drm_state()->src_h();
+			return plane->drmState()->src_h();
 		}
 	};
 	registerProperty(_srcHProperty = std::make_shared<SrcHProperty>());
@@ -84,10 +84,10 @@ drm_core::Device::Device() {
 			state->plane(assignment.object->id())->fb_id(static_pointer_cast<FrameBuffer>(assignment.objectValue));
 		}
 
-		std::shared_ptr<ModeObject> modeobjFromState(std::shared_ptr<ModeObject> obj) override {
+		std::shared_ptr<ModeObject> modeObjFromState(std::shared_ptr<ModeObject> obj) override {
 			auto plane = obj->asPlane();
 			assert(plane);
-			return static_pointer_cast<ModeObject>(plane->drm_state()->fb_id());
+			return static_pointer_cast<ModeObject>(plane->drmState()->fb_id());
 		}
 	};
 	registerProperty(_fbIdProperty = std::make_shared<FbIdProperty>());
@@ -152,9 +152,9 @@ drm_core::Device::Device() {
 	struct PlaneTypeProperty : drm_core::Property {
 		PlaneTypeProperty()
 		: drm_core::Property{planeType, drm_core::EnumPropertyType{}, "type"} {
-			add_enum_info(0, "Overlay");
-			add_enum_info(1, "Primary");
-			add_enum_info(2, "Cursor");
+			addEnumInfo(0, "Overlay");
+			addEnumInfo(1, "Primary");
+			addEnumInfo(2, "Cursor");
 		}
 
 		bool validate(const Assignment& assignment) override {
@@ -286,7 +286,7 @@ std::shared_ptr<drm_core::ModeObject> drm_core::Device::findObject(uint32_t id) 
 }
 
 uint32_t drm_core::Device::registerBlob(std::shared_ptr<drm_core::Blob> blob) {
-	uint32_t id = _blob_id_allocator.allocate();
+	uint32_t id = _blobIdAllocator.allocate();
 	_blobs.insert({id, blob});
 
 	return id;
@@ -414,15 +414,12 @@ std::shared_ptr<drm_core::Property> drm_core::Device::getProperty(uint32_t id) {
 	return it->second;
 }
 
-const std::unordered_map<uint32_t, std::shared_ptr<drm_core::Property>>& drm_core::Device::getProperties() {
-	return _properties;
-}
-
 // ----------------------------------------------------------------
 // Property
 // ----------------------------------------------------------------
 
-std::vector<drm_core::Assignment> drm_core::ModeObject::getAssignments(std::shared_ptr<Device> dev) {	switch(this->type()) {
+std::vector<drm_core::Assignment> drm_core::ModeObject::getAssignments(std::shared_ptr<Device> dev) {
+	switch(this->type()) {
 		case ObjectType::connector: {
 			auto connector = this->asConnector();
 			assert(connector);
@@ -469,12 +466,12 @@ std::string drm_core::Property::name() {
 	return _name;
 }
 
-void drm_core::Property::add_enum_info(uint64_t value, std::string name) {
+void drm_core::Property::addEnumInfo(uint64_t value, std::string name) {
 	assert(std::holds_alternative<EnumPropertyType>(_propertyType));
 	_enum_info.insert({value, name});
 }
 
-const std::unordered_map<uint64_t, std::string>& drm_core::Property::enum_info() {
+const std::unordered_map<uint64_t, std::string>& drm_core::Property::enumInfo() {
 	return _enum_info;
 }
 
@@ -489,7 +486,7 @@ uint32_t drm_core::Property::intFromState(std::shared_ptr<drm_core::ModeObject> 
 	return 0;
 }
 
-std::shared_ptr<drm_core::ModeObject> drm_core::Property::modeobjFromState(std::shared_ptr<drm_core::ModeObject> obj) {
+std::shared_ptr<drm_core::ModeObject> drm_core::Property::modeObjFromState(std::shared_ptr<drm_core::ModeObject> obj) {
 	(void) obj;
 	return nullptr;
 }
@@ -498,15 +495,15 @@ std::shared_ptr<drm_core::ModeObject> drm_core::Property::modeobjFromState(std::
 // Assignment
 // ----------------------------------------------------------------
 
-drm_core::Assignment drm_core::Assignment::with_int(std::shared_ptr<drm_core::ModeObject> obj, drm_core::Property *property, uint64_t val) {
+drm_core::Assignment drm_core::Assignment::withInt(std::shared_ptr<drm_core::ModeObject> obj, drm_core::Property *property, uint64_t val) {
 	return drm_core::Assignment{obj, property, val, nullptr, nullptr};
 }
 
-drm_core::Assignment drm_core::Assignment::with_modeobj(std::shared_ptr<drm_core::ModeObject> obj, drm_core::Property *property, std::shared_ptr<drm_core::ModeObject> modeobj) {
+drm_core::Assignment drm_core::Assignment::withModeObj(std::shared_ptr<drm_core::ModeObject> obj, drm_core::Property *property, std::shared_ptr<drm_core::ModeObject> modeobj) {
 	return drm_core::Assignment{obj, property, 0, modeobj, nullptr};
 }
 
-drm_core::Assignment drm_core::Assignment::with_blob(std::shared_ptr<drm_core::ModeObject> obj, drm_core::Property *property, std::shared_ptr<drm_core::Blob> blob) {
+drm_core::Assignment drm_core::Assignment::withBlob(std::shared_ptr<drm_core::ModeObject> obj, drm_core::Property *property, std::shared_ptr<drm_core::Blob> blob) {
 	return drm_core::Assignment{obj, property, 0, nullptr, blob};
 }
 
@@ -631,19 +628,19 @@ drm_core::Plane *drm_core::Crtc::cursorPlane() {
 	return nullptr;
 }
 
-std::shared_ptr<drm_core::CrtcState> drm_core::Crtc::drm_state() {
+std::shared_ptr<drm_core::CrtcState> drm_core::Crtc::drmState() {
 	return _drmState;
 }
 
-void drm_core::Crtc::set_drm_state(std::shared_ptr<drm_core::CrtcState> new_state) {
+void drm_core::Crtc::setDrmState(std::shared_ptr<drm_core::CrtcState> new_state) {
 	_drmState = new_state;
 }
 
 std::vector<drm_core::Assignment> drm_core::Crtc::getAssignments(std::shared_ptr<drm_core::Device> dev) {
 	std::vector<drm_core::Assignment> assignments = std::vector<drm_core::Assignment>();
 
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->activeProperty(), drm_state()->active()));
-	assignments.push_back(drm_core::Assignment::with_blob(this->sharedModeObject(), dev->modeIdProperty(), drm_state()->mode()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->activeProperty(), drmState()->active()));
+	assignments.push_back(drm_core::Assignment::withBlob(this->sharedModeObject(), dev->modeIdProperty(), drmState()->mode()));
 
 	return assignments;
 }
@@ -718,28 +715,28 @@ const std::vector<drm_core::Crtc *> &drm_core::Plane::getPossibleCrtcs() {
 	return _possibleCrtcs;
 }
 
-std::shared_ptr<drm_core::PlaneState> drm_core::Plane::drm_state() {
+std::shared_ptr<drm_core::PlaneState> drm_core::Plane::drmState() {
 	return _drmState;
 }
 
-void drm_core::Plane::set_drm_state(std::shared_ptr<drm_core::PlaneState> new_state) {
+void drm_core::Plane::setDrmState(std::shared_ptr<drm_core::PlaneState> new_state) {
 	_drmState = new_state;
 }
 
 std::vector<drm_core::Assignment> drm_core::Plane::getAssignments(std::shared_ptr<drm_core::Device> dev) {
 	std::vector<drm_core::Assignment> assignments = std::vector<drm_core::Assignment>();
 
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->planeTypeProperty(), static_cast<uint64_t>(drm_state()->type())));
-	assignments.push_back(drm_core::Assignment::with_modeobj(this->sharedModeObject(), dev->crtcIdProperty(), drm_state()->crtc()));
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->srcHProperty(), drm_state()->src_h()));
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->srcWProperty(), drm_state()->src_w()));
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->crtcHProperty(), drm_state()->crtc_h()));
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->crtcWProperty(), drm_state()->crtc_w()));
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->srcXProperty(), drm_state()->src_x()));
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->srcYProperty(), drm_state()->src_y()));
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->crtcXProperty(), drm_state()->crtc_x()));
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->crtcYProperty(), drm_state()->crtc_y()));
-	assignments.push_back(drm_core::Assignment::with_modeobj(this->sharedModeObject(), dev->fbIdProperty(), drm_state()->fb_id()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->planeTypeProperty(), static_cast<uint64_t>(drmState()->type())));
+	assignments.push_back(drm_core::Assignment::withModeObj(this->sharedModeObject(), dev->crtcIdProperty(), drmState()->crtc()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->srcHProperty(), drmState()->src_h()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->srcWProperty(), drmState()->src_w()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->crtcHProperty(), drmState()->crtc_h()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->crtcWProperty(), drmState()->crtc_w()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->srcXProperty(), drmState()->src_x()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->srcYProperty(), drmState()->src_y()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->crtcXProperty(), drmState()->crtc_x()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->crtcYProperty(), drmState()->crtc_y()));
+	assignments.push_back(drm_core::Assignment::withModeObj(this->sharedModeObject(), dev->fbIdProperty(), drmState()->fb_id()));
 
 	return assignments;
 }
@@ -907,19 +904,19 @@ uint32_t drm_core::Connector::connectorType() {
 	return _connectorType;
 }
 
-std::shared_ptr<drm_core::ConnectorState> drm_core::Connector::drm_state() {
+std::shared_ptr<drm_core::ConnectorState> drm_core::Connector::drmState() {
 	return _drmState;
 }
 
-void drm_core::Connector::set_drm_state(std::shared_ptr<drm_core::ConnectorState> new_state) {
+void drm_core::Connector::setDrmState(std::shared_ptr<drm_core::ConnectorState> new_state) {
 	_drmState = new_state;
 }
 
 std::vector<drm_core::Assignment> drm_core::Connector::getAssignments(std::shared_ptr<drm_core::Device> dev) {
 	std::vector<drm_core::Assignment> assignments = std::vector<drm_core::Assignment>();
 
-	assignments.push_back(drm_core::Assignment::with_int(this->sharedModeObject(), dev->dpmsProperty(), drm_state()->dpms()));
-	assignments.push_back(drm_core::Assignment::with_modeobj(this->sharedModeObject(), dev->crtcIdProperty(), drm_state()->crtc()));
+	assignments.push_back(drm_core::Assignment::withInt(this->sharedModeObject(), dev->dpmsProperty(), drmState()->dpms()));
+	assignments.push_back(drm_core::Assignment::withModeObj(this->sharedModeObject(), dev->crtcIdProperty(), drmState()->crtc()));
 
 	return assignments;
 }
@@ -953,46 +950,46 @@ const void *drm_core::Blob::data() {
 }
 
 std::shared_ptr<drm_core::CrtcState> drm_core::AtomicState::crtc(uint32_t id) {
-	if(_crtc_states.contains(id)) {
-		return _crtc_states.find(id)->second;
+	if(_crtcStates.contains(id)) {
+		return _crtcStates.find(id)->second;
 	} else {
 		auto crtc = _device->findObject(id)->asCrtc();
-		assert(crtc->drm_state());
-		auto crtc_state = CrtcState(*crtc->drm_state());
+		assert(crtc->drmState());
+		auto crtc_state = CrtcState(*crtc->drmState());
 		auto crtc_state_shared = std::make_shared<drm_core::CrtcState>(crtc_state);
-		_crtc_states.insert({id, crtc_state_shared});
+		_crtcStates.insert({id, crtc_state_shared});
 		return crtc_state_shared;
 	}
 }
 
 std::shared_ptr<drm_core::PlaneState> drm_core::AtomicState::plane(uint32_t id) {
-	if(_plane_states.contains(id)) {
-		return _plane_states.find(id)->second;
+	if(_planeStates.contains(id)) {
+		return _planeStates.find(id)->second;
 	} else {
 		auto plane = _device->findObject(id)->asPlane();
-		assert(plane->drm_state());
-		auto plane_state = PlaneState(*plane->drm_state());
+		assert(plane->drmState());
+		auto plane_state = PlaneState(*plane->drmState());
 		auto plane_state_shared = std::make_shared<drm_core::PlaneState>(plane_state);
-		_plane_states.insert({id, plane_state_shared});
+		_planeStates.insert({id, plane_state_shared});
 		return plane_state_shared;
 	}
 }
 
 std::shared_ptr<drm_core::ConnectorState> drm_core::AtomicState::connector(uint32_t id) {
-	if(_connector_states.contains(id)) {
-		return _connector_states.find(id)->second;
+	if(_connectorStates.contains(id)) {
+		return _connectorStates.find(id)->second;
 	} else {
 		auto connector = _device->findObject(id)->asConnector();
-		assert(connector->drm_state());
-		auto connector_state = ConnectorState(*connector->drm_state());
+		assert(connector->drmState());
+		auto connector_state = ConnectorState(*connector->drmState());
 		auto connector_state_shared = std::make_shared<drm_core::ConnectorState>(connector_state);
-		_connector_states.insert({id, connector_state_shared});
+		_connectorStates.insert({id, connector_state_shared});
 		return connector_state_shared;
 	}
 }
 
 std::unordered_map<uint32_t, std::shared_ptr<drm_core::CrtcState>>& drm_core::AtomicState::crtc_states(void) {
-	return _crtc_states;
+	return _crtcStates;
 }
 
 // ----------------------------------------------------------------
@@ -1267,7 +1264,7 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		}
 		resp.set_drm_possible_crtcs(crtc_mask);
 
-		auto crtc = plane->drm_state()->crtc();
+		auto crtc = plane->drmState()->crtc();
 		if(crtc != nullptr) {
 			resp.set_drm_crtc_id(crtc->id());
 		} else {
@@ -1371,9 +1368,9 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		assert(crtc);
 
 		drm_mode_modeinfo mode_info;
-		if(crtc->drm_state()->mode()) {
+		if(crtc->drmState()->mode()) {
 			/* TODO: Set x, y, fb_id, gamma_size */
-			memcpy(&mode_info, crtc->drm_state()->mode()->data(), sizeof(drm_mode_modeinfo));
+			memcpy(&mode_info, crtc->drmState()->mode()->data(), sizeof(drm_mode_modeinfo));
 			resp.set_drm_mode_valid(1);
 		}else{
 			memset(&mode_info, 0, sizeof(drm_mode_modeinfo));
@@ -1413,10 +1410,10 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 			auto fb = self->_device->findObject(req.drm_fb_id());
 			assert(fb);
 
-			assignments.push_back(Assignment::with_blob(crtc->sharedModeObject(), self->_device->modeIdProperty(), mode_blob));
-			assignments.push_back(Assignment::with_modeobj(crtc->primaryPlane()->sharedModeObject(), self->_device->fbIdProperty(), fb));
+			assignments.push_back(Assignment::withBlob(crtc->sharedModeObject(), self->_device->modeIdProperty(), mode_blob));
+			assignments.push_back(Assignment::withModeObj(crtc->primaryPlane()->sharedModeObject(), self->_device->fbIdProperty(), fb));
 		}else{
-			assignments.push_back(Assignment::with_blob(crtc->sharedModeObject(), self->_device->modeIdProperty(), nullptr));
+			assignments.push_back(Assignment::withBlob(crtc->sharedModeObject(), self->_device->modeIdProperty(), nullptr));
 		}
 
 		auto config = self->_device->createConfiguration();
@@ -1447,7 +1444,7 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 
 		auto fb = self->_device->findObject(req.drm_fb_id());
 		assert(fb);
-		assignments.push_back(Assignment::with_modeobj(crtc->primaryPlane()->sharedModeObject(), self->_device->fbIdProperty(), fb));
+		assignments.push_back(Assignment::withModeObj(crtc->primaryPlane()->sharedModeObject(), self->_device->fbIdProperty(), fb));
 
 		auto config = self->_device->createConfiguration();
 		auto state = self->_device->atomicState();
@@ -1507,23 +1504,23 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 			auto width = req.drm_width();
 			auto height = req.drm_height();
 
-			assignments.push_back(Assignment::with_int(cursor_plane->sharedModeObject(), self->_device->srcWProperty(), width << 16));
-			assignments.push_back(Assignment::with_int(cursor_plane->sharedModeObject(), self->_device->srcHProperty(), height << 16));
+			assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->srcWProperty(), width << 16));
+			assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->srcHProperty(), height << 16));
 
 			if (bo) {
 				auto fb = self->_device->createFrameBuffer(bo->sharedBufferObject(), width, height, DRM_FORMAT_ARGB8888, width * 4);
 				assert(fb);
-				assignments.push_back(Assignment::with_modeobj(crtc->cursorPlane()->sharedModeObject(), self->_device->fbIdProperty(), fb));
+				assignments.push_back(Assignment::withModeObj(crtc->cursorPlane()->sharedModeObject(), self->_device->fbIdProperty(), fb));
 			} else {
-				assignments.push_back(Assignment::with_modeobj(crtc->cursorPlane()->sharedModeObject(), self->_device->fbIdProperty(), nullptr));
+				assignments.push_back(Assignment::withModeObj(crtc->cursorPlane()->sharedModeObject(), self->_device->fbIdProperty(), nullptr));
 			}
 		}else if (req.drm_flags() == DRM_MODE_CURSOR_MOVE) {
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 			auto x = req.drm_x();
 			auto y = req.drm_y();
 
-			assignments.push_back(Assignment::with_int(cursor_plane->sharedModeObject(), self->_device->crtcXProperty(), x));
-			assignments.push_back(Assignment::with_int(cursor_plane->sharedModeObject(), self->_device->crtcYProperty(), y));
+			assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->crtcXProperty(), x));
+			assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->crtcYProperty(), y));
 		}else{
 			printf("\e[35mcore/drm: invalid request whilst handling DRM_IOCTL_MODE_CURSOR\e[39m\n");
 			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
@@ -1561,6 +1558,7 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 
 		if(req.drm_capability() == DRM_CLIENT_CAP_STEREO_3D) {
 			std::cout << "\e[31mcore/drm: DRM client cap for stereo 3D unsupported\e[39m" << std::endl;
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 		} else if(req.drm_capability() == DRM_CLIENT_CAP_UNIVERSAL_PLANES) {
 			self->universalPlanes = true;
 			resp.set_error(managarm::fs::Errors::SUCCESS);
@@ -1614,7 +1612,7 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 			resp.set_drm_property_flags(prop->flags());
 
 			if(std::holds_alternative<EnumPropertyType>(prop->propertyType())) {
-				for(auto &[value, name] : prop->enum_info()) {
+				for(auto &[value, name] : prop->enumInfo()) {
 					resp.add_drm_enum_value(value);
 					resp.add_drm_enum_name(name);
 				}
@@ -1636,6 +1634,8 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 
 		std::cout << "\e[31mcore/drm: DRM_IOCTL_MODE_SETPROPERTY is a no-op\e[39m"
 				<< std::endl;
+
+		resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
@@ -1760,15 +1760,15 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 				auto prop_type = prop->propertyType();
 
 				if(std::holds_alternative<IntPropertyType>(prop_type)) {
-					assignments.push_back(Assignment::with_int(mode_obj, prop.get(), value));
+					assignments.push_back(Assignment::withInt(mode_obj, prop.get(), value));
 				} else if(std::holds_alternative<BlobPropertyType>(prop_type)) {
 					auto blob = self->_device->findBlob(value);
 
-					assignments.push_back(Assignment::with_blob(mode_obj, prop.get(), blob));
+					assignments.push_back(Assignment::withBlob(mode_obj, prop.get(), blob));
 				} else if(std::holds_alternative<ObjectPropertyType>(prop_type)) {
 					auto obj = self->_device->findObject(value);
 
-					assignments.push_back(Assignment::with_modeobj(mode_obj, prop.get(), obj));
+					assignments.push_back(Assignment::withModeObj(mode_obj, prop.get(), obj));
 				}
 			}
 

--- a/core/drm/src/core.cpp
+++ b/core/drm/src/core.cpp
@@ -627,14 +627,6 @@ void drm_core::Crtc::setupState(std::shared_ptr<drm_core::Crtc> crtc) {
 	crtc->_drmState = std::make_shared<drm_core::CrtcState>(drm_core::CrtcState(crtc));
 }
 
-std::shared_ptr<drm_core::Blob> drm_core::Crtc::currentMode() {
-	return _curMode;
-}
-
-void drm_core::Crtc::setCurrentMode(std::shared_ptr<drm_core::Blob> mode) {
-	_curMode = mode;
-}
-
 drm_core::Plane *drm_core::Crtc::cursorPlane() {
 	return nullptr;
 }

--- a/core/drm/src/core.cpp
+++ b/core/drm/src/core.cpp
@@ -753,10 +753,10 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 	if(req.command() == DRM_IOCTL_VERSION) {
 		helix::SendBuffer send_resp;
 		managarm::fs::SvrResponse resp;
-	
+
 		auto version = self->_device->driverVersion();
 		auto info = self->_device->driverInfo();
-		
+
 		resp.set_drm_version_major(std::get<0>(version));
 		resp.set_drm_version_minor(std::get<1>(version));
 		resp.set_drm_version_patchlevel(std::get<2>(version));
@@ -766,7 +766,7 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		resp.set_drm_driver_date(std::get<2>(info));
 
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-		
+
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size()));
@@ -775,19 +775,25 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 	}else if(req.command() == DRM_IOCTL_GET_CAP) {
 		helix::SendBuffer send_resp;
 		managarm::fs::SvrResponse resp;
-		
+
+		resp.set_error(managarm::fs::Errors::SUCCESS);
+
 		if(req.drm_capability() == DRM_CAP_TIMESTAMP_MONOTONIC) {
 			resp.set_drm_value(1);
-			resp.set_error(managarm::fs::Errors::SUCCESS);
 		}else if(req.drm_capability() == DRM_CAP_DUMB_BUFFER) {
 			resp.set_drm_value(1);
-			resp.set_error(managarm::fs::Errors::SUCCESS);
+		}else if(req.drm_capability() == DRM_CAP_CRTC_IN_VBLANK_EVENT) {
+			resp.set_drm_value(1);
+		}else if(req.drm_capability() == DRM_CAP_CURSOR_WIDTH) {
+			resp.set_drm_value(0);
+		}else if(req.drm_capability() == DRM_CAP_CURSOR_HEIGHT) {
+			resp.set_drm_value(0);
 		}else{
 			std::cout << "core/drm: Unknown capability " << req.drm_capability() << std::endl;
 			resp.set_drm_value(0);
 			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 		}
-		
+
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size()));
@@ -801,28 +807,28 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		for(size_t i = 0; i < crtcs.size(); i++) {
 			resp.add_drm_crtc_ids(crtcs[i]->id());
 		}
-			
+
 		auto &encoders = self->_device->getEncoders();
 		for(size_t i = 0; i < encoders.size(); i++) {
 			resp.add_drm_encoder_ids(encoders[i]->id());
 		}
-	
+
 		auto &connectors = self->_device->getConnectors();
 		for(size_t i = 0; i < connectors.size(); i++) {
 			resp.add_drm_connector_ids(connectors[i]->id());
 		}
-		
+
 		auto &fbs = self->getFrameBuffers();
 		for(size_t i = 0; i < fbs.size(); i++) {
 			resp.add_drm_fb_ids(fbs[i]->id());
 		}
-	
+
 		resp.set_drm_min_width(self->_device->getMinWidth());
 		resp.set_drm_max_width(self->_device->getMaxWidth());
 		resp.set_drm_min_height(self->_device->getMinHeight());
 		resp.set_drm_max_height(self->_device->getMaxHeight());
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-	
+
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size()));
@@ -832,14 +838,14 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		helix::SendBuffer send_resp;
 		helix::SendBuffer send_list;
 		managarm::fs::SvrResponse resp;
-	
+
 		auto obj = self->_device->findObject(req.drm_connector_id());
 		assert(obj);
 		auto conn = obj->asConnector();
 		assert(conn);
-		
+
 		auto psbl_enc = conn->getPossibleEncoders();
-		for(size_t i = 0; i < psbl_enc.size(); i++) { 
+		for(size_t i = 0; i < psbl_enc.size(); i++) {
 			resp.add_drm_encoders(psbl_enc[i]->id());
 		}
 
@@ -852,7 +858,7 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		resp.set_drm_subpixel(conn->getSubpixel());
 		resp.set_drm_num_modes(conn->modeList().size());
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-	
+
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size(), kHelItemChain),
@@ -873,13 +879,13 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		auto enc = obj->asEncoder();
 		assert(enc);
 		resp.set_drm_crtc_id(enc->currentCrtc()->id());
-		
+
 		uint32_t crtc_mask = 0;
 		for(auto crtc : enc->getPossibleCrtcs()) {
 			crtc_mask |= 1 << crtc->index;
 		}
 		resp.set_drm_possible_crtcs(crtc_mask);
-		
+
 		uint32_t clone_mask = 0;
 		for(auto clone : enc->getPossibleClones()) {
 			clone_mask |= 1 << clone->index;
@@ -887,7 +893,48 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		resp.set_drm_possible_clones(clone_mask);
 
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-	
+
+		auto ser = resp.SerializeAsString();
+		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+			helix::action(&send_resp, ser.data(), ser.size()));
+		co_await transmit.async_wait();
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == DRM_IOCTL_MODE_GETPLANE) {
+		helix::SendBuffer send_resp;
+		managarm::fs::SvrResponse resp;
+
+		resp.set_drm_encoder_type(0);
+
+		auto obj = self->_device->findObject(req.drm_plane_id());
+		assert(obj);
+		auto plane = obj->asPlane();
+		assert(plane);
+
+		uint32_t crtc_mask = 0;
+		for(auto crtc : plane->getPossibleCrtcs()) {
+			crtc_mask |= 1 << crtc->index;
+		}
+		resp.set_drm_possible_crtcs(crtc_mask);
+
+		auto crtc_id = plane->getAssignment(CrtcId);
+		if(crtc_id) {
+			resp.set_drm_crtc_id(crtc_id->intValue);
+		} else {
+			resp.set_drm_crtc_id(0);
+		}
+
+		auto fb = plane->getFrameBuffer();
+		if(fb) {
+			resp.set_drm_fb_id(fb->id());
+		} else {
+			resp.set_drm_fb_id(0);
+		}
+
+		resp.set_drm_gamma_size(0);
+		resp.add_drm_format_type(DRM_FORMAT_XRGB8888);
+
+		resp.set_error(managarm::fs::Errors::SUCCESS);
+
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size()));
@@ -904,7 +951,7 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		resp.set_drm_pitch(pair.second);
 		resp.set_drm_size(pair.first->getSize());
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-	
+
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size()));
@@ -917,14 +964,14 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		auto bo = self->resolveHandle(req.drm_handle());
 		assert(bo);
 		auto buffer = bo->sharedBufferObject();
-		
+
 		auto fourcc = convertLegacyFormat(req.drm_bpp(), req.drm_depth());
 		auto fb = self->_device->createFrameBuffer(buffer, req.drm_width(), req.drm_height(),
 				fourcc, req.drm_pitch());
 		self->attachFrameBuffer(fb);
 		resp.set_drm_fb_id(fb->id());
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-	
+
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size()));
@@ -933,14 +980,14 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 	}else if(req.command() == DRM_IOCTL_MODE_RMFB) {
 		helix::SendBuffer send_resp;
 		managarm::fs::SvrResponse resp;
-		
+
 		auto obj = self->_device->findObject(req.drm_fb_id());
 		assert(obj);
 		auto fb = obj->asFrameBuffer();
 		assert(fb);
 		self->detachFrameBuffer(fb);
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-		
+
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size()));
@@ -953,10 +1000,10 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 		auto bo = self->resolveHandle(req.drm_handle());
 		assert(bo);
 		auto buffer = bo->sharedBufferObject();
-	
+
 		resp.set_drm_offset(buffer->getMapping());
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-	
+
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size()));
@@ -981,9 +1028,9 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 			memset(&mode_info, 0, sizeof(drm_mode_modeinfo));
 			resp.set_drm_mode_valid(0);
 		}
-			
+
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-	
+
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size(), kHelItemChain),
@@ -1000,29 +1047,29 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 				helix::action(&recv_buffer, mode_buffer.data(), sizeof(drm_mode_modeinfo)));
 		co_await buff.async_wait();
 		HEL_CHECK(recv_buffer.error());
-		
+
 		helix::SendBuffer send_resp;
 		managarm::fs::SvrResponse resp;
-	
+
 		auto obj = self->_device->findObject(req.drm_crtc_id());
 		assert(obj);
 		auto crtc = obj->asCrtc();
 		assert(crtc);
-	
+
 		std::vector<drm_core::Assignment> assignments;
 		if(req.drm_mode_valid()) {
 			auto mode_blob = std::make_shared<Blob>(std::move(mode_buffer));
-			assignments.push_back(Assignment{ 
+			assignments.push_back(Assignment{
 				crtc->sharedModeObject(),
 				self->_device->modeIdProperty(),
 				0,
 				nullptr,
 				mode_blob
 			});
-			
+
 			auto fb = self->_device->findObject(req.drm_fb_id());
 			assert(fb);
-			assignments.push_back(Assignment{ 
+			assignments.push_back(Assignment{
 				crtc->primaryPlane()->sharedModeObject(),
 				self->_device->fbIdProperty(),
 				0,
@@ -1030,7 +1077,7 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 				nullptr
 			});
 		}else{
-			assignments.push_back(Assignment{ 
+			assignments.push_back(Assignment{
 				crtc->sharedModeObject(),
 				self->_device->modeIdProperty(),
 				0,
@@ -1056,17 +1103,17 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 	}else if(req.command() == DRM_IOCTL_MODE_PAGE_FLIP) {
 		helix::SendBuffer send_resp;
 		managarm::fs::SvrResponse resp;
-	
+
 		auto obj = self->_device->findObject(req.drm_crtc_id());
 		assert(obj);
 		auto crtc = obj->asCrtc();
 		assert(crtc);
-	
+
 		std::vector<drm_core::Assignment> assignments;
 
 		auto fb = self->_device->findObject(req.drm_fb_id());
 		assert(fb);
-		assignments.push_back(Assignment{ 
+		assignments.push_back(Assignment{
 			crtc->primaryPlane()->sharedModeObject(),
 			self->_device->fbIdProperty(),
 			0,
@@ -1107,7 +1154,7 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 	}else if(req.command() == DRM_IOCTL_MODE_CURSOR) {
 		helix::SendBuffer send_resp;
 		managarm::fs::SvrResponse resp;
-	
+
 		auto crtc_obj = self->_device->findObject(req.drm_crtc_id());
 		assert(crtc_obj);
 		auto crtc = crtc_obj->asCrtc();
@@ -1130,11 +1177,11 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 			auto bo = self->resolveHandle(req.drm_handle());
 			auto width = req.drm_width();
 			auto height = req.drm_height();
-			
-			assignments.push_back(Assignment{ 
+
+			assignments.push_back(Assignment{
 				cursor_plane->sharedModeObject(),
 				self->_device->srcWProperty(),
-				width,
+				width << 16,
 				nullptr,
 				nullptr
 			});
@@ -1142,15 +1189,15 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 			assignments.push_back(Assignment{
 				cursor_plane->sharedModeObject(),
 				self->_device->srcHProperty(),
-				height,
+				height << 16,
 				nullptr,
 				nullptr
 			});
 
-			if (bo) {	
+			if (bo) {
 				auto fb = self->_device->createFrameBuffer(bo->sharedBufferObject(), width, height, DRM_FORMAT_ARGB8888, width * 4);
 				assert(fb);
-				assignments.push_back(Assignment{ 
+				assignments.push_back(Assignment{
 					cursor_plane->sharedModeObject(),
 					self->_device->fbIdProperty(),
 					0,
@@ -1158,7 +1205,7 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 					nullptr
 				});
 			} else {
-				assignments.push_back(Assignment{ 
+				assignments.push_back(Assignment{
 					cursor_plane->sharedModeObject(),
 					self->_device->fbIdProperty(),
 					0,
@@ -1211,6 +1258,266 @@ drm_core::File::ioctl(void *object, managarm::fs::CntRequest req,
 
 		resp.set_error(managarm::fs::Errors::SUCCESS);
 
+		auto ser = resp.SerializeAsString();
+		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+			helix::action(&send_resp, ser.data(), ser.size()));
+		co_await transmit.async_wait();
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == DRM_IOCTL_SET_CLIENT_CAP) {
+		helix::SendBuffer send_resp;
+		managarm::fs::SvrResponse resp;
+
+		if(req.drm_capability() == DRM_CLIENT_CAP_STEREO_3D) {
+			std::cout << "\e[31mcore/drm: DRM client cap for stereo 3D unsupported\e[39m" << std::endl;
+		} else if(req.drm_capability() == DRM_CLIENT_CAP_UNIVERSAL_PLANES) {
+			self->universalPlanes = true;
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+		} else if(req.drm_capability() == DRM_CLIENT_CAP_ATOMIC) {
+			self->atomic = true;
+			self->universalPlanes = true;
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+		} else {
+			std::cout << "\e[31mcore/drm: Attempt to set unknown client capability " << req.drm_capability() << "\e[39m" << std::endl;
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+		}
+
+		auto ser = resp.SerializeAsString();
+		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+			helix::action(&send_resp, ser.data(), ser.size()));
+		co_await transmit.async_wait();
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == DRM_IOCTL_MODE_OBJ_GETPROPERTIES) {
+		helix::SendBuffer send_resp;
+		managarm::fs::SvrResponse resp;
+
+		auto obj = self->_device->findObject(req.drm_obj_id());
+		assert(obj);
+
+		for(auto ass : obj->getAssignments()) {
+			resp.add_drm_obj_property_ids(ass.property->id());
+			resp.add_drm_obj_property_values(ass.intValue);
+		}
+
+		if(!resp.drm_obj_property_ids_size()) {
+			std::cout << "\e[31mcore/drm: No properties found for object id " << req.drm_obj_id() << "\e[39m" << std::endl;
+		}
+
+		resp.set_error(managarm::fs::Errors::SUCCESS);
+
+		auto ser = resp.SerializeAsString();
+		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+			helix::action(&send_resp, ser.data(), ser.size()));
+		co_await transmit.async_wait();
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == DRM_IOCTL_MODE_GETPROPERTY) {
+		helix::SendBuffer send_resp;
+		managarm::fs::SvrResponse resp;
+
+		uint32_t prop_id = req.drm_property_id();
+		auto prop = self->_device->getProperty(prop_id);
+
+		if(prop) {
+			resp.set_drm_property_name(prop->name());
+			resp.add_drm_property_vals(1);
+			resp.set_drm_property_flags(prop->flags());
+
+			if(std::holds_alternative<EnumPropertyType>(prop->propertyType())) {
+				for(auto &[value, name] : prop->enum_info()) {
+					resp.add_drm_enum_value(value);
+					resp.add_drm_enum_name(name);
+				}
+			}
+
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+		} else {
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+		}
+
+		auto ser = resp.SerializeAsString();
+		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+			helix::action(&send_resp, ser.data(), ser.size()));
+		co_await transmit.async_wait();
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == DRM_IOCTL_MODE_SETPROPERTY) {
+		helix::SendBuffer send_resp;
+		managarm::fs::SvrResponse resp;
+
+		std::cout << "\e[31mcore/drm: DRM_IOCTL_MODE_SETPROPERTY is a no-op\e[39m"
+				<< std::endl;
+
+		auto ser = resp.SerializeAsString();
+		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+			helix::action(&send_resp, ser.data(), ser.size()));
+		co_await transmit.async_wait();
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == DRM_IOCTL_MODE_GETPLANERESOURCES) {
+		helix::SendBuffer send_resp;
+		managarm::fs::SvrResponse resp;
+
+		auto &crtcs = self->_device->getCrtcs();
+		for(size_t i = 0; i < crtcs.size(); i++) {
+			resp.add_drm_plane_res(crtcs[i]->primaryPlane()->id());
+
+			if(crtcs[i]->cursorPlane()) {
+				resp.add_drm_plane_res(crtcs[i]->cursorPlane()->id());
+			}
+		}
+
+		resp.set_error(managarm::fs::Errors::SUCCESS);
+
+		auto ser = resp.SerializeAsString();
+		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+			helix::action(&send_resp, ser.data(), ser.size()));
+		co_await transmit.async_wait();
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == DRM_IOCTL_MODE_GETPROPBLOB) {
+		helix::SendBuffer send_resp;
+		managarm::fs::SvrResponse resp;
+
+		auto blob = self->_device->findBlob(req.drm_blob_id());
+
+		if(blob) {
+			auto data = reinterpret_cast<const uint8_t *>(blob->data());
+			for(size_t i = 0; i < blob->size(); i++) {
+				resp.add_drm_property_blob(data[i]);
+			}
+
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+		} else {
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+		}
+
+		auto ser = resp.SerializeAsString();
+		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+			helix::action(&send_resp, ser.data(), ser.size()));
+		co_await transmit.async_wait();
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == DRM_IOCTL_MODE_CREATEPROPBLOB) {
+		std::vector<char> blob_data;
+		blob_data.resize(req.drm_blob_size());
+
+		helix::RecvBuffer recv_buffer;
+		auto &&buff = helix::submitAsync(conversation, helix::Dispatcher::global(),
+				helix::action(&recv_buffer, blob_data.data(), req.drm_blob_size()));
+		co_await buff.async_wait();
+		HEL_CHECK(recv_buffer.error());
+
+		helix::SendBuffer send_resp;
+		managarm::fs::SvrResponse resp;
+
+		if(!req.drm_blob_size()) {
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+		} else {
+			auto blob = std::make_shared<Blob>(std::move(blob_data));
+			auto id = self->_device->registerBlob(blob);
+
+			resp.set_drm_blob_id(id);
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+		}
+
+		auto ser = resp.SerializeAsString();
+		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+			helix::action(&send_resp, ser.data(), ser.size()));
+		co_await transmit.async_wait();
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == DRM_IOCTL_MODE_DESTROYPROPBLOB) {
+		helix::SendBuffer send_resp;
+		managarm::fs::SvrResponse resp;
+
+		if(!self->_device->deleteBlob(req.drm_blob_id())) {
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+		} else {
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+		}
+
+		auto ser = resp.SerializeAsString();
+		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
+			helix::action(&send_resp, ser.data(), ser.size()));
+		co_await transmit.async_wait();
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == DRM_IOCTL_MODE_ATOMIC) {
+		helix::SendBuffer send_resp;
+		managarm::fs::SvrResponse resp;
+
+		size_t prop_count = 0;
+		std::vector<drm_core::Assignment> assignments;
+
+		std::vector<uint32_t> crtc_ids;
+
+		auto config = self->_device->createConfiguration();
+
+		if(!self->atomic || req.drm_flags() & ~DRM_MODE_ATOMIC_FLAGS || ((req.drm_flags() & DRM_MODE_ATOMIC_TEST_ONLY) && (req.drm_flags() & DRM_MODE_PAGE_FLIP_EVENT))) {
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+			goto send;
+		}
+
+		for(size_t i = 0; i < req.drm_obj_ids_size(); i++) {
+			auto mode_obj = self->_device->findObject(req.drm_obj_ids(i));
+			assert(mode_obj);
+
+			if(mode_obj->type() == ObjectType::crtc) {
+				crtc_ids.push_back(mode_obj->id());
+			}
+
+			for(size_t j = 0; j < req.drm_prop_counts(i); j++) {
+				auto prop = self->_device->getProperty(req.drm_props(prop_count + j));
+				assert(prop);
+				auto value = req.drm_prop_values(prop_count + j);
+
+				auto prop_type = prop->propertyType();
+
+				if(std::holds_alternative<IntPropertyType>(prop_type)) {
+					assignments.push_back(Assignment{
+						mode_obj,
+						prop.get(),
+						value,
+						nullptr,
+						nullptr
+					});
+				} else if(std::holds_alternative<BlobPropertyType>(prop_type)) {
+					auto blob = self->_device->findBlob(value);
+
+					assignments.push_back(Assignment{
+						mode_obj,
+						prop.get(),
+						0,
+						nullptr,
+						blob
+					});
+				} else if(std::holds_alternative<ObjectPropertyType>(prop_type)) {
+					auto obj = self->_device->findObject(value);
+
+					assignments.push_back(Assignment{
+						mode_obj,
+						prop.get(),
+						0,
+						obj,
+						nullptr
+					});
+				}
+			}
+
+			prop_count += req.drm_prop_counts(i);
+		}
+
+		{
+			auto valid = config->capture(assignments);
+			assert(valid);
+		}
+
+		if(!(req.drm_flags() & DRM_MODE_ATOMIC_TEST_ONLY)) {
+			config->commit();
+			co_await config->waitForCompletion();
+		}
+
+		if(req.drm_flags() & DRM_MODE_PAGE_FLIP_EVENT) {
+			assert(crtc_ids.size() == 1);
+			self->_retirePageFlip(std::move(config), req.drm_cookie(), crtc_ids.front());
+		}
+
+		resp.set_error(managarm::fs::Errors::SUCCESS);
+
+send:
 		auto ser = resp.SerializeAsString();
 		auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
 			helix::action(&send_resp, ser.data(), ser.size()));
@@ -1351,7 +1658,7 @@ uint32_t drm_core::convertLegacyFormat(uint32_t bpp, uint32_t depth) {
 		case 8:
 			assert(depth == 8);
 			return DRM_FORMAT_C8;
-		
+
 		case 16:
 			assert(depth == 15 || depth == 16);
 			if(depth == 15) {
@@ -1359,7 +1666,7 @@ uint32_t drm_core::convertLegacyFormat(uint32_t bpp, uint32_t depth) {
 			}else {
 				return DRM_FORMAT_RGB565;
 			}
-		
+
 		case 24:
 			assert(depth == 24);
 			return DRM_FORMAT_RGB888;

--- a/drivers/gfx/bochs/src/bochs.hpp
+++ b/drivers/gfx/bochs/src/bochs.hpp
@@ -15,37 +15,33 @@ struct GfxDevice final : drm_core::Device, std::enable_shared_from_this<GfxDevic
 
 	struct Configuration : drm_core::Configuration {
 		Configuration(GfxDevice *device)
-		: _device(device), _width(0), _height(0), _fb(nullptr) { };
-		
-		bool capture(std::vector<drm_core::Assignment> assignment) override;
+		: _device(device) { };
+
+		bool capture(std::vector<drm_core::Assignment> assignment, std::unique_ptr<drm_core::AtomicState> &state) override;
 		void dispose() override;
-		void commit() override;
-		
+		void commit(std::unique_ptr<drm_core::AtomicState> &state) override;
+
 	private:
-		async::detached _doCommit();
+		async::detached _doCommit(std::unique_ptr<drm_core::AtomicState> &state);
 
 		GfxDevice *_device;
-		int _width;
-		int _height;
-		GfxDevice::FrameBuffer *_fb;
-		std::shared_ptr<drm_core::Blob> _mode;
 	};
 
 	struct Plane : drm_core::Plane {
-		Plane(GfxDevice *device);
+		Plane(GfxDevice *device, PlaneType type);
 	};
-	
+
 	struct BufferObject final : drm_core::BufferObject, std::enable_shared_from_this<BufferObject> {
 		BufferObject(GfxDevice *device, size_t alignment, size_t size,
 				uintptr_t offset, ptrdiff_t displacement);
-		
+
 		std::shared_ptr<drm_core::BufferObject> sharedBufferObject() override;
 		size_t getSize() override;
 		std::pair<helix::BorrowedDescriptor, uint64_t> getMemory() override;
-		
+
 		size_t getAlignment();
 		uintptr_t getAddress();
-		
+
 	private:
 		GfxDevice *_device;
 		size_t _alignment;
@@ -65,13 +61,13 @@ struct GfxDevice final : drm_core::Device, std::enable_shared_from_this<GfxDevic
 	struct Encoder : drm_core::Encoder {
 		Encoder(GfxDevice *device);
 	};
-	
+
 	struct Crtc final : drm_core::Crtc {
 		Crtc(GfxDevice *device);
-		
+
 		drm_core::Plane *primaryPlane() override;
-	
-	private:	
+
+	private:
 		GfxDevice *_device;
 	};
 
@@ -90,20 +86,20 @@ struct GfxDevice final : drm_core::Device, std::enable_shared_from_this<GfxDevic
 
 	GfxDevice(protocols::hw::Device hw_device,
 			helix::UniqueDescriptor video_ram, void* frame_buffer);
-	
+
 	async::detached initialize();
 	std::unique_ptr<drm_core::Configuration> createConfiguration() override;
 	std::pair<std::shared_ptr<drm_core::BufferObject>, uint32_t> createDumb(uint32_t width,
 			uint32_t height, uint32_t bpp) override;
-	std::shared_ptr<drm_core::FrameBuffer> 
+	std::shared_ptr<drm_core::FrameBuffer>
 			createFrameBuffer(std::shared_ptr<drm_core::BufferObject> bo,
 			uint32_t width, uint32_t height, uint32_t format, uint32_t pitch) override;
-	
+
 	//returns major, minor, patchlvl
 	std::tuple<int, int, int> driverVersion() override;
 	//returns name, desc, date
 	std::tuple<std::string, std::string, std::string> driverInfo() override;
-	
+
 private:
 	std::shared_ptr<Crtc> _theCrtc;
 	std::shared_ptr<Encoder> _theEncoder;
@@ -111,7 +107,7 @@ private:
 	std::shared_ptr<Plane> _primaryPlane;
 
 public:
-	// FIX ME: this is a hack	
+	// FIX ME: this is a hack
 	helix::UniqueDescriptor _videoRam;
 
 private:

--- a/drivers/gfx/bochs/src/main.cpp
+++ b/drivers/gfx/bochs/src/main.cpp
@@ -72,22 +72,22 @@ async::detached GfxDevice::initialize() {
 	registerObject(_theConnector.get());
 	registerObject(_primaryPlane.get());
 
-	assignments.push_back(drm_core::Assignment::with_int(_theCrtc, activeProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_theCrtc, activeProperty(), 0));
 
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, planeTypeProperty(), 1));
-	assignments.push_back(drm_core::Assignment::with_modeobj(_primaryPlane, crtcIdProperty(), _theCrtc));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, srcHProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, srcWProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, crtcHProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, crtcWProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, srcXProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, srcYProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, crtcXProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, crtcYProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_modeobj(_primaryPlane, fbIdProperty(), nullptr));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, planeTypeProperty(), 1));
+	assignments.push_back(drm_core::Assignment::withModeObj(_primaryPlane, crtcIdProperty(), _theCrtc));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, srcHProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, srcWProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, crtcHProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, crtcWProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, srcXProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, srcYProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, crtcXProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, crtcYProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withModeObj(_primaryPlane, fbIdProperty(), nullptr));
 
-	assignments.push_back(drm_core::Assignment::with_int(_theConnector, dpmsProperty(), 3));
-	assignments.push_back(drm_core::Assignment::with_modeobj(_theConnector, crtcIdProperty(), _theCrtc));
+	assignments.push_back(drm_core::Assignment::withInt(_theConnector, dpmsProperty(), 3));
+	assignments.push_back(drm_core::Assignment::withModeObj(_theConnector, crtcIdProperty(), _theCrtc));
 
 	_theEncoder->setCurrentCrtc(_theCrtc.get());
 	_theConnector->setupPossibleEncoders({_theEncoder.get()});
@@ -244,8 +244,8 @@ async::detached GfxDevice::Configuration::_doCommit(std::unique_ptr<drm_core::At
 
 	drm_mode_modeinfo last_mode;
 	memset(&last_mode, 0, sizeof(drm_mode_modeinfo));
-	if(_device->_theCrtc->drm_state()->mode())
-		memcpy(&last_mode, _device->_theCrtc->drm_state()->mode()->data(), sizeof(drm_mode_modeinfo));
+	if(_device->_theCrtc->drmState()->mode())
+		memcpy(&last_mode, _device->_theCrtc->drmState()->mode()->data(), sizeof(drm_mode_modeinfo));
 
 	auto switch_mode = last_mode.hdisplay != primary_plane_state->src_w() || last_mode.vdisplay != primary_plane_state->src_h();
 

--- a/drivers/gfx/plainfb/src/main.cpp
+++ b/drivers/gfx/plainfb/src/main.cpp
@@ -166,15 +166,15 @@ bool GfxDevice::Configuration::capture(std::vector<drm_core::Assignment> assignm
 	auto plane_state = state->plane(_device->_plane->id());
 	auto crtc_state = state->crtc(_device->_theCrtc->id());
 
-	if(crtc_state->mode() != nullptr) {
+	if(crtc_state->mode != nullptr) {
 		// TODO: Consider current width/height if FB did not change.
 		drm_mode_modeinfo mode_info;
-		memcpy(&mode_info, crtc_state->mode()->data(), sizeof(drm_mode_modeinfo));
-		plane_state->src_h(mode_info.vdisplay);
-		plane_state->src_w(mode_info.hdisplay);
+		memcpy(&mode_info, crtc_state->mode->data(), sizeof(drm_mode_modeinfo));
+		plane_state->src_h = mode_info.vdisplay;
+		plane_state->src_w = mode_info.hdisplay;
 
 		// TODO: Check max dimensions: plane_state->width > 1024 || plane_state->height > 768
-		if(plane_state->src_w() <= 0 || plane_state->src_h() <= 0) {
+		if(plane_state->src_w <= 0 || plane_state->src_h <= 0) {
 			std::cout << "\e[31m" "gfx/plainfb: invalid state width of height" << "\e[39m" << std::endl;
 			return false;
 		}
@@ -196,7 +196,7 @@ void GfxDevice::Configuration::commit(std::unique_ptr<drm_core::AtomicState> &st
 async::detached GfxDevice::Configuration::_dispatch(std::unique_ptr<drm_core::AtomicState> &state) {
 	auto crtc_state = state->crtc(_device->_theCrtc->id());
 
-	if(crtc_state->mode() != nullptr) {
+	if(crtc_state->mode != nullptr) {
 		if(!_device->_claimedDevice) {
 			co_await _device->_hwDevice.claimDevice();
 			_device->_claimedDevice = true;
@@ -204,8 +204,8 @@ async::detached GfxDevice::Configuration::_dispatch(std::unique_ptr<drm_core::At
 
 		auto plane_state = state->plane(_device->_plane->id());
 
-		if(plane_state->fb_id() != nullptr) {
-			auto fb = static_pointer_cast<GfxDevice::FrameBuffer>(plane_state->fb_id());
+		if(plane_state->fb != nullptr) {
+			auto fb = static_pointer_cast<GfxDevice::FrameBuffer>(plane_state->fb);
 
 			auto bo = fb->getBufferObject();
 			assert(bo->getWidth() == _device->_screenWidth);

--- a/drivers/gfx/plainfb/src/main.cpp
+++ b/drivers/gfx/plainfb/src/main.cpp
@@ -38,13 +38,13 @@ GfxDevice::GfxDevice(protocols::hw::Device hw_device,
 	}
 }
 
-async::detached GfxDevice::initialize() { 
+async::detached GfxDevice::initialize() {
 	// Setup planes, encoders and CRTCs (i.e. the static entities).
-	auto plane = std::make_shared<Plane>(this);
-	_theCrtc = std::make_shared<Crtc>(this, plane);
+	_plane = std::make_shared<Plane>(this, Plane::PlaneType::PRIMARY);
+	_theCrtc = std::make_shared<Crtc>(this);
 	_theEncoder = std::make_shared<Encoder>(this);
-	
-	plane->setupWeakPtr(plane);
+
+	_plane->setupWeakPtr(_plane);
 	_theCrtc->setupWeakPtr(_theCrtc);
 	_theEncoder->setupWeakPtr(_theEncoder);
 
@@ -52,9 +52,30 @@ async::detached GfxDevice::initialize() {
 	_theEncoder->setupPossibleClones({_theEncoder.get()});
 	_theEncoder->setCurrentCrtc(_theCrtc.get());
 
-	registerObject(plane.get());
+	_theCrtc->setupState(_theCrtc);
+	_plane->setupState(_plane);
+	_plane->setupPossibleCrtcs({_theCrtc.get()});
+
+	std::vector<drm_core::Assignment> assignments;
+
+	assignments.push_back(drm_core::Assignment::with_int(_theCrtc, activeProperty(), 0));
+	assignments.push_back(drm_core::Assignment::with_int(_plane, planeTypeProperty(), 1));
+
+	registerObject(_plane.get());
 	registerObject(_theCrtc.get());
 	registerObject(_theEncoder.get());
+
+	assignments.push_back(drm_core::Assignment::with_blob(_theCrtc, modeIdProperty(), nullptr));
+	assignments.push_back(drm_core::Assignment::with_modeobj(_plane, crtcIdProperty(), _theCrtc));
+	assignments.push_back(drm_core::Assignment::with_int(_plane, srcHProperty(), 0));
+	assignments.push_back(drm_core::Assignment::with_int(_plane, srcWProperty(), 0));
+	assignments.push_back(drm_core::Assignment::with_int(_plane, crtcHProperty(), 0));
+	assignments.push_back(drm_core::Assignment::with_int(_plane, crtcWProperty(), 0));
+	assignments.push_back(drm_core::Assignment::with_int(_plane, srcXProperty(), 0));
+	assignments.push_back(drm_core::Assignment::with_int(_plane, srcYProperty(), 0));
+	assignments.push_back(drm_core::Assignment::with_int(_plane, crtcXProperty(), 0));
+	assignments.push_back(drm_core::Assignment::with_int(_plane, crtcYProperty(), 0));
+	assignments.push_back(drm_core::Assignment::with_modeobj(_plane, fbIdProperty(), nullptr));
 
 	setupCrtc(_theCrtc.get());
 	setupEncoder(_theEncoder.get());
@@ -62,14 +83,18 @@ async::detached GfxDevice::initialize() {
 	// Setup the connector.
 	_theConnector = std::make_shared<Connector>(this);
 	_theConnector->setupWeakPtr(_theConnector);
+	_theConnector->setupState(_theConnector);
 
 	_theConnector->setupPossibleEncoders({_theEncoder.get()});
 	_theConnector->setCurrentEncoder(_theEncoder.get());
 	_theConnector->setCurrentStatus(1);
-	
+
 	registerObject(_theConnector.get());
 	attachConnector(_theConnector.get());
-	
+
+	assignments.push_back(drm_core::Assignment::with_int(_theConnector, dpmsProperty(), 3));
+	assignments.push_back(drm_core::Assignment::with_modeobj(_theConnector, crtcIdProperty(), _theCrtc));
+
 	std::vector<drm_mode_modeinfo> supported_modes;
 	drm_core::addDmtModes(supported_modes, _screenWidth, _screenHeight);
 	std::sort(supported_modes.begin(), supported_modes.end(),
@@ -77,7 +102,12 @@ async::detached GfxDevice::initialize() {
 		return u.hdisplay * u.vdisplay > v.hdisplay * v.vdisplay;
 	});
 	_theConnector->setModeList(supported_modes);
-	co_return;
+
+	auto config = createConfiguration();
+	auto state = atomicState();
+	assert(config->capture(assignments, state));
+	config->commit(state);
+	co_await config->waitForCompletion();
 }
 
 std::unique_ptr<drm_core::Configuration> GfxDevice::createConfiguration() {
@@ -87,9 +117,9 @@ std::unique_ptr<drm_core::Configuration> GfxDevice::createConfiguration() {
 std::shared_ptr<drm_core::FrameBuffer> GfxDevice::createFrameBuffer(std::shared_ptr<drm_core::BufferObject> base_bo,
 		uint32_t width, uint32_t height, uint32_t, uint32_t pitch) {
 	auto bo = std::static_pointer_cast<GfxDevice::BufferObject>(base_bo);
-		
+
 	assert(pitch % 4 == 0);
-	
+
 	assert(pitch / 4 >= width);
 	assert(bo->getSize() >= pitch * height);
 
@@ -116,10 +146,10 @@ GfxDevice::createDumb(uint32_t width, uint32_t height, uint32_t bpp) {
 	auto bo = std::make_shared<BufferObject>(this, size,
 			helix::UniqueDescriptor(handle), width, height);
 	uint32_t pitch = width * bpp / 8;
-	
+
 	auto mapping = installMapping(bo.get());
 	bo->setupMapping(mapping);
-	
+
 	return std::make_pair(bo, pitch);
 }
 
@@ -127,59 +157,27 @@ GfxDevice::createDumb(uint32_t width, uint32_t height, uint32_t bpp) {
 // GfxDevice::Configuration.
 // ----------------------------------------------------------------
 
-bool GfxDevice::Configuration::capture(std::vector<drm_core::Assignment> assignment) {
-	auto captureScanout = [&] () {
-		if(_state)
-			return;
-
-		_state.emplace();
-		// TODO: Capture FB, width and height.
-		_state->mode = _device->_theCrtc->currentMode();
-	};
-
-	for(auto &assign : assignment) {
-		if(assign.property == _device->srcWProperty()) {
-			//TODO: check this outside of capure
-			assert(assign.property->validate(assign));
-			
-			captureScanout();
-			_state->width = assign.intValue;
-		}else if(assign.property == _device->srcHProperty()) {
-			//TODO: check this outside of capure
-			assert(assign.property->validate(assign));
-
-			captureScanout();
-			_state->height = assign.intValue;
-		}else if(assign.property == _device->fbIdProperty()) {
-			//TODO: check this outside of capure
-			assert(assign.property->validate(assign));
-
-			auto fb = assign.objectValue->asFrameBuffer();
-			captureScanout();
-			_state->fb = static_cast<GfxDevice::FrameBuffer *>(fb);
-		}else if(assign.property == _device->modeIdProperty()) {
-			//TODO: check this outside of capture.
-			assert(assign.property->validate(assign));
-		
-			captureScanout();
-			_state->mode = assign.blobValue;
-		}else{
-			return false;
-		}
+bool GfxDevice::Configuration::capture(std::vector<drm_core::Assignment> assignments, std::unique_ptr<drm_core::AtomicState> &state) {
+	for(auto &assign : assignments) {
+		assert(assign.property->validate(assign));
+		assign.property->writeToState(assign, state);
 	}
 
-	if(_state && _state->mode) {
+	auto plane_state = state->plane(_device->_plane->id());
+	auto crtc_state = state->crtc(_device->_theCrtc->id());
+
+	if(crtc_state->mode() != nullptr) {
 		// TODO: Consider current width/height if FB did not change.
 		drm_mode_modeinfo mode_info;
-		memcpy(&mode_info, _state->mode->data(), sizeof(drm_mode_modeinfo));
-		_state->height = mode_info.vdisplay;
-		_state->width = mode_info.hdisplay;
-		
-		// TODO: Check max dimensions: _state->width > 1024 || _state->height > 768
-		if(_state->width <= 0 || _state->height <= 0)
+		memcpy(&mode_info, crtc_state->mode()->data(), sizeof(drm_mode_modeinfo));
+		plane_state->src_h(mode_info.vdisplay);
+		plane_state->src_w(mode_info.hdisplay);
+
+		// TODO: Check max dimensions: plane_state->width > 1024 || plane_state->height > 768
+		if(plane_state->src_w() <= 0 || plane_state->src_h() <= 0) {
+			std::cout << "\e[31m" "gfx/plainfb: invalid state width of height" << "\e[39m" << std::endl;
 			return false;
-		if(!_state->fb)
-			return false;
+		}
 	}
 	return true;
 }
@@ -188,44 +186,48 @@ void GfxDevice::Configuration::dispose() {
 
 }
 
-void GfxDevice::Configuration::commit() {
-	if(_state)
-		_device->_theCrtc->setCurrentMode(_state->mode);
+void GfxDevice::Configuration::commit(std::unique_ptr<drm_core::AtomicState> &state) {
+	_dispatch(state);
 
-	_dispatch();
+	_device->_theCrtc->set_drm_state(state->crtc(_device->_theCrtc->id()));
+	_device->_plane->set_drm_state(state->plane(_device->_plane->id()));
 }
 
-async::detached GfxDevice::Configuration::_dispatch() {
-	if(_state && _state->mode) {
-//		std::cout << "Swap to framebuffer " << _state[i]->fb->id()
-//				<< " " << _state[i]->width << "x" << _state[i]->height << std::endl;
+async::detached GfxDevice::Configuration::_dispatch(std::unique_ptr<drm_core::AtomicState> &state) {
+	auto crtc_state = state->crtc(_device->_theCrtc->id());
 
+	if(crtc_state->mode() != nullptr) {
 		if(!_device->_claimedDevice) {
 			co_await _device->_hwDevice.claimDevice();
 			_device->_claimedDevice = true;
 		}
 
-		auto bo = _state->fb->getBufferObject();
-		assert(bo->getWidth() == _device->_screenWidth);
-		assert(bo->getHeight() == _device->_screenHeight);
-		auto dest = reinterpret_cast<char *>(_device->_fbMapping.get());
-		auto src = reinterpret_cast<char *>(bo->accessMapping());
+		auto plane_state = state->plane(_device->_plane->id());
 
-		if(_state->fb->fastScanout()) {
-			for(unsigned int k = 0; k < bo->getHeight(); k++) {
-				drm_core::fastCopy16(dest, src, bo->getWidth() * 4);
-				dest += _device->_screenPitch;
-				src += _state->fb->getPitch();
-			}
-		}else{
-			for(unsigned int k = 0; k < bo->getHeight(); k++) {
-				memcpy(dest, src, bo->getWidth() * 4);
-				dest += _device->_screenPitch;
-				src += _state->fb->getPitch();
+		if(plane_state->fb_id() != nullptr) {
+			auto fb = static_pointer_cast<GfxDevice::FrameBuffer>(plane_state->fb_id());
+
+			auto bo = fb->getBufferObject();
+			assert(bo->getWidth() == _device->_screenWidth);
+			assert(bo->getHeight() == _device->_screenHeight);
+			auto dest = reinterpret_cast<char *>(_device->_fbMapping.get());
+			auto src = reinterpret_cast<char *>(bo->accessMapping());
+
+			if(fb->fastScanout()) {
+				for(unsigned int k = 0; k < bo->getHeight(); k++) {
+					drm_core::fastCopy16(dest, src, bo->getWidth() * 4);
+					dest += _device->_screenPitch;
+					src += fb->getPitch();
+				}
+			}else{
+				for(unsigned int k = 0; k < bo->getHeight(); k++) {
+					memcpy(dest, src, bo->getWidth() * 4);
+					dest += _device->_screenPitch;
+					src += fb->getPitch();
+				}
 			}
 		}
-	}else if(_state) {
-		assert(!_state->mode);
+	} else {
 		std::cout << "gfx/plainfb: Disable scanout" << std::endl;
 	}
 
@@ -253,14 +255,13 @@ GfxDevice::Encoder::Encoder(GfxDevice *device)
 // GfxDevice::Crtc.
 // ----------------------------------------------------------------
 
-GfxDevice::Crtc::Crtc(GfxDevice *device, std::shared_ptr<Plane> plane)
-: drm_core::Crtc{device->allocator.allocate()},
-		_primaryPlane{std::move(plane)} {
-	(void)device;
+GfxDevice::Crtc::Crtc(GfxDevice *device)
+: drm_core::Crtc{device->allocator.allocate()} {
+	_device = device;
 }
 
 drm_core::Plane *GfxDevice::Crtc::primaryPlane() {
-	return _primaryPlane.get();
+	return _device->_plane.get();
 }
 
 // ----------------------------------------------------------------
@@ -297,8 +298,8 @@ void GfxDevice::FrameBuffer::notifyDirty() {
 // GfxDevice: Plane.
 // ----------------------------------------------------------------
 
-GfxDevice::Plane::Plane(GfxDevice *device)
-: drm_core::Plane{device->allocator.allocate()} { }
+GfxDevice::Plane::Plane(GfxDevice *device, PlaneType type)
+: drm_core::Plane{device->allocator.allocate(), type} { }
 
 // ----------------------------------------------------------------
 // GfxDevice: BufferObject.
@@ -350,7 +351,7 @@ async::detached bindController(mbus::Entity entity) {
 			<< "x" << info.height << " (" << info.bpp
 			<< " bpp, pitch: " << info.pitch << ")" << std::endl;
 	assert(info.bpp == 32);
-	
+
 	auto gfx_device = std::make_shared<GfxDevice>(std::move(hw_device),
 			info.width, info.height, info.pitch,
 			helix::Mapping{fb_memory, 0, info.pitch * info.height});
@@ -358,7 +359,7 @@ async::detached bindController(mbus::Entity entity) {
 
 	// Create an mbus object for the device.
 	auto root = co_await mbus::Instance::global().getRoot();
-	
+
 	mbus::Properties descriptor{
 		{"drvcore.mbus-parent", mbus::StringItem{std::to_string(entity.getId())}},
 		{"unix.subsystem", mbus::StringItem{"drm"}},

--- a/drivers/gfx/plainfb/src/main.cpp
+++ b/drivers/gfx/plainfb/src/main.cpp
@@ -58,24 +58,24 @@ async::detached GfxDevice::initialize() {
 
 	std::vector<drm_core::Assignment> assignments;
 
-	assignments.push_back(drm_core::Assignment::with_int(_theCrtc, activeProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_plane, planeTypeProperty(), 1));
+	assignments.push_back(drm_core::Assignment::withInt(_theCrtc, activeProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_plane, planeTypeProperty(), 1));
 
 	registerObject(_plane.get());
 	registerObject(_theCrtc.get());
 	registerObject(_theEncoder.get());
 
-	assignments.push_back(drm_core::Assignment::with_blob(_theCrtc, modeIdProperty(), nullptr));
-	assignments.push_back(drm_core::Assignment::with_modeobj(_plane, crtcIdProperty(), _theCrtc));
-	assignments.push_back(drm_core::Assignment::with_int(_plane, srcHProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_plane, srcWProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_plane, crtcHProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_plane, crtcWProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_plane, srcXProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_plane, srcYProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_plane, crtcXProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_plane, crtcYProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_modeobj(_plane, fbIdProperty(), nullptr));
+	assignments.push_back(drm_core::Assignment::withBlob(_theCrtc, modeIdProperty(), nullptr));
+	assignments.push_back(drm_core::Assignment::withModeObj(_plane, crtcIdProperty(), _theCrtc));
+	assignments.push_back(drm_core::Assignment::withInt(_plane, srcHProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_plane, srcWProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_plane, crtcHProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_plane, crtcWProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_plane, srcXProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_plane, srcYProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_plane, crtcXProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_plane, crtcYProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withModeObj(_plane, fbIdProperty(), nullptr));
 
 	setupCrtc(_theCrtc.get());
 	setupEncoder(_theEncoder.get());
@@ -92,8 +92,8 @@ async::detached GfxDevice::initialize() {
 	registerObject(_theConnector.get());
 	attachConnector(_theConnector.get());
 
-	assignments.push_back(drm_core::Assignment::with_int(_theConnector, dpmsProperty(), 3));
-	assignments.push_back(drm_core::Assignment::with_modeobj(_theConnector, crtcIdProperty(), _theCrtc));
+	assignments.push_back(drm_core::Assignment::withInt(_theConnector, dpmsProperty(), 3));
+	assignments.push_back(drm_core::Assignment::withModeObj(_theConnector, crtcIdProperty(), _theCrtc));
 
 	std::vector<drm_mode_modeinfo> supported_modes;
 	drm_core::addDmtModes(supported_modes, _screenWidth, _screenHeight);
@@ -189,8 +189,8 @@ void GfxDevice::Configuration::dispose() {
 void GfxDevice::Configuration::commit(std::unique_ptr<drm_core::AtomicState> &state) {
 	_dispatch(state);
 
-	_device->_theCrtc->set_drm_state(state->crtc(_device->_theCrtc->id()));
-	_device->_plane->set_drm_state(state->plane(_device->_plane->id()));
+	_device->_theCrtc->setDrmState(state->crtc(_device->_theCrtc->id()));
+	_device->_plane->setDrmState(state->plane(_device->_plane->id()));
 }
 
 async::detached GfxDevice::Configuration::_dispatch(std::unique_ptr<drm_core::AtomicState> &state) {

--- a/drivers/gfx/virtio/src/main.cpp
+++ b/drivers/gfx/virtio/src/main.cpp
@@ -230,14 +230,14 @@ bool GfxDevice::Configuration::capture(std::vector<drm_core::Assignment> assignm
 		auto cs = pair.second;
 		auto pps = state->plane(cs->crtc().lock()->primaryPlane()->id());
 
-		if(cs->mode_changed() && cs->mode() != nullptr) {
+		if(cs->modeChanged && cs->mode != nullptr) {
 			drm_mode_modeinfo mode_info;
-			memcpy(&mode_info, cs->mode()->data(), sizeof(drm_mode_modeinfo));
-			pps->src_h(mode_info.vdisplay);
-			pps->src_w(mode_info.hdisplay);
+			memcpy(&mode_info, cs->mode->data(), sizeof(drm_mode_modeinfo));
+			pps->src_h = mode_info.vdisplay;
+			pps->src_w = mode_info.hdisplay;
 
 			// TODO: Check max dimensions: _state[i]->width > 1024 || _state[i]->height > 768
-			if(pps->src_w() <= 0 || pps->src_h() <= 0) {
+			if(pps->src_w <= 0 || pps->src_h <= 0) {
 				return false;
 			}
 		}
@@ -267,7 +267,7 @@ async::detached GfxDevice::Configuration::_dispatch(std::unique_ptr<drm_core::At
 		auto crtc = cs->crtc().lock();
 		auto pps = state->plane(crtc->primaryPlane()->id());
 
-		if(cs->mode() == nullptr) {
+		if(cs->mode == nullptr) {
 			std::cout << "gfx/virtio: Disable scanout" << std::endl;
 			spec::SetScanout scanout;
 			memset(&scanout, 0, sizeof(spec::SetScanout));
@@ -286,8 +286,8 @@ async::detached GfxDevice::Configuration::_dispatch(std::unique_ptr<drm_core::At
 			continue;
 		}
 
-		if(pps->fb_id() != nullptr) {
-			auto fb = static_pointer_cast<GfxDevice::FrameBuffer>(pps->fb_id());
+		if(pps->fb != nullptr) {
+			auto fb = static_pointer_cast<GfxDevice::FrameBuffer>(pps->fb);
 
 			co_await fb->getBufferObject()->wait();
 
@@ -296,8 +296,8 @@ async::detached GfxDevice::Configuration::_dispatch(std::unique_ptr<drm_core::At
 			xfer.header.type = spec::cmd::xferToHost2d;
 			xfer.rect.x = 0;
 			xfer.rect.y = 0;
-			xfer.rect.width = pps->src_w();
-			xfer.rect.height = pps->src_h();
+			xfer.rect.width = pps->src_w;
+			xfer.rect.height = pps->src_h;
 			xfer.resourceId = fb->getBufferObject()->hardwareId();
 
 			spec::Header xfer_result;
@@ -316,9 +316,9 @@ async::detached GfxDevice::Configuration::_dispatch(std::unique_ptr<drm_core::At
 			scanout.header.type = spec::cmd::setScanout;
 			scanout.rect.x = 0;
 			scanout.rect.y = 0;
-			scanout.rect.width = pps->src_w();
-			scanout.rect.height = pps->src_h();
-			scanout.scanoutId = static_pointer_cast<GfxDevice::Plane>(pps->plane())->scanoutId();
+			scanout.rect.width = pps->src_w;
+			scanout.rect.height = pps->src_h;
+			scanout.scanoutId = static_pointer_cast<GfxDevice::Plane>(pps->plane)->scanoutId();
 			scanout.resourceId = fb->getBufferObject()->hardwareId();
 
 			spec::Header scanout_result;
@@ -337,8 +337,8 @@ async::detached GfxDevice::Configuration::_dispatch(std::unique_ptr<drm_core::At
 			flush.header.type = spec::cmd::resourceFlush;
 			flush.rect.x = 0;
 			flush.rect.y = 0;
-			flush.rect.width = pps->src_w();
-			flush.rect.height = pps->src_h();
+			flush.rect.width = pps->src_w;
+			flush.rect.height = pps->src_h;
 			flush.resourceId = fb->getBufferObject()->hardwareId();
 
 			spec::Header flush_result;

--- a/drivers/gfx/virtio/src/main.cpp
+++ b/drivers/gfx/virtio/src/main.cpp
@@ -63,7 +63,7 @@ private:
 GfxDevice::GfxDevice(std::unique_ptr<virtio_core::Transport> transport)
 : _transport{std::move(transport)}, _claimedDevice{false} { }
 
-async::detached GfxDevice::initialize() { 
+async::detached GfxDevice::initialize() {
 	_transport->finalizeFeatures();
 	_transport->claimQueues(2);
 
@@ -72,15 +72,21 @@ async::detached GfxDevice::initialize() {
 
 	_transport->runDevice();
 
+	std::vector<drm_core::Assignment> assignments;
+
 	auto num_scanouts = static_cast<uint32_t>(_transport->space().load(spec::cfg::numScanouts));
 	for(size_t i = 0; i < num_scanouts; i++) {
-		auto plane = std::make_shared<Plane>(this, i);
+		auto plane = std::make_shared<Plane>(this, i, Plane::PlaneType::PRIMARY);
 		auto crtc = std::make_shared<Crtc>(this, i, plane);
 		auto encoder = std::make_shared<Encoder>(this);
 
 		plane->setupWeakPtr(plane);
+		plane->setupState(plane);
 		crtc->setupWeakPtr(crtc);
+		crtc->setupState(crtc);
 		encoder->setupWeakPtr(encoder);
+
+		plane->setupPossibleCrtcs({crtc.get()});
 
 		encoder->setupPossibleCrtcs({crtc.get()});
 		encoder->setupPossibleClones({encoder.get()});
@@ -89,6 +95,20 @@ async::detached GfxDevice::initialize() {
 		registerObject(plane.get());
 		registerObject(crtc.get());
 		registerObject(encoder.get());
+
+		assignments.push_back(drm_core::Assignment::with_int(crtc, activeProperty(), 0));
+
+		assignments.push_back(drm_core::Assignment::with_int(plane, planeTypeProperty(), 1));
+		assignments.push_back(drm_core::Assignment::with_modeobj(plane, crtcIdProperty(), crtc));
+		assignments.push_back(drm_core::Assignment::with_int(plane, srcHProperty(), 0));
+		assignments.push_back(drm_core::Assignment::with_int(plane, srcWProperty(), 0));
+		assignments.push_back(drm_core::Assignment::with_int(plane, crtcHProperty(), 0));
+		assignments.push_back(drm_core::Assignment::with_int(plane, crtcWProperty(), 0));
+		assignments.push_back(drm_core::Assignment::with_int(plane, srcXProperty(), 0));
+		assignments.push_back(drm_core::Assignment::with_int(plane, srcYProperty(), 0));
+		assignments.push_back(drm_core::Assignment::with_int(plane, crtcXProperty(), 0));
+		assignments.push_back(drm_core::Assignment::with_int(plane, crtcYProperty(), 0));
+		assignments.push_back(drm_core::Assignment::with_modeobj(plane, fbIdProperty(), nullptr));
 
 		setupCrtc(crtc.get());
 		setupEncoder(encoder.get());
@@ -117,13 +137,18 @@ async::detached GfxDevice::initialize() {
 		if(info.modes[i].enabled) {
 			auto connector = std::make_shared<Connector>(this);
 			connector->setupWeakPtr(connector);
+			connector->setupState(connector);
 
 			connector->setupPossibleEncoders({_theEncoders[i].get()});
 			connector->setCurrentEncoder(_theEncoders[i].get());
 			connector->setCurrentStatus(1);
+			connector->setConnectorType(DRM_MODE_CONNECTOR_VIRTUAL);
 
 			registerObject(connector.get());
 			attachConnector(connector.get());
+
+			assignments.push_back(drm_core::Assignment::with_int(connector, dpmsProperty(), 3));
+			assignments.push_back(drm_core::Assignment::with_modeobj(connector, crtcIdProperty(), nullptr));
 
 			std::vector<drm_mode_modeinfo> supported_modes;
 			drm_core::addDmtModes(supported_modes, info.modes[i].rect.width,
@@ -137,6 +162,12 @@ async::detached GfxDevice::initialize() {
 			_activeConnectors[i] = connector;
 		}
 	}
+
+	auto config = createConfiguration();
+	auto state = atomicState();
+	assert(config->capture(assignments, state));
+	config->commit(state);
+	co_await config->waitForCompletion();
 }
 
 std::unique_ptr<drm_core::Configuration> GfxDevice::createConfiguration() {
@@ -187,69 +218,31 @@ GfxDevice::createDumb(uint32_t width, uint32_t height, uint32_t bpp) {
 // GfxDevice::Configuration.
 // ----------------------------------------------------------------
 
-bool GfxDevice::Configuration::capture(std::vector<drm_core::Assignment> assignment) {
-	auto captureScanout = [&] (int index) {
-		if(_state[index])
-			return;
-
-		_state[index].emplace();
-		// TODO: Capture FB, width and height.
-		_state[index]->mode = _device->_theCrtcs[index]->currentMode();
-	};
-
+bool GfxDevice::Configuration::capture(std::vector<drm_core::Assignment> assignment, std::unique_ptr<drm_core::AtomicState> &state) {
 	for(auto &assign : assignment) {
-		if(assign.property == _device->srcWProperty()) {
-			//TODO: check this outside of capure
-			assert(assign.property->validate(assign));
-
-			auto plane = static_cast<Plane *>(assign.object.get());
-			captureScanout(plane->scanoutId());
-			_state[plane->scanoutId()]->width = assign.intValue;
-		}else if(assign.property == _device->srcHProperty()) {
-			//TODO: check this outside of capure
-			assert(assign.property->validate(assign));
-
-			auto plane = static_cast<Plane *>(assign.object.get());
-			captureScanout(plane->scanoutId());
-			_state[plane->scanoutId()]->height = assign.intValue;
-		}else if(assign.property == _device->fbIdProperty()) {
-			//TODO: check this outside of capure
-			assert(assign.property->validate(assign));
-
-			auto plane = static_cast<Plane *>(assign.object.get());
-			auto fb = assign.objectValue->asFrameBuffer();
-			captureScanout(plane->scanoutId());
-			_state[plane->scanoutId()]->fb = static_cast<GfxDevice::FrameBuffer *>(fb);
-		}else if(assign.property == _device->modeIdProperty()) {
-			//TODO: check this outside of capture.
-			assert(assign.property->validate(assign));
-
-			auto crtc = static_cast<Crtc *>(assign.object.get());
-			captureScanout(crtc->scanoutId());
-			_state[crtc->scanoutId()]->mode = assign.blobValue;
-		}else{
-			return false;
-		}
+		assert(assign.property->validate(assign));
+		assign.property->writeToState(assign, state);
 	}
 
-	for(size_t i = 0; i < _state.size(); i++) {
-		if(!_state[i])
-			continue;
+	auto crtc_states = state->crtc_states();
 
-		if(_state[i]->mode) {
-			// TODO: Consider current width/height if FB did not change.
+	for(auto pair : crtc_states) {
+		auto cs = pair.second;
+		auto pps = state->plane(cs->crtc().lock()->primaryPlane()->id());
+
+		if(cs->mode_changed() && cs->mode() != nullptr) {
 			drm_mode_modeinfo mode_info;
-			memcpy(&mode_info, _state[i]->mode->data(), sizeof(drm_mode_modeinfo));
-			_state[i]->height = mode_info.vdisplay;
-			_state[i]->width = mode_info.hdisplay;
+			memcpy(&mode_info, cs->mode()->data(), sizeof(drm_mode_modeinfo));
+			pps->src_h(mode_info.vdisplay);
+			pps->src_w(mode_info.hdisplay);
 
 			// TODO: Check max dimensions: _state[i]->width > 1024 || _state[i]->height > 768
-			if(_state[i]->width <= 0 || _state[i]->height <= 0)
+			if(pps->src_w() <= 0 || pps->src_h() <= 0) {
 				return false;
-			if(!_state[i]->fb)
-				return false;
+			}
 		}
 	}
+
 	return true;
 }
 
@@ -257,27 +250,24 @@ void GfxDevice::Configuration::dispose() {
 
 }
 
-void GfxDevice::Configuration::commit() {
-	for(size_t i = 0; i < _state.size(); i++) {
-		if(!_state[i])
-			continue;
-		_device->_theCrtcs[i]->setCurrentMode(_state[i]->mode);
-	}
-
-	_dispatch();
+void GfxDevice::Configuration::commit(std::unique_ptr<drm_core::AtomicState> &state) {
+	_dispatch(state);
 }
 
-async::detached GfxDevice::Configuration::_dispatch() {
-	for(size_t i = 0; i < _state.size(); i++) {
-		if(!_state[i])
-			continue;
+async::detached GfxDevice::Configuration::_dispatch(std::unique_ptr<drm_core::AtomicState> &state) {
+	if(!_device->_claimedDevice) {
+		co_await _device->_transport->hwDevice().claimDevice();
+		_device->_claimedDevice = true;
+	}
 
-		if(!_device->_claimedDevice) {
-			co_await _device->_transport->hwDevice().claimDevice();
-			_device->_claimedDevice = true;
-		}
+	auto crtc_states = state->crtc_states();
 
-		if(!_state[i]->mode) {
+	for(auto pair : crtc_states) {
+		auto cs = pair.second;
+		auto crtc = cs->crtc().lock();
+		auto pps = state->plane(crtc->primaryPlane()->id());
+
+		if(cs->mode() == nullptr) {
 			std::cout << "gfx/virtio: Disable scanout" << std::endl;
 			spec::SetScanout scanout;
 			memset(&scanout, 0, sizeof(spec::SetScanout));
@@ -296,71 +286,72 @@ async::detached GfxDevice::Configuration::_dispatch() {
 			continue;
 		}
 
-		co_await _state[i]->fb->getBufferObject()->wait();
+		if(pps->fb_id() != nullptr) {
+			auto fb = static_pointer_cast<GfxDevice::FrameBuffer>(pps->fb_id());
 
-//		std::cout << "Swap to framebuffer " << _state[i]->fb->id()
-//				<< " " << _state[i]->width << "x" << _state[i]->height << std::endl;
+			co_await fb->getBufferObject()->wait();
 
-		spec::XferToHost2d xfer;
-		memset(&xfer, 0, sizeof(spec::XferToHost2d));
-		xfer.header.type = spec::cmd::xferToHost2d;
-		xfer.rect.x = 0;
-		xfer.rect.y = 0;
-		xfer.rect.width = _state[i]->width;
-		xfer.rect.height = _state[i]->height;
-		xfer.resourceId = _state[i]->fb->getBufferObject()->hardwareId();
+			spec::XferToHost2d xfer;
+			memset(&xfer, 0, sizeof(spec::XferToHost2d));
+			xfer.header.type = spec::cmd::xferToHost2d;
+			xfer.rect.x = 0;
+			xfer.rect.y = 0;
+			xfer.rect.width = pps->src_w();
+			xfer.rect.height = pps->src_h();
+			xfer.resourceId = fb->getBufferObject()->hardwareId();
 
-		spec::Header xfer_result;
-		virtio_core::Chain xfer_chain;
-		co_await virtio_core::scatterGather(virtio_core::hostToDevice,
-				xfer_chain, _device->_controlQ,
-				arch::dma_buffer_view{nullptr, &xfer, sizeof(spec::XferToHost2d)});
-		co_await virtio_core::scatterGather(virtio_core::deviceToHost,
-				xfer_chain, _device->_controlQ,
-				arch::dma_buffer_view{nullptr, &xfer_result, sizeof(spec::Header)});
-		co_await AwaitableRequest{_device->_controlQ, xfer_chain.front()};
-		assert(xfer_result.type == spec::resp::noData);
+			spec::Header xfer_result;
+			virtio_core::Chain xfer_chain;
+			co_await virtio_core::scatterGather(virtio_core::hostToDevice,
+					xfer_chain, _device->_controlQ,
+					arch::dma_buffer_view{nullptr, &xfer, sizeof(spec::XferToHost2d)});
+			co_await virtio_core::scatterGather(virtio_core::deviceToHost,
+					xfer_chain, _device->_controlQ,
+					arch::dma_buffer_view{nullptr, &xfer_result, sizeof(spec::Header)});
+			co_await AwaitableRequest{_device->_controlQ, xfer_chain.front()};
+			assert(xfer_result.type == spec::resp::noData);
 
-		spec::SetScanout scanout;
-		memset(&scanout, 0, sizeof(spec::SetScanout));
-		scanout.header.type = spec::cmd::setScanout;
-		scanout.rect.x = 0;
-		scanout.rect.y = 0;
-		scanout.rect.width = _state[i]->width;
-		scanout.rect.height = _state[i]->height;
-		scanout.scanoutId = i;
-		scanout.resourceId = _state[i]->fb->getBufferObject()->hardwareId();
+			spec::SetScanout scanout;
+			memset(&scanout, 0, sizeof(spec::SetScanout));
+			scanout.header.type = spec::cmd::setScanout;
+			scanout.rect.x = 0;
+			scanout.rect.y = 0;
+			scanout.rect.width = pps->src_w();
+			scanout.rect.height = pps->src_h();
+			scanout.scanoutId = static_pointer_cast<GfxDevice::Plane>(pps->plane())->scanoutId();
+			scanout.resourceId = fb->getBufferObject()->hardwareId();
 
-		spec::Header scanout_result;
-		virtio_core::Chain scanout_chain;
-		co_await virtio_core::scatterGather(virtio_core::hostToDevice,
-				scanout_chain, _device->_controlQ,
-				arch::dma_buffer_view{nullptr, &scanout, sizeof(spec::SetScanout)});
-		co_await virtio_core::scatterGather(virtio_core::deviceToHost,
-				scanout_chain, _device->_controlQ,
-				arch::dma_buffer_view{nullptr, &scanout_result, sizeof(spec::Header)});
-		co_await AwaitableRequest{_device->_controlQ, scanout_chain.front()};
-		assert(scanout_result.type == spec::resp::noData);
+			spec::Header scanout_result;
+			virtio_core::Chain scanout_chain;
+			co_await virtio_core::scatterGather(virtio_core::hostToDevice,
+					scanout_chain, _device->_controlQ,
+					arch::dma_buffer_view{nullptr, &scanout, sizeof(spec::SetScanout)});
+			co_await virtio_core::scatterGather(virtio_core::deviceToHost,
+					scanout_chain, _device->_controlQ,
+					arch::dma_buffer_view{nullptr, &scanout_result, sizeof(spec::Header)});
+			co_await AwaitableRequest{_device->_controlQ, scanout_chain.front()};
+			assert(scanout_result.type == spec::resp::noData);
 
-		spec::ResourceFlush flush;
-		memset(&flush, 0, sizeof(spec::ResourceFlush));
-		flush.header.type = spec::cmd::resourceFlush;
-		flush.rect.x = 0;
-		flush.rect.y = 0;
-		flush.rect.width = _state[i]->width;
-		flush.rect.height = _state[i]->height;
-		flush.resourceId = _state[i]->fb->getBufferObject()->hardwareId();
+			spec::ResourceFlush flush;
+			memset(&flush, 0, sizeof(spec::ResourceFlush));
+			flush.header.type = spec::cmd::resourceFlush;
+			flush.rect.x = 0;
+			flush.rect.y = 0;
+			flush.rect.width = pps->src_w();
+			flush.rect.height = pps->src_h();
+			flush.resourceId = fb->getBufferObject()->hardwareId();
 
-		spec::Header flush_result;
-		virtio_core::Chain flush_chain;
-		co_await virtio_core::scatterGather(virtio_core::hostToDevice,
-				flush_chain, _device->_controlQ,
-				arch::dma_buffer_view{nullptr, &flush, sizeof(spec::ResourceFlush)});
-		co_await virtio_core::scatterGather(virtio_core::deviceToHost,
-				flush_chain, _device->_controlQ,
-				arch::dma_buffer_view{nullptr, &flush_result, sizeof(spec::Header)});
-		co_await AwaitableRequest{_device->_controlQ, flush_chain.front()};
-		assert(flush_result.type == spec::resp::noData);
+			spec::Header flush_result;
+			virtio_core::Chain flush_chain;
+			co_await virtio_core::scatterGather(virtio_core::hostToDevice,
+					flush_chain, _device->_controlQ,
+					arch::dma_buffer_view{nullptr, &flush, sizeof(spec::ResourceFlush)});
+			co_await virtio_core::scatterGather(virtio_core::deviceToHost,
+					flush_chain, _device->_controlQ,
+					arch::dma_buffer_view{nullptr, &flush_result, sizeof(spec::Header)});
+			co_await AwaitableRequest{_device->_controlQ, flush_chain.front()};
+			assert(flush_result.type == spec::resp::noData);
+		}
 	}
 
 	complete();
@@ -461,8 +452,8 @@ async::detached GfxDevice::FrameBuffer::_xferAndFlush() {
 // GfxDevice: Plane.
 // ----------------------------------------------------------------
 
-GfxDevice::Plane::Plane(GfxDevice *device, int id)
-	:drm_core::Plane { device->allocator.allocate() } {
+GfxDevice::Plane::Plane(GfxDevice *device, int id, PlaneType type)
+	:drm_core::Plane { device->allocator.allocate(), type } {
 	_scanoutId = id;
 }
 
@@ -502,7 +493,7 @@ std::pair<helix::BorrowedDescriptor, uint64_t> GfxDevice::BufferObject::getMemor
 	return std::make_pair(helix::BorrowedDescriptor(_memory), 0);
 }
 
-async::detached GfxDevice::BufferObject::_initHw() { 
+async::detached GfxDevice::BufferObject::_initHw() {
 	void *ptr;
 	HEL_CHECK(helMapMemory(_memory.getHandle(), kHelNullHandle,
 		nullptr, 0, getSize(), kHelMapProtRead, &ptr));

--- a/drivers/gfx/virtio/src/main.cpp
+++ b/drivers/gfx/virtio/src/main.cpp
@@ -96,19 +96,19 @@ async::detached GfxDevice::initialize() {
 		registerObject(crtc.get());
 		registerObject(encoder.get());
 
-		assignments.push_back(drm_core::Assignment::with_int(crtc, activeProperty(), 0));
+		assignments.push_back(drm_core::Assignment::withInt(crtc, activeProperty(), 0));
 
-		assignments.push_back(drm_core::Assignment::with_int(plane, planeTypeProperty(), 1));
-		assignments.push_back(drm_core::Assignment::with_modeobj(plane, crtcIdProperty(), crtc));
-		assignments.push_back(drm_core::Assignment::with_int(plane, srcHProperty(), 0));
-		assignments.push_back(drm_core::Assignment::with_int(plane, srcWProperty(), 0));
-		assignments.push_back(drm_core::Assignment::with_int(plane, crtcHProperty(), 0));
-		assignments.push_back(drm_core::Assignment::with_int(plane, crtcWProperty(), 0));
-		assignments.push_back(drm_core::Assignment::with_int(plane, srcXProperty(), 0));
-		assignments.push_back(drm_core::Assignment::with_int(plane, srcYProperty(), 0));
-		assignments.push_back(drm_core::Assignment::with_int(plane, crtcXProperty(), 0));
-		assignments.push_back(drm_core::Assignment::with_int(plane, crtcYProperty(), 0));
-		assignments.push_back(drm_core::Assignment::with_modeobj(plane, fbIdProperty(), nullptr));
+		assignments.push_back(drm_core::Assignment::withInt(plane, planeTypeProperty(), 1));
+		assignments.push_back(drm_core::Assignment::withModeObj(plane, crtcIdProperty(), crtc));
+		assignments.push_back(drm_core::Assignment::withInt(plane, srcHProperty(), 0));
+		assignments.push_back(drm_core::Assignment::withInt(plane, srcWProperty(), 0));
+		assignments.push_back(drm_core::Assignment::withInt(plane, crtcHProperty(), 0));
+		assignments.push_back(drm_core::Assignment::withInt(plane, crtcWProperty(), 0));
+		assignments.push_back(drm_core::Assignment::withInt(plane, srcXProperty(), 0));
+		assignments.push_back(drm_core::Assignment::withInt(plane, srcYProperty(), 0));
+		assignments.push_back(drm_core::Assignment::withInt(plane, crtcXProperty(), 0));
+		assignments.push_back(drm_core::Assignment::withInt(plane, crtcYProperty(), 0));
+		assignments.push_back(drm_core::Assignment::withModeObj(plane, fbIdProperty(), nullptr));
 
 		setupCrtc(crtc.get());
 		setupEncoder(encoder.get());
@@ -147,8 +147,8 @@ async::detached GfxDevice::initialize() {
 			registerObject(connector.get());
 			attachConnector(connector.get());
 
-			assignments.push_back(drm_core::Assignment::with_int(connector, dpmsProperty(), 3));
-			assignments.push_back(drm_core::Assignment::with_modeobj(connector, crtcIdProperty(), nullptr));
+			assignments.push_back(drm_core::Assignment::withInt(connector, dpmsProperty(), 3));
+			assignments.push_back(drm_core::Assignment::withModeObj(connector, crtcIdProperty(), nullptr));
 
 			std::vector<drm_mode_modeinfo> supported_modes;
 			drm_core::addDmtModes(supported_modes, info.modes[i].rect.width,

--- a/drivers/gfx/virtio/src/virtio.hpp
+++ b/drivers/gfx/virtio/src/virtio.hpp
@@ -31,20 +31,18 @@ struct GfxDevice final : drm_core::Device, std::enable_shared_from_this<GfxDevic
 		Configuration(GfxDevice *device)
 		: _device(device) { };
 
-		bool capture(std::vector<drm_core::Assignment> assignment) override;
+		bool capture(std::vector<drm_core::Assignment> assignment, std::unique_ptr<drm_core::AtomicState> &state) override;
 		void dispose() override;
-		void commit() override;
+		void commit(std::unique_ptr<drm_core::AtomicState> &state) override;
 
 	private:
-		async::detached _dispatch();
+		async::detached _dispatch(std::unique_ptr<drm_core::AtomicState> &state);
 
-		std::array<std::optional<ScanoutState>, 16> _state;
 		GfxDevice *_device;
-		std::shared_ptr<drm_core::Blob> _mode;
 	};
 
 	struct Plane : drm_core::Plane {
-		Plane(GfxDevice *device, int id);
+		Plane(GfxDevice *device, int id, PlaneType type);
 
 		int scanoutId();
 

--- a/drivers/gfx/vmware/src/main.cpp
+++ b/drivers/gfx/vmware/src/main.cpp
@@ -100,19 +100,19 @@ async::detached GfxDevice::initialize() {
 	_primaryPlane->setupWeakPtr(_primaryPlane);
 	_primaryPlane->setupState(_primaryPlane);
 
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, planeTypeProperty(), 1));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, planeTypeProperty(), 1));
 
 	if (hasCapability(caps::cursor)) {
 		_cursorPlane = std::make_shared<Plane>(this, Plane::PlaneType::CURSOR);
 		_cursorPlane->setupWeakPtr(_cursorPlane);
 		_cursorPlane->setupState(_cursorPlane);
 
-		assignments.push_back(drm_core::Assignment::with_int(_cursorPlane, planeTypeProperty(), 2));
+		assignments.push_back(drm_core::Assignment::withInt(_cursorPlane, planeTypeProperty(), 2));
 	}
 
-	assignments.push_back(drm_core::Assignment::with_int(_connector, dpmsProperty(), 3));
-	assignments.push_back(drm_core::Assignment::with_blob(_crtc, modeIdProperty(), nullptr));
-	assignments.push_back(drm_core::Assignment::with_int(_crtc, activeProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_connector, dpmsProperty(), 3));
+	assignments.push_back(drm_core::Assignment::withBlob(_crtc, modeIdProperty(), nullptr));
+	assignments.push_back(drm_core::Assignment::withInt(_crtc, activeProperty(), 0));
 
 	registerObject(_crtc.get());
 	registerObject(_encoder.get());
@@ -123,17 +123,17 @@ async::detached GfxDevice::initialize() {
 		registerObject(_cursorPlane.get());
 	}
 
-	assignments.push_back(drm_core::Assignment::with_modeobj(_connector, crtcIdProperty(), nullptr));
-	assignments.push_back(drm_core::Assignment::with_modeobj(_primaryPlane, crtcIdProperty(), _crtc));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, crtcWProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, crtcHProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, srcWProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, srcHProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, srcXProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, srcYProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, crtcXProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_int(_primaryPlane, crtcYProperty(), 0));
-	assignments.push_back(drm_core::Assignment::with_modeobj(_primaryPlane, fbIdProperty(), nullptr));
+	assignments.push_back(drm_core::Assignment::withModeObj(_connector, crtcIdProperty(), nullptr));
+	assignments.push_back(drm_core::Assignment::withModeObj(_primaryPlane, crtcIdProperty(), _crtc));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, crtcWProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, crtcHProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, srcWProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, srcHProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, srcXProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, srcYProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, crtcXProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withInt(_primaryPlane, crtcYProperty(), 0));
+	assignments.push_back(drm_core::Assignment::withModeObj(_primaryPlane, fbIdProperty(), nullptr));
 
 	_encoder->setCurrentCrtc(_crtc.get());
 	_connector->setupPossibleEncoders({_encoder.get()});
@@ -146,8 +146,8 @@ async::detached GfxDevice::initialize() {
 	if (hasCapability(caps::cursor)) {
 		_cursorPlane->setupPossibleCrtcs({_crtc.get()});
 
-		assignments.push_back(drm_core::Assignment::with_modeobj(_cursorPlane, crtcIdProperty(), _crtc));
-		assignments.push_back(drm_core::Assignment::with_modeobj(_cursorPlane, fbIdProperty(), nullptr));
+		assignments.push_back(drm_core::Assignment::withModeObj(_cursorPlane, crtcIdProperty(), _crtc));
+		assignments.push_back(drm_core::Assignment::withModeObj(_cursorPlane, fbIdProperty(), nullptr));
 	}
 
 	setupCrtc(_crtc.get());
@@ -482,8 +482,8 @@ bool GfxDevice::Configuration::capture(std::vector<drm_core::Assignment> assignm
 	drm_mode_modeinfo current_mode;
 	memset(&current_mode, 0, sizeof(drm_mode_modeinfo));
 
-	if (_device->_crtc->drm_state()->mode() != nullptr) {
-		memcpy(&current_mode, _device->_crtc->drm_state()->mode()->data(), sizeof(drm_mode_modeinfo));
+	if (_device->_crtc->drmState()->mode() != nullptr) {
+		memcpy(&current_mode, _device->_crtc->drmState()->mode()->data(), sizeof(drm_mode_modeinfo));
 	}
 
 	auto primary_plane_state = state->plane(_device->_primaryPlane->id());
@@ -559,9 +559,9 @@ void GfxDevice::Configuration::dispose() {
 void GfxDevice::Configuration::commit(std::unique_ptr<drm_core::AtomicState> & state) {
 	commitConfiguration(state);
 
-	_device->_crtc->set_drm_state(state->crtc(_device->_crtc->id()));
-	_device->_primaryPlane->set_drm_state(state->plane(_device->_primaryPlane->id()));
-	_device->_cursorPlane->set_drm_state(state->plane(_device->_cursorPlane->id()));
+	_device->_crtc->setDrmState(state->crtc(_device->_crtc->id()));
+	_device->_primaryPlane->setDrmState(state->plane(_device->_primaryPlane->id()));
+	_device->_cursorPlane->setDrmState(state->plane(_device->_cursorPlane->id()));
 }
 
 async::detached GfxDevice::Configuration::commitConfiguration(std::unique_ptr<drm_core::AtomicState> & state) {
@@ -571,8 +571,8 @@ async::detached GfxDevice::Configuration::commitConfiguration(std::unique_ptr<dr
 
 	drm_mode_modeinfo last_mode;
 	memset(&last_mode, 0, sizeof(drm_mode_modeinfo));
-	if (_device->_crtc->drm_state()->mode() != nullptr)
-		memcpy(&last_mode, _device->_crtc->drm_state()->mode()->data(), sizeof(drm_mode_modeinfo));
+	if (_device->_crtc->drmState()->mode() != nullptr)
+		memcpy(&last_mode, _device->_crtc->drmState()->mode()->data(), sizeof(drm_mode_modeinfo));
 
 	auto switch_mode = last_mode.hdisplay != primary_plane_state->src_w() || last_mode.vdisplay != primary_plane_state->src_h();
 

--- a/drivers/gfx/vmware/src/vmware.hpp
+++ b/drivers/gfx/vmware/src/vmware.hpp
@@ -15,34 +15,23 @@ struct GfxDevice final : drm_core::Device, std::enable_shared_from_this<GfxDevic
 
 	struct Configuration : drm_core::Configuration {
 		Configuration(GfxDevice *device)
-		: _device(device), _width(0), _height(0), _fb(nullptr),
-		_cursorWidth(0), _cursorHeight(0), _cursorX(0), _cursorY(0),
-		_cursorFb(nullptr), _cursorUpdate(false), _cursorMove(false) { };
+		: _device(device), _cursorUpdate(false), _cursorMove(false) { };
 
-		bool capture(std::vector<drm_core::Assignment> assignment) override;
+		bool capture(std::vector<drm_core::Assignment> assignment, std::unique_ptr<drm_core::AtomicState> & state) override;
 		void dispose() override;
-		void commit() override;
+		void commit(std::unique_ptr<drm_core::AtomicState> & state) override;
 
 	private:
-		async::detached commitConfiguration();
+		async::detached commitConfiguration(std::unique_ptr<drm_core::AtomicState> & state);
 
 		GfxDevice *_device;
-		int _width;
-		int _height;
-		GfxDevice::FrameBuffer *_fb;
-		std::shared_ptr<drm_core::Blob> _mode;
 
-		int _cursorWidth;
-		int _cursorHeight;
-		uint64_t _cursorX;
-		uint64_t _cursorY;
-		GfxDevice::FrameBuffer *_cursorFb;
 		bool _cursorUpdate;
 		bool _cursorMove;
 	};
 
 	struct Plane : drm_core::Plane {
-		Plane(GfxDevice *device);
+		Plane(GfxDevice *device, PlaneType type);
 	};
 
 	struct BufferObject final : drm_core::BufferObject, std::enable_shared_from_this<BufferObject> {


### PR DESCRIPTION
This PR aims to land atomic modesetting support in DRM and wiring up `vmware` and `plainfb` drivers for it. Atomic modesetting has been tested with `weston` and the [`drm-howto`](https://github.com/dvdhrm/docs/). `kmscon` does not utilize atomic modesetting.

These changes depend on managarm/mlibc#272.