### PR TITLE
posix: implement O_NONBLOCK for netlink

### DIFF
--- a/posix/init/src/stage2.cpp
+++ b/posix/init/src/stage2.cpp
@@ -93,7 +93,8 @@ int main() {
 	// Set the into blocking mode, so that we don't have to poll it.
 	auto flags = fcntl(udev_monitor_get_fd(init_udev_mon), F_GETFL, 0);
 	assert(flags >= 0);
-	assert(!fcntl(udev_monitor_get_fd(init_udev_mon), F_SETFL, flags & ~O_NONBLOCK));
+	auto ret = fcntl(udev_monitor_get_fd(init_udev_mon), F_SETFL, flags & ~O_NONBLOCK);
+	assert(!ret);
 
 	std::cout << "init: udev initialization is done" << std::endl;
 

--- a/posix/init/src/stage2.cpp
+++ b/posix/init/src/stage2.cpp
@@ -90,6 +90,11 @@ int main() {
 
 	waitpid(udev_settle, nullptr, 0);
 
+	// Set the into blocking mode, so that we don't have to poll it.
+	auto flags = fcntl(udev_monitor_get_fd(init_udev_mon), F_GETFL, 0);
+	assert(flags >= 0);
+	assert(!fcntl(udev_monitor_get_fd(init_udev_mon), F_SETFL, flags & ~O_NONBLOCK));
+
 	std::cout << "init: udev initialization is done" << std::endl;
 
 	// Determine what to launch.

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -2872,7 +2872,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = un_socket::createSocketFile(req->flags() & SOCK_NONBLOCK);
 			}else if(req->domain() == AF_NETLINK) {
 				assert(req->socktype() == SOCK_RAW || req->socktype() == SOCK_DGRAM);
-				file = nl_socket::createSocketFile(req->protocol());
+				file = nl_socket::createSocketFile(req->protocol(), req->flags() & SOCK_NONBLOCK);
 			} else if (req->domain() == AF_INET) {
 				file = co_await extern_socket::createSocket(
 					co_await net::getNetLane(),

--- a/posix/subsystem/src/nl-socket.hpp
+++ b/posix/subsystem/src/nl-socket.hpp
@@ -10,7 +10,7 @@ void configure(int proto_idx, int num_groups);
 // Broadcasts a kernel message to the given netlink multicast group.
 void broadcast(int proto_idx, int grp_idx, std::string buffer);
 
-smarter::shared_ptr<File, FileHandle> createSocketFile(int proto_idx);
+smarter::shared_ptr<File, FileHandle> createSocketFile(int proto_idx, bool nonBlock);
 std::array<smarter::shared_ptr<File, FileHandle>, 2> createSocketPair(int proto_idx);
 
 } // namespace nl_socket


### PR DESCRIPTION
This PR fixes a hang in `kmscon` caused by the use of a `O_NONBLOCK` netlink socket in `eudev`. Since we don't support that yet, the call to `recvmsg` never returns.

We implement the required functionality and also modify init to block on the call to `udev_monitor_receive_device`, as would have happened before.

See also https://github.com/managarm/mlibc/pull/379 which fixes some further boot failures with this patch.