### PR TITLE
posix/init: Launch native X by default (DO NOT MERGE)

### DIFF
--- a/posix/init/src/stage2.cpp
+++ b/posix/init/src/stage2.cpp
@@ -172,8 +172,9 @@ int main() {
 			if(mkdir("/tmp/.X11-unix", 1777))
 				throw std::runtime_error("mkdir() failed");
 			//execl("/usr/bin/weston", "weston", nullptr);
-			execl("/usr/bin/weston", "weston", "--xwayland", nullptr);
+			//execl("/usr/bin/weston", "weston", "--xwayland", nullptr);
 			//execl("/usr/bin/weston", "weston", "--use-pixman", nullptr);
+			execl("/usr/bin/Xorg", "Xorg", "-ac", "-verbose", "-logverbose", nullptr);
 		}else if(launch == "headless") {
 			auto fd = open("/dev/ttyS0", O_RDWR);
 			if(fd < 0)


### PR DESCRIPTION
This PR changes the weston option to launch Xorg, which should launch a default config bspwm. Do not merge, this is for testing only.