### PR TITLE
drivers/{xhci,virtio}: enableMsi after installMsi

### DIFF
--- a/core/virtio/src/core.cpp
+++ b/core/virtio/src/core.cpp
@@ -646,8 +646,8 @@ discover(protocols::hw::Device hw_device, DiscoverMode mode) {
 
 			// Enable MSI-X.
 			if (info.numMsis) {
-				co_await hw_device.enableMsi();
 				queueMsi = co_await hw_device.installMsi(0);
+				co_await hw_device.enableMsi();
 			}
 
 			// Set the ACKNOWLEDGE and DRIVER bits.

--- a/drivers/usb/hcds/xhci/src/main.cpp
+++ b/drivers/usb/hcds/xhci/src/main.cpp
@@ -1368,8 +1368,8 @@ async::detached bindController(mbus::Entity entity) {
 	helix::UniqueDescriptor irq;
 
 	if (info.numMsis) {
-		co_await device.enableMsi();
 		irq = co_await device.installMsi(0);
+		co_await device.enableMsi();
 	} else {
 		irq = co_await device.accessIrq();
 	}


### PR DESCRIPTION
Since `installMsi` masks and `enableMsi` unmasks, it should really be done in this order.
