### PR TITLE
posix: Handle POLLWRNORM in the poll request

### DIFF
--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -2397,7 +2397,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 				// Translate POLL events to EPOLL events.
 				if(req.events(i) & ~(POLLIN | POLLPRI | POLLOUT | POLLRDHUP | POLLERR | POLLHUP
-						| POLLNVAL)) {
+						| POLLNVAL | POLLWRNORM)) {
 					std::cout << "\e[31mposix: Unexpected events for poll()\e[39m" << std::endl;
 					co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
 					errorOut = true;
@@ -2407,6 +2407,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				unsigned int mask = 0;
 				if(req.events(i) & POLLIN) mask |= EPOLLIN;
 				if(req.events(i) & POLLOUT) mask |= EPOLLOUT;
+				if(req.events(i) & POLLWRNORM) mask |= EPOLLOUT;
 				if(req.events(i) & POLLPRI) mask |= EPOLLPRI;
 				if(req.events(i) & POLLRDHUP) mask |= EPOLLRDHUP;
 				if(req.events(i) & POLLERR) mask |= EPOLLERR;


### PR DESCRIPTION
This fixes `curl` crashing with unknown poll events and together with two mlibc PRs allows `curl` to work.