### PR TITLE
Some bragi recvInline fixes

### DIFF
--- a/core/drm/src/ioctl.cpp
+++ b/core/drm/src/ioctl.cpp
@@ -841,6 +841,7 @@ send:
 
 		managarm::posix::SvrResponse posix_resp;
 		posix_resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 
 		// 'export' the object so that we can locate it from other threads, too
 		std::array<char, 16> creds;

--- a/drivers/clocktracker/src/main.cpp
+++ b/drivers/clocktracker/src/main.cpp
@@ -53,6 +53,7 @@ async::result<RtcTime> getRtcTime() {
 
 	managarm::clock::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	assert(resp.error() == managarm::clock::Error::SUCCESS);
 	
 	co_return RtcTime{resp.ref_nanos(), resp.time_nanos()};
@@ -87,6 +88,7 @@ async::detached serve(helix::UniqueLane lane) {
 
 		managarm::clock::CntRequest req;
 		req.ParseFromArray(recv_req.data(), recv_req.length());
+		recv_req.reset();
 		if(req.req_type() == managarm::clock::CntReqType::ACCESS_PAGE) {
 			managarm::clock::SvrResponse resp;
 			resp.set_error(managarm::clock::Error::SUCCESS);

--- a/drivers/kernletcc/src/main.cpp
+++ b/drivers/kernletcc/src/main.cpp
@@ -72,6 +72,7 @@ async::result<helix::UniqueDescriptor> upload(const void *elf, size_t size,
 
 	managarm::kernlet::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	assert(resp.error() == managarm::kernlet::Error::SUCCESS);
 	std::cout << "kernletcc: Upload success" << std::endl;
 
@@ -102,6 +103,7 @@ async::detached serveCompiler(helix::UniqueLane lane) {
 
 		managarm::kernlet::CntRequest req;
 		req.ParseFromArray(recv_req.data(), recv_req.length());
+		recv_req.reset();
 		if(req.req_type() == managarm::kernlet::CntReqType::COMPILE) {
 			std::vector<BindType> bind_types;
 			for(int i = 0; i < req.bind_types_size(); i++) {
@@ -119,6 +121,7 @@ async::detached serveCompiler(helix::UniqueLane lane) {
 
 			auto elf = compileFafnir(reinterpret_cast<const uint8_t *>(recv_code.data()),
 					recv_code.length(), bind_types);
+			recv_code.reset();
 
 			if(dumpHex) {
 				for(size_t i = 0; i < elf.size(); i++) {

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -618,6 +618,7 @@ async::detached servePartition(helix::UniqueLane lane) {
 
 			req = *o;
 		}
+		recv_head.reset();
 
 		if(req.req_type() == managarm::fs::CntReqType::DEV_MOUNT) {
 			helix::UniqueLane local_lane, remote_lane;

--- a/drivers/libevbackend/src/libevbackend.cpp
+++ b/drivers/libevbackend/src/libevbackend.cpp
@@ -76,6 +76,7 @@ async::detached issueReset() {
 	HEL_CHECK(recv_tail.error());
 
 	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
+	recv_head.reset();
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 	throw std::runtime_error("Return from PM_RESET request");
@@ -318,6 +319,7 @@ async::detached serveDevice(std::shared_ptr<EventDevice> device,
 		auto conversation = accept.descriptor();
 		managarm::fs::CntRequest req;
 		req.ParseFromArray(recv_req.data(), recv_req.length());
+		recv_req.reset();
 		if(req.req_type() == managarm::fs::CntReqType::DEV_OPEN) {
 			auto file = smarter::make_shared<File>(device.get(),
 					req.flags() & managarm::fs::OpenFlags::OF_NONBLOCK);

--- a/drivers/tty/virtio-console/src/console.cpp
+++ b/drivers/tty/virtio-console/src/console.cpp
@@ -57,6 +57,7 @@ getKerncfgByteRingPart(helix::BorrowedLane lane,
 
 	managarm::kerncfg::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	assert(resp.error() == managarm::kerncfg::Error::SUCCESS);
 
 	co_return std::make_tuple(resp.size(), resp.effective_dequeue(), resp.new_dequeue());

--- a/drivers/uart/src/main.cpp
+++ b/drivers/uart/src/main.cpp
@@ -284,6 +284,7 @@ async::detached serveTerminal(helix::UniqueLane lane) {
 
 		managarm::fs::CntRequest req;
 		req.ParseFromArray(recv_req.data(), recv_req.length());
+		recv_req.reset();
 		if(req.req_type() == managarm::fs::CntReqType::DEV_OPEN) {
 			helix::UniqueLane local_lane, remote_lane;
 			std::tie(local_lane, remote_lane) = helix::createStream();

--- a/posix/subsystem/src/clock.cpp
+++ b/posix/subsystem/src/clock.cpp
@@ -37,6 +37,7 @@ async::detached fetchTrackerPage() {
 
 	managarm::clock::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	assert(resp.error() == managarm::clock::Error::SUCCESS);
 	globalTrackerPageMemory = pull_memory.descriptor();
 	

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -261,6 +261,7 @@ openExternalDevice(helix::BorrowedLane lane,
 
 	managarm::fs::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	assert(resp.error() == managarm::fs::Errors::SUCCESS);
 
 	helix::Mapping status_mapping;
@@ -369,6 +370,7 @@ FutureMaybe<std::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lan
 
 	managarm::fs::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	assert(resp.error() == managarm::fs::Errors::SUCCESS);
 	co_return extern_fs::createRoot(lane.dup(), pull_node.descriptor());
 }

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -98,6 +98,7 @@ struct Node : FsNode {
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 
 		co_return Error::success;
@@ -125,6 +126,7 @@ struct Node : FsNode {
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 
 		co_return Error::success;
@@ -237,6 +239,7 @@ public:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 		co_return {};
 	}
@@ -370,6 +373,7 @@ public:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 		co_return frg::success_tag{};
 	}
@@ -473,6 +477,7 @@ private:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 
 		if (resp.error() == managarm::fs::Errors::FILE_NOT_FOUND) {
 			co_return Error::noSuchFile;
@@ -536,6 +541,7 @@ private:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recvResp.data(), recvResp.length());
+		recvResp.reset();
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pullNode.error());
 
@@ -573,6 +579,7 @@ private:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recvResp.data(), recvResp.length());
+		recvResp.reset();
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pullNode.error());
 
@@ -724,6 +731,7 @@ private:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 
 		co_return {};
@@ -861,6 +869,7 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
 
 	managarm::fs::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	if(resp.error() == managarm::fs::Errors::SUCCESS) {
 		co_return internalizePeripheralLink(target_node, name, shared_node);
 	}else{

--- a/posix/subsystem/src/subsystem/input.cpp
+++ b/posix/subsystem/src/subsystem/input.cpp
@@ -107,6 +107,7 @@ async::result<std::string> CapabilityAttribute::show(sysfs::Object *object) {
 	
 	managarm::fs::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	assert(resp.error() == managarm::fs::Errors::SUCCESS);
 
 	std::stringstream ss;

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -109,6 +109,7 @@ async::result<void> populateRootView() {
 
 			managarm::fs::SvrResponse resp;
 			resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+			recv_resp.reset();
 			if(resp.error() == managarm::fs::Errors::END_OF_FILE)
 				break;
 			assert(resp.error() == managarm::fs::Errors::SUCCESS);

--- a/servers/netserver/src/main.cpp
+++ b/servers/netserver/src/main.cpp
@@ -107,6 +107,7 @@ async::detached serve(helix::UniqueLane lane) {
 
 		managarm::fs::CntRequest req;
 		req.ParseFromArray(recv_req.data(), recv_req.length());
+		recv_req.reset();
 
 		if (req.req_type() == managarm::fs::CntReqType::CREATE_SOCKET) {
 			auto [local_lane, remote_lane] = helix::createStream();

--- a/utils/runsvr/src/main.cpp
+++ b/utils/runsvr/src/main.cpp
@@ -111,6 +111,7 @@ async::result<helix::UniqueLane> runServer(const char *name) {
 
 	managarm::svrctl::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	assert(resp.error() == managarm::svrctl::Error::SUCCESS);
 	co_return pull_server.descriptor();
 }
@@ -136,6 +137,7 @@ async::result<void> uploadFile(const char *name) {
 
 		managarm::svrctl::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		if(resp.error() == managarm::svrctl::Error::DATA_REQUIRED)
 			co_return false;
 		assert(resp.error() == managarm::svrctl::Error::SUCCESS);
@@ -162,6 +164,7 @@ async::result<void> uploadFile(const char *name) {
 
 		managarm::svrctl::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		assert(resp.error() == managarm::svrctl::Error::SUCCESS);
 	};
 
@@ -192,6 +195,7 @@ async::result<void> bindServer(helix::UniqueLane &lane, int mbusId) {
 
 	managarm::svrctl::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	assert(resp.error() == managarm::svrctl::Error::SUCCESS);
 }
 


### PR DESCRIPTION
This PR addresses some missing reset calls after the use of a buffer that was received with `recvInline`. This should catch all uses in the Managarm codebase. Note that some of the users already did this, so not all users have been changed.