### PR TITLE
netserver: implement operators for `CidrAddress` and `Route`

### DIFF
--- a/servers/netserver/src/ip/ip4.hpp
+++ b/servers/netserver/src/ip/ip4.hpp
@@ -57,7 +57,8 @@ struct Ip4Router {
 		uint32_t flags = 0;
 		uint8_t family = 0;
 
-		friend bool operator<(const Route &, const Route &);
+		friend auto operator<=>(const Route &, const Route &);
+		friend bool operator==(const Route &, const Route &);
 	};
 
 	// false if insertion fails


### PR DESCRIPTION
These were previously part of #510, but got dropped mistakenly.