### PR TITLE
posix: Guard against nullptrs in FSTATAT request

### DIFF
--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -1216,6 +1216,13 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				target_link = resolver.currentLink();
 			}
 
+			// This catches cases where associatedLink is called on a file, but the file doesn't implement that.
+			// Instead of blowing up, return ENOENT.
+			if(target_link == nullptr) {
+				co_await sendErrorResponse(managarm::posix::Errors::FILE_NOT_FOUND);
+				continue;
+			}
+
 			auto statsResult = co_await target_link->getTarget()->getStats();
 			assert(statsResult);
 			auto stats = statsResult.value();


### PR DESCRIPTION
Calling `associatedLink` on files that don't support it can lead to trying to call nullptr's. As this is bad, I figured that returning ENOENT is a good fallback (while keeping the log about which kind of file is being called intact).