### PR TITLE
Implement pwrite

### DIFF
--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -167,6 +167,17 @@ async::result<frg::expected<protocols::fs::Error, size_t>> write(void *object, c
 	co_return length;
 }
 
+async::result<frg::expected<protocols::fs::Error, size_t>> pwrite(void *object, int64_t offset, const char *credentials,
+			const void *buffer, size_t length) {
+	if(!length) {
+		co_return 0;
+	}
+
+	auto self = static_cast<ext2fs::OpenFile *>(object);
+	co_await self->inode->fs.write(self->inode.get(), offset, buffer, length);
+	co_return length;
+}
+
 async::result<helix::BorrowedDescriptor>
 accessMemory(void *object) {
 	auto self = static_cast<ext2fs::OpenFile *>(object);
@@ -208,6 +219,7 @@ constexpr protocols::fs::FileOperations fileOperations {
 	.read         = &read,
 	.pread        = &pread,
 	.write        = &write,
+	.pwrite       = &pwrite,
 	.readEntries  = &readEntries,
 	.accessMemory = &accessMemory,
 	.truncate     = &truncate,

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -159,7 +159,9 @@ async::result<protocols::fs::ReadResult> pread(void *object, int64_t offset, con
 
 async::result<frg::expected<protocols::fs::Error, size_t>> write(void *object, const char *,
 		const void *buffer, size_t length) {
-	assert(length);
+	if(!length) {
+		co_return 0;
+	}
 
 	auto self = static_cast<ext2fs::OpenFile *>(object);
 	co_await self->inode->fs.write(self->inode.get(), self->offset, buffer, length);

--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -118,6 +118,9 @@ public:
 	static async::result<frg::expected<protocols::fs::Error, size_t>>
 	ptWrite(void *object, const char *credentials, const void *buffer, size_t length);
 
+	static async::result<frg::expected<protocols::fs::Error, size_t>>
+	ptPwrite(void *object, int64_t offset, const char *credentials, const void *buffer, size_t length);
+
 	static async::result<protocols::fs::ReadEntriesResult>
 	ptReadEntries(void *object);
 
@@ -181,6 +184,7 @@ public:
 		.seekEof = &ptSeekEof,
 		.read = &ptRead,
 		.write = &ptWrite,
+		.pwrite = &ptPwrite,
 		.readEntries = &ptReadEntries,
 		.truncate = &ptTruncate,
 		.fallocate = &ptAllocate,
@@ -278,6 +282,9 @@ public:
 
 	virtual async::result<frg::expected<Error, ControllingTerminalState *>>
 	getControllingTerminal();
+
+	virtual async::result<frg::expected<Error, size_t>>
+	pwrite(Process *process, int64_t offset, const void *data, size_t length);
 
 	virtual FutureMaybe<ReadEntriesResult> readEntries();
 

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -123,7 +123,9 @@ enum CntReqType {
 	NODE_UTIMENSAT = 41,
 
 	PT_GET_SEALS = 48,
-	PT_ADD_SEALS = 49
+	PT_ADD_SEALS = 49,
+
+	PT_PWRITE = 50
 }
 
 struct Rect {

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -76,6 +76,11 @@ struct FileOperations {
 		write = f;
 		return *this;
 	}
+	constexpr FileOperations &withPwrite(async::result<frg::expected<protocols::fs::Error, size_t>> (*f)(void *object,
+			int64_t offset, const char *, const void *buffer, size_t length)) {
+		pwrite = f;
+		return *this;
+	}
 	constexpr FileOperations &withReadEntries(async::result<ReadEntriesResult> (*f)(void *object)) {
 		readEntries = f;
 		return *this;

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -149,6 +149,8 @@ struct FileOperations {
 			void *buffer, size_t length);
 	async::result<frg::expected<protocols::fs::Error, size_t>> (*write)(void *object, const char *credentials,
 			const void *buffer, size_t length);
+	async::result<frg::expected<protocols::fs::Error, size_t>> (*pwrite)(void *object, int64_t offset, const char *credentials,
+			const void *buffer, size_t length);
 	async::result<ReadEntriesResult> (*readEntries)(void *object);
 	async::result<helix::BorrowedDescriptor>(*accessMemory)(void *object);
 	async::result<frg::expected<protocols::fs::Error>> (*truncate)(void *object, size_t size);


### PR DESCRIPTION
While we've had `pread()` for a while now, `pwrite()` wasn't implemented. This PR adds `pwrite()` support for ext2 and tmpfs, which pleases `gtk3`, specifically `dconf`.

A corresponding mlibc PR will be provided shortly.