### PR TITLE
protocols/fs: sendMsg fixes and refactor

### DIFF
--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -957,6 +957,16 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 				resp.set_error(managarm::fs::Errors::DESTINATION_ADDRESS_REQUIRED);
 			} else if(res.error() == Error::addressNotAvailable) {
 				resp.set_error(managarm::fs::Errors::ADDRESS_NOT_AVAILABLE);
+			} else if(res.error() == Error::illegalArguments) {
+				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+			} else if(res.error() == Error::afNotSupported) {
+				resp.set_error(managarm::fs::Errors::AF_NOT_SUPPORTED);
+			} else if(res.error() == Error::messageSize) {
+				resp.set_error(managarm::fs::Errors::MESSAGE_TOO_LARGE);
+			} else if(res.error() == Error::brokenPipe) {
+				resp.set_error(managarm::fs::Errors::BROKEN_PIPE);
+			} else if(res.error() == Error::notConnected) {
+				resp.set_error(managarm::fs::Errors::NOT_CONNECTED);
 			} else {
 				std::cout << "Unknown error from sendMsg()" << std::endl;
 				co_return;

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -947,66 +947,24 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 		if(!res) {
 			if(res.error() == Error::wouldBlock) {
 				resp.set_error(managarm::fs::Errors::WOULD_BLOCK);
-
-				auto ser = resp.SerializeAsString();
-				auto [send_resp] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBuffer(ser.data(), ser.size())
-				);
-				HEL_CHECK(send_resp.error());
 			} else if(res.error() == Error::hostUnreachable) {
 				resp.set_error(managarm::fs::Errors::HOST_UNREACHABLE);
-
-				auto ser = resp.SerializeAsString();
-				auto [send_resp] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBuffer(ser.data(), ser.size())
-				);
-				HEL_CHECK(send_resp.error());
 			} else if(res.error() == Error::accessDenied) {
 				resp.set_error(managarm::fs::Errors::ACCESS_DENIED);
-
-				auto ser = resp.SerializeAsString();
-				auto [send_resp] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBuffer(ser.data(), ser.size())
-				);
-				HEL_CHECK(send_resp.error());
 			} else if(res.error() == Error::netUnreachable) {
 				resp.set_error(managarm::fs::Errors::NETWORK_UNREACHABLE);
-
-				auto ser = resp.SerializeAsString();
-				auto [send_resp] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBuffer(ser.data(), ser.size())
-				);
-				HEL_CHECK(send_resp.error());
 			} else if(res.error() == Error::destAddrRequired) {
 				resp.set_error(managarm::fs::Errors::DESTINATION_ADDRESS_REQUIRED);
-
-				auto ser = resp.SerializeAsString();
-				auto [send_resp] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBuffer(ser.data(), ser.size())
-				);
-				HEL_CHECK(send_resp.error());
 			} else if(res.error() == Error::addressNotAvailable) {
 				resp.set_error(managarm::fs::Errors::ADDRESS_NOT_AVAILABLE);
-
-				auto ser = resp.SerializeAsString();
-				auto [send_resp] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBuffer(ser.data(), ser.size())
-				);
-				HEL_CHECK(send_resp.error());
 			} else {
 				std::cout << "Unknown error from sendMsg()" << std::endl;
 				co_return;
 			}
+		} else {
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+			resp.set_size(res.value());
 		}
-
-		resp.set_error(managarm::fs::Errors::SUCCESS);
-		resp.set_size(res.value());
 
 		auto ser = resp.SerializeAsString();
 		auto [send_resp] = co_await helix_ng::exchangeMsgs(


### PR DESCRIPTION
This PR refactors the way errors are reported in sendMsg, reducing code duplication, and adds missing error returns to sendMsg.