### PR TITLE
protocols/fs: fix error reply for PT_SOCKNAME

### DIFF
--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -704,11 +704,13 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 			resp.set_error(managarm::fs::Errors::ILLEGAL_OPERATION_TARGET);
 
 			auto ser = resp.SerializeAsString();
-			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+			auto [send_resp, send_addr] = co_await helix_ng::exchangeMsgs(
 				conversation,
-				helix_ng::sendBuffer(ser.data(), ser.size())
+				helix_ng::sendBuffer(ser.data(), ser.size()),
+				helix_ng::sendBuffer(nullptr, 0)
 			);
 			HEL_CHECK(send_resp.error());
+			HEL_CHECK(send_addr.error());
 			co_return;
 		}
 


### PR DESCRIPTION
Previously, if sockname was unsupported, this resulted in `End of lane` errors. This prevented curl from working, which is fixed by this.