### PR TITLE
posix: Rewrite two bragi messages to use the new format

### DIFF
--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -39,7 +39,6 @@ consts CntReqType uint32 {
 	CHROOT = 24,
 	CHDIR = 58,
 	FCHDIR = 61,
-	ACCESSAT = 20,
 	MKDIRAT = 46,
 	SYMLINKAT = 47,
 	READLINK = 31,
@@ -491,4 +490,12 @@ tail:
 
 message GetPidRequest 86 {
 head(128):
+}
+
+message AccessAtRequest 87 {
+head(128):
+	int32 fd;
+	int32 flags;
+tail:
+	string path;
 }

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -39,7 +39,6 @@ consts CntReqType uint32 {
 	CHROOT = 24,
 	CHDIR = 58,
 	FCHDIR = 61,
-	MKDIRAT = 46,
 	SYMLINKAT = 47,
 	READLINK = 31,
 	READ = 3,
@@ -496,6 +495,13 @@ message AccessAtRequest 87 {
 head(128):
 	int32 fd;
 	int32 flags;
+tail:
+	string path;
+}
+
+message MkdirAtRequest 88 {
+head(128):
+	int32 fd;
 tail:
 	string path;
 }


### PR DESCRIPTION
`WebKitGTK` did some long paths on `ACCESSAT` and `MKDIRAT`, so I rewrote them to account for this.

Blocked on managarm/mlibc#822