### PR TITLE
posix: implement memfd and file sealing

### DIFF
--- a/posix/init/src/stage2.cpp
+++ b/posix/init/src/stage2.cpp
@@ -158,6 +158,7 @@ int main() {
 		setenv("XDG_RUNTIME_DIR", "/run", 1);
 		setenv("MESA_GLSL_CACHE_DISABLE", "1", 1);
 //		setenv("MESA_DEBUG", "1", 1);
+		setenv("SHELL", "/bin/bash", 1);
 
 		if(launch == "kmscon") {
 			// TODO: kmscon should invoke a login program which sets these environment vars.

--- a/posix/subsystem/meson.build
+++ b/posix/subsystem/meson.build
@@ -21,6 +21,7 @@ src = [
 	'src/gdbserver.cpp',
 	'src/inotify.cpp',
 	'src/main.cpp',
+	'src/memfd.cpp',
 	'src/net.cpp',
 	'src/nl-socket.cpp',
 	'src/process.cpp',

--- a/posix/subsystem/src/file.cpp
+++ b/posix/subsystem/src/file.cpp
@@ -1,5 +1,6 @@
 
 #include <string.h>
+#include <fcntl.h>
 #include <future>
 
 #include <sys/socket.h>
@@ -102,10 +103,11 @@ async::result<frg::expected<protocols::fs::Error>> File::ptTruncate(void *object
 	return self->truncate(size);
 }
 
-async::result<void> File::ptAllocate(void *object,
+async::result<frg::expected<protocols::fs::Error>> File::ptAllocate(void *object,
 		int64_t offset, size_t size) {
 	auto self = static_cast<File *>(object);
-	return self->allocate(offset, size);
+
+	co_return co_await self->allocate(offset, size);
 }
 
 async::result<int> File::ptGetOption(void *object, int option) {
@@ -162,6 +164,16 @@ async::result<void> File::ptSetFileFlags(void *object, int flags) {
 async::result<frg::expected<protocols::fs::Error, size_t>> File::ptPeername(void *object, void *addr_ptr, size_t max_addr_length) {
 	auto self = static_cast<File *>(object);
 	return self->peername(addr_ptr, max_addr_length);
+}
+
+async::result<frg::expected<protocols::fs::Error, int>> File::ptGetSeals(void *object) {
+	auto self = static_cast<File *>(object);
+	co_return co_await self->getSeals();
+}
+
+async::result<frg::expected<protocols::fs::Error, int>> File::ptAddSeals(void *object, int seals) {
+	auto self = static_cast<File *>(object);
+	co_return co_await self->addSeals(seals);
 }
 
 async::result<protocols::fs::RecvResult>
@@ -280,7 +292,7 @@ async::result<frg::expected<protocols::fs::Error>> File::truncate(size_t) {
 	co_return protocols::fs::Error::illegalOperationTarget;
 }
 
-async::result<void> File::allocate(int64_t, size_t) {
+async::result<frg::expected<protocols::fs::Error>> File::allocate(int64_t, size_t) {
 	throw std::runtime_error("posix: Object has no File::allocate()");
 }
 
@@ -404,3 +416,10 @@ async::result<frg::expected<protocols::fs::Error, size_t>> File::peername(void *
 	co_return protocols::fs::Error::illegalOperationTarget;
 }
 
+async::result<frg::expected<protocols::fs::Error, int>> File::getSeals() {
+	co_return protocols::fs::Error::illegalOperationTarget;
+}
+
+async::result<frg::expected<protocols::fs::Error, int>> File::addSeals(int seals) {
+	co_return protocols::fs::Error::illegalOperationTarget;
+}

--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -121,7 +121,7 @@ public:
 	static async::result<frg::expected<protocols::fs::Error>>
 	ptTruncate(void *object, size_t size);
 
-	static async::result<void>
+	static async::result<frg::expected<protocols::fs::Error>>
 	ptAllocate(void *object, int64_t offset, size_t size);
 
 	static async::result<int>
@@ -169,6 +169,8 @@ public:
 	static async::result<frg::expected<protocols::fs::Error, size_t>>
 	ptPeername(void *object, void *addr_ptr, size_t max_addr_length);
 
+	static async::result<frg::expected<protocols::fs::Error, int>> ptGetSeals(void *object);
+	static async::result<frg::expected<protocols::fs::Error, int>> ptAddSeals(void *object, int seals);
 
 	static constexpr auto fileOperations = protocols::fs::FileOperations{
 		.seekAbs = &ptSeekAbs,
@@ -191,6 +193,8 @@ public:
 		.recvMsg = &ptRecvMsg,
 		.sendMsg = &ptSendMsg,
 		.peername = &ptPeername,
+		.getSeals = &ptGetSeals,
+		.addSeals = &ptAddSeals,
 	};
 
 	// ------------------------------------------------------------------------
@@ -284,7 +288,7 @@ public:
 
 	virtual async::result<frg::expected<protocols::fs::Error>> truncate(size_t size);
 
-	virtual async::result<void> allocate(int64_t offset, size_t size);
+	virtual async::result<frg::expected<protocols::fs::Error>> allocate(int64_t offset, size_t size);
 
 	// poll() uses a sequence number mechansim for synchronization.
 	// Before returning, it waits until current-sequence > in-sequence.
@@ -331,6 +335,8 @@ public:
 
 	virtual helix::BorrowedDescriptor getPassthroughLane() = 0;
 
+	virtual async::result<frg::expected<protocols::fs::Error, int>> getSeals();
+	virtual async::result<frg::expected<protocols::fs::Error, int>> addSeals(int flags);
 private:
 	smarter::weak_ptr<File> _weakPtr;
 	StructName _structName;

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -3705,7 +3705,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			}
 
 			auto link = SpecialLink::makeSpecialLink(VfsType::regular, 0777);
-			auto memFile = smarter::make_shared<MemoryFile>(nullptr, link);
+			auto memFile = smarter::make_shared<MemoryFile>(nullptr, link, (req->flags() & MFD_ALLOW_SEALING) == true);
 			MemoryFile::serve(memFile);
 			auto file = File::constructHandle(std::move(memFile));
 

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -3700,7 +3700,8 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			std::cout << "posix: MEMFD_CREATE ignores some flags" << std::endl;
 
-			auto memFile = smarter::make_shared<MemoryFile>();
+			auto link = SpecialLink::makeSpecialLink(VfsType::regular, 0777);
+			auto memFile = smarter::make_shared<MemoryFile>(nullptr, link);
 			MemoryFile::serve(memFile);
 			auto file = File::constructHandle(std::move(memFile));
 

--- a/posix/subsystem/src/memfd.cpp
+++ b/posix/subsystem/src/memfd.cpp
@@ -64,6 +64,10 @@ MemoryFile::getSeals() {
 
 async::result<frg::expected<protocols::fs::Error, int>>
 MemoryFile::addSeals(int seals) {
+	if(_seals & F_SEAL_SEAL) {
+		co_return protocols::fs::Error::insufficientPermissions;
+	}
+
 	_seals |= seals;
 	co_return int{_seals};
 }

--- a/posix/subsystem/src/memfd.cpp
+++ b/posix/subsystem/src/memfd.cpp
@@ -1,0 +1,69 @@
+#include "memfd.hpp"
+
+void MemoryFile::handleClose() {
+	_cancelServe.cancel();
+}
+
+async::result<frg::expected<Error, off_t>>
+MemoryFile::seek(off_t delta, VfsSeek whence) {
+	if(whence == VfsSeek::absolute) {
+		_offset = delta;
+	}else if(whence == VfsSeek::relative){
+		_offset += delta;
+	}else if(whence == VfsSeek::eof) {
+		assert(whence == VfsSeek::eof);
+		_offset += delta;
+	}
+	co_return _offset;
+}
+
+async::result<frg::expected<protocols::fs::Error>>
+MemoryFile::allocate(int64_t offset, size_t size) {
+	assert(!offset);
+
+	if(_seals & F_SEAL_WRITE)
+		co_return protocols::fs::Error::insufficientPermissions;
+	/* check if the file size is enough */
+	if(offset + size <= _fileSize)
+		co_return {};
+	/* if the file size isn't enough */
+	if(_seals & F_SEAL_GROW)
+		co_return protocols::fs::Error::insufficientPermissions;
+	_resizeFile(offset + size);
+	co_return {};
+}
+
+FutureMaybe<helix::UniqueDescriptor>
+MemoryFile::accessMemory() {
+	co_return _memory.dup();
+}
+
+void MemoryFile::_resizeFile(size_t new_size) {
+	_fileSize = new_size;
+
+	size_t aligned_size = (new_size + 0xFFF) & ~size_t(0xFFF);
+	if(aligned_size <= _areaSize)
+		return;
+
+	if(_memory) {
+		HEL_CHECK(helResizeMemory(_memory.getHandle(), aligned_size));
+	}else{
+		HelHandle handle;
+		HEL_CHECK(helAllocateMemory(aligned_size, 0, nullptr, &handle));
+		_memory = helix::UniqueDescriptor{handle};
+	}
+
+	_mapping = helix::Mapping{_memory, 0, aligned_size};
+	_areaSize = aligned_size;
+}
+
+async::result<frg::expected<protocols::fs::Error, int>>
+MemoryFile::getSeals() {
+	co_return int{_seals};
+}
+
+async::result<frg::expected<protocols::fs::Error, int>>
+MemoryFile::addSeals(int seals) {
+	_seals |= seals;
+	co_return int{_seals};
+}

--- a/posix/subsystem/src/memfd.cpp
+++ b/posix/subsystem/src/memfd.cpp
@@ -17,6 +17,11 @@ MemoryFile::seek(off_t delta, VfsSeek whence) {
 	co_return _offset;
 }
 
+async::result<frg::expected<protocols::fs::Error>> MemoryFile::truncate(size_t size) {
+	_resizeFile(size);
+	co_return {};
+}
+
 async::result<frg::expected<protocols::fs::Error>>
 MemoryFile::allocate(int64_t offset, size_t size) {
 	assert(!offset);

--- a/posix/subsystem/src/memfd.hpp
+++ b/posix/subsystem/src/memfd.hpp
@@ -25,6 +25,8 @@ public:
 	async::result<frg::expected<Error, off_t>> seek(off_t delta, VfsSeek whence) override;
 	async::result<frg::expected<protocols::fs::Error>> allocate(int64_t offset, size_t size) override;
 
+	async::result<frg::expected<protocols::fs::Error>> truncate(size_t size) override;
+
 	async::result<frg::expected<protocols::fs::Error, int>> getSeals() override;
 	async::result<frg::expected<protocols::fs::Error, int>> addSeals(int seals) override;
 

--- a/posix/subsystem/src/memfd.hpp
+++ b/posix/subsystem/src/memfd.hpp
@@ -13,8 +13,8 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	MemoryFile()
-	: File{StructName::get("memfd-file")}, _offset{0} { }
+	MemoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	: File{StructName::get("memfd-file"), mount, link}, _offset{0} { }
 
 	void handleClose() override;
 

--- a/posix/subsystem/src/memfd.hpp
+++ b/posix/subsystem/src/memfd.hpp
@@ -13,8 +13,12 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	MemoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
-	: File{StructName::get("memfd-file"), mount, link}, _offset{0} { }
+	MemoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, bool allowSealing)
+	: File{StructName::get("memfd-file"), mount, link}, _offset{0} {
+		if(!allowSealing) {
+			_seals = F_SEAL_SEAL;
+		}
+	}
 
 	void handleClose() override;
 

--- a/posix/subsystem/src/memfd.hpp
+++ b/posix/subsystem/src/memfd.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <fcntl.h>
+
+#include "file.hpp"
+
+struct MemoryFile final : File {
+public:
+	static void serve(smarter::shared_ptr<MemoryFile> file) {
+		helix::UniqueLane lane;
+		std::tie(lane, file->_passthrough) = helix::createStream();
+		async::detach(protocols::fs::servePassthrough(std::move(lane),
+				file, &fileOperations, file->_cancelServe));
+	}
+
+	MemoryFile()
+	: File{StructName::get("memfd-file")}, _offset{0} { }
+
+	void handleClose() override;
+
+	async::result<frg::expected<Error, off_t>> seek(off_t delta, VfsSeek whence) override;
+	async::result<frg::expected<protocols::fs::Error>> allocate(int64_t offset, size_t size) override;
+
+	async::result<frg::expected<protocols::fs::Error, int>> getSeals() override;
+	async::result<frg::expected<protocols::fs::Error, int>> addSeals(int seals) override;
+
+	FutureMaybe<helix::UniqueDescriptor> accessMemory() override;
+
+	helix::BorrowedDescriptor getPassthroughLane() override {
+		return _passthrough;
+	}
+
+private:
+	void _resizeFile(size_t new_size);
+
+	helix::UniqueLane _passthrough;
+	async::cancellation_event _cancelServe;
+
+	uint64_t _offset;
+
+	helix::UniqueDescriptor _memory;
+	helix::Mapping _mapping;
+	size_t _areaSize;
+	size_t _fileSize;
+	int _seals;
+};

--- a/posix/subsystem/src/memfd.hpp
+++ b/posix/subsystem/src/memfd.hpp
@@ -46,7 +46,7 @@ private:
 
 	helix::UniqueDescriptor _memory;
 	helix::Mapping _mapping;
-	size_t _areaSize;
-	size_t _fileSize;
-	int _seals;
+	size_t _areaSize = 0;
+	size_t _fileSize = 0;
+	int _seals = 0;
 };

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -1124,7 +1124,11 @@ async::result<void> Process::terminate(TerminationState state) {
 	_fileContext = nullptr;
 	//_signalContext = nullptr; // TODO: Migrate the notifications to PID 1.
 	_currentGeneration = nullptr;
-	assert(co_await _procfs_dir->getOwner()->unlink(_procfs_dir->getName()));
+	if(_procfs_dir) {
+		auto result = co_await _procfs_dir->getOwner()->unlink(_procfs_dir->getName());
+		assert(result);
+		(void)result;
+	}
 
 	// Notify the parent of our status change.
 	assert(_notifyType == NotifyType::null);

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -390,7 +390,7 @@ public:
 
 	async::result<frg::expected<protocols::fs::Error>> truncate(size_t size) override;
 
-	FutureMaybe<void> allocate(int64_t offset, size_t size) override;
+	async::result<frg::expected<protocols::fs::Error>> allocate(int64_t offset, size_t size) override;
 
 	FutureMaybe<helix::UniqueDescriptor> accessMemory() override;
 
@@ -568,7 +568,7 @@ MemoryFile::truncate(size_t size) {
 	co_return {};
 }
 
-async::result<void>
+async::result<frg::expected<protocols::fs::Error>>
 MemoryFile::allocate(int64_t offset, size_t size) {
 	assert(!offset);
 
@@ -576,8 +576,9 @@ MemoryFile::allocate(int64_t offset, size_t size) {
 
 	// TODO: Careful about overflow.
 	if(offset + size <= node->_fileSize)
-		co_return;
+		co_return {};
 	node->_resizeFile(offset + size);
+	co_return {};
 }
 
 FutureMaybe<helix::UniqueDescriptor>

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -120,7 +120,10 @@ enum CntReqType {
 	NODE_CHMOD = 38,
 
 	NODE_RMDIR = 40,
-	NODE_UTIMENSAT = 41
+	NODE_UTIMENSAT = 41,
+
+	PT_GET_SEALS = 48,
+	PT_ADD_SEALS = 49
 }
 
 struct Rect {
@@ -256,6 +259,8 @@ head(128):
 
 		// used by PT_IOCTL for TIOCSPGRP
 		tag(69) int64 pgid;
+
+		tag(84) int32 seals;
 	}
 }
 
@@ -413,6 +418,8 @@ head(128):
 
 		// returned by FIONREAD
 		tag(94) uint32 fionread_count;
+
+		tag(97) int32 seals;
 	}
 }
 

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -89,7 +89,7 @@ struct FileOperations {
 		truncate = f;
 		return *this;
 	}
-	constexpr FileOperations &withFallocate(async::result<void> (*f)(void *object,
+	constexpr FileOperations &withFallocate(async::result<frg::expected<protocols::fs::Error>> (*f)(void *object,
 			int64_t offset, size_t size)) {
 		fallocate = f;
 		return *this;
@@ -152,7 +152,7 @@ struct FileOperations {
 	async::result<ReadEntriesResult> (*readEntries)(void *object);
 	async::result<helix::BorrowedDescriptor>(*accessMemory)(void *object);
 	async::result<frg::expected<protocols::fs::Error>> (*truncate)(void *object, size_t size);
-	async::result<void> (*fallocate)(void *object, int64_t offset, size_t size);
+	async::result<frg::expected<protocols::fs::Error>> (*fallocate)(void *object, int64_t offset, size_t size);
 	async::result<void> (*ioctl)(void *object, managarm::fs::CntRequest req,
 			helix::UniqueLane conversation);
 	async::result<protocols::fs::Error> (*flock)(void *object, int flags);
@@ -179,6 +179,8 @@ struct FileOperations {
 			void *addr_buf, size_t addr_size,
 			std::vector<uint32_t> fds);
 	async::result<frg::expected<Error, size_t>> (*peername)(void *object, void *addr_ptr, size_t max_addr_length);
+	async::result<frg::expected<Error, int>> (*getSeals)(void *object);
+	async::result<frg::expected<Error, int>> (*addSeals)(void *object, int seals);
 
 	bool logRequests = false;
 };

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -919,7 +919,16 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 		auto seals = co_await file_ops->addSeals(file.get(), req.seals());
 
 		if(!seals) {
-			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+			switch(seals.error()) {
+				case protocols::fs::Error::insufficientPermissions: {
+					resp.set_error(managarm::fs::Errors::INSUFFICIENT_PERMISSIONS);
+					break;
+				}
+				default: {
+					resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+					break;
+				}
+			}
 			resp.set_seals(0);
 		} else {
 			resp.set_seals(seals.value());

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -480,3 +480,10 @@ message IoctlFioclexRequest 83 {
 head(128):
 	int32 fd;	
 }
+
+message MemFdCreateRequest 84 {
+head(128):
+	int32 flags;
+tail:
+	string name;
+}

--- a/testsuites/posix-tests/meson.build
+++ b/testsuites/posix-tests/meson.build
@@ -10,7 +10,8 @@ src = [
 	'src/stat.cpp',
 	'src/unixnames.cpp',
 	'src/sigaltstack.cpp',
-	'src/mmap.cpp'
+	'src/mmap.cpp',
+	'src/memfd.cpp'
 ]
 
 executable('posix-tests', src, install : true)

--- a/testsuites/posix-tests/src/memfd.cpp
+++ b/testsuites/posix-tests/src/memfd.cpp
@@ -1,0 +1,20 @@
+#include <cassert>
+
+#include <signal.h>
+#include <setjmp.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+
+#include "testsuite.hpp"
+
+DEFINE_TEST(memfd_create, ([] {
+	int fd = memfd_create("posix-tests", 0);
+	assert(fd != -1);
+
+	int ret = ftruncate(fd, 0x1000);
+	assert(ret == 0);
+
+	ret = close(fd);
+	assert(ret == 0);
+}))


### PR DESCRIPTION
The `MemoryFile` used here is an adapted version of the same struct in tmpfs, stripped of some functionality not yet needed.