### PR TITLE
General sysfs block improvements

### DIFF
--- a/posix/subsystem/src/subsystem/block.cpp
+++ b/posix/subsystem/src/subsystem/block.cpp
@@ -56,7 +56,10 @@ struct Device final : UnixDevice, drvcore::BlockDevice {
 	}
 
 	void composeUevent(drvcore::UeventProperties &ue) override {
+		std::pair<int, int> dev = getId();
 		ue.set("SUBSYSTEM", "block");
+		ue.set("MAJOR", std::to_string(dev.first));
+		ue.set("MINOR", std::to_string(dev.second));
 	}
 
 private:

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -656,6 +656,8 @@ head(128):
 		tag(70) uint32[] drm_pitches;
 		tag(71) uint32[] drm_offsets;
 		tag(72) uint32[] drm_handles;
+
+		tag(73) uint64 size;
 	}
 }
 


### PR DESCRIPTION
This PR exposes some more attributes over sysfs for blockdevices. Most are hardcoded to a sane value (R/O is always zero), some are just a placeholder (size being 3.3G) and some are correct (major:minor number). This makes `lsblk` show `sda0`!