### PR TITLE
posix: Add /proc/[pid]/{status,cwd}

### DIFF
--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -261,6 +261,7 @@ std::shared_ptr<Link> DirectoryNode::createProcDirectory(std::string name,
 
 	proc_dir->directMknode("exe", std::make_shared<ExeLink>(process));
 	proc_dir->directMknode("root", std::make_shared<RootLink>(process));
+	proc_dir->directMknode("cwd", std::make_shared<CwdLink>(process));
 	proc_dir->directMkregular("maps", std::make_shared<MapNode>(process));
 	proc_dir->directMkregular("comm", std::make_shared<CommNode>(process));
 	proc_dir->directMkregular("stat", std::make_shared<StatNode>(process));
@@ -593,6 +594,19 @@ async::result<std::string> StatusNode::show() {
 async::result<void> StatusNode::store(std::string) {
 	// TODO: proper error reporting.
 	throw std::runtime_error("Can't store to a /proc/status file!");
+}
+
+VfsType CwdLink::getType() {
+	return VfsType::symlink;
+}
+
+expected<std::string> CwdLink::readSymlink(FsLink *link, Process *process) {
+	co_return _process->fsContext()->getWorkingDirectory().getPath(_process->fsContext()->getWorkingDirectory());
+}
+
+async::result<frg::expected<Error, FileStats>> CwdLink::getStats() {
+	std::cout << "\e[31mposix: Fix procfs CwdLink::getStats()\e[39m" << std::endl;
+	co_return FileStats{};
 }
 
 } // namespace procfs

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -216,6 +216,17 @@ private:
 
 struct StatmNode final : RegularNode {
 	StatmNode(Process *process)
+        : _process(process)
+        { }
+
+        async::result<std::string> show() override;
+        async::result<void> store(std::string) override;
+private:
+        Process *_process;
+};
+
+struct StatusNode final : RegularNode {
+	StatusNode(Process *process)
 	: _process(process)
 	{ }
 

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -181,6 +181,18 @@ private:
 	Process *_process;
 };
 
+struct CwdLink final : FsNode, std::enable_shared_from_this<CwdLink> {
+	CwdLink(Process *process)
+	: _process(process)
+	{ }
+
+	async::result<frg::expected<Error, FileStats>> getStats() override;
+	VfsType getType() override;
+	expected<std::string> readSymlink(FsLink *link, Process *process) override;
+private:
+	Process *_process;
+};
+
 struct MapNode final : RegularNode {
 	MapNode(Process *process)
 	: _process(process)


### PR DESCRIPTION
This PR adds two new nodes in `/proc`, namely `/proc/[pid]/status` and `/proc/[pid]/cwd`. While the `status` node is lacking in comparison to the Linux counterpart, it does expose some information we didn't export before, and the layout matches what I have in my man page (see the comments in the file for more explanation). The `cwd` node is behaving the same as the Linux version, minus perhaps some permission stuff.