### PR TITLE
More proc additions

### DIFF
--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -240,6 +240,8 @@ std::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 	auto kernelLink = sys->directMkdir("kernel");
 	auto kernel = std::static_pointer_cast<DirectoryNode>(kernelLink->getTarget());
 
+	kernel->directMkregular("ostype", std::make_shared<OstypeNode>());
+
 	return link;
 }
 
@@ -360,6 +362,20 @@ async::result<std::string> UptimeNode::show() {
 async::result<void> UptimeNode::store(std::string) {
 	// TODO: proper error reporting.
 	std::cout << "posix: Can't store to a /proc/uptime file" << std::endl;
+	co_return;
+}
+
+async::result<std::string> OstypeNode::show() {
+	// See man 5 proc for more details.
+	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
+	std::stringstream stream;
+	stream << "Managarm\n";
+	co_return stream.str();
+}
+
+async::result<void> OstypeNode::store(std::string) {
+	// TODO: proper error reporting.
+	std::cout << "posix: Can't store to a /proc/sys/kernel/ostype file" << std::endl;
 	co_return;
 }
 

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -242,6 +242,7 @@ std::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 
 	kernel->directMkregular("ostype", std::make_shared<OstypeNode>());
 	kernel->directMkregular("osrelease", std::make_shared<OsreleaseNode>());
+	kernel->directMkregular("arch", std::make_shared<ArchNode>());
 
 	return link;
 }
@@ -392,6 +393,28 @@ async::result<std::string> OsreleaseNode::show() {
 async::result<void> OsreleaseNode::store(std::string) {
 	// TODO: proper error reporting.
 	std::cout << "posix: Can't store to a /proc/sys/kernel/osrelease file" << std::endl;
+	co_return;
+}
+
+async::result<std::string> ArchNode::show() {
+	// See man 5 proc for more details.
+	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
+	std::stringstream stream;
+#if defined(__x86_64__)
+	stream << "x86_64\n";
+#elif defined(__aarch64__)
+	stream << "AArch64\n";
+#elif defined(__riscv) && __riscv_xlen == 64
+	stream << "riscv64";
+#else
+	#error "Unknown architecture"
+#endif
+	co_return stream.str();
+}
+
+async::result<void> ArchNode::store(std::string) {
+	// TODO: proper error reporting.
+	std::cout << "posix: Can't store to a /proc/sys/kernel/arch file" << std::endl;
 	co_return;
 }
 

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -241,6 +241,7 @@ std::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 	auto kernel = std::static_pointer_cast<DirectoryNode>(kernelLink->getTarget());
 
 	kernel->directMkregular("ostype", std::make_shared<OstypeNode>());
+	kernel->directMkregular("osrelease", std::make_shared<OsreleaseNode>());
 
 	return link;
 }
@@ -376,6 +377,21 @@ async::result<std::string> OstypeNode::show() {
 async::result<void> OstypeNode::store(std::string) {
 	// TODO: proper error reporting.
 	std::cout << "posix: Can't store to a /proc/sys/kernel/ostype file" << std::endl;
+	co_return;
+}
+
+async::result<std::string> OsreleaseNode::show() {
+	// See man 5 proc for more details.
+	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
+	// TODO: The version is a placeholder!
+	std::stringstream stream;
+	stream << "0.0.1\n";
+	co_return stream.str();
+}
+
+async::result<void> OsreleaseNode::store(std::string) {
+	// TODO: proper error reporting.
+	std::cout << "posix: Can't store to a /proc/sys/kernel/osrelease file" << std::endl;
 	co_return;
 }
 

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -235,6 +235,11 @@ std::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 
 	the_node->directMkregular("uptime", std::make_shared<UptimeNode>());
 
+	auto sysLink = the_node->directMkdir("sys");
+	auto sys = std::static_pointer_cast<DirectoryNode>(sysLink->getTarget());
+	auto kernelLink = sys->directMkdir("kernel");
+	auto kernel = std::static_pointer_cast<DirectoryNode>(kernelLink->getTarget());
+
 	return link;
 }
 

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -219,6 +219,13 @@ struct UptimeNode final : RegularNode {
 	async::result<void> store(std::string) override;
 };
 
+struct OstypeNode final : RegularNode {
+	OstypeNode() {}
+
+	async::result<std::string> show() override;
+	async::result<void> store(std::string) override;
+};
+
 struct CommNode final : RegularNode {
 	CommNode(Process *process)
 	: _process(process)

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -226,6 +226,13 @@ struct OstypeNode final : RegularNode {
 	async::result<void> store(std::string) override;
 };
 
+struct OsreleaseNode final : RegularNode {
+	OsreleaseNode() {}
+
+	async::result<std::string> show() override;
+	async::result<void> store(std::string) override;
+};
+
 struct CommNode final : RegularNode {
 	CommNode(Process *process)
 	: _process(process)

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -233,6 +233,13 @@ struct OsreleaseNode final : RegularNode {
 	async::result<void> store(std::string) override;
 };
 
+struct ArchNode final : RegularNode {
+	ArchNode() {}
+
+	async::result<std::string> show() override;
+	async::result<void> store(std::string) override;
+};
+
 struct CommNode final : RegularNode {
 	CommNode(Process *process)
 	: _process(process)


### PR DESCRIPTION
This time I decided to tackle some low hanging fruits in `/proc/sys/kernel`, so here are `ostype` (Managarm), `osrelease` (0.0.1) and `arch` (set to either `x86_64` or `AArch64` depending on architecture).