### PR TITLE
Implement USB sysfs support

### DIFF
--- a/drivers/gfx/bochs/src/main.cpp
+++ b/drivers/gfx/bochs/src/main.cpp
@@ -428,7 +428,7 @@ async::detached bindController(mbus::Entity entity) {
 	mbus::Properties descriptor{
 		{"drvcore.mbus-parent", mbus::StringItem{std::to_string(entity.getId())}},
 		{"unix.subsystem", mbus::StringItem{"drm"}},
-		{"unix.devname", mbus::StringItem{"dri/card0"}}
+		{"unix.devname", mbus::StringItem{"dri/card"}}
 	};
 
 	auto handler = mbus::ObjectHandler{}

--- a/drivers/gfx/plainfb/src/main.cpp
+++ b/drivers/gfx/plainfb/src/main.cpp
@@ -374,7 +374,7 @@ async::detached bindController(mbus::Entity entity) {
 	mbus::Properties descriptor{
 		{"drvcore.mbus-parent", mbus::StringItem{std::to_string(entity.getId())}},
 		{"unix.subsystem", mbus::StringItem{"drm"}},
-		{"unix.devname", mbus::StringItem{"dri/card0"}}
+		{"unix.devname", mbus::StringItem{"dri/card"}}
 	};
 
 	auto handler = mbus::ObjectHandler{}

--- a/drivers/gfx/virtio/src/main.cpp
+++ b/drivers/gfx/virtio/src/main.cpp
@@ -463,7 +463,7 @@ async::result<void> doBind(mbus::Entity base_entity) {
 	mbus::Properties descriptor{
 		{"drvcore.mbus-parent", mbus::StringItem{std::to_string(base_entity.getId())}},
 		{"unix.subsystem", mbus::StringItem{"drm"}},
-		{"unix.devname", mbus::StringItem{"dri/card0"}}
+		{"unix.devname", mbus::StringItem{"dri/card"}}
 	};
 
 	auto handler = mbus::ObjectHandler{}

--- a/drivers/gfx/vmware/src/main.cpp
+++ b/drivers/gfx/vmware/src/main.cpp
@@ -748,7 +748,7 @@ async::result<void> setupDevice(mbus::Entity entity) {
 	mbus::Properties descriptor{
 		{"drvcore.mbus-parent", mbus::StringItem{std::to_string(entity.getId())}},
 		{"unix.subsystem", mbus::StringItem{"drm"}},
-		{"unix.devname", mbus::StringItem{"dri/card0"}}
+		{"unix.devname", mbus::StringItem{"dri/card"}}
 	};
 
 	auto handler = mbus::ObjectHandler{}

--- a/drivers/uart/src/main.cpp
+++ b/drivers/uart/src/main.cpp
@@ -313,7 +313,7 @@ async::detached runTerminal() {
 
 	mbus::Properties descriptor{
 		{"generic.devtype", mbus::StringItem{"block"}},
-		{"generic.devname", mbus::StringItem{"ttyS0"}}
+		{"generic.devname", mbus::StringItem{"ttyS"}}
 	};
 
 	auto handler = mbus::ObjectHandler{}

--- a/drivers/usb/devices/hid/src/hid.hpp
+++ b/drivers/usb/devices/hid/src/hid.hpp
@@ -50,8 +50,8 @@ struct Element {
 
 struct HidDevice {
 	HidDevice();
-	void parseReportDescriptor(Device device, uint8_t* p, uint8_t* limit);
-	async::detached run(Device device, int intf_num, int config_num);
+	void parseReportDescriptor(protocols::usb::Device device, uint8_t* p, uint8_t* limit);
+	async::detached run(protocols::usb::Device device, int intf_num, int config_num);
 
 	std::vector<Field> fields;
 	std::vector<Element> elements;

--- a/drivers/usb/devices/hid/src/spec.hpp
+++ b/drivers/usb/devices/hid/src/spec.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <protocols/usb/client.hpp>
+
 namespace pages {
 	constexpr int genericDesktop = 0x01;
 	constexpr int simulationControls = 0x02;
@@ -25,7 +28,7 @@ namespace item {
 	constexpr uint32_t relative = (1 << 2);
 }
 
-struct HidDescriptor : public DescriptorBase {
+struct HidDescriptor : public protocols::usb::DescriptorBase {
 	struct [[ gnu::packed ]] Entry {
 		uint8_t descriptorType;
 		uint16_t descriptorLength;

--- a/drivers/usb/devices/storage/src/main.cpp
+++ b/drivers/usb/devices/storage/src/main.cpp
@@ -236,7 +236,7 @@ async::detached bindDevice(mbus::Entity entity) {
 			auto desc = (InterfaceDescriptor *)p;
 			intf_class = desc->interfaceClass;
 			intf_subclass = desc->interfaceSubClass;
-			intf_protocol = desc->interfaceProtocoll;
+			intf_protocol = desc->interfaceProtocol;
 		}
 	});
 

--- a/drivers/usb/devices/storage/src/main.cpp
+++ b/drivers/usb/devices/storage/src/main.cpp
@@ -24,14 +24,16 @@ namespace {
 	constexpr bool enableRead6 = false;
 }
 
+namespace proto = protocols::usb;
+
 async::detached StorageDevice::run(int config_num, int intf_num) {
 	auto descriptor = (co_await _usbDevice.configurationDescriptor()).unwrap();
 
 	std::optional<int> in_endp_number;
 	std::optional<int> out_endp_number;
 
-	walkConfiguration(descriptor, [&] (int type, size_t, void *, const auto &info) {
-		if(type == descriptor_type::endpoint) {
+	proto::walkConfiguration(descriptor, [&] (int type, size_t, void *, const auto &info) {
+		if(type == proto::descriptor_type::endpoint) {
 			if(info.endpointIn.value()) {
 				in_endp_number = info.endpointNumber.value();
 			}else if(!info.endpointIn.value()) {
@@ -50,8 +52,8 @@ async::detached StorageDevice::run(int config_num, int intf_num) {
 
 	auto config = (co_await _usbDevice.useConfiguration(config_num)).unwrap();
 	auto intf = (co_await config.useInterface(intf_num, 0)).unwrap();
-	auto endp_in = (co_await intf.getEndpoint(PipeType::in, in_endp_number.value())).unwrap();
-	auto endp_out = (co_await intf.getEndpoint(PipeType::out, out_endp_number.value())).unwrap();
+	auto endp_in = (co_await intf.getEndpoint(proto::PipeType::in, in_endp_number.value())).unwrap();
+	auto endp_out = (co_await intf.getEndpoint(proto::PipeType::out, out_endp_number.value())).unwrap();
 
 	if(logSteps)
 		std::cout << "block-usb: Device is ready" << std::endl;
@@ -134,26 +136,26 @@ async::detached StorageDevice::run(int config_num, int intf_num) {
 
 			if(logSteps)
 				std::cout << "block-usb: Sending CBW" << std::endl;
-			(co_await endp_out.transfer(BulkTransfer{XferFlags::kXferToDevice,
+			(co_await endp_out.transfer(proto::BulkTransfer{proto::XferFlags::kXferToDevice,
 					arch::dma_buffer_view{nullptr, &cbw, sizeof(CommandBlockWrapper)}})).unwrap();
 
 			if(logSteps)
 				std::cout << "block-usb: Waiting for data" << std::endl;
 			if(!req->isWrite) {
-				BulkTransfer data_info{XferFlags::kXferToHost,
+				proto::BulkTransfer data_info{proto::XferFlags::kXferToHost,
 						arch::dma_buffer_view{nullptr, req->buffer, req->numSectors * 512}};
 				// TODO: We want this to be lazy but that only works if can ensure that
 				// the next transaction is also posted to the queue.
 	//			data_info.lazyNotification = true;
 				(co_await endp_in.transfer(data_info)).unwrap();
 			}else{
-				(co_await endp_out.transfer(BulkTransfer{XferFlags::kXferToDevice,
+				(co_await endp_out.transfer(proto::BulkTransfer{proto::XferFlags::kXferToDevice,
 						arch::dma_buffer_view{nullptr, req->buffer, req->numSectors * 512}})).unwrap();
 			}
 
 			if(logSteps)
 				std::cout << "block-usb: Waiting for CSW" << std::endl;
-			(co_await endp_in.transfer(BulkTransfer{XferFlags::kXferToHost,
+			(co_await endp_in.transfer(proto::BulkTransfer{proto::XferFlags::kXferToHost,
 					arch::dma_buffer_view{nullptr, &csw, sizeof(CommandStatusWrapper)}})).unwrap();
 
 			if(logSteps)
@@ -198,7 +200,7 @@ async::result<size_t> StorageDevice::getSize() {
 
 async::detached bindDevice(mbus::Entity entity) {
 	auto lane = helix::UniqueLane(co_await entity.bind());
-	auto device = protocols::usb::connect(std::move(lane));
+	auto device = proto::connect(std::move(lane));
 
 	std::optional<int> config_number;
 	std::optional<int> intf_number;
@@ -215,11 +217,11 @@ async::detached bindDevice(mbus::Entity entity) {
 		co_return;
 	}
 
-	walkConfiguration(descriptorOrError.value(), [&] (int type, size_t, void *p, const auto &info) {
-		if(type == descriptor_type::configuration) {
+	proto::walkConfiguration(descriptorOrError.value(), [&] (int type, size_t, void *p, const auto &info) {
+		if(type == proto::descriptor_type::configuration) {
 			assert(!config_number);
 			config_number = info.configNumber.value();
-		}else if(type == descriptor_type::interface) {
+		}else if(type == proto::descriptor_type::interface) {
 			if(intf_number) {
 				std::cout << "block-usb: Ignoring interface "
 						<< info.interfaceNumber.value() << std::endl;
@@ -233,7 +235,7 @@ async::detached bindDevice(mbus::Entity entity) {
 			assert(!intf_class);
 			assert(!intf_subclass);
 			assert(!intf_protocol);
-			auto desc = (InterfaceDescriptor *)p;
+			auto desc = (proto::InterfaceDescriptor *)p;
 			intf_class = desc->interfaceClass;
 			intf_subclass = desc->interfaceSubClass;
 			intf_protocol = desc->interfaceProtocol;

--- a/drivers/usb/devices/storage/src/storage.hpp
+++ b/drivers/usb/devices/storage/src/storage.hpp
@@ -97,7 +97,7 @@ struct Read32 {
 
 struct StorageDevice : blockfs::BlockDevice {
 	//TODO(geert): hook up USB to sysfs too
-	StorageDevice(Device usb_device)
+	StorageDevice(protocols::usb::Device usb_device)
 	: blockfs::BlockDevice(512, -1), _usbDevice(std::move(usb_device)) { }
 
 	async::detached run(int config_num, int intf_num);
@@ -123,7 +123,7 @@ private:
 		boost::intrusive::list_member_hook<> requestHook;
 	};
 
-	Device _usbDevice;
+	protocols::usb::Device _usbDevice;
 	async::recurring_event _doorbell;
 
 	boost::intrusive::list<

--- a/drivers/usb/hcds/ehci/src/ehci.hpp
+++ b/drivers/usb/hcds/ehci/src/ehci.hpp
@@ -113,6 +113,7 @@ struct Controller : std::enable_shared_from_this<Controller> {
 	DeviceSlot _activeDevices[128];
 
 public:
+	async::result<frg::expected<proto::UsbError, std::string>> deviceDescriptor(int address);
 	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor(int address);
 
 	async::result<frg::expected<proto::UsbError>>
@@ -201,6 +202,7 @@ struct DeviceState final : proto::DeviceData {
 	arch::dma_pool *setupPool() override;
 	arch::dma_pool *bufferPool() override;
 
+	async::result<frg::expected<proto::UsbError, std::string>> deviceDescriptor() override;
 	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor() override;
 	async::result<frg::expected<proto::UsbError, proto::Configuration>> useConfiguration(int number) override;
 	async::result<frg::expected<proto::UsbError>> transfer(proto::ControlTransfer info) override;

--- a/drivers/usb/hcds/ehci/src/ehci.hpp
+++ b/drivers/usb/hcds/ehci/src/ehci.hpp
@@ -2,12 +2,18 @@
 #include <queue>
 
 #include <arch/mem_space.hpp>
+#include <arch/dma_structs.hpp>
 #include <async/recurring-event.hpp>
 #include <async/promise.hpp>
 #include <async/mutex.hpp>
 #include <async/result.hpp>
+#include <boost/intrusive/list.hpp>
 #include <helix/memory.hpp>
+#include <frg/expected.hpp>
 #include <frg/std_compat.hpp>
+#include <protocols/hw/client.hpp>
+#include <protocols/mbus/client.hpp>
+#include <protocols/usb/api.hpp>
 
 #include "spec.hpp"
 
@@ -47,6 +53,7 @@ private:
 
 struct Controller : std::enable_shared_from_this<Controller> {
 	Controller(protocols::hw::Device hw_device,
+			mbus::Entity entity,
 			helix::Mapping mapping,
 			helix::UniqueDescriptor mmio, helix::UniqueIrq irq);
 
@@ -180,6 +187,8 @@ private:
 
 	int _numPorts;
 	Enumerator _enumerator;
+
+	mbus::Entity _entity;
 };
 
 // ----------------------------------------------------------------------------

--- a/drivers/usb/hcds/ehci/src/ehci.hpp
+++ b/drivers/usb/hcds/ehci/src/ehci.hpp
@@ -11,6 +11,8 @@
 
 #include "spec.hpp"
 
+namespace proto = protocols::usb;
+
 struct Controller;
 struct DeviceState;
 struct ConfigurationState;
@@ -47,11 +49,11 @@ struct Controller : std::enable_shared_from_this<Controller> {
 	Controller(protocols::hw::Device hw_device,
 			helix::Mapping mapping,
 			helix::UniqueDescriptor mmio, helix::UniqueIrq irq);
-	
+
 	async::detached initialize();
 	async::result<void> probeDevice();
 	async::detached handleIrqs();
-	
+
 	// ------------------------------------------------------------------------
 	// Schedule classes.
 	// ------------------------------------------------------------------------
@@ -64,18 +66,18 @@ struct Controller : std::enable_shared_from_this<Controller> {
 		explicit Transaction(arch::dma_array<TransferDescriptor> transfers, size_t size)
 		: transfers{std::move(transfers)}, fullSize{size},
 				numComplete{0}, lostSize{0} { }
-		
+
 		arch::dma_array<TransferDescriptor> transfers;
 		size_t fullSize;
 		size_t numComplete;
 		size_t lostSize; // Size lost in short packets.
-		async::promise<frg::expected<UsbError, size_t>, frg::stl_allocator> promise;
-		async::promise<frg::expected<UsbError>, frg::stl_allocator> voidPromise;
+		async::promise<frg::expected<proto::UsbError, size_t>, frg::stl_allocator> promise;
+		async::promise<frg::expected<proto::UsbError>, frg::stl_allocator> voidPromise;
 	};
 
 	struct QueueEntity : AsyncItem {
 		QueueEntity(arch::dma_object<QueueHead> the_head, int address,
-				int pipe, PipeType type, size_t packet_size);
+				int pipe, proto::PipeType type, size_t packet_size);
 
 		bool getReclaim();
 		void setReclaim(bool reclaim);
@@ -104,58 +106,58 @@ struct Controller : std::enable_shared_from_this<Controller> {
 	DeviceSlot _activeDevices[128];
 
 public:
-	async::result<frg::expected<UsbError, std::string>> configurationDescriptor(int address);
+	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor(int address);
 
-	async::result<frg::expected<UsbError>>
+	async::result<frg::expected<proto::UsbError>>
 	useConfiguration(int address, int configuration);
 
-	async::result<frg::expected<UsbError>>
+	async::result<frg::expected<proto::UsbError>>
 	useInterface(int address, int interface, int alternative);
 
 	// ------------------------------------------------------------------------
 	// Transfer functions.
 	// ------------------------------------------------------------------------
-	
-	static Transaction *_buildControl(XferFlags dir,
-			arch::dma_object_view<SetupPacket> setup, arch::dma_buffer_view buffer,
+
+	static Transaction *_buildControl(proto::XferFlags dir,
+			arch::dma_object_view<proto::SetupPacket> setup, arch::dma_buffer_view buffer,
 			size_t max_packet_size);
-	static Transaction *_buildInterruptOrBulk(XferFlags dir,
+	static Transaction *_buildInterruptOrBulk(proto::XferFlags dir,
 			arch::dma_buffer_view buffer, size_t max_packet_size,
 			bool lazy_notification);
 
 
-	async::result<frg::expected<UsbError>>
-	transfer(int address, int pipe, ControlTransfer info);
+	async::result<frg::expected<proto::UsbError>>
+	transfer(int address, int pipe, proto::ControlTransfer info);
 
-	async::result<frg::expected<UsbError, size_t>>
-	transfer(int address, PipeType type, int pipe, InterruptTransfer info);
+	async::result<frg::expected<proto::UsbError, size_t>>
+	transfer(int address, proto::PipeType type, int pipe, proto::InterruptTransfer info);
 
-	async::result<frg::expected<UsbError, size_t>>
-	transfer(int address, PipeType type, int pipe, BulkTransfer info);
+	async::result<frg::expected<proto::UsbError, size_t>>
+	transfer(int address, proto::PipeType type, int pipe, proto::BulkTransfer info);
 
 private:
-	async::result<frg::expected<UsbError>> _directTransfer(ControlTransfer info,
+	async::result<frg::expected<proto::UsbError>> _directTransfer(proto::ControlTransfer info,
 			QueueEntity *queue, size_t max_packet_size);
-	
+
 
 	// ------------------------------------------------------------------------
 	// Schedule management.
 	// ------------------------------------------------------------------------
-	
+
 	void _linkAsync(QueueEntity *entity);
 	void _linkTransaction(QueueEntity *queue, Transaction *transaction);
-	
+
 	void _progressSchedule();
 	void _progressQueue(QueueEntity *entity);
-	
+
 	boost::intrusive::list<QueueEntity> _asyncSchedule;
 	arch::dma_object<QueueHead> _asyncQh;
-	
+
 	// ----------------------------------------------------------------------------
 	// Port management.
 	// ----------------------------------------------------------------------------
 
-	void _checkPorts();	
+	void _checkPorts();
 
 public:
 	async::detached resetPort(int number);
@@ -166,7 +168,7 @@ public:
 private:
 	void _dump(Transaction *transaction);
 	void _dump(QueueEntity *entity);
-	
+
 
 private:
 	protocols::hw::Device _hwDevice;
@@ -184,15 +186,15 @@ private:
 // DeviceState
 // ----------------------------------------------------------------------------
 
-struct DeviceState final : DeviceData {
+struct DeviceState final : proto::DeviceData {
 	explicit DeviceState(std::shared_ptr<Controller> controller, int device);
 
 	arch::dma_pool *setupPool() override;
 	arch::dma_pool *bufferPool() override;
 
-	async::result<frg::expected<UsbError, std::string>> configurationDescriptor() override;
-	async::result<frg::expected<UsbError, Configuration>> useConfiguration(int number) override;
-	async::result<frg::expected<UsbError>> transfer(ControlTransfer info) override;
+	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor() override;
+	async::result<frg::expected<proto::UsbError, proto::Configuration>> useConfiguration(int number) override;
+	async::result<frg::expected<proto::UsbError>> transfer(proto::ControlTransfer info) override;
 
 private:
 	std::shared_ptr<Controller> _controller;
@@ -203,11 +205,11 @@ private:
 // ConfigurationState
 // ----------------------------------------------------------------------------
 
-struct ConfigurationState final : ConfigurationData {
+struct ConfigurationState final : proto::ConfigurationData {
 	explicit ConfigurationState(std::shared_ptr<Controller> controller,
 			int device, int configuration);
 
-	async::result<frg::expected<UsbError, Interface>>
+	async::result<frg::expected<proto::UsbError, proto::Interface>>
 	useInterface(int number, int alternative) override;
 
 private:
@@ -220,12 +222,12 @@ private:
 // InterfaceState
 // ----------------------------------------------------------------------------
 
-struct InterfaceState final : InterfaceData {
+struct InterfaceState final : proto::InterfaceData {
 	explicit InterfaceState(std::shared_ptr<Controller> controller,
 			int device, int configuration);
 
-	async::result<frg::expected<UsbError, Endpoint>>
-	getEndpoint(PipeType type, int number) override;
+	async::result<frg::expected<proto::UsbError, proto::Endpoint>>
+	getEndpoint(proto::PipeType type, int number) override;
 
 private:
 	std::shared_ptr<Controller> _controller;
@@ -237,18 +239,18 @@ private:
 // EndpointState
 // ----------------------------------------------------------------------------
 
-struct EndpointState final : EndpointData {
+struct EndpointState final : proto::EndpointData {
 	explicit EndpointState(std::shared_ptr<Controller> controller,
-			int device, PipeType type, int endpoint);
+			int device, proto::PipeType type, int endpoint);
 
-	async::result<frg::expected<UsbError>> transfer(ControlTransfer info) override;
-	async::result<frg::expected<UsbError, size_t>> transfer(InterruptTransfer info) override;
-	async::result<frg::expected<UsbError, size_t>> transfer(BulkTransfer info) override;
+	async::result<frg::expected<proto::UsbError>> transfer(proto::ControlTransfer info) override;
+	async::result<frg::expected<proto::UsbError, size_t>> transfer(proto::InterruptTransfer info) override;
+	async::result<frg::expected<proto::UsbError, size_t>> transfer(proto::BulkTransfer info) override;
 
 private:
 	std::shared_ptr<Controller> _controller;
 	int _device;
-	PipeType _type;
+	proto::PipeType _type;
 	int _endpoint;
 };
 

--- a/drivers/usb/hcds/ehci/src/main.cpp
+++ b/drivers/usb/hcds/ehci/src/main.cpp
@@ -366,12 +366,12 @@ async::result<void> Controller::probeDevice() {
 
 	char class_code[3], sub_class[3], protocol[3];
 	char vendor[5], product[5], release[5];
-	sprintf(class_code, "%.2x", descriptor->deviceClass);
-	sprintf(sub_class, "%.2x", descriptor->deviceSubclass);
-	sprintf(protocol, "%.2x", descriptor->deviceProtocol);
-	sprintf(vendor, "%.4x", descriptor->idVendor);
-	sprintf(product, "%.4x", descriptor->idProduct);
-	sprintf(release, "%.4x", descriptor->bcdDevice);
+	snprintf(class_code, 3, "%.2x", descriptor->deviceClass);
+	snprintf(sub_class, 3, "%.2x", descriptor->deviceSubclass);
+	snprintf(protocol, 3, "%.2x", descriptor->deviceProtocol);
+	snprintf(vendor, 5, "%.4x", descriptor->idVendor);
+	snprintf(product, 5, "%.4x", descriptor->idProduct);
+	snprintf(release, 5, "%.4x", descriptor->bcdDevice);
 
 	mbus::Properties mbus_desc{
 		{"usb.type", mbus::StringItem{"device"}},

--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -461,12 +461,12 @@ async::result<void> Controller::enumerateDevice(std::shared_ptr<Hub> parentHub, 
 
 	char class_code[3], sub_class[3], protocol[3];
 	char vendor[5], product[5], release[5];
-	sprintf(class_code, "%.2x", descriptor->deviceClass);
-	sprintf(sub_class, "%.2x", descriptor->deviceSubclass);
-	sprintf(protocol, "%.2x", descriptor->deviceProtocol);
-	sprintf(vendor, "%.4x", descriptor->idVendor);
-	sprintf(product, "%.4x", descriptor->idProduct);
-	sprintf(release, "%.4x", descriptor->bcdDevice);
+	snprintf(class_code, 3, "%.2x", descriptor->deviceClass);
+	snprintf(sub_class, 3, "%.2x", descriptor->deviceSubclass);
+	snprintf(protocol, 3, "%.2x", descriptor->deviceProtocol);
+	snprintf(vendor, 5, "%.4x", descriptor->idVendor);
+	snprintf(product, 5, "%.4x", descriptor->idProduct);
+	snprintf(release, 5, "%.4x", descriptor->bcdDevice);
 
 	std::cout << "uhci: Enumerating device of class: 0x" << class_code
 			<< ", sub class: 0x" << sub_class << ", protocol: 0x" << protocol << std::endl;

--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -74,6 +74,10 @@ arch::dma_pool *DeviceState::bufferPool() {
 	return &schedulePool;
 }
 
+async::result<frg::expected<proto::UsbError, std::string>> DeviceState::deviceDescriptor() {
+	return _controller->deviceDescriptor(_device);
+}
+
 async::result<frg::expected<proto::UsbError, std::string>> DeviceState::configurationDescriptor() {
 	return _controller->configurationDescriptor(_device);
 }
@@ -522,6 +526,37 @@ async::result<void> Controller::enumerateDevice(std::shared_ptr<proto::Hub> pare
 // ------------------------------------------------------------------------
 // Controller: Device management.
 // ------------------------------------------------------------------------
+
+async::result<frg::expected<proto::UsbError, std::string>>
+Controller::deviceDescriptor(int address) {
+	arch::dma_object<proto::SetupPacket> get_header{&schedulePool};
+	get_header->type = proto::setup_type::targetDevice | proto::setup_type::byStandard
+			| proto::setup_type::toHost;
+	get_header->request = proto::request_type::getDescriptor;
+	get_header->value = proto::descriptor_type::device << 8;
+	get_header->index = 0;
+	get_header->length = 8;
+
+	arch::dma_object<proto::DeviceDescriptor> descriptor{&schedulePool};
+	FRG_CO_TRY(co_await transfer(address, 0, proto::ControlTransfer{proto::kXferToHost,
+			get_header, descriptor.view_buffer().subview(0, 8)}));
+
+	// Read the rest of the device descriptor.
+	arch::dma_object<proto::SetupPacket> get_descriptor{&schedulePool};
+	get_descriptor->type = proto::setup_type::targetDevice | proto::setup_type::byStandard
+			| proto::setup_type::toHost;
+	get_descriptor->request = proto::request_type::getDescriptor;
+	get_descriptor->value = proto::descriptor_type::device << 8;
+	get_descriptor->index = 0;
+	get_descriptor->length = sizeof(proto::DeviceDescriptor);
+
+	FRG_CO_TRY(co_await transfer(address, 0, proto::ControlTransfer{proto::kXferToHost,
+			get_descriptor, descriptor.view_buffer()}));
+	assert(descriptor->length == sizeof(proto::DeviceDescriptor));
+
+	std::string copy((char *)descriptor.data(), sizeof(proto::DeviceDescriptor));
+	co_return std::move(copy);
+}
 
 async::result<frg::expected<proto::UsbError, std::string>>
 Controller::configurationDescriptor(int address) {

--- a/drivers/usb/hcds/uhci/src/schedule.hpp
+++ b/drivers/usb/hcds/uhci/src/schedule.hpp
@@ -5,7 +5,11 @@
 #include <async/recurring-event.hpp>
 #include <async/promise.hpp>
 #include <async/mutex.hpp>
+#include <boost/intrusive/list.hpp>
 #include <protocols/hw/client.hpp>
+#include <protocols/mbus/client.hpp>
+#include <protocols/usb/api.hpp>
+#include <protocols/usb/hub.hpp>
 
 #include <frg/std_compat.hpp>
 
@@ -30,8 +34,8 @@ struct Controller final : std::enable_shared_from_this<Controller>, proto::BaseC
 		Controller *_controller;
 	};
 
-	Controller(protocols::hw::Device hw_device, uintptr_t base,
-			arch::io_space space, helix::UniqueIrq irq);
+	Controller(protocols::hw::Device hw_device, mbus::Entity entity,
+			uintptr_t base, arch::io_space space, helix::UniqueIrq irq);
 
 	void initialize();
 	async::detached _handleIrqs();
@@ -49,6 +53,8 @@ private:
 	int64_t _frameCounter;
 	proto::PortState _portState[2];
 	async::recurring_event _portDoorbell;
+
+	mbus::Entity _entity;
 
 	void _updateFrame();
 

--- a/drivers/usb/hcds/uhci/src/schedule.hpp
+++ b/drivers/usb/hcds/uhci/src/schedule.hpp
@@ -125,6 +125,7 @@ private:
 	DeviceSlot _activeDevices[128];
 
 public:
+	async::result<frg::expected<proto::UsbError, std::string>> deviceDescriptor(int address);
 	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor(int address);
 
 	async::result<frg::expected<proto::UsbError>>
@@ -201,6 +202,7 @@ struct DeviceState final : proto::DeviceData {
 	arch::dma_pool *setupPool() override;
 	arch::dma_pool *bufferPool() override;
 
+	async::result<frg::expected<proto::UsbError, std::string>> deviceDescriptor() override;
 	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor() override;
 	async::result<frg::expected<proto::UsbError, proto::Configuration>> useConfiguration(int number) override;
 	async::result<frg::expected<proto::UsbError>> transfer(proto::ControlTransfer info) override;

--- a/drivers/usb/hcds/xhci/src/main.cpp
+++ b/drivers/usb/hcds/xhci/src/main.cpp
@@ -742,6 +742,13 @@ arch::dma_pool *Controller::Device::bufferPool() {
 }
 
 async::result<frg::expected<proto::UsbError, std::string>>
+Controller::Device::deviceDescriptor() {
+	arch::dma_object<proto::DeviceDescriptor> descriptor{bufferPool()};
+	FRG_CO_TRY(co_await readDescriptor(descriptor.view_buffer(), 0x0100));
+	co_return std::string{(char *)descriptor.data(), descriptor.view_buffer().size()};
+}
+
+async::result<frg::expected<proto::UsbError, std::string>>
 Controller::Device::configurationDescriptor() {
 	arch::dma_object<proto::ConfigDescriptor> header{&_controller->_memoryPool};
 	FRG_CO_TRY(co_await readDescriptor(header.view_buffer(), 0x0200));

--- a/drivers/usb/hcds/xhci/src/main.cpp
+++ b/drivers/usb/hcds/xhci/src/main.cpp
@@ -26,12 +26,16 @@
 #include "xhci.hpp"
 #include "trb.hpp"
 
+namespace proto = protocols::usb;
+
 // When set to true, the driver ignores any speeds defined in the supported protocols
 // in favor of the default values defined in the XHCI spec. This behavior imitates
 // what Linux is doing in it's driver.
 inline constexpr bool ignoreControllerSpeeds = true;
 
-inline frg::expected<UsbError> completionToError(Event ev) {
+inline frg::expected<proto::UsbError> completionToError(Event ev) {
+	using proto::UsbError;
+
 	switch (ev.completionCode) {
 		case 1: return frg::success;
 		case 13: return frg::success; // Should short packets always be treated as success?
@@ -97,7 +101,7 @@ std::vector<std::pair<uint8_t, uint16_t>> Controller::getExtendedCapabilityOffse
 async::detached Controller::initialize() {
 	auto caps = getExtendedCapabilityOffsets();
 
-	auto usb_legacy_cap = std::find_if(caps.begin(), caps.end(), 
+	auto usb_legacy_cap = std::find_if(caps.begin(), caps.end(),
 			[](auto &a){
 				return a.first == 0x1;
 			});
@@ -182,7 +186,7 @@ async::detached Controller::initialize() {
 	for (auto &p : _supportedProtocols) {
 		printf("xhci: supported protocol:\n");
 		printf("xhci: name: \"%s\" %u.%u\n", p.name.c_str(), p.major, p.minor);
-		printf("xhci: compatible ports: %lu to %lu\n", p.compatiblePortStart, 
+		printf("xhci: compatible ports: %lu to %lu\n", p.compatiblePortStart,
 				p.compatiblePortStart + p.compatiblePortCount - 1);
 		printf("xhci: protocol defined: %03x\n", p.protocolDefined);
 		printf("xhci: protocol slot type: %lu\n", p.protocolSlotType);
@@ -210,13 +214,13 @@ async::detached Controller::initialize() {
 
 		printf("xhci: supported speeds:\n");
 		for (auto &s : p.speeds) {
-			printf("xhci:\tspeed:%u %s\n", s.mantissa, 
+			printf("xhci:\tspeed:%u %s\n", s.mantissa,
 					exponent[s.exponent]);
 			printf("xhci:\tfull duplex? %s\n",
 					s.fullDuplex ? "yes" : "no");
 			printf("xhci:\ttype: %s\n", type[s.type]);
 			if (p.major == 3)
-				printf("xhci:\tlink protocol: %s\n", 
+				printf("xhci:\tlink protocol: %s\n",
 						linkProtocol[s.linkProtocol]);
 		}
 	}
@@ -352,7 +356,7 @@ void Controller::ringDoorbell(uint8_t doorbell, uint8_t target, uint16_t stream_
 			target | (stream_id << 16));
 }
 
-async::result<void> Controller::enumerateDevice(std::shared_ptr<Hub> parentHub, int port, DeviceSpeed speed) {
+async::result<void> Controller::enumerateDevice(std::shared_ptr<proto::Hub> parentHub, int port, proto::DeviceSpeed speed) {
 	uint32_t route = 0;
 	size_t rootPort = port;
 
@@ -360,7 +364,7 @@ async::result<void> Controller::enumerateDevice(std::shared_ptr<Hub> parentHub, 
 		route |= port > 14 ? 14 : (port + 1);
 	}
 
-	std::shared_ptr<Hub> h = parentHub;
+	std::shared_ptr<proto::Hub> h = parentHub;
 
 	while (h->parent()) {
 		if (h->parent()->parent()) {
@@ -388,7 +392,7 @@ async::result<void> Controller::enumerateDevice(std::shared_ptr<Hub> parentHub, 
 	// TODO: if isFullSpeed is set, read the first 8 bytes of the device descriptor
 	// and update the control endpoint's max packet size to match the bMaxPacketSize0 value
 
-	arch::dma_object<DeviceDescriptor> descriptor{&_memoryPool};
+	arch::dma_object<proto::DeviceDescriptor> descriptor{&_memoryPool};
 	(co_await device->readDescriptor(descriptor.view_buffer(), 0x0100)).unwrap();
 
 	// Advertise the USB device on mbus.
@@ -402,7 +406,7 @@ async::result<void> Controller::enumerateDevice(std::shared_ptr<Hub> parentHub, 
 	snprintf(release, 5, "%.4x", descriptor->bcdDevice);
 
 	if (descriptor->deviceClass == 0x09 && descriptor->deviceSubclass == 0) {
-		auto hub = (co_await createHubFromDevice(parentHub, ::Device{device}, port)).unwrap();
+		auto hub = (co_await createHubFromDevice(parentHub, proto::Device{device}, port)).unwrap();
 
 		(co_await device->configureHub(hub, speed)).unwrap();
 
@@ -428,7 +432,7 @@ async::result<void> Controller::enumerateDevice(std::shared_ptr<Hub> parentHub, 
 	.withBind([=] () -> async::result<helix::UniqueDescriptor> {
 		helix::UniqueLane local_lane, remote_lane;
 		std::tie(local_lane, remote_lane) = helix::createStream();
-		protocols::usb::serve(::Device{device}, std::move(local_lane));
+		proto::serve(proto::Device{device}, std::move(local_lane));
 
 		co_return std::move(remote_lane);
 	});
@@ -594,37 +598,37 @@ async::detached Controller::Port::initPort() {
 		assert(linkStatus == 0); // U0
 	}
 
-	_state.changes |= HubStatus::connect | HubStatus::enable;
-	_state.status |= HubStatus::connect | HubStatus::enable;
+	_state.changes |= proto::HubStatus::connect | proto::HubStatus::enable;
+	_state.status |= proto::HubStatus::connect | proto::HubStatus::enable;
 	_pollEv.raise();
 }
 
-async::result<PortState> Controller::Port::pollState() {
+async::result<proto::PortState> Controller::Port::pollState() {
 	_pollSeq = co_await _pollEv.async_wait(_pollSeq);
 	co_return _state;
 }
 
-async::result<frg::expected<UsbError, DeviceSpeed>> Controller::Port::getGenericSpeed() {
+async::result<frg::expected<proto::UsbError, proto::DeviceSpeed>> Controller::Port::getGenericSpeed() {
 	uint8_t speedId = getSpeed();
 
-	std::optional<DeviceSpeed> speed;
+	std::optional<proto::DeviceSpeed> speed;
 
 	if (ignoreControllerSpeeds || _proto->speeds.empty()) {
 		switch(speedId) {
 			case 1:
-				speed = DeviceSpeed::fullSpeed;
+				speed = proto::DeviceSpeed::fullSpeed;
 				break;
 			case 2:
-				speed = DeviceSpeed::lowSpeed;
+				speed = proto::DeviceSpeed::lowSpeed;
 				break;
 			case 3:
-				speed = DeviceSpeed::highSpeed;
+				speed = proto::DeviceSpeed::highSpeed;
 				break;
 			case 4:
 			case 5:
 			case 6:
 			case 7:
-				speed = DeviceSpeed::superSpeed;
+				speed = proto::DeviceSpeed::superSpeed;
 		}
 	} else {
 		for (auto &pSpeed : _proto->speeds) {
@@ -632,21 +636,21 @@ async::result<frg::expected<UsbError, DeviceSpeed>> Controller::Port::getGeneric
 				if (pSpeed.exponent == 2
 						&& pSpeed.mantissa == 12) {
 					// Full Speed
-					speed = DeviceSpeed::fullSpeed;
+					speed = proto::DeviceSpeed::fullSpeed;
 				} else if (pSpeed.exponent == 1
 						&& pSpeed.mantissa == 1500) {
 					// Low Speed
-					speed = DeviceSpeed::lowSpeed;
+					speed = proto::DeviceSpeed::lowSpeed;
 				} else if (pSpeed.exponent == 2
 						&& pSpeed.mantissa == 480) {
 					// High Speed
-					speed = DeviceSpeed::highSpeed;
+					speed = proto::DeviceSpeed::highSpeed;
 				} else if (pSpeed.exponent == 3
 						&& (pSpeed.mantissa == 5
 							|| pSpeed.mantissa == 10
 							|| pSpeed.mantissa == 20)) {
 					// SuperSpeed
-					speed = DeviceSpeed::superSpeed;
+					speed = proto::DeviceSpeed::superSpeed;
 				}else if (pSpeed.exponent == 2
 						&& (pSpeed.mantissa == 1248
 							|| pSpeed.mantissa == 2496
@@ -655,7 +659,7 @@ async::result<frg::expected<UsbError, DeviceSpeed>> Controller::Port::getGeneric
 							|| pSpeed.mantissa == 2915
 							|| pSpeed.mantissa == 5830)) {
 					// SSIC SuperSpeed
-					speed = DeviceSpeed::superSpeed;
+					speed = proto::DeviceSpeed::superSpeed;
 				}
 
 				break;
@@ -670,7 +674,7 @@ async::result<frg::expected<UsbError, DeviceSpeed>> Controller::Port::getGeneric
 		co_return speed.value();
 	} else {
 		printf("xhci: Invalid speed ID: %u\n", speedId);
-		co_return UsbError::unsupported;
+		co_return proto::UsbError::unsupported;
 	}
 }
 
@@ -683,7 +687,7 @@ Controller::RootHub::RootHub(Controller *controller, SupportedProtocol &proto)
 	for (size_t i = 0; i < proto.compatiblePortCount; i++) {
 		_ports.push_back(std::make_unique<Port>(i + proto.compatiblePortStart, controller, &proto));
 		_ports.back()->initPort();
-		_controller->_ports[(i + proto.compatiblePortStart - 1)] = 
+		_controller->_ports[(i + proto.compatiblePortStart - 1)] =
 				_ports.back().get();
 	}
 }
@@ -692,11 +696,11 @@ size_t Controller::RootHub::numPorts() {
 	return _proto->compatiblePortCount;
 }
 
-async::result<PortState> Controller::RootHub::pollState(int port) {
+async::result<proto::PortState> Controller::RootHub::pollState(int port) {
 	co_return co_await _ports[port]->pollState();
 }
 
-async::result<frg::expected<UsbError, DeviceSpeed>> Controller::RootHub::issueReset(int port) {
+async::result<frg::expected<proto::UsbError, proto::DeviceSpeed>> Controller::RootHub::issueReset(int port) {
 	co_return FRG_CO_TRY(co_await _ports[port]->getGenericSpeed());
 }
 
@@ -716,9 +720,9 @@ arch::dma_pool *Controller::Device::bufferPool() {
 	return &_controller->_memoryPool;
 }
 
-async::result<frg::expected<UsbError, std::string>>
+async::result<frg::expected<proto::UsbError, std::string>>
 Controller::Device::configurationDescriptor() {
-	arch::dma_object<ConfigDescriptor> header{&_controller->_memoryPool};
+	arch::dma_object<proto::ConfigDescriptor> header{&_controller->_memoryPool};
 	FRG_CO_TRY(co_await readDescriptor(header.view_buffer(), 0x0200));
 
 	arch::dma_buffer descriptor{&_controller->_memoryPool, header->totalLength};
@@ -726,25 +730,25 @@ Controller::Device::configurationDescriptor() {
 	co_return std::string{(char *)descriptor.data(), descriptor.size()};
 }
 
-async::result<frg::expected<UsbError, Configuration>>
+async::result<frg::expected<proto::UsbError, proto::Configuration>>
 Controller::Device::useConfiguration(int number) {
 	auto descriptor = FRG_CO_TRY(co_await configurationDescriptor());
 
 	struct EndpointInfo {
 		int pipe;
-		PipeType dir;
+		proto::PipeType dir;
 		int packetSize;
-		EndpointType type;
+		proto::EndpointType type;
 	};
 
 	std::vector<EndpointInfo> _eps = {};
 
-	walkConfiguration(descriptor, [&] (int type, size_t length, void *p, const auto &info) {
+	proto::walkConfiguration(descriptor, [&] (int type, size_t length, void *p, const auto &info) {
 		(void)length;
 
-		if(type != descriptor_type::endpoint)
+		if(type != proto::descriptor_type::endpoint)
 			return;
-		auto desc = (EndpointDescriptor *)p;
+		auto desc = (proto::EndpointDescriptor *)p;
 
 		// TODO: Pay attention to interface/alternative.
 		auto packetSize = desc->maxPacketSize & 0x7FF;
@@ -752,15 +756,15 @@ Controller::Device::useConfiguration(int number) {
 
 		int pipe = info.endpointNumber.value();
 		if (info.endpointIn.value()) {
-			_eps.push_back({pipe, PipeType::in, packetSize, epType});
+			_eps.push_back({pipe, proto::PipeType::in, packetSize, epType});
 		} else {
-			_eps.push_back({pipe, PipeType::out, packetSize, epType});
+			_eps.push_back({pipe, proto::PipeType::out, packetSize, epType});
 		}
 	});
 
 	for (auto &ep : _eps) {
-		printf("xhci: setting up %s endpoint %d (max packet size: %d)\n", 
-			ep.dir == PipeType::in ? "in" : "out", ep.pipe, ep.packetSize);
+		printf("xhci: setting up %s endpoint %d (max packet size: %d)\n",
+			ep.dir == proto::PipeType::in ? "in" : "out", ep.pipe, ep.packetSize);
 		FRG_CO_TRY(co_await setupEndpoint(ep.pipe, ep.dir, ep.packetSize, ep.type));
 	}
 
@@ -770,7 +774,7 @@ Controller::Device::useConfiguration(int number) {
 		if (last)
 			trb.val[3] |= 1 << 5; // IOC
 		pushRawTransfer(0, trb, last ? &comp : nullptr);
-	}, { .request = request_type::setConfig, .value = static_cast<uint16_t>(number), .length = 0 }, { }, false);
+	}, { .request = proto::request_type::setConfig, .value = static_cast<uint16_t>(number), .length = 0 }, { }, false);
 
 	submit(1);
 
@@ -783,18 +787,18 @@ Controller::Device::useConfiguration(int number) {
 	FRG_CO_TRY(completionToError(comp.event));
 	printf("xhci: configuration set\n");
 
-	co_return Configuration{std::make_shared<Controller::ConfigurationState>(_controller, shared_from_this(), number)};
+	co_return proto::Configuration{std::make_shared<Controller::ConfigurationState>(_controller, shared_from_this(), number)};
 }
 
-async::result<frg::expected<UsbError>>
-Controller::Device::transfer(ControlTransfer info) {
+async::result<frg::expected<proto::UsbError>>
+Controller::Device::transfer(proto::ControlTransfer info) {
 	ProducerRing::Completion ev;
 
 	Transfer::buildControlChain([&] (RawTrb trb, bool last) {
 		if (last)
 			trb.val[3] |= 1 << 5; // IOC
 		pushRawTransfer(0, trb, last ? &ev : nullptr);
-	}, *info.setup.data(), info.buffer, info.flags == kXferToHost);
+	}, *info.setup.data(), info.buffer, info.flags == proto::kXferToHost);
 
 	submit(1);
 
@@ -809,9 +813,9 @@ void Controller::Device::submit(int endpoint) {
 	_controller->ringDoorbell(_slotId, endpoint, /* stream */ 0);
 }
 
-static inline uint8_t getHcdSpeedId(DeviceSpeed speed) {
+static inline uint8_t getHcdSpeedId(proto::DeviceSpeed speed) {
 	switch (speed) {
-		using enum DeviceSpeed;
+		using enum proto::DeviceSpeed;
 
 		case lowSpeed: return 2;
 		case fullSpeed: return 1;
@@ -822,8 +826,8 @@ static inline uint8_t getHcdSpeedId(DeviceSpeed speed) {
 	return 0;
 }
 
-async::result<frg::expected<UsbError>>
-Controller::Device::enumerate(size_t rootPort, size_t port, uint32_t route, std::shared_ptr<Hub> hub, DeviceSpeed speed, int slotType) {
+async::result<frg::expected<proto::UsbError>>
+Controller::Device::enumerate(size_t rootPort, size_t port, uint32_t route, std::shared_ptr<proto::Hub> hub, proto::DeviceSpeed speed, int slotType) {
 	auto event = co_await _controller->submitCommand(
 			Command::enableSlot(slotType));
 
@@ -850,7 +854,7 @@ Controller::Device::enumerate(size_t rootPort, size_t port, uint32_t route, std:
 	slotCtx |= SlotFields::ctxEntries(1);
 	slotCtx |= SlotFields::speed(getHcdSpeedId(speed));
 
-	if ((speed == DeviceSpeed::lowSpeed || speed == DeviceSpeed::fullSpeed)
+	if ((speed == proto::DeviceSpeed::lowSpeed || speed == proto::DeviceSpeed::fullSpeed)
 			&& hub->parent()) {
 		// We need to fill these fields out for split transactions.
 
@@ -864,7 +868,7 @@ Controller::Device::enumerate(size_t rootPort, size_t port, uint32_t route, std:
 
 	size_t packetSize = 0;
 	switch (speed) {
-		using enum DeviceSpeed;
+		using enum proto::DeviceSpeed;
 
 		case lowSpeed:
 		case fullSpeed: packetSize = 8; break;
@@ -872,7 +876,7 @@ Controller::Device::enumerate(size_t rootPort, size_t port, uint32_t route, std:
 		case superSpeed: packetSize = 512; break;
 	}
 
-	_initEpCtx(inputCtx, 0, PipeType::control, packetSize, EndpointType::control);
+	_initEpCtx(inputCtx, 0, proto::PipeType::control, packetSize, proto::EndpointType::control);
 
 	_controller->_dcbaa[_slotId] = helix::ptrToPhysical(_devCtx.rawData());
 
@@ -895,7 +899,7 @@ void Controller::Device::pushRawTransfer(int endpoint, RawTrb cmd, ProducerRing:
 	_transferRings[endpoint]->pushRawTrb(cmd, comp);
 }
 
-async::result<frg::expected<UsbError>>
+async::result<frg::expected<proto::UsbError>>
 Controller::Device::readDescriptor(arch::dma_buffer_view dest, uint16_t desc) {
 	ProducerRing::Completion ev;
 
@@ -903,8 +907,8 @@ Controller::Device::readDescriptor(arch::dma_buffer_view dest, uint16_t desc) {
 		if (last)
 			trb.val[3] |= 1 << 5; // IOC
 		pushRawTransfer(0, trb, last ? &ev : nullptr);
-	}, { .type = 0x80, .request = request_type::getDescriptor,
-		.value = static_cast<uint16_t>(desc), .length = static_cast<uint16_t>(dest.size()) }, dest, true);
+	}, { .type = 0x80, .request = proto::request_type::getDescriptor,
+		.value = desc, .length = static_cast<uint16_t>(dest.size()) }, dest, true);
 
 	submit(1);
 
@@ -921,7 +925,10 @@ Controller::Device::readDescriptor(arch::dma_buffer_view dest, uint16_t desc) {
 	co_return frg::success;
 }
 
-static inline uint32_t getHcdEndpointType(PipeType dir, EndpointType type) {
+static inline uint32_t getHcdEndpointType(proto::PipeType dir, proto::EndpointType type) {
+	using proto::EndpointType;
+	using proto::PipeType;
+
 	if (type == EndpointType::control)
 		return 4;
 	if (type == EndpointType::isochronous)
@@ -933,7 +940,9 @@ static inline uint32_t getHcdEndpointType(PipeType dir, EndpointType type) {
 	return 0;
 }
 
-static inline uint32_t getDefaultAverageTrbLen(EndpointType type) {
+static inline uint32_t getDefaultAverageTrbLen(proto::EndpointType type) {
+	using proto::EndpointType;
+
 	if (type == EndpointType::control)
 		return 8;
 	if (type == EndpointType::isochronous)
@@ -945,8 +954,8 @@ static inline uint32_t getDefaultAverageTrbLen(EndpointType type) {
 	return 0;
 }
 
-async::result<frg::expected<UsbError>>
-Controller::Device::setupEndpoint(int endpoint, PipeType dir, size_t maxPacketSize, EndpointType type) {
+async::result<frg::expected<proto::UsbError>>
+Controller::Device::setupEndpoint(int endpoint, proto::PipeType dir, size_t maxPacketSize, proto::EndpointType type) {
 	InputContext inputCtx{_controller->_largeCtx, &_controller->_memoryPool};
 
 	inputCtx.get(inputCtxCtrl) |= InputControlFields::add(0); // Slot Context
@@ -956,7 +965,7 @@ Controller::Device::setupEndpoint(int endpoint, PipeType dir, size_t maxPacketSi
 	_initEpCtx(inputCtx, endpoint, dir, maxPacketSize, type);
 
 	auto event = co_await _controller->submitCommand(
-			Command::configureEndpoint(_slotId, 
+			Command::configureEndpoint(_slotId,
 				helix::ptrToPhysical(inputCtx.rawData())));
 
 	if (event.completionCode != 1)
@@ -970,8 +979,8 @@ Controller::Device::setupEndpoint(int endpoint, PipeType dir, size_t maxPacketSi
 	co_return frg::success;
 }
 
-async::result<frg::expected<UsbError>>
-Controller::Device::configureHub(std::shared_ptr<Hub> hub, DeviceSpeed speed) {
+async::result<frg::expected<proto::UsbError>>
+Controller::Device::configureHub(std::shared_ptr<proto::Hub> hub, proto::DeviceSpeed speed) {
 	InputContext inputCtx{_controller->_largeCtx, &_controller->_memoryPool};
 
 	inputCtx.get(inputCtxCtrl) |= InputControlFields::add(0); // Slot Context
@@ -980,7 +989,7 @@ Controller::Device::configureHub(std::shared_ptr<Hub> hub, DeviceSpeed speed) {
 	inputCtx.get(inputCtxSlot) |= SlotFields::hub(true);
 	inputCtx.get(inputCtxSlot) |= SlotFields::portCount(hub->numPorts());
 
-	if (speed == DeviceSpeed::highSpeed)
+	if (speed == proto::DeviceSpeed::highSpeed)
 		inputCtx.get(inputCtxSlot) |= SlotFields::ttThinkTime(
 				hub->getCharacteristics().unwrap().ttThinkTime / 8 - 1);
 
@@ -998,9 +1007,9 @@ Controller::Device::configureHub(std::shared_ptr<Hub> hub, DeviceSpeed speed) {
 	co_return frg::success;
 }
 
-void Controller::Device::_initEpCtx(InputContext &ctx, int endpoint, PipeType dir, size_t maxPacketSize, EndpointType type) {
+void Controller::Device::_initEpCtx(InputContext &ctx, int endpoint, proto::PipeType dir, size_t maxPacketSize, proto::EndpointType type) {
 	int endpointId = endpoint * 2
-			+ ((dir == PipeType::in || dir == PipeType::control)
+			+ ((dir == proto::PipeType::in || dir == proto::PipeType::control)
 				? 1
 				: 0);
 
@@ -1029,42 +1038,42 @@ void Controller::Device::_initEpCtx(InputContext &ctx, int endpoint, PipeType di
 // Controller::ConfigurationState
 // ------------------------------------------------------------------------
 
-Controller::ConfigurationState::ConfigurationState(Controller *controller, 
+Controller::ConfigurationState::ConfigurationState(Controller *controller,
 		std::shared_ptr<Device> device, int)
 :_controller{controller}, _device{device} {
 }
 
-async::result<frg::expected<UsbError, Interface>>
+async::result<frg::expected<proto::UsbError, proto::Interface>>
 Controller::ConfigurationState::useInterface(int number, int alternative) {
 	assert(!alternative);
-	co_return Interface{std::make_shared<Controller::InterfaceState>(_controller, _device, number)};
+	co_return proto::Interface{std::make_shared<Controller::InterfaceState>(_controller, _device, number)};
 }
 
 // ------------------------------------------------------------------------
 // Controller::InterfaceState
 // ------------------------------------------------------------------------
 
-Controller::InterfaceState::InterfaceState(Controller *controller, 
+Controller::InterfaceState::InterfaceState(Controller *controller,
 		std::shared_ptr<Device> device, int)
 : _controller{controller}, _device{device} {
 }
 
-async::result<frg::expected<UsbError, Endpoint>>
-Controller::InterfaceState::getEndpoint(PipeType type, int number) {
-	co_return Endpoint{std::make_shared<Controller::EndpointState>(_controller, _device, number, type)};
+async::result<frg::expected<proto::UsbError, proto::Endpoint>>
+Controller::InterfaceState::getEndpoint(proto::PipeType type, int number) {
+	co_return proto::Endpoint{std::make_shared<Controller::EndpointState>(_controller, _device, number, type)};
 }
 
 // ------------------------------------------------------------------------
 // Controller::EndpointState
 // ------------------------------------------------------------------------
 
-Controller::EndpointState::EndpointState(Controller *, 
-		std::shared_ptr<Device> device, int endpoint, PipeType type)
+Controller::EndpointState::EndpointState(Controller *,
+		std::shared_ptr<Device> device, int endpoint, proto::PipeType type)
 : _device{device}, _endpoint{endpoint}, _type{type} {
 }
 
-async::result<frg::expected<UsbError>>
-Controller::EndpointState::transfer(ControlTransfer info) {
+async::result<frg::expected<proto::UsbError>>
+Controller::EndpointState::transfer(proto::ControlTransfer info) {
 	int endpointId = _endpoint * 2;
 
 	ProducerRing::Completion ev;
@@ -1073,7 +1082,7 @@ Controller::EndpointState::transfer(ControlTransfer info) {
 		if (last)
 			trb.val[3] |= 1 << 5; // IOC
 		_device->pushRawTransfer(endpointId - 1, trb, last ? &ev : nullptr);
-	}, *info.setup.data(), info.buffer, info.flags == kXferToHost);
+	}, *info.setup.data(), info.buffer, info.flags == proto::kXferToHost);
 
 	_device->submit(endpointId);
 
@@ -1083,9 +1092,9 @@ Controller::EndpointState::transfer(ControlTransfer info) {
 	co_return frg::success;
 }
 
-async::result<frg::expected<UsbError, size_t>>
-Controller::EndpointState::transfer(InterruptTransfer info) {
-	int endpointId = _endpoint * 2 + (_type == PipeType::in ? 1 : 0);
+async::result<frg::expected<proto::UsbError, size_t>>
+Controller::EndpointState::transfer(proto::InterruptTransfer info) {
+	int endpointId = _endpoint * 2 + (_type == proto::PipeType::in ? 1 : 0);
 
 	ProducerRing::Completion ev;
 
@@ -1103,9 +1112,9 @@ Controller::EndpointState::transfer(InterruptTransfer info) {
 	co_return info.buffer.size() - ev.event.transferLen;
 }
 
-async::result<frg::expected<UsbError, size_t>>
-Controller::EndpointState::transfer(BulkTransfer info) {
-	int endpointId = _endpoint * 2 + (_type == PipeType::in ? 1 : 0);
+async::result<frg::expected<proto::UsbError, size_t>>
+Controller::EndpointState::transfer(proto::BulkTransfer info) {
+	int endpointId = _endpoint * 2 + (_type == proto::PipeType::in ? 1 : 0);
 
 	ProducerRing::Completion ev;
 
@@ -1180,4 +1189,4 @@ int main() {
 	observeControllers();
 	async::run_forever(helix::currentDispatcher);
 }
- 
+

--- a/drivers/usb/hcds/xhci/src/main.cpp
+++ b/drivers/usb/hcds/xhci/src/main.cpp
@@ -394,12 +394,12 @@ async::result<void> Controller::enumerateDevice(std::shared_ptr<Hub> parentHub, 
 	// Advertise the USB device on mbus.
 	char class_code[3], sub_class[3], protocol[3];
 	char vendor[5], product[5], release[5];
-	sprintf(class_code, "%.2x", descriptor->deviceClass);
-	sprintf(sub_class, "%.2x", descriptor->deviceSubclass);
-	sprintf(protocol, "%.2x", descriptor->deviceProtocol);
-	sprintf(vendor, "%.4x", descriptor->idVendor);
-	sprintf(product, "%.4x", descriptor->idProduct);
-	sprintf(release, "%.4x", descriptor->bcdDevice);
+	snprintf(class_code, 3, "%.2x", descriptor->deviceClass);
+	snprintf(sub_class, 3, "%.2x", descriptor->deviceSubclass);
+	snprintf(protocol, 3, "%.2x", descriptor->deviceProtocol);
+	snprintf(vendor, 5, "%.4x", descriptor->idVendor);
+	snprintf(product, 5, "%.4x", descriptor->idProduct);
+	snprintf(release, 5, "%.4x", descriptor->bcdDevice);
 
 	if (descriptor->deviceClass == 0x09 && descriptor->deviceSubclass == 0) {
 		auto hub = (co_await createHubFromDevice(parentHub, ::Device{device}, port)).unwrap();

--- a/drivers/usb/hcds/xhci/src/trb.hpp
+++ b/drivers/usb/hcds/xhci/src/trb.hpp
@@ -103,7 +103,7 @@ namespace Command {
 } // namespace Command
 
 namespace Transfer {
-	constexpr RawTrb setupStage(SetupPacket setup, bool hasDataStage, bool dataIn) {
+	constexpr RawTrb setupStage(protocols::usb::SetupPacket setup, bool hasDataStage, bool dataIn) {
 		return RawTrb{
 			(uint32_t{setup.value} << 16) | (uint32_t{setup.request} << 8) | uint32_t{setup.type},
 			(uint32_t{setup.length} << 16) | uint32_t{setup.index},
@@ -164,7 +164,7 @@ namespace Transfer {
 	}
 
 	template <typename FU>
-	inline void buildControlChain(FU use, SetupPacket setup, arch::dma_buffer_view view, bool dataIn) {
+	inline void buildControlChain(FU use, protocols::usb::SetupPacket setup, arch::dma_buffer_view view, bool dataIn) {
 		bool statusIn = true;
 
 		if (view.size() && dataIn)

--- a/drivers/usb/hcds/xhci/src/xhci.hpp
+++ b/drivers/usb/hcds/xhci/src/xhci.hpp
@@ -173,6 +173,7 @@ private:
 		// Public API inherited from DeviceData.
 		arch::dma_pool *setupPool() override;
 		arch::dma_pool *bufferPool() override;
+		async::result<frg::expected<proto::UsbError, std::string>> deviceDescriptor() override;
 		async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor() override;
 		async::result<frg::expected<proto::UsbError, proto::Configuration>> useConfiguration(int number) override;
 		async::result<frg::expected<proto::UsbError>> transfer(proto::ControlTransfer info) override;

--- a/drivers/usb/hcds/xhci/src/xhci.hpp
+++ b/drivers/usb/hcds/xhci/src/xhci.hpp
@@ -9,6 +9,7 @@
 #include <async/result.hpp>
 #include <helix/memory.hpp>
 #include <helix/timer.hpp>
+#include <protocols/mbus/client.hpp>
 #include <protocols/usb/api.hpp>
 #include <protocols/usb/hub.hpp>
 #include <protocols/hw/client.hpp>
@@ -66,6 +67,7 @@ constexpr const char *completionCodeNames[256] = {
 
 struct Controller final : proto::BaseController {
 	Controller(protocols::hw::Device hw_device,
+			mbus::Entity entity,
 			helix::Mapping mapping,
 			helix::UniqueDescriptor mmio,
 			helix::UniqueIrq irq, bool useMsis);
@@ -154,10 +156,15 @@ private:
 			return _proto;
 		}
 
+		auto entityId() {
+			return _entity.getId();
+		}
+
 	private:
 		Controller *_controller;
 		SupportedProtocol *_proto;
 		std::vector<std::unique_ptr<Port>> _ports;
+		mbus::Entity _entity;
 	};
 
 	struct Device final : proto::DeviceData, std::enable_shared_from_this<Device> {
@@ -308,6 +315,8 @@ private:
 	proto::Enumerator _enumerator;
 
 	bool _largeCtx;
+
+	mbus::Entity _entity;
 };
 
 

--- a/posix/subsystem/meson.build
+++ b/posix/subsystem/meson.build
@@ -35,6 +35,7 @@ src = [
 	'src/subsystem/generic.cpp',
 	'src/subsystem/input.cpp',
 	'src/subsystem/pci.cpp',
+	'src/subsystem/usb/attributes.cpp',
 	'src/subsystem/usb/usb.cpp',
 	'src/sysfs.cpp',
 	'src/timerfd.cpp',

--- a/posix/subsystem/meson.build
+++ b/posix/subsystem/meson.build
@@ -46,6 +46,6 @@ src = [
 ]
 
 executable('posix-subsystem', src,
-	dependencies : [ mbus_proto_dep, fs_proto_dep, posix_extra_dep, clock_proto_dep, kerncfg_proto_dep, hw_proto_dep, frigg ],
+	dependencies : [ mbus_proto_dep, fs_proto_dep, posix_extra_dep, clock_proto_dep, kerncfg_proto_dep, hw_proto_dep, usb_proto_dep, frigg ],
 	install : true
 )

--- a/posix/subsystem/meson.build
+++ b/posix/subsystem/meson.build
@@ -35,6 +35,7 @@ src = [
 	'src/subsystem/generic.cpp',
 	'src/subsystem/input.cpp',
 	'src/subsystem/pci.cpp',
+	'src/subsystem/usb/usb.cpp',
 	'src/sysfs.cpp',
 	'src/timerfd.cpp',
 	'src/tmp_fs.cpp',

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -18,6 +18,7 @@
 #include "subsystem/generic.hpp"
 #include "subsystem/input.hpp"
 #include "subsystem/pci.hpp"
+#include "subsystem/usb/usb.hpp"
 #include "observations.hpp"
 
 #include <bragi/helpers-std.hpp>
@@ -165,6 +166,7 @@ int main() {
 	generic_subsystem::run();
 	input_subsystem::run();
 	pci_subsystem::run();
+	usb_subsystem::run();
 
 	runInit();
 

--- a/posix/subsystem/src/subsystem/usb/attributes.cpp
+++ b/posix/subsystem/src/subsystem/usb/attributes.cpp
@@ -1,0 +1,172 @@
+#include "attributes.hpp"
+#include "devices.hpp"
+
+namespace usb_subsystem {
+
+async::result<std::string> VendorAttribute::show(sysfs::Object *object) {
+	char buffer[6]; // The format is 1234\n\0.
+	auto device = static_cast<UsbBase *>(object);
+	snprintf(buffer, 6, "%.4x\n", device->desc()->idVendor);
+	co_return std::string{buffer};
+}
+
+async::result<std::string> DeviceAttribute::show(sysfs::Object *object) {
+	char buffer[6]; // The format is 1234\n\0.
+	auto device = static_cast<UsbBase *>(object);
+	snprintf(buffer, 6, "%.4x\n", device->desc()->idProduct);
+	co_return std::string{buffer};
+}
+
+async::result<std::string> DeviceClassAttribute::show(sysfs::Object *object) {
+	char buffer[4]; // The format is 34\n\0.
+	auto device = static_cast<UsbBase *>(object);
+	snprintf(buffer, 4, "%.2x\n", device->desc()->deviceClass);
+	co_return std::string{buffer};
+}
+
+async::result<std::string> DeviceSubClassAttribute::show(sysfs::Object *object) {
+	char buffer[4]; // The format is 34\n\0.
+	auto device = static_cast<UsbBase *>(object);
+	snprintf(buffer, 4, "%.2x\n", device->desc()->deviceSubclass);
+	co_return std::string{buffer};
+}
+
+async::result<std::string> DeviceProtocolAttribute::show(sysfs::Object *object) {
+	char buffer[4]; // The format is 34\n\0.
+	auto device = static_cast<UsbBase *>(object);
+	snprintf(buffer, 4, "%.2x\n", device->desc()->deviceProtocol);
+	co_return std::string{buffer};
+}
+
+async::result<std::string> BcdDeviceAttribute::show(sysfs::Object *object) {
+	char buffer[6]; // The format is 34\n\0.
+	auto device = static_cast<UsbBase *>(object);
+	snprintf(buffer, 6, "%.4x\n", device->desc()->bcdDevice);
+	co_return std::string{buffer};
+}
+
+async::result<std::string> VersionAttribute::show(sysfs::Object *object) {
+	char buffer[7]; // The format is " 2.00\n\0".
+	auto device = static_cast<UsbBase *>(object);
+	snprintf(buffer, 7, "%2x.%02x\n", device->desc()->bcdUsb >> 8, device->desc()->bcdUsb & 0xFF);
+	co_return std::string{buffer};
+}
+
+async::result<std::string> SpeedAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbBase *>(object);
+	co_return device->speed + "\n";
+}
+
+async::result<std::string> MaxPowerAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbDevice *>(object);
+	co_return std::to_string(device->maxPower) + "mA\n";
+}
+
+async::result<std::string> MaxChildAttribute::show(sysfs::Object *object) {
+	co_return "2\n";
+}
+
+async::result<std::string> NumInterfacesAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbDevice *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%2x\n", device->numInterfaces);
+	co_return std::string{buf};
+}
+
+async::result<std::string> BusNumAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbBase *>(object);
+	co_return std::to_string(device->busNum) + "\n";
+}
+
+async::result<std::string> DevNumAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbBase *>(object);
+	co_return std::to_string(device->portNum) + "\n";
+}
+
+async::result<std::string> DescriptorsAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbBase *>(object);
+	co_return std::string{reinterpret_cast<char *>(device->descriptors.data()), device->descriptors.size()};
+}
+
+async::result<std::string> RxLanesAttribute::show(sysfs::Object *object) {
+	co_return "1\n";
+}
+
+async::result<std::string> TxLanesAttribute::show(sysfs::Object *object) {
+	co_return "1\n";
+}
+
+async::result<std::string> ConfigValueAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbDevice *>(object);
+	auto config_val = (co_await device->device().currentConfigurationValue()).value();
+
+	co_return std::to_string(config_val) + "\n";
+}
+
+async::result<std::string> MaxPacketSize0Attribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbDevice *>(object);
+
+	co_return std::to_string(device->desc()->maxPacketSize) + "\n";
+}
+
+async::result<std::string> ConfigurationAttribute::show(sysfs::Object *object) {
+	co_return "\n";
+}
+
+async::result<std::string> BmAttributesAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbDevice *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->bmAttributes);
+	co_return std::string{buf};
+}
+
+async::result<std::string> NumConfigurationsAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbDevice *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->desc()->numConfigs);
+	co_return std::string{buf};
+}
+
+async::result<std::string> InterfaceClassAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbInterface *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->interfaceClass);
+	co_return std::string{buf};
+}
+
+async::result<std::string> InterfaceSubClassAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbInterface *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->interfaceSubClass);
+	co_return std::string{buf};
+}
+
+async::result<std::string> InterfaceProtocolAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbInterface *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->interfaceProtocol);
+	co_return std::string{buf};
+}
+
+async::result<std::string> AlternateSettingAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbInterface *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%2x\n", device->alternateSetting);
+	co_return std::string{buf};
+}
+
+async::result<std::string> InterfaceNumberAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbInterface *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->interfaceNumber);
+	co_return std::string{buf};
+}
+
+async::result<std::string> EndpointNumAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbInterface *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->endpoints);
+	co_return std::string{buf};
+}
+
+} // namespace usb_subsystem

--- a/posix/subsystem/src/subsystem/usb/attributes.hpp
+++ b/posix/subsystem/src/subsystem/usb/attributes.hpp
@@ -1,0 +1,196 @@
+#pragma once
+
+#include "../../drvcore.hpp"
+
+namespace usb_subsystem {
+
+struct VendorAttribute : sysfs::Attribute {
+	VendorAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct DeviceAttribute : sysfs::Attribute {
+	DeviceAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct DeviceClassAttribute : sysfs::Attribute {
+	DeviceClassAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct DeviceSubClassAttribute : sysfs::Attribute {
+	DeviceSubClassAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct DeviceProtocolAttribute : sysfs::Attribute {
+	DeviceProtocolAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct BcdDeviceAttribute : sysfs::Attribute {
+	BcdDeviceAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct VersionAttribute : sysfs::Attribute {
+	VersionAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct SpeedAttribute : sysfs::Attribute {
+	SpeedAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct MaxPowerAttribute : sysfs::Attribute {
+	MaxPowerAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct MaxChildAttribute : sysfs::Attribute {
+	MaxChildAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct NumInterfacesAttribute : sysfs::Attribute {
+	NumInterfacesAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct BusNumAttribute : sysfs::Attribute {
+	BusNumAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct DevNumAttribute : sysfs::Attribute {
+	DevNumAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct DescriptorsAttribute : sysfs::Attribute {
+	DescriptorsAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct RxLanesAttribute : sysfs::Attribute {
+	RxLanesAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct TxLanesAttribute : sysfs::Attribute {
+	TxLanesAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct ConfigValueAttribute : sysfs::Attribute {
+	ConfigValueAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct MaxPacketSize0Attribute : sysfs::Attribute {
+	MaxPacketSize0Attribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct ConfigurationAttribute : sysfs::Attribute {
+	ConfigurationAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct BmAttributesAttribute : sysfs::Attribute {
+	BmAttributesAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct NumConfigurationsAttribute : sysfs::Attribute {
+	NumConfigurationsAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct InterfaceClassAttribute : sysfs::Attribute {
+	InterfaceClassAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct InterfaceSubClassAttribute : sysfs::Attribute {
+	InterfaceSubClassAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct InterfaceProtocolAttribute : sysfs::Attribute {
+	InterfaceProtocolAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct AlternateSettingAttribute : sysfs::Attribute {
+	AlternateSettingAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct InterfaceNumberAttribute : sysfs::Attribute {
+	InterfaceNumberAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+struct EndpointNumAttribute : sysfs::Attribute {
+	EndpointNumAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<std::string> show(sysfs::Object *object) override;
+};
+
+} // namespace usb_subsystem

--- a/posix/subsystem/src/subsystem/usb/devices.hpp
+++ b/posix/subsystem/src/subsystem/usb/devices.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "../../drvcore.hpp"
+#include "protocols/usb/client.hpp"
+
+namespace usb_subsystem {
+
+struct UsbBase : drvcore::Device {
+protected:
+	UsbBase(std::string sysfs_name, int64_t mbus_id, std::shared_ptr<drvcore::Device> parent)
+	: drvcore::Device{parent, std::move(sysfs_name), nullptr},
+			mbusId{mbus_id} { }
+
+public:
+	protocols::usb::DeviceDescriptor *desc() {
+		return reinterpret_cast<protocols::usb::DeviceDescriptor *>(descriptors.data());
+	}
+
+	int64_t mbusId;
+	size_t busNum;
+	size_t portNum;
+	std::string speed;
+
+	std::vector<uint8_t> descriptors;
+};
+
+struct UsbController final : UsbBase {
+	UsbController(std::string sysfs_name, int64_t mbus_id, std::shared_ptr<drvcore::Device> parent)
+		: UsbBase{sysfs_name, mbus_id, parent} { }
+
+	void composeUevent(drvcore::UeventProperties &ue) override {
+		char product[15];
+		snprintf(product, 15, "%x:%x:%x", desc()->idVendor, desc()->idProduct, desc()->bcdDevice);
+		char devname[16];
+		char busnum[4];
+		char devnum[4];
+		snprintf(devname, 16, "bus/usb/%03zu/%03zu", busNum, portNum);
+		snprintf(busnum, 4, "%03zu", busNum);
+		snprintf(devnum, 4, "%03zu", portNum);
+
+		ue.set("DEVTYPE", "usb_device");
+		ue.set("DEVNAME", devname);
+		ue.set("PRODUCT", product);
+		ue.set("SUBSYSTEM", "usb");
+		ue.set("BUSNUM", busnum);
+		ue.set("DEVNUM", devnum);
+		ue.set("MBUS_ID", std::to_string(mbusId));
+	}
+
+	uint8_t maxPower = 0;
+	uint8_t bmAttributes = 0;
+	uint8_t numInterfaces = 0;
+};
+
+} // namespace usb_subsystem

--- a/posix/subsystem/src/subsystem/usb/root-hub.hpp
+++ b/posix/subsystem/src/subsystem/usb/root-hub.hpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace usb_subsystem::root_hub {
+
+constexpr std::array<uint8_t, 18> descUsb3_0 = {
+	0x12, /* bLength */
+	0x01, /* bDescriptorType */
+	0x00, 0x03, /* bcdUsb */
+
+	0x09, /* bDeviceClass */
+	0x00, /* bDeviceSubClass */
+	0x03, /* bDeviceProtocol */
+	0x09, /* bMaxPacketSize0 */
+
+	0x6b, 0x1d, /* idVendor */
+	0x03, 0x00, /* idProduct */
+	0x00, 0x00, /* bcdDevice */
+
+	0x03, /* iManufacturer */
+	0x02, /* iProduct */
+	0x01, /* iSerialNumber */
+	0x01, /* bNumConfigurations */
+};
+
+constexpr std::array<uint8_t, 18> descUsb2_0 = {
+	0x12, /* bLength */
+	0x01, /* bDescriptorType */
+	0x00, 0x02, /* bcdUsb */
+
+	0x09, /* bDeviceClass */
+	0x00, /* bDeviceSubClass */
+	0x00, /* bDeviceProtocol */
+	0x40, /* bMaxPacketSize0 */
+
+	0x6b, 0x1d, /* idVendor */
+	0x02, 0x00, /* idProduct */
+	0x00, 0x00, /* bcdDevice */
+
+	0x03, /* iManufacturer */
+	0x02, /* iProduct */
+	0x01, /* iSerialNumber */
+	0x01, /* bNumConfigurations */
+};
+
+constexpr std::array<uint8_t, 18> descUsb1_1 = {
+	0x12, /* bLength */
+	0x01, /* bDescriptorType */
+	0x10, 0x01, /* bcdUsb */
+
+	0x09, /* bDeviceClass */
+	0x00, /* bDeviceSubClass */
+	0x00, /* bDeviceProtocol */
+	0x40, /* bMaxPacketSize0 */
+
+	0x6b, 0x1d, /* idVendor */
+	0x01, 0x00, /* idProduct */
+	0x00, 0x00, /* bcdDevice */
+
+	0x03, /* iManufacturer */
+	0x02, /* iProduct */
+	0x01, /* iSerialNumber */
+	0x01, /* bNumConfigurations */
+};
+
+constexpr std::array<uint8_t, 25> descFullSpeed = {
+	/* configuration descriptor */
+	0x09, /* bLength */
+	0x02, /* bDescriptorType */
+	0x19, 0x00, /* wTotalLength */
+	0x01, /* bNumInterfaces */
+	0x01, /* bConfigurationValue */
+	0x00, /* iConfiguration */
+	0xC0, /* bmAttributes */
+	0x00, /* MaxPower */
+
+	/* interface descriptor */
+	0x09, /* bLength */
+	0x04, /* bDescriptorType */
+	0x00, /* bInterfaceNumber */
+	0x00, /* bAlternateSetting */
+	0x01, /* bNumEndpoints */
+	0x09, /* bInterfaceClass */
+	0x00, /* bInterfaceSubClass */
+	0x00, /* bInterfaceProtocol */
+	0x00, /* iInterface */
+
+	/* endpoint descriptor */
+	0x07, /* bLength */
+	0x05, /* bDescriptorType */
+	0x81, /* bEndpointAddress */
+	0x03, /* bmAttributes */
+	0x02, 0x00, /* wMaxPacketSize */
+	0xFF, /* bInterval */
+};
+
+constexpr std::array<uint8_t, 25> descHighSpeed = {
+	/* configuration descriptor */
+	0x09, /* bLength */
+	0x02, /* bDescriptorType */
+	0x19, 0x00, /* wTotalLength */
+	0x01, /* bNumInterfaces */
+	0x01, /* bConfigurationValue */
+	0x00, /* iConfiguration */
+	0xC0, /* bmAttributes */
+	0x00, /* MaxPower */
+
+	/* interface descriptor */
+	0x09, /* bLength */
+	0x04, /* bDescriptorType */
+	0x00, /* bInterfaceNumber */
+	0x00, /* bAlternateSetting */
+	0x01, /* bNumEndpoints */
+	0x09, /* bInterfaceClass */
+	0x00, /* bInterfaceSubClass */
+	0x00, /* bInterfaceProtocol */
+	0x00, /* iInterface */
+
+	/* endpoint descriptor */
+	0x07, /* bLength */
+	0x05, /* bDescriptorType */
+	0x81, /* bEndpointAddress */
+	0x03, /* bmAttributes */
+	0x04, 0x00, /* wMaxPacketSize */
+	0x0c, /* bInterval */
+};
+
+constexpr std::array<uint8_t, 31> descSuperSpeed = {
+	/* configuration descriptor */
+	0x09, /* bLength */
+	0x02, /* bDescriptorType */
+	0x1f, 0x00, /* wTotalLength */
+	0x01, /* bNumInterfaces */
+	0x01, /* bConfigurationValue */
+	0x00, /* iConfiguration */
+	0xC0, /* bmAttributes */
+	0x00, /* MaxPower */
+
+	/* interface descriptor */
+	0x09, /* bLength */
+	0x04, /* bDescriptorType */
+	0x00, /* bInterfaceNumber */
+	0x00, /* bAlternateSetting */
+	0x01, /* bNumEndpoints */
+	0x09, /* bInterfaceClass */
+	0x00, /* bInterfaceSubClass */
+	0x00, /* bInterfaceProtocol */
+	0x00, /* iInterface */
+
+	/* endpoint descriptor */
+	0x07, /* bLength */
+	0x05, /* bDescriptorType */
+	0x81, /* bEndpointAddress */
+	0x03, /* bmAttributes */
+	0x04, 0x00, /* wMaxPacketSize */
+	0x0c, /* bInterval */
+
+	0x06,
+	0x30,
+	0x00,
+	0x00,
+	0x02, 0x00,
+};
+
+} // namespace usb_subsystem

--- a/posix/subsystem/src/subsystem/usb/usb.cpp
+++ b/posix/subsystem/src/subsystem/usb/usb.cpp
@@ -1,0 +1,65 @@
+#include <string.h>
+#include <iostream>
+
+#include <protocols/mbus/client.hpp>
+
+#include "../../util.hpp"
+#include "../pci.hpp"
+#include "usb.hpp"
+
+namespace {
+
+std::unordered_map<mbus::_detail::EntityId, uint64_t> usbControllerMap;
+id_allocator<uint64_t> usbControllerAllocator;
+
+}
+
+namespace usb_subsystem {
+
+drvcore::BusSubsystem *sysfsSubsystem;
+
+std::unordered_map<int, std::shared_ptr<drvcore::Device>> mbusMap;
+
+
+async::detached bindController(mbus::Entity entity, mbus::Properties properties, uint64_t bus_num) {
+	auto pci_parent_id = std::stoi(std::get<mbus::StringItem>(properties["usb.root.parent"]).value);
+	auto pci = pci_subsystem::getDeviceByMbus(pci_parent_id);
+
+	auto sysfs_name = "usb" + std::to_string(bus_num);
+
+	auto version_major_str = std::get<mbus::StringItem>(properties["usb.version.major"]);
+	auto version_minor_str = std::get<mbus::StringItem>(properties["usb.version.minor"]);
+	co_return;
+}
+
+async::detached run() {
+	usbControllerAllocator.use_range();
+
+	sysfsSubsystem = new drvcore::BusSubsystem{"usb"};
+
+	auto root = co_await mbus::Instance::global().getRoot();
+
+	auto usbControllerFilter = mbus::Conjunction({
+		mbus::EqualsFilter("generic.devtype", "usb-controller")
+	});
+
+	auto usbControllerHandler = mbus::ObserverHandler{}
+	.withAttach([] (mbus::Entity entity, mbus::Properties properties) {
+		auto id = usbControllerAllocator.allocate();
+		usbControllerMap.insert({entity.getId(), id});
+		bindController(std::move(entity), std::move(properties), id);
+	});
+
+	co_await root.linkObserver(std::move(usbControllerFilter), std::move(usbControllerHandler));
+}
+
+std::shared_ptr<drvcore::Device> getDeviceByMbus(int id) {
+	auto it = mbusMap.find(id);
+
+	if(it != mbusMap.end())
+		return it->second;
+
+	return nullptr;
+}
+
+} // namespace usb_subsystem

--- a/posix/subsystem/src/subsystem/usb/usb.cpp
+++ b/posix/subsystem/src/subsystem/usb/usb.cpp
@@ -28,6 +28,10 @@ drvcore::BusSubsystem *sysfsSubsystem;
 
 std::unordered_map<int, std::shared_ptr<drvcore::Device>> mbusMap;
 
+protocols::usb::Device &UsbInterface::device() {
+	return std::static_pointer_cast<UsbDevice>(parentDevice())->device();
+}
+
 
 async::detached bindController(mbus::Entity entity, mbus::Properties properties, uint64_t bus_num) {
 	auto pci_parent_id = std::stoi(std::get<mbus::StringItem>(properties["usb.root.parent"]).value);
@@ -110,6 +114,62 @@ async::detached bindDevice(mbus::Entity entity, mbus::Properties properties) {
 	auto sysfs_name = std::to_string(bus_num) + "-" + std::to_string(std::stoi(address.value, 0, 16));
 
 	std::cout << "POSIX: Installing USB device " << sysfs_name << " (mbus ID: " << entity.getId() << ")" << std::endl;
+
+	auto lane = helix::UniqueLane(co_await entity.bind());
+	auto hw = protocols::usb::connect(std::move(lane));
+
+	auto device = std::make_shared<UsbDevice>(sysfs_name, entity.getId(), parent, std::move(hw));
+
+	/* obtain the device descroptor */
+	auto raw_dev_desc = (co_await device->device().deviceDescriptor()).value();
+	/* obtain the tree of configuration descriptors and its subdescriptors */
+	auto raw_descs = (co_await device->device().configurationDescriptor()).value();
+
+	device->portNum = std::stoi(address.value) + 1;
+	device->busNum = bus_num;
+	device->speed = std::get<mbus::StringItem>(properties["usb.speed"]).value;
+
+	device->descriptors.insert(device->descriptors.end(), raw_dev_desc.begin(), raw_dev_desc.end());
+	device->descriptors.insert(device->descriptors.end(), raw_descs.begin(), raw_descs.end());
+
+	auto config_val = (co_await device->device().currentConfigurationValue()).value();
+
+	protocols::usb::walkConfiguration(raw_descs, [&] (int type, size_t, void *, const auto &info) {
+		if(type == protocols::usb::descriptor_type::configuration) {
+			auto desc = reinterpret_cast<protocols::usb::ConfigDescriptor *>(*info.desc);
+			device->maxPower = desc->maxPower * 2;
+
+			if(info.configNumber == config_val) {
+				device->bmAttributes = desc->bmAttributes;
+				device->numInterfaces = reinterpret_cast<protocols::usb::ConfigDescriptor *>(*info.desc)->numInterfaces;
+			}
+		} else if(type == protocols::usb::descriptor_type::interface) {
+			auto desc = reinterpret_cast<protocols::usb::InterfaceDescriptor *>(*info.desc);
+
+			auto if_sysfs_name = sysfs_name + ":" + std::to_string(*info.configNumber) + "-" + std::to_string(desc->interfaceNumber);
+			auto interface = std::make_shared<UsbInterface>(if_sysfs_name, entity.getId(), device);
+
+			interface->interfaceClass = desc->interfaceClass;
+			interface->interfaceSubClass = desc->interfaceSubClass;
+			interface->interfaceProtocol = desc->interfaceProtocol;
+			interface->alternateSetting = desc->alternateSetting;
+			interface->interfaceNumber = desc->interfaceNumber;
+			interface->endpoints = desc->numEndpoints;
+			interface->descriptors = device->descriptors;
+
+			device->interfaces.push_back(interface);
+		}
+	});
+
+	drvcore::installDevice(device);
+	sysfsSubsystem->devicesObject()->createSymlink(sysfs_name, device);
+
+	for(auto interface : device->interfaces) {
+		drvcore::installDevice(interface);
+		sysfsSubsystem->devicesObject()->createSymlink(interface->sysfs_name, interface);
+	}
+
+	mbusMap.insert({entity.getId(), device});
 }
 
 async::detached run() {

--- a/posix/subsystem/src/subsystem/usb/usb.cpp
+++ b/posix/subsystem/src/subsystem/usb/usb.cpp
@@ -1,16 +1,24 @@
 #include <string.h>
 #include <iostream>
 
+#include <async/queue.hpp>
 #include <protocols/mbus/client.hpp>
 
+#include <protocols/usb/api.hpp>
+#include <protocols/usb/client.hpp>
+
+#include "../../drvcore.hpp"
 #include "../../util.hpp"
 #include "../pci.hpp"
+#include "devices.hpp"
+#include "root-hub.hpp"
 #include "usb.hpp"
 
 namespace {
 
 std::unordered_map<mbus::_detail::EntityId, uint64_t> usbControllerMap;
 id_allocator<uint64_t> usbControllerAllocator;
+async::queue<uint64_t, frg::stl_allocator> controllerDetectedQueue;
 
 }
 
@@ -26,10 +34,82 @@ async::detached bindController(mbus::Entity entity, mbus::Properties properties,
 	auto pci = pci_subsystem::getDeviceByMbus(pci_parent_id);
 
 	auto sysfs_name = "usb" + std::to_string(bus_num);
+	auto device = std::make_shared<UsbController>(sysfs_name, entity.getId(), pci);
+	/* set up the /sys/bus/usb/devices/usbX symlink  */
+	sysfsSubsystem->devicesObject()->createSymlink(sysfs_name, device);
 
 	auto version_major_str = std::get<mbus::StringItem>(properties["usb.version.major"]);
 	auto version_minor_str = std::get<mbus::StringItem>(properties["usb.version.minor"]);
+
+	device->busNum = bus_num;
+	device->portNum = 1;
+	device->numInterfaces = 1;
+
+	auto major = std::stoi(version_major_str.value);
+	auto minor = std::stoi(version_minor_str.value);
+
+	switch(major) {
+		case 1:
+			switch(minor) {
+				case 0:
+					device->speed = "1.5";
+					break;
+				case 0x10:
+					device->speed = "12";
+					break;
+				default:
+					printf("USB version 1.%u\n", minor);
+					assert(!"invalid USB 1 minor revision");
+					break;
+			}
+			device->descriptors.insert(device->descriptors.end(), root_hub::descUsb1_1.begin(), root_hub::descUsb1_1.end());
+			device->descriptors.insert(device->descriptors.end(), root_hub::descFullSpeed.begin(), root_hub::descFullSpeed.end());
+			break;
+		case 2:
+			device->speed = "480"; // High speed
+			device->descriptors.insert(device->descriptors.end(), root_hub::descUsb2_0.begin(), root_hub::descUsb2_0.end());
+			device->descriptors.insert(device->descriptors.end(), root_hub::descHighSpeed.begin(), root_hub::descHighSpeed.end());
+			break;
+		case 3:
+			switch(minor) {
+				case 0:
+					device->speed = "5000";
+				device->descriptors.insert(device->descriptors.end(), root_hub::descUsb3_0.begin(), root_hub::descUsb3_0.end());
+				device->descriptors.insert(device->descriptors.end(), root_hub::descSuperSpeed.begin(), root_hub::descSuperSpeed.end());
+					break;
+				default:
+					assert(!"unhandled USB 3 minor revision");
+					break;
+			}
+			break;
+		default:
+			device->speed = "unknown";
+			break;
+	}
+
+	assert(device->descriptors.size() >= 18 + 25);
+
+	drvcore::installDevice(device);
+
+	mbusMap.insert({entity.getId(), device});
+
+	controllerDetectedQueue.put(entity.getId());
+
 	co_return;
+}
+
+async::detached bindDevice(mbus::Entity entity, mbus::Properties properties) {
+	auto address = std::get<mbus::StringItem>(properties["usb.hub_port"]);
+	auto mbus_bus = std::get<mbus::StringItem>(properties["usb.bus"]);
+	uint64_t bus = std::stol(mbus_bus.value);
+	auto parent = getDeviceByMbus(bus);
+
+	assert(usbControllerMap.find(bus) != usbControllerMap.end());
+	auto bus_num = usbControllerMap[bus];
+
+	auto sysfs_name = std::to_string(bus_num) + "-" + std::to_string(std::stoi(address.value, 0, 16));
+
+	std::cout << "POSIX: Installing USB device " << sysfs_name << " (mbus ID: " << entity.getId() << ")" << std::endl;
 }
 
 async::detached run() {
@@ -51,6 +131,24 @@ async::detached run() {
 	});
 
 	co_await root.linkObserver(std::move(usbControllerFilter), std::move(usbControllerHandler));
+
+	while(1) {
+		auto id = co_await controllerDetectedQueue.async_get();
+
+		if(id) {
+			auto filter = mbus::Conjunction({
+				mbus::EqualsFilter("unix.subsystem", "usb"),
+				mbus::EqualsFilter("usb.bus", std::to_string(*id)),
+			});
+
+			auto handler = mbus::ObserverHandler{}
+			.withAttach([] (mbus::Entity entity, mbus::Properties properties) {
+				bindDevice(std::move(entity), std::move(properties));
+			});
+
+			co_await root.linkObserver(std::move(filter), std::move(handler));
+		}
+	}
 }
 
 std::shared_ptr<drvcore::Device> getDeviceByMbus(int id) {

--- a/posix/subsystem/src/subsystem/usb/usb.cpp
+++ b/posix/subsystem/src/subsystem/usb/usb.cpp
@@ -10,6 +10,7 @@
 #include "../../drvcore.hpp"
 #include "../../util.hpp"
 #include "../pci.hpp"
+#include "attributes.hpp"
 #include "devices.hpp"
 #include "root-hub.hpp"
 #include "usb.hpp"
@@ -32,6 +33,35 @@ protocols::usb::Device &UsbInterface::device() {
 	return std::static_pointer_cast<UsbDevice>(parentDevice())->device();
 }
 
+VendorAttribute vendorAttr{"idVendor"};
+DeviceAttribute deviceAttr{"idProduct"};
+DeviceClassAttribute deviceClassAttr{"bDeviceClass"};
+DeviceSubClassAttribute deviceSubClassAttr{"bDeviceSubClass"};
+DeviceProtocolAttribute deviceProtocolAttr{"bDeviceProtocol"};
+BcdDeviceAttribute bcdDeviceAttr{"bcdDevice"};
+VersionAttribute versionAttr{"version"};
+SpeedAttribute speedAttr{"speed"};
+MaxPowerAttribute maxPowerAttr{"bMaxPower"};
+MaxChildAttribute maxChildAttr{"maxchild"};
+NumInterfacesAttribute numInterfacesAttr{"bNumInterfaces"};
+BusNumAttribute busNumAttr{"busnum"};
+DevNumAttribute devNumAttr{"devnum"};
+DescriptorsAttribute descriptorsAttr{"descriptors"};
+RxLanesAttribute rxLanesAttr{"rx_lanes"};
+TxLanesAttribute txLanesAttr{"tx_lanes"};
+ConfigValueAttribute configValueAttr{"bConfigurationValue"};
+MaxPacketSize0Attribute maxPacketSize0Attr{"bMaxPacketSize0"};
+ConfigurationAttribute configurationAttr{"configuration"};
+BmAttributesAttribute bmAttributesAttr{"bmAttributes"};
+NumConfigurationsAttribute numConfigurationsAttr{"bNumConfigurations"};
+
+/* USB Interface-specific attributes */
+InterfaceClassAttribute interfaceClassAttr{"bInterfaceClass"};
+InterfaceSubClassAttribute interfaceSubClassAttr{"bInterfaceSubClass"};
+InterfaceProtocolAttribute interfaceProtocolAttr{"bInterfaceProtocol"};
+AlternateSettingAttribute alternateSettingAttr{"bAlternateSetting"};
+InterfaceNumberAttribute interfaceNumAttr{"bInterfaceNumber"};
+EndpointNumAttribute numEndpointsAttr{"bNumEndpoints"};
 
 async::detached bindController(mbus::Entity entity, mbus::Properties properties, uint64_t bus_num) {
 	auto pci_parent_id = std::stoi(std::get<mbus::StringItem>(properties["usb.root.parent"]).value);
@@ -94,6 +124,22 @@ async::detached bindController(mbus::Entity entity, mbus::Properties properties,
 	assert(device->descriptors.size() >= 18 + 25);
 
 	drvcore::installDevice(device);
+
+	device->realizeAttribute(&vendorAttr);
+	device->realizeAttribute(&deviceAttr);
+	device->realizeAttribute(&deviceClassAttr);
+	device->realizeAttribute(&deviceSubClassAttr);
+	device->realizeAttribute(&deviceProtocolAttr);
+	device->realizeAttribute(&versionAttr);
+	device->realizeAttribute(&speedAttr);
+	device->realizeAttribute(&maxPowerAttr);
+	device->realizeAttribute(&maxChildAttr);
+	device->realizeAttribute(&numInterfacesAttr);
+	device->realizeAttribute(&busNumAttr);
+	device->realizeAttribute(&devNumAttr);
+	device->realizeAttribute(&descriptorsAttr);
+	device->realizeAttribute(&rxLanesAttr);
+	device->realizeAttribute(&txLanesAttr);
 
 	mbusMap.insert({entity.getId(), device});
 
@@ -167,7 +213,38 @@ async::detached bindDevice(mbus::Entity entity, mbus::Properties properties) {
 	for(auto interface : device->interfaces) {
 		drvcore::installDevice(interface);
 		sysfsSubsystem->devicesObject()->createSymlink(interface->sysfs_name, interface);
+
+		interface->realizeAttribute(&interfaceClassAttr);
+		interface->realizeAttribute(&interfaceSubClassAttr);
+		interface->realizeAttribute(&interfaceProtocolAttr);
+		interface->realizeAttribute(&alternateSettingAttr);
+		interface->realizeAttribute(&interfaceNumAttr);
+		interface->realizeAttribute(&numEndpointsAttr);
 	}
+
+	// TODO: Call realizeAttribute *before* installing the device.
+	device->realizeAttribute(&vendorAttr);
+	device->realizeAttribute(&deviceAttr);
+	device->realizeAttribute(&deviceClassAttr);
+	device->realizeAttribute(&deviceSubClassAttr);
+	device->realizeAttribute(&deviceProtocolAttr);
+	device->realizeAttribute(&bcdDeviceAttr);
+
+	device->realizeAttribute(&versionAttr);
+	device->realizeAttribute(&speedAttr);
+	device->realizeAttribute(&maxPowerAttr);
+	device->realizeAttribute(&maxChildAttr);
+	device->realizeAttribute(&numInterfacesAttr);
+	device->realizeAttribute(&busNumAttr);
+	device->realizeAttribute(&devNumAttr);
+	device->realizeAttribute(&descriptorsAttr);
+	device->realizeAttribute(&rxLanesAttr);
+	device->realizeAttribute(&txLanesAttr);
+	device->realizeAttribute(&configValueAttr);
+	device->realizeAttribute(&maxPacketSize0Attr);
+	device->realizeAttribute(&configurationAttr);
+	device->realizeAttribute(&bmAttributesAttr);
+	device->realizeAttribute(&numConfigurationsAttr);
 
 	mbusMap.insert({entity.getId(), device});
 }

--- a/posix/subsystem/src/subsystem/usb/usb.hpp
+++ b/posix/subsystem/src/subsystem/usb/usb.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <async/result.hpp>
+#include "../../drvcore.hpp"
+
+namespace usb_subsystem {
+
+async::detached run();
+
+std::shared_ptr<drvcore::Device> getDeviceByMbus(int id);
+
+} // namespace usb_subsystem

--- a/protocols/usb/include/protocols/usb/api.hpp
+++ b/protocols/usb/include/protocols/usb/api.hpp
@@ -8,6 +8,8 @@
 
 #include "usb.hpp"
 
+namespace protocols::usb {
+
 enum class UsbError {
 	none,
 	stall,
@@ -186,3 +188,5 @@ protected:
 public:
 	virtual async::result<void> enumerateDevice(std::shared_ptr<Hub> hub, int port, DeviceSpeed speed) = 0;
 };
+
+} // namespace protocols::usb

--- a/protocols/usb/include/protocols/usb/api.hpp
+++ b/protocols/usb/include/protocols/usb/api.hpp
@@ -152,6 +152,7 @@ public:
 	virtual arch::dma_pool *setupPool() = 0;
 	virtual arch::dma_pool *bufferPool() = 0;
 
+	virtual async::result<frg::expected<UsbError, std::string>> deviceDescriptor() = 0;
 	virtual async::result<frg::expected<UsbError, std::string>> configurationDescriptor() = 0;
 	virtual async::result<frg::expected<UsbError, Configuration>> useConfiguration(int number) = 0;
 	virtual async::result<frg::expected<UsbError>> transfer(ControlTransfer info) = 0;
@@ -163,7 +164,9 @@ struct Device {
 	arch::dma_pool *setupPool() const;
 	arch::dma_pool *bufferPool() const;
 
+	async::result<frg::expected<UsbError, std::string>> deviceDescriptor() const;
 	async::result<frg::expected<UsbError, std::string>> configurationDescriptor() const;
+	async::result<frg::expected<UsbError, uint8_t>> currentConfigurationValue() const;
 	async::result<frg::expected<UsbError, Configuration>> useConfiguration(int number) const;
 	async::result<frg::expected<UsbError>> transfer(ControlTransfer info) const;
 

--- a/protocols/usb/include/protocols/usb/api.hpp
+++ b/protocols/usb/include/protocols/usb/api.hpp
@@ -189,4 +189,24 @@ public:
 	virtual async::result<void> enumerateDevice(std::shared_ptr<Hub> hub, int port, DeviceSpeed speed) = 0;
 };
 
+inline std::string getSpeedMbps(DeviceSpeed speed) {
+	switch(speed) {
+		case DeviceSpeed::fullSpeed: {
+			return "12";
+		}
+		case DeviceSpeed::lowSpeed: {
+			return "1.5";
+		}
+		case DeviceSpeed::highSpeed: {
+			return "480";
+		}
+		case DeviceSpeed::superSpeed: {
+			return "5000";
+		}
+		default: {
+			return "unknown";
+		}
+	}
+}
+
 } // namespace protocols::usb

--- a/protocols/usb/include/protocols/usb/client.hpp
+++ b/protocols/usb/include/protocols/usb/client.hpp
@@ -3,9 +3,8 @@
 #include <helix/ipc.hpp>
 #include "api.hpp"
 
-namespace protocols {
-namespace usb {
+namespace protocols::usb {
 
 Device connect(helix::UniqueLane lane);
 
-} } // namespace protocols::usb
+} // namespace protocols::usb

--- a/protocols/usb/include/protocols/usb/hub.hpp
+++ b/protocols/usb/include/protocols/usb/hub.hpp
@@ -10,6 +10,8 @@
 #include "usb.hpp"
 #include "api.hpp"
 
+namespace protocols::usb {
+
 // ----------------------------------------------------------------
 // Hub.
 // ----------------------------------------------------------------
@@ -82,3 +84,5 @@ private:
 	BaseController *controller_;
 	async::mutex enumerateMutex_;
 };
+
+} // namespace protocols::usb

--- a/protocols/usb/include/protocols/usb/server.hpp
+++ b/protocols/usb/include/protocols/usb/server.hpp
@@ -4,9 +4,8 @@
 #include <helix/ipc.hpp>
 #include "api.hpp"
 
-namespace protocols {
-namespace usb {
+namespace protocols::usb {
 
 async::detached serve(Device device, helix::UniqueLane lane);
 
-} } // namespace protocols::usb
+} // namespace protocols::usb

--- a/protocols/usb/include/protocols/usb/usb.hpp
+++ b/protocols/usb/include/protocols/usb/usb.hpp
@@ -129,6 +129,7 @@ void walkConfiguration(std::string buffer, F functor) {
 		std::optional<int> endpointNumber;
 		std::optional<bool> endpointIn;
 		std::optional<EndpointType> endpointType;
+		std::optional<DescriptorBase *> desc;
 	} info;
 
 	auto p = &buffer[0];
@@ -140,6 +141,7 @@ void walkConfiguration(std::string buffer, F functor) {
 		if(base->descriptorType == descriptor_type::configuration) {
 			auto desc = (ConfigDescriptor *)base;
 			assert(desc->length == sizeof(ConfigDescriptor));
+			info.desc = base;
 
 			info.configNumber = desc->configValue;
 			info.interfaceNumber = std::nullopt;
@@ -149,6 +151,7 @@ void walkConfiguration(std::string buffer, F functor) {
 		}else if(base->descriptorType == descriptor_type::interface) {
 			auto desc = (InterfaceDescriptor *)base;
 			assert(desc->length == sizeof(InterfaceDescriptor));
+			info.desc = base;
 
 			info.interfaceNumber = desc->interfaceNumber;
 			info.interfaceAlternative = desc->alternateSetting;
@@ -157,6 +160,7 @@ void walkConfiguration(std::string buffer, F functor) {
 		}else if(base->descriptorType == descriptor_type::endpoint) {
 			auto desc = (EndpointDescriptor *)base;
 			assert(desc->length == sizeof(EndpointDescriptor));
+			info.desc = base;
 
 			info.endpointNumber = desc->endpointAddress & 0x0F;
 			info.endpointIn = desc->endpointAddress & 0x80;

--- a/protocols/usb/include/protocols/usb/usb.hpp
+++ b/protocols/usb/include/protocols/usb/usb.hpp
@@ -102,7 +102,7 @@ struct InterfaceDescriptor : public DescriptorBase {
 	uint8_t numEndpoints;
 	uint8_t interfaceClass;
 	uint8_t interfaceSubClass;
-	uint8_t interfaceProtocoll;
+	uint8_t interfaceProtocol;
 	uint8_t iInterface;
 };
 

--- a/protocols/usb/include/protocols/usb/usb.hpp
+++ b/protocols/usb/include/protocols/usb/usb.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include <optional>
 #include <assert.h>
+#include <cstdint>
+#include <string>
+#include <optional>
+
+namespace protocols::usb {
 
 namespace setup_type {
 	enum : uint8_t {
@@ -170,3 +174,5 @@ void walkConfiguration(std::string buffer, F functor) {
 		functor(base->descriptorType, base->length, base, info);
 	}
 }
+
+} // namespace protocols::usb

--- a/protocols/usb/src/api.cpp
+++ b/protocols/usb/src/api.cpp
@@ -1,6 +1,8 @@
 
 #include "protocols/usb/api.hpp"
 
+namespace protocols::usb {
+
 // ----------------------------------------------------------------------------
 // Device.
 // ----------------------------------------------------------------------------
@@ -67,3 +69,4 @@ async::result<frg::expected<UsbError, size_t>> Endpoint::transfer(BulkTransfer i
 	return _state->transfer(info);
 }
 
+} // namespace protocols::usb

--- a/protocols/usb/src/api.cpp
+++ b/protocols/usb/src/api.cpp
@@ -18,8 +18,28 @@ arch::dma_pool *Device::bufferPool() const {
 	return _state->bufferPool();
 }
 
+async::result<frg::expected<UsbError, std::string>> Device::deviceDescriptor() const {
+	return _state->deviceDescriptor();
+}
+
 async::result<frg::expected<UsbError, std::string>> Device::configurationDescriptor() const {
 	return _state->configurationDescriptor();
+}
+
+async::result<frg::expected<UsbError, uint8_t>> Device::currentConfigurationValue() const {
+	arch::dma_object<SetupPacket> get{setupPool()};
+	get->type = setup_type::targetDevice | setup_type::byStandard
+			| setup_type::toHost;
+	get->request = request_type::getConfig;
+	get->value = 0;
+	get->index = 0;
+	get->length = 1;
+
+	arch::dma_object<uint8_t> descriptor{bufferPool()};
+	FRG_CO_TRY(co_await transfer(ControlTransfer{kXferToHost,
+			get, descriptor.view_buffer()}));
+
+	co_return *descriptor.data();
 }
 
 async::result<frg::expected<UsbError, Configuration>> Device::useConfiguration(int number) const {

--- a/protocols/usb/src/hub.cpp
+++ b/protocols/usb/src/hub.cpp
@@ -2,6 +2,8 @@
 
 #include <async/recurring-event.hpp>
 
+namespace protocols::usb {
+
 // ----------------------------------------------------------------
 // Enumerator.
 // ----------------------------------------------------------------
@@ -326,3 +328,5 @@ createHubFromDevice(std::shared_ptr<Hub> parentHub, Device device, size_t port) 
 	FRG_CO_TRY(co_await hub->initialize());
 	co_return hub;
 }
+
+} // namespace protocols::usb

--- a/protocols/usb/usb.bragi
+++ b/protocols/usb/usb.bragi
@@ -65,6 +65,10 @@ head(128):
 	}
 }
 
+message GetDeviceDescriptorRequest 6 {
+head(128):
+}
+
 }
 
 group {


### PR DESCRIPTION
Conveniently, this also enables USB support for udev, no recompile needed.

Aside from that, device numbering (for e.g. `/dev/ttyS0`, `/dev/ttyS1` etc.) is now handled by posix. Previously, drivers hardcoded a number, with obvious implications.