### PR TITLE
netserver: Stub netlink SO_PASSCRED

### DIFF
--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -665,3 +665,7 @@ message DrmIoctlGemCloseReply 13 {
 head(128):
 	Errors error;
 }
+
+message InitializePosixLane 14 {
+head(128):
+}

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -669,3 +669,14 @@ head(128):
 message InitializePosixLane 14 {
 head(128):
 }
+
+message ResolveCredentialsToPidReq 15 {
+head(128):
+	uint8[16] credentials;
+}
+
+message ResolveCredentialsToPidReply 16 {
+head(128):
+	Errors error;
+	int64 pid;
+}

--- a/servers/netserver/src/netlink/netlink.hpp
+++ b/servers/netserver/src/netlink/netlink.hpp
@@ -41,9 +41,12 @@ public:
 		co_return protocols::fs::Error::none;
 	}
 
+	static async::result<void> setOption(void *, int option, int value);
+
 	static async::result<size_t> sockname(void *, void *, size_t);
 
 	constexpr static protocols::fs::FileOperations ops {
+		.setOption = &setOption,
 		.bind = &bind,
 		.sockname = &sockname,
 		.recvMsg = &recvMsg,
@@ -78,6 +81,7 @@ private:
 	bool _isClosed = false;
 	uint64_t _currentSeq;
 	uint64_t _inSeq;
+	bool _passCreds = false;
 
 	std::deque<nl::Packet> _recvQueue;
 };


### PR DESCRIPTION
I'm pretty sure 'WebKitGTK' needed it, but we don't see it called. The `SO_PASSCRED` implementation is lacking things, but it works for 'WebKitGTK', so I want it in.

Supercedes #526 