### PR TITLE
meson: declare frigg as a dependency everywhere

### DIFF
--- a/core/drm/meson.build
+++ b/core/drm/meson.build
@@ -6,7 +6,7 @@ elif arch == 'aarch64'
 	src += 'aarch64-src/copy-fp.S'
 endif
 
-deps = [ libarch, fs_proto_dep, hw_proto_dep, mbus_proto_dep ]
+deps = [ libarch, fs_proto_dep, hw_proto_dep, mbus_proto_dep, frigg ]
 inc = [ 'include' ]
 
 headers = [

--- a/hel/meson.build
+++ b/hel/meson.build
@@ -6,7 +6,7 @@ headers = [
 	'include/helix/memory.hpp'
 ]
 
-deps = [ coroutines, bragi_dep ]
+deps = [ coroutines, bragi_dep, frigg ]
 inc = [ 'include' ]
 
 helix = shared_library('helix', 'src/globals.cpp',

--- a/mbus/meson.build
+++ b/mbus/meson.build
@@ -1,4 +1,4 @@
 executable('mbus', 'src/main.cpp',
-	dependencies : mbus_proto_dep,
+	dependencies : [mbus_proto_dep, frigg],
 	install : true
 )

--- a/posix/subsystem/meson.build
+++ b/posix/subsystem/meson.build
@@ -42,6 +42,6 @@ src = [
 ]
 
 executable('posix-subsystem', src,
-	dependencies : [ mbus_proto_dep, fs_proto_dep, posix_extra_dep, clock_proto_dep, kerncfg_proto_dep ],
+	dependencies : [ mbus_proto_dep, fs_proto_dep, posix_extra_dep, clock_proto_dep, kerncfg_proto_dep, frigg ],
 	install : true
 )

--- a/protocols/fs/meson.build
+++ b/protocols/fs/meson.build
@@ -2,7 +2,7 @@ fs_bragi = cxxbragi.process('fs.bragi')
 
 inc = [ 'include' ]
 src = [ 'src/client.cpp', 'src/server.cpp', 'src/file-locks.cpp', fs_bragi ]
-deps = [ helix_dep, proto_lite_dep ]
+deps = [ helix_dep, proto_lite_dep, frigg ]
 headers = [ 'include/protocols/fs/client.hpp', 'include/protocols/fs/common.hpp' ]
 
 libfs = shared_library('fs_protocol', src,

--- a/protocols/hw/meson.build
+++ b/protocols/hw/meson.build
@@ -4,7 +4,7 @@ hw_pb = cxxbragi.process(here/'hw.bragi',
 )
 
 incs = [ 'include' ]
-deps = [ helix_dep, proto_lite_dep ]
+deps = [ helix_dep, proto_lite_dep, frigg ]
 src = [ 'src/client.cpp', hw_pb ]
 
 libhw = shared_library('hw_protocol', src,

--- a/protocols/kernlet/meson.build
+++ b/protocols/kernlet/meson.build
@@ -3,7 +3,7 @@ kernlet_pb = protocxx.process(here/'kernlet.proto',
 	extra_args : [ '-I' + here ]
 )
 
-deps = [ mbus_proto_dep ]
+deps = [ mbus_proto_dep, frigg ]
 src = [ 'src/compiler.cpp', kernlet_pb ]
 inc = [ 'include' ]
 

--- a/protocols/mbus/meson.build
+++ b/protocols/mbus/meson.build
@@ -5,7 +5,7 @@ mbus_pb = protocxx.process(here/'mbus.proto',
 
 src = [ 'src/client.cpp', mbus_pb ]
 inc = [ 'include' ]
-deps = [ helix_dep, proto_lite_dep, posix_extra_dep ]
+deps = [ helix_dep, proto_lite_dep, posix_extra_dep, frigg ]
 
 libmbus = shared_library('mbus', src,
 	dependencies : deps,

--- a/protocols/ostrace/meson.build
+++ b/protocols/ostrace/meson.build
@@ -2,7 +2,7 @@ ostrace_bragi = cxxbragi.process('ostrace.bragi')
 
 src = [ 'src/ostrace.cpp', ostrace_bragi ]
 inc = [ 'include' ]
-deps = [ mbus_proto_dep, bragi_dep ]
+deps = [ mbus_proto_dep, bragi_dep, frigg ]
 
 libostrace_protocol = shared_library('ostrace_protocol', src,
 	dependencies : deps,

--- a/protocols/usb/meson.build
+++ b/protocols/usb/meson.build
@@ -5,7 +5,7 @@ usb_pb = protocxx.process(here/'usb.proto',
 
 inc = [ 'include' ]
 src = [ 'src/api.cpp', 'src/client.cpp', 'src/server.cpp', usb_pb ]
-deps = [ libarch, helix_dep, proto_lite_dep ]
+deps = [ libarch, helix_dep, proto_lite_dep, frigg ]
 headers = [
 	'include/protocols/usb/client.hpp',
 	'include/protocols/usb/server.hpp',


### PR DESCRIPTION
Some userspace programs didn't do this correctly. This is needed when we move the frigg headers from `/usr/include/frg` to `/usr/share/frigg/include/frg`, since the latter isn't picked up automatically.
