### PR TITLE
thor: Fix PCI MSI handling around EnableMsi and InstallMsi requests

### DIFF
--- a/kernel/thor/generic/debug.cpp
+++ b/kernel/thor/generic/debug.cpp
@@ -167,12 +167,14 @@ void UrgentSink::operator() (const char *msg) {
 void PanicSink::operator() (const char *msg) {
 	StatelessIrqLock irqLock;
 
-	{
-		auto lock = frg::guard(&logMutex);
+	auto lock = frg::guard(&logMutex);
 
-		logProcessor.print(msg);
-		logProcessor.print('\n');
-	}
+	logProcessor.print(msg);
+	logProcessor.print('\n');
+}
+
+void PanicSink::finalize(bool) {
+	StatelessIrqLock irqLock;
 
 #ifdef THOR_HAS_FRAME_POINTERS
 	urgentLogger() << "Stacktrace:" << frg::endlog;

--- a/kernel/thor/generic/thor-internal/debug.hpp
+++ b/kernel/thor/generic/thor-internal/debug.hpp
@@ -52,6 +52,7 @@ struct PanicSink {
 	constexpr PanicSink() = default;
 
 	void operator() (const char *msg);
+	void finalize(bool);
 };
 
 extern frg::stack_buffer_logger<InfoSink, logLineLength> infoLogger;

--- a/kernel/thor/system/pci/thor-internal/pci/pci.hpp
+++ b/kernel/thor/system/pci/thor-internal/pci/pci.hpp
@@ -323,6 +323,8 @@ struct PciDevice final : PciEntity {
 	int msixIndex = -1;
 	void *msixMapping = nullptr;
 	int msiIndex = -1;
+	bool msiEnabled = false;
+	bool msiInstalled = false;
 
 	// Device attachments.
 	FbInfo *associatedFrameBuffer;


### PR DESCRIPTION
Closes #451.

Also fixes panic messages being truncated after first 256 bytes.