### PR TITLE
meta: prepare for Werror and Wimplicit-fallthrough

### DIFF
--- a/drivers/usb/hcds/xhci/src/main.cpp
+++ b/drivers/usb/hcds/xhci/src/main.cpp
@@ -600,6 +600,7 @@ Controller::Event Controller::Event::fromRawTrb(RawTrb trb) {
 				(static_cast<uintptr_t>(trb.val[1]) << 32))
 				>> 8;
 			ev.notificationType = (trb.val[0] >> 4) & 0xF;
+			break;
 
 		default:
 			assert(!"xhci: trb passed to fromRawTrb is not a proper event trb\n");
@@ -788,6 +789,7 @@ async::detached Controller::Port::initPort() {
 		switch(speedId) {
 			case 1:
 				isFullSpeed = true;
+				[[fallthrough]];
 			case 2:
 				targetPacketSize = 8;
 				break;

--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -15,6 +15,7 @@ namespace {
 	constexpr bool logCleanup = false;
 	constexpr bool logUsage = false;
 
+	[[maybe_unused]]
 	void logRss(VirtualSpace *space) {
 		if(!logUsage)
 			return;

--- a/kernel/thor/generic/gdbserver.cpp
+++ b/kernel/thor/generic/gdbserver.cpp
@@ -198,6 +198,7 @@ struct EmitOverlay {
 			case '*':
 				buf_->push_back('}');
 				buf_->push_back(b[i] ^ 0x20);
+				break;
 			default:
 				buf_->push_back(b[i]);
 			}

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3229,6 +3229,7 @@ HelError helQueryRegisterInfo(int set, HelRegisterInfo *info) {
 #else
 #			error Unknown architecture
 #endif
+			break;
 
 		case kHelRegsThread:
 #if defined (__x86_64__)
@@ -3238,6 +3239,7 @@ HelError helQueryRegisterInfo(int set, HelRegisterInfo *info) {
 #else
 #			error Unknown architecture
 #endif
+			break;
 
 #if defined (__x86_64__)
 		case kHelRegsVirtualization:

--- a/kernel/thor/generic/ostrace.cpp
+++ b/kernel/thor/generic/ostrace.cpp
@@ -70,7 +70,7 @@ OsTraceEventId announceOsTraceEvent(frg::string_view name) {
 
 	managarm::ostrace::AnnounceEventRecord<KernelAlloc> record{*kernelAlloc};
 	record.set_id(id);
-	record.set_name({*kernelAlloc, name});
+	record.set_name(frg::string<KernelAlloc>{*kernelAlloc, name});
 	commitOsTrace(std::move(record));
 
 	return static_cast<OsTraceEventId>(id);

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,8 @@ project('managarm', ['c', 'cpp'],
 	]
 )
 
+add_project_arguments('-Wimplicit-fallthrough', language: ['c', 'cpp'])
+
 # build documentation
 if get_option('build_docs')
 	subdir('docs')

--- a/posix/subsystem/src/gdbserver.cpp
+++ b/posix/subsystem/src/gdbserver.cpp
@@ -226,6 +226,7 @@ struct EmitOverlay {
 			case '*':
 				buf_->push_back('}');
 				buf_->push_back(b ^ 0x20);
+				break;
 			default:
 				buf_->push_back(b);
 			}


### PR DESCRIPTION
These changes enable compilation with `-Wimplicit-fallthrough` and, while not currently enabling it, work with `-Werror` if desired.