### PR TITLE
posix+protocols/fs: Handle writes to an unconnected socket

### DIFF
--- a/posix/subsystem/src/file.cpp
+++ b/posix/subsystem/src/file.cpp
@@ -105,6 +105,8 @@ async::result<frg::expected<protocols::fs::Error, size_t>> File::ptWrite(void *o
 		switch(result.error()) {
 		case Error::noSpaceLeft:
 			co_return protocols::fs::Error::noSpaceLeft;
+		case Error::notConnected:
+			co_return protocols::fs::Error::notConnected;
 		default:
 			assert(!"Unexpected error from writeAll()");
 			__builtin_unreachable();

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -255,6 +255,8 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 				resp.set_error(managarm::fs::Errors::WOULD_BLOCK);
 			} else if(res.error() == Error::seekOnPipe) {
 				resp.set_error(managarm::fs::Errors::SEEK_ON_PIPE);
+			} else if(res.error() == Error::notConnected) {
+				resp.set_error(managarm::fs::Errors::NOT_CONNECTED);
 			} else {
 				std::cout << "Unknown error from write()" << std::endl;
 				co_return;


### PR DESCRIPTION
This fixes some crashes in `glxgears` during shutdown.