### PR TITLE
posix/subsystem: account for padding size in CtrlBuilder

### DIFF
--- a/posix/subsystem/src/sockutil.hpp
+++ b/posix/subsystem/src/sockutil.hpp
@@ -22,7 +22,7 @@ struct CtrlBuilder {
 		h.cmsg_type = type;
 
 		memcpy(_buffer.data(), &h, sizeof(struct cmsghdr));
-		_offset += sizeof(struct cmsghdr);
+		_offset += CMSG_ALIGN(sizeof(struct cmsghdr));
 
 		return true;
 	}


### PR DESCRIPTION
```
Excerpt from mlibcs sys/socket.h:
	// Control message format:
	// The offsets marked with ^ are aligned to alignof(size_t).
	//
	// |---HEADER---|---DATA---|---PADDING---|---HEADER---|...
	// ^            ^                        ^
	// |---------CMSG_LEN------|
	// |---------------CMSG_SPACE------------|

Currently, CtrlBuilder pushes DATA right up against HEADER, without any
room for the few bytes of padding that exist when HEADERs right boundary
is not aligned against alignof(sizeof_t). This patch corrects that by
aligning the size of the header up to alignof(size_t).
```

Mutual blocker with https://github.com/managarm/mlibc/pull/728