### PR TITLE
posix: Set the controlling terminal of the process on open

### DIFF
--- a/posix/subsystem/src/file.cpp
+++ b/posix/subsystem/src/file.cpp
@@ -266,6 +266,12 @@ async::result<frg::expected<Error, size_t>> File::writeAll(Process *, const void
 	throw std::runtime_error("posix: Object has no File::writeAll()");
 }
 
+async::result<frg::expected<Error, ControllingTerminalState *>> File::getControllingTerminal() {
+	std::cout << "posix \e[1;34m" << structName()
+			<< "\e[0m: Object does not implement getControllingTerminal()\e[39m" << std::endl;
+	co_return Error::notTerminal;
+}
+
 async::result<ReadEntriesResult> File::readEntries() {
 	throw std::runtime_error("posix: Object has no File::readEntries()");
 }

--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -15,6 +15,7 @@ struct File;
 struct MountView;
 struct FsLink;
 struct Process;
+struct ControllingTerminalState;
 
 struct FileHandle { };
 
@@ -274,6 +275,9 @@ public:
 
 	virtual async::result<frg::expected<Error, size_t>>
 	writeAll(Process *process, const void *data, size_t length);
+
+	virtual async::result<frg::expected<Error, ControllingTerminalState *>>
+	getControllingTerminal();
 
 	virtual FutureMaybe<ReadEntriesResult> readEntries();
 

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -139,6 +139,9 @@ public:
 	async::result<frg::expected<Error, size_t>>
 	writeAll(Process *, const void *data, size_t length) override;
 
+	async::result<frg::expected<Error, ControllingTerminalState *>>
+	getControllingTerminal() override;
+
 	async::result<frg::expected<Error, PollWaitResult>>
 	pollWait(Process *, uint64_t sequence, int mask,
 			async::cancellation_token cancellation) override;
@@ -180,6 +183,9 @@ public:
 
 	async::result<frg::expected<Error, size_t>>
 	writeAll(Process *, const void *data, size_t length) override;
+
+	async::result<frg::expected<Error, ControllingTerminalState *>>
+	getControllingTerminal() override;
 
 	async::result<frg::expected<Error, PollWaitResult>>
 	pollWait(Process *, uint64_t sequence, int mask,
@@ -521,6 +527,11 @@ MasterFile::writeAll(Process *, const void *data, size_t length) {
 	co_return length;
 }
 
+async::result<frg::expected<Error, ControllingTerminalState *>>
+MasterFile::getControllingTerminal() {
+	co_return &_channel->cts;
+}
+
 async::result<frg::expected<Error, PollWaitResult>>
 MasterFile::pollWait(Process *, uint64_t past_seq, int mask,
 		async::cancellation_token cancellation) {
@@ -689,6 +700,11 @@ SlaveFile::writeAll(Process *, const void *data, size_t length) {
 	_channel->masterInSeq = ++_channel->currentSeq;
 	_channel->statusBell.raise();
 	co_return length;
+}
+
+async::result<frg::expected<Error, ControllingTerminalState *>>
+SlaveFile::getControllingTerminal() {
+	co_return &_channel->cts;
 }
 
 async::result<frg::expected<Error, PollWaitResult>>

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -107,7 +107,8 @@ consts OpenFlags uint32 {
 	OF_WRONLY = 16,
 	OF_RDWR = 32,
 	OF_TRUNC = 64,
-	OF_PATH = 128
+	OF_PATH = 128,
+	OF_NOCTTY = 512
 }
 
 message CntRequest 1 {


### PR DESCRIPTION
If a session leader opens a terminal device without using O_NOCTTY then it should become the controlling terminal if the controlling terminal is not present.

Note: This depends on https://github.com/managarm/mlibc/pull/409 