### PR TITLE
posix: Implement killpg(int, int) support

### DIFF
--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -507,6 +507,7 @@ SignalHandler SignalContext::changeHandler(int sn, SignalHandler handler) {
 }
 
 void SignalContext::issueSignal(int sn, SignalInfo info) {
+	assert(sn > 0);
 	assert(sn - 1 < 64);
 	auto item = new SignalItem;
 	item->signalNumber = sn;
@@ -1170,6 +1171,13 @@ async::result<int> Process::wait(int pid, bool nonBlocking, TerminationState *st
 // --------------------------------------------------------------------------------------
 // Process groups and sessions.
 // --------------------------------------------------------------------------------------
+
+std::shared_ptr<ProcessGroup> ProcessGroup::findProcessGroup(ProcessId pid) {
+	auto it = globalPidMap.find(pid);
+	if(it == globalPidMap.end())
+		return nullptr;
+	return it->second->getProcessGroup();
+}
 
 ProcessGroup::ProcessGroup(std::shared_ptr<PidHull> hull)
 : hull_{std::move(hull)} { }

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -643,6 +643,8 @@ struct ProcessGroup : std::enable_shared_from_this<ProcessGroup> {
 	friend struct TerminalSession;
 	friend struct ControllingTerminalState;
 
+	static std::shared_ptr<ProcessGroup> findProcessGroup(ProcessId pgid);
+
 	ProcessGroup(std::shared_ptr<PidHull> hull);
 
 	~ProcessGroup();


### PR DESCRIPTION
When receiving a kill syscall, check if the PID is less than 0 and if so kill the entire group.  Also, apply the todo logic in the kill(0) path so that the entire group of the running process is killed