### PR TITLE
PCI MSI support and minor fixes

### DIFF
--- a/kernel/thor/arch/arm/gic.cpp
+++ b/kernel/thor/arch/arm/gic.cpp
@@ -117,6 +117,7 @@ frg::string<KernelAlloc> GicDistributor::buildPinName(uint32_t irq) {
 }
 
 extern frg::manual_box<IrqSlot> globalIrqSlots[numIrqSlots];
+extern IrqSpinlock globalIrqSlotsLock;
 
 auto GicDistributor::setupIrq(uint32_t irq, TriggerMode trigger) -> Pin * {
 	if (irq >= irqPins_.size())
@@ -129,6 +130,8 @@ auto GicDistributor::setupIrq(uint32_t irq, TriggerMode trigger) -> Pin * {
 }
 
 IrqStrategy GicDistributor::Pin::program(TriggerMode mode, Polarity polarity) {
+	auto guard = frg::guard(&globalIrqSlotsLock);
+
 	bool success = setMode(mode, polarity);
 	assert(success);
 

--- a/kernel/thor/generic/debug.cpp
+++ b/kernel/thor/generic/debug.cpp
@@ -171,19 +171,22 @@ void UrgentSink::operator() (const char *msg) {
 }
 
 void PanicSink::operator() (const char *msg) {
+	StatelessIrqLock irqLock;
+
 	{
-		StatelessIrqLock irqLock;
 		auto lock = frg::guard(&logMutex);
 
 		logProcessor.print(msg);
 		logProcessor.print('\n');
 	}
+
 #ifdef THOR_HAS_FRAME_POINTERS
 	urgentLogger() << "Stacktrace:" << frg::endlog;
 	walkThisStack([&](uintptr_t ip) {
 		urgentLogger() << "\t<" << (void*)ip << ">" << frg::endlog;
 	});
 #endif
+
 	panic();
 }
 

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -33,6 +33,7 @@ bool debugToSerial = false;
 bool debugToBochs = false;
 
 frg::manual_box<IrqSlot> globalIrqSlots[numIrqSlots];
+IrqSpinlock globalIrqSlotsLock;
 
 MfsDirectory *mfsRoot;
 frg::manual_box<frg::string<KernelAlloc>> kernelCommandLine;

--- a/kernel/thor/system/pci/thor-internal/pci/pci.hpp
+++ b/kernel/thor/system/pci/thor-internal/pci/pci.hpp
@@ -290,6 +290,9 @@ struct PciDevice final : PciEntity {
 
 	void enableIrq();
 
+	void setupMsi(MsiPin *msi, size_t index);
+	void enableMsi();
+
 	// mbus object ID of the device
 	int64_t mbusId;
 
@@ -319,6 +322,7 @@ struct PciDevice final : PciEntity {
 	unsigned int numMsis = 0;
 	int msixIndex = -1;
 	void *msixMapping = nullptr;
+	int msiIndex = -1;
 
 	// Device attachments.
 	FbInfo *associatedFrameBuffer;


### PR DESCRIPTION
Fixes race condition in MSI vector allocation and the possibility of entering an IRQ handler between printing the panic message and the stack trace.