### PR TITLE
posix: Add /proc/[pid]/comm and /proc/[pid]/root

### DIFF
--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -261,6 +261,7 @@ std::shared_ptr<Link> DirectoryNode::createProcDirectory(std::string name,
 
 	proc_dir->directMknode("exe", std::make_shared<ExeLink>(process));
 	proc_dir->directMkregular("maps", std::make_shared<MapNode>(process));
+	proc_dir->directMkregular("comm", std::make_shared<CommNode>(process));
 
 	return link;
 }
@@ -383,6 +384,23 @@ async::result<std::string> MapNode::show() {
 async::result<void> MapNode::store(std::string) {
 	// TODO: proper error reporting.
 	throw std::runtime_error("Can't store to a /proc/maps file!");
+}
+
+async::result<std::string> CommNode::show() {
+	// See man 5 proc for more details.
+	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
+	std::stringstream stream;
+	auto path = _process->path();
+	size_t pos = path.rfind('/');
+	assert(pos != std::string::npos);
+	auto name = path.substr(pos + 1);
+	stream << name << "\n";
+	co_return stream.str();
+}
+
+async::result<void> CommNode::store(std::string) {
+	// TODO: proper error reporting.
+	throw std::runtime_error("Can't store to a /proc/comm file!");
 }
 
 } // namespace procfs

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -260,6 +260,7 @@ std::shared_ptr<Link> DirectoryNode::createProcDirectory(std::string name,
 	auto proc_dir = static_cast<DirectoryNode*>(link->getTarget().get());
 
 	proc_dir->directMknode("exe", std::make_shared<ExeLink>(process));
+	proc_dir->directMknode("root", std::make_shared<RootLink>(process));
 	proc_dir->directMkregular("maps", std::make_shared<MapNode>(process));
 	proc_dir->directMkregular("comm", std::make_shared<CommNode>(process));
 
@@ -401,6 +402,19 @@ async::result<std::string> CommNode::show() {
 async::result<void> CommNode::store(std::string) {
 	// TODO: proper error reporting.
 	throw std::runtime_error("Can't store to a /proc/comm file!");
+}
+
+VfsType RootLink::getType() {
+	return VfsType::symlink;
+}
+
+expected<std::string> RootLink::readSymlink(FsLink *link, Process *process) {
+	co_return _process->fsContext()->getRoot().getPath(_process->fsContext()->getRoot());
+}
+
+async::result<frg::expected<Error, FileStats>> RootLink::getStats() {
+	std::cout << "\e[31mposix: Fix procfs RootLink::getStats()\e[39m" << std::endl;
+	co_return FileStats{};
 }
 
 } // namespace procfs

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -169,6 +169,18 @@ private:
 	Process *_process;
 };
 
+struct RootLink final : FsNode, std::enable_shared_from_this<RootLink> {
+	RootLink(Process *process)
+	: _process(process)
+	{ }
+
+	async::result<frg::expected<Error, FileStats>> getStats() override;
+	VfsType getType() override;
+	expected<std::string> readSymlink(FsLink *link, Process *process) override;
+private:
+	Process *_process;
+};
+
 struct MapNode final : RegularNode {
 	MapNode(Process *process)
 	: _process(process)

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -180,6 +180,17 @@ private:
 	Process *_process;
 };
 
+struct CommNode final : RegularNode {
+	CommNode(Process *process)
+	: _process(process)
+	{ }
+
+	async::result<std::string> show() override;
+	async::result<void> store(std::string) override;
+private:
+	Process *_process;
+};
+
 } // namespace procfs
 
 std::shared_ptr<FsLink> getProcfs();


### PR DESCRIPTION
This PR adds the `/proc/[pid]/comm` and `/proc/[pid]/root` nodes, exposing more information that might be of use to the userspace. They should both match Linux from what I can tell.