### PR TITLE
meson: use libasync as a subproject

### DIFF
--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -84,7 +84,6 @@ inc += include_directories(
 	'system/pci',
 	'../common',
 	'../../subprojects/libarch/include',
-	'../../subprojects/libasync/include',
 	'../../tools/pb2frigg/include',
 	'../../protocols/posix/include',
 	'../../hel/include'
@@ -151,7 +150,7 @@ link_with += static_library('cralgo', cralgo_sources,
 	pic : false
 )
 
-deps = [ coroutines, cxxshim_dep, frigg, libsmarter, bragi_dep ]
+deps = [ coroutines, cxxshim_dep, frigg, libsmarter, bragi_dep, libasync_dep ]
 
 # TODO: also build thor on RISC-V.
 if arch != 'riscv64'

--- a/meson.build
+++ b/meson.build
@@ -147,11 +147,13 @@ endif
 if build_kernel
 	cralgo = subproject('cralgo')
 	lai = subproject('lai')
+	libasync = subproject('libasync', default_options : [ 'install_headers=false' ])
 	cralgo_sources = cralgo.get_variable('sources')
 	cralgo_includes = cralgo.get_variable('includes')
 	cxxshim_dep = cxxshim.get_variable('cxxshim_dep')
 	lai_sources = lai.get_variable('sources')
 	lai_includes = lai.get_variable('includes')
+	libasync_dep = libasync.get_variable('libasync_dep')
 
 	subdir('kernel/eir')
 	subdir('kernel/thor')


### PR DESCRIPTION
This is related to managarm/libasync#12.