### PR TITLE
Implement FIONREAD ioctl

### DIFF
--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -410,6 +410,9 @@ head(128):
 		// used by NODE_TRAVERSE_LINKS
 		tag(79) uint64 links_traversed;
 		tag(80) int64[] ids;
+
+		// returned by FIONREAD
+		tag(94) uint32 fionread_count;
 	}
 }
 


### PR DESCRIPTION
This implements the `FIONREAD` ioctl managarm-side. This code appears to work with sway. On the mlibc side, PR managarm/mlibc#358 enables the use of this.