### PR TITLE
posix/init: Launch native X if xorg is passed on the command line

### DIFF
--- a/posix/init/src/stage2.cpp
+++ b/posix/init/src/stage2.cpp
@@ -174,6 +174,13 @@ int main() {
 			//execl("/usr/bin/weston", "weston", nullptr);
 			execl("/usr/bin/weston", "weston", "--xwayland", nullptr);
 			//execl("/usr/bin/weston", "weston", "--use-pixman", nullptr);
+		}else if(launch == "xorg") {
+			// Hack: This should move to proper location
+			if(mkdir("/tmp/.ICE-unix", 1777))
+				throw std::runtime_error("mkdir() failed");
+			if(mkdir("/tmp/.X11-unix", 1777))
+				throw std::runtime_error("mkdir() failed");
+			execl("/usr/bin/Xorg", "Xorg", "-ac", "-verbose", "-logverbose", nullptr);
 		}else if(launch == "headless") {
 			auto fd = open("/dev/ttyS0", O_RDWR);
 			if(fd < 0)


### PR DESCRIPTION
This PR adds a new option to posix-init, allowing to launch pure X if requested.

Supersedes #413 
Softblocked on managarm/bootstrap-managarm#158
Softblocked on managarm/mlibc#365