### PR TITLE
protocols/fs: Refactor the NODE_TRAVERSE_LINKS request to bragi

### DIFF
--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -439,3 +439,9 @@ tail:
 	string old_name;
 	string new_name;
 }
+
+message NodeTraverseLinksRequest 4 {
+head(128):
+tail:
+	string[] path_segments;
+}


### PR DESCRIPTION
As paths can become quite large, we should use the new bragi style messages with a variable sized tail to communicate those paths in `NODE_TRAVERSE_LINKS`. This fixes crashes on long paths, as I managed to trigger with Chromium.

Part of the Chromium on Managarm project.