### PR TITLE
posix: Create a NETLINK_ROUTE group

### DIFF
--- a/posix/subsystem/src/drvcore.cpp
+++ b/posix/subsystem/src/drvcore.cpp
@@ -162,6 +162,7 @@ void ClassDevice::linkToSubsystem() {
 
 void initialize() {
 	nl_socket::configure(NETLINK_KOBJECT_UEVENT, 32);
+	nl_socket::configure(NETLINK_ROUTE, 32);
 
 	// Create the /sys/dev/{char,block} directories.
 	auto dev_object = std::make_shared<sysfs::Object>(nullptr, "dev");


### PR DESCRIPTION
`WebKitGTK` tries to connect to a netlink socket with `NETLINK_ROUTE`. By creating this group, this connect operation won't fail, allowing `WebKitGTK` to continue further in boot.