### PR TITLE
Correctly expose PCI hierarchy in sysfs

### DIFF
--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -200,6 +200,7 @@ extern "C" void thorMain() {
 
 		transitionBootFb();
 
+		pci::runAllBridges();
 		pci::runAllDevices();
 
 		// Parse the initrd image.

--- a/kernel/thor/generic/mbus.cpp
+++ b/kernel/thor/generic/mbus.cpp
@@ -8,7 +8,7 @@ namespace thor {
 // TODO: Move this to a header file.
 extern frg::manual_box<LaneHandle> mbusClient;
 
-coroutine<frg::expected<Error>> KernelBusObject::createObject(Properties &&properties) {
+coroutine<frg::expected<Error, size_t>> KernelBusObject::createObject(Properties &&properties) {
 	auto [offerError, conversation] = co_await OfferSender{*mbusClient};
 	if (offerError != Error::success)
 		co_return offerError;
@@ -55,7 +55,7 @@ coroutine<frg::expected<Error>> KernelBusObject::createObject(Properties &&prope
 	async::detach_with_allocator(*kernelAlloc, handleMbusComms_(
 			descriptor.get<LaneDescriptor>().handle));
 
-	co_return frg::success;
+	co_return resp.id();
 }
 
 coroutine<void> KernelBusObject::handleMbusComms_(LaneHandle objectLane) {

--- a/kernel/thor/generic/thor-internal/mbus.hpp
+++ b/kernel/thor/generic/thor-internal/mbus.hpp
@@ -18,6 +18,10 @@ struct Properties {
 		stringProperty(name, frg::to_allocated_string(*kernelAlloc, value, 16, padding));
 	}
 
+	void decStringProperty(frg::string_view name, uint32_t value, int padding) {
+		stringProperty(name, frg::to_allocated_string(*kernelAlloc, value, 10, padding));
+	}
+
 private:
 	struct Property {
 		Property(frg::string_view name,

--- a/kernel/thor/generic/thor-internal/mbus.hpp
+++ b/kernel/thor/generic/thor-internal/mbus.hpp
@@ -36,7 +36,7 @@ private:
 };
 
 struct KernelBusObject {
-	coroutine<frg::expected<Error>> createObject(Properties &&properties);
+	coroutine<frg::expected<Error, size_t>> createObject(Properties &&properties);
 
 	virtual LaneHandle initiateClient() {
 		auto stream = createStream();

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -1148,7 +1148,8 @@ void checkPciFunction(PciBus *bus, uint32_t slot, uint32_t function,
 
 		applyPciDeviceQuirks(device);
 	} else if ((header_type & 0x7F) == 1) {
-		auto bridge = frg::construct<PciBridge>(*kernelAlloc, bus, bus->segId, bus->busId, slot, function);
+		auto bridge = frg::construct<PciBridge>(*kernelAlloc, bus, bus->segId, bus->busId, slot, function,
+				vendor, device_id, revision, class_code, sub_class, interface);
 		bus->childBridges.push_back(bridge);
 
 		findPciCaps(bridge);

--- a/posix/subsystem/src/drvcore.cpp
+++ b/posix/subsystem/src/drvcore.cpp
@@ -125,8 +125,8 @@ BusSubsystem::BusSubsystem(std::string name)
 }
 
 BusDevice::BusDevice(BusSubsystem *subsystem, std::string name,
-		UnixDevice *unix_device)
-: Device{nullptr, std::move(name), unix_device},
+		UnixDevice *unix_device, std::shared_ptr<Device> parent)
+: Device{parent, std::move(name), unix_device},
 		_subsystem{subsystem} { }
 
 void BusDevice::linkToSubsystem() {

--- a/posix/subsystem/src/drvcore.hpp
+++ b/posix/subsystem/src/drvcore.hpp
@@ -80,7 +80,7 @@ private:
 
 struct BusDevice : Device {
 	BusDevice(BusSubsystem *subsystem, std::string name,
-			UnixDevice *unix_device);
+			UnixDevice *unix_device, std::shared_ptr<Device> parent = nullptr);
 
 protected:
 	~BusDevice() = default;

--- a/posix/subsystem/src/subsystem/block.cpp
+++ b/posix/subsystem/src/subsystem/block.cpp
@@ -152,8 +152,10 @@ async::detached run() {
 		auto parent_property = std::get<mbus::StringItem>(properties.at("drvcore.mbus-parent"));
 		auto mbus_parent = std::stoi(parent_property.value);
 		std::shared_ptr<drvcore::Device> parent_device;
-		if (mbus_parent != -1)
+		if (mbus_parent != -1) {
 			parent_device = pci_subsystem::getDeviceByMbus(mbus_parent);
+			assert(parent_device);
+		}
 
 		auto lane = helix::UniqueLane(co_await entity.bind());
 

--- a/posix/subsystem/src/subsystem/drm.cpp
+++ b/posix/subsystem/src/subsystem/drm.cpp
@@ -73,10 +73,11 @@ async::detached run() {
 				<< std::get<mbus::StringItem>(properties.at("unix.devname")).value << std::endl;
 		auto parent_property = std::get<mbus::StringItem>(properties.at("drvcore.mbus-parent"));
 		auto mbus_parent = std::stoi(parent_property.value);
+		auto pci_parent = pci_subsystem::getDeviceByMbus(mbus_parent);
+		assert(pci_parent);
 
 		auto lane = helix::UniqueLane(co_await entity.bind());
-		auto device = std::make_shared<Device>(index, std::move(lane),
-				pci_subsystem::getDeviceByMbus(mbus_parent));
+		auto device = std::make_shared<Device>(index, std::move(lane), pci_parent);
 		// The minor is only correct for card* devices but not for control* and render*.
 		device->assignId({226, index});
 

--- a/posix/subsystem/src/subsystem/pci.cpp
+++ b/posix/subsystem/src/subsystem/pci.cpp
@@ -310,8 +310,9 @@ async::detached run() {
 
 std::shared_ptr<drvcore::Device> getDeviceByMbus(int id) {
 	auto it = mbusMap.find(id);
-	assert(it != mbusMap.end());
-	return it->second;
+	if(it != mbusMap.end())
+		return it->second;
+	return {};
 }
 
 } // namespace pci_subsystem

--- a/posix/subsystem/src/subsystem/pci.cpp
+++ b/posix/subsystem/src/subsystem/pci.cpp
@@ -85,6 +85,13 @@ struct ClassAttribute : sysfs::Attribute {
 	async::result<frg::expected<Error, std::string>> show(sysfs::Object *object) override;
 };
 
+struct IrqAttribute : sysfs::Attribute {
+	IrqAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<frg::expected<Error, std::string>> show(sysfs::Object *object) override;
+};
+
 VendorAttribute vendorAttr{"vendor"};
 DeviceAttribute deviceAttr{"device"};
 PlainfbAttribute plainfbAttr{"owns_plainfb"};
@@ -93,6 +100,7 @@ SubsystemDeviceAttribute subsystemDeviceAttr{"subsystem_device"};
 ConfigAttribute configAttr{"config"};
 ClassAttribute classAttr{"class"};
 ResourceAttribute resourceAttr{"resource"};
+IrqAttribute irqAttr{"irq"};
 
 std::vector<std::shared_ptr<ResourceNAttribute>> resources;
 
@@ -215,6 +223,11 @@ async::result<frg::expected<Error, std::string>> ResourceNAttribute::show(sysfs:
 	co_return Error::illegalOperationTarget;
 }
 
+async::result<frg::expected<Error, std::string>> IrqAttribute::show(sysfs::Object *) {
+	// TODO: we have no sane way of resolving this yet
+	co_return "0\n";
+}
+
 async::detached bind(mbus::Entity entity, mbus::Properties properties) {
 	std::string sysfs_name = "0000:" + std::get<mbus::StringItem>(properties["pci-bus"]).value
 			+ ":" + std::get<mbus::StringItem>(properties["pci-slot"]).value
@@ -257,6 +270,7 @@ async::detached bind(mbus::Entity entity, mbus::Properties properties) {
 	device->realizeAttribute(&configAttr);
 	device->realizeAttribute(&classAttr);
 	device->realizeAttribute(&resourceAttr);
+	device->realizeAttribute(&irqAttr);
 
 	auto info = co_await device->hwDevice().getPciInfo();
 

--- a/posix/subsystem/src/subsystem/usb/usb.cpp
+++ b/posix/subsystem/src/subsystem/usb/usb.cpp
@@ -67,6 +67,7 @@ EndpointNumAttribute numEndpointsAttr{"bNumEndpoints"};
 async::detached bindController(mbus::Entity entity, mbus::Properties properties, uint64_t bus_num) {
 	auto pci_parent_id = std::stoi(std::get<mbus::StringItem>(properties["usb.root.parent"]).value);
 	auto pci = pci_subsystem::getDeviceByMbus(pci_parent_id);
+	assert(pci);
 
 	auto sysfs_name = "usb" + std::to_string(bus_num);
 	auto device = std::make_shared<UsbController>(sysfs_name, entity.getId(), pci);

--- a/protocols/hw/src/client.cpp
+++ b/protocols/hw/src/client.cpp
@@ -56,7 +56,16 @@ async::result<PciInfo> Device::getPciInfo() {
 	for(size_t i = 0; i < resp.capabilities_size(); i++)
 		info.caps.push_back({resp.capabilities(i).type()});
 
-	for(int i = 0; i < 6; i++) {
+	for(size_t i = 0; i < 6; i++) {
+		if(i >= resp.bars_size()) {
+			info.barInfo[i].ioType = IoType::kIoTypeNone;
+			info.barInfo[i].hostType = IoType::kIoTypeNone;
+			info.barInfo[i].address = 0;
+			info.barInfo[i].length = 0;
+			info.barInfo[i].offset = 0;
+			continue;
+		}
+
 		if(resp.bars(i).io_type() == managarm::hw::IoType::NO_BAR) {
 			info.barInfo[i].ioType = IoType::kIoTypeNone;
 		}else if(resp.bars(i).io_type() == managarm::hw::IoType::PORT) {


### PR DESCRIPTION
This allows for `lspci -tv` and `lspci -vv` to work as intended.