### PR TITLE
posix: Only launch gdbserver once

### DIFF
--- a/posix/subsystem/src/gdbserver.cpp
+++ b/posix/subsystem/src/gdbserver.cpp
@@ -512,18 +512,23 @@ async::result<frg::expected<ProtocolError>> GdbServer::handleRequest_() {
 
 } // anonymous namespace
 
+static bool launched = false;
+
 void launchGdbServer(Process *process) {
-	async::detach([] (Process *process) -> async::result<void> {
-		std::cout << "posix: Starting GDB server" << std::endl;
+	if(!launched) {
+		launched = true;
+		async::detach([] (Process *process) -> async::result<void> {
+			std::cout << "posix: Starting GDB server" << std::endl;
 
-		auto root = rootPath();
-		auto fileOrError = co_await open(root, root, "dev/ttyS0", process);
-		if(!fileOrError) {
-			std::cout << "posix, gdbserver: Could not open /dev/ttyS0" << std::endl;
-			co_return;
-		}
+			auto root = rootPath();
+			auto fileOrError = co_await open(root, root, "dev/ttyS0", process);
+			if(!fileOrError) {
+				std::cout << "posix, gdbserver: Could not open /dev/ttyS0" << std::endl;
+				co_return;
+			}
 
-		GdbServer server{process, fileOrError.value()};
-		co_await server.run();
-	}(process));
+			GdbServer server{process, fileOrError.value()};
+			co_await server.run();
+		}(process));
+	}
 }


### PR DESCRIPTION
This avoids launching 3 gdbservers if one process crashes 3 threads (firefox and chromium I'm looking at you).