### PR TITLE
UHCI: Fixed a modify while iterating bug

### DIFF
--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -1127,10 +1127,13 @@ void Controller::_linkTransaction(QueueEntity *queue, Transaction *transaction) 
 }
 
 void Controller::_progressSchedule() {
-	auto it = _activeEntities.begin();
-	while(it != _activeEntities.end()) {
-		_progressQueue(*it);
-		++it;
+	// NOTE: This loop is intentionally weird to account for the fact that
+	// _progressQueue may in fact add entries to the active list.  Any iterators
+	// are then potentially invalidated.
+	volatile size_t size = _activeEntities.size();
+	for(size_t i = 0; i < size; i++) {
+		_progressQueue(_activeEntities[i]);
+		size = _activeEntities.size();
 	}
 }
 


### PR DESCRIPTION
The progressSchedule function runs queue entries which potentially add more entries into the list of things that progressSchedule is iterating.  If the vector allocates more memory to accomdate the addition then the C++ spec says that all iterators are invalidated and thus the function will iterate in a bad way, probably right off the end and into undefined memory causing a GPF