### PR TITLE
ehci: Fix multiple issues regarding controller stack and HID 

### DIFF
--- a/drivers/usb/devices/hid/src/main.cpp
+++ b/drivers/usb/devices/hid/src/main.cpp
@@ -412,6 +412,11 @@ void HidDevice::parseReportDescriptor(Device, uint8_t *p, uint8_t* limit) {
 			local = LocalState();
 			break;
 
+		case 0xB0:
+			if(logDescriptorParser)
+				printf("usb-hid:      Feature: 0x%x\n", data);
+			break;
+
 		case 0x80:
 			if(logDescriptorParser)
 				printf("usb-hid:     Input: 0x%x\n", data);

--- a/drivers/usb/hcds/ehci/src/ehci.hpp
+++ b/drivers/usb/hcds/ehci/src/ehci.hpp
@@ -27,16 +27,14 @@ struct Enumerator {
 	// Called by the USB hub driver once a device completes reset.
 	void enablePort(int port);
 
-private:
-	enum class State {
-		null, resetting, probing
-	};
+	// Called by the USB hub driver if a port fails to enable after connection
+	void portDisabled(int port);
 
-	async::detached _reset();
+private:
+	async::detached _reset(int port);
 	async::detached _probe();
 
 	Controller *_controller;
-	State _state;
 	int _activePort;
 	async::mutex _addressMutex;
 };

--- a/drivers/usb/hcds/ehci/src/main.cpp
+++ b/drivers/usb/hcds/ehci/src/main.cpp
@@ -41,21 +41,22 @@ Enumerator::Enumerator(Controller *controller)
 : _controller{controller} { }
 
 void Enumerator::connectPort(int port) {
-	assert(_state == State::null);
-	_state = State::resetting;
-	_activePort = port;
-	_reset();
+	_reset(port);
 }
 
 void Enumerator::enablePort(int port) {
-	assert(_state == State::resetting);
 	assert(_activePort == port);
-	_state = State::probing;
 	_probe();
 }
 
-async::detached Enumerator::_reset() {
+void Enumerator::portDisabled(int port) {
+	assert(_activePort == port);
+	_addressMutex.unlock();
+}
+
+async::detached Enumerator::_reset(int port) {
 	co_await _addressMutex.async_lock();
+	_activePort = port;
 	_controller->resetPort(_activePort);
 }
 
@@ -912,7 +913,7 @@ void Controller::_progressQueue(QueueEntity *entity) {
 			std::cout << "ehci: Transfer complete!" << std::endl;
 		assert(active->fullSize >= active->lostSize);
 		active->promise.set_value(active->fullSize - active->lostSize);
-		active->voidPromise.set_value(UsbError{});
+		active->voidPromise.set_value(frg::success);
 
 		// Clean up the Queue.
 		entity->transactions.pop_front();
@@ -976,8 +977,9 @@ async::detached Controller::resetPort(int number) {
 		std::cout << "ehci: Port " << number << " was enabled." << std::endl;
 		_enumerator.enablePort(number);
 	}else{
-		// TODO: We should grant the port to the companion controller here.
-		std::cout << "ehci: Port " << number << " disabled after reset." << std::endl;
+		std::cout << "ehci: Device on port " << number << " is not high-speed" << std::endl;
+		port_space.store(port_regs::sc, portsc::portOwner(true));
+		_enumerator.portDisabled(number);
 	}
 }
 

--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -1195,7 +1195,7 @@ void Controller::_progressQueue(QueueEntity *entity) {
 
 	//printf("Transfer complete!\n");
 	front->promise.set_value(front->lengthComplete);
-	front->voidPromise.set_value(UsbError{});
+	front->voidPromise.set_value(frg::success);
 
 	// Schedule the next transaction.
 	entity->transactions.pop_front();


### PR DESCRIPTION
- The assertions happening in the EHCI controller regarding clean state transition appear to not be reliable for more than one device being connected to the controller.  The port connections will be happening simultaneously and there is no guaranteed starting state for them to be in.
- Implemented TODO for handing off port to UHCI in the event that it is not a high speed device
- Added the FEATURE (0xB0) token to the list of recognized tokens for HID