### PR TITLE
Sysfs seeking improvements

### DIFF
--- a/posix/subsystem/src/file.cpp
+++ b/posix/subsystem/src/file.cpp
@@ -24,8 +24,11 @@ File::ptSeekAbs(void *object, int64_t offset) {
 	auto self = static_cast<File *>(object);
 	auto result = co_await self->seek(offset, VfsSeek::absolute);
 	if(!result) {
-		assert(result.error() == Error::seekOnPipe);
-		co_return protocols::fs::Error::seekOnPipe;
+		if(result.error() == Error::seekOnPipe)
+			co_return protocols::fs::Error::seekOnPipe;
+		else if(result.error() == Error::illegalArguments)
+			co_return protocols::fs::Error::illegalArguments;
+		assert(!"Unexpected error!");
 	}else{
 		co_return result.value();
 	}
@@ -36,8 +39,11 @@ File::ptSeekRel(void *object, int64_t offset) {
 	auto self = static_cast<File *>(object);
 	auto result = co_await self->seek(offset, VfsSeek::relative);
 	if(!result) {
-		assert(result.error() == Error::seekOnPipe);
-		co_return protocols::fs::Error::seekOnPipe;
+		if(result.error() == Error::seekOnPipe)
+			co_return protocols::fs::Error::seekOnPipe;
+		else if(result.error() == Error::illegalArguments)
+			co_return protocols::fs::Error::illegalArguments;
+		assert(!"Unexpected error!");
 	}else{
 		co_return result.value();
 	}
@@ -48,8 +54,11 @@ File::ptSeekEof(void *object, int64_t offset) {
 	auto self = static_cast<File *>(object);
 	auto result = co_await self->seek(offset, VfsSeek::eof);
 	if(!result) {
-		assert(result.error() == Error::seekOnPipe);
-		co_return protocols::fs::Error::seekOnPipe;
+		if(result.error() == Error::seekOnPipe)
+			co_return protocols::fs::Error::seekOnPipe;
+		else if(result.error() == Error::illegalArguments)
+			co_return protocols::fs::Error::illegalArguments;
+		assert(!"Unexpected error!");
 	}else{
 		co_return result.value();
 	}

--- a/posix/subsystem/src/sysfs.cpp
+++ b/posix/subsystem/src/sysfs.cpp
@@ -119,6 +119,11 @@ void DirectoryFile::handleClose() {
 	_cancelServe.cancel();
 }
 
+// TODO: Verify that this is correct
+async::result<frg::expected<Error, off_t>> DirectoryFile::seek(off_t, VfsSeek) {
+	co_return Error::illegalArguments;
+}
+
 // TODO: This iteration mechanism only works as long as _iter is not concurrently deleted.
 async::result<ReadEntriesResult> DirectoryFile::readEntries() {
 	if(_iter != _node->_entries.end()) {

--- a/posix/subsystem/src/sysfs.hpp
+++ b/posix/subsystem/src/sysfs.hpp
@@ -66,6 +66,7 @@ public:
 
 	FutureMaybe<ReadEntriesResult> readEntries() override;
 	helix::BorrowedDescriptor getPassthroughLane() override;
+	async::result<frg::expected<Error, off_t>> seek(off_t offset, VfsSeek whence) override;
 
 private:
 	// TODO: Remove this and extract it from the associatedLink().

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -38,10 +38,18 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 			co_return;
 		}
 		auto result = co_await file_ops->seekAbs(file.get(), req.rel_offset());
+		auto error = std::get_if<Error>(&result);
 
 		managarm::fs::SvrResponse resp;
-		resp.set_error(managarm::fs::Errors::SUCCESS);
-		resp.set_offset(std::get<int64_t>(result));
+		if(error && *error == Error::seekOnPipe) {
+			resp.set_error(managarm::fs::Errors::SEEK_ON_PIPE);
+		} else if(error && *error == Error::illegalArguments) {
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+		} else {
+			assert(!error);
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+			resp.set_offset(std::get<int64_t>(result));
+		}
 
 		auto ser = resp.SerializeAsString();
 		auto [send_resp] = co_await helix_ng::exchangeMsgs(
@@ -68,7 +76,9 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 		managarm::fs::SvrResponse resp;
 		if(error && *error == Error::seekOnPipe) {
 			resp.set_error(managarm::fs::Errors::SEEK_ON_PIPE);
-		}else{
+		} else if(error && *error == Error::illegalArguments) {
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+		} else {
 			assert(!error);
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 			resp.set_offset(std::get<int64_t>(result));
@@ -94,10 +104,18 @@ async::detached handlePassthrough(smarter::shared_ptr<void> file,
 			co_return;
 		}
 		auto result = co_await file_ops->seekEof(file.get(), req.rel_offset());
+		auto error = std::get_if<Error>(&result);
 
 		managarm::fs::SvrResponse resp;
-		resp.set_error(managarm::fs::Errors::SUCCESS);
-		resp.set_offset(std::get<int64_t>(result));
+		if(error && *error == Error::seekOnPipe) {
+			resp.set_error(managarm::fs::Errors::SEEK_ON_PIPE);
+		} else if(error && *error == Error::illegalArguments) {
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+		} else {
+			assert(!error);
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+			resp.set_offset(std::get<int64_t>(result));
+		}
 
 		auto ser = resp.SerializeAsString();
 		auto [send_resp] = co_await helix_ng::exchangeMsgs(


### PR DESCRIPTION
`lsblk` was crashing posix on seeking on a sysfs directory. Return EINVAL for now and add some error handling while we're at it.

mlibc counterpart to be provided shortly.