### PR TITLE
posix: Fix most compiler warnings

### DIFF
--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -332,10 +332,11 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			HelThreadStats stats;
 			HEL_CHECK(helQueryThreadStats(self->threadDescriptor().getHandle(), &stats));
 
+			int32_t mode = static_cast<int32_t>(req.mode());
 			uint64_t user_time;
-			if(req.mode() == RUSAGE_SELF) {
+			if(mode == RUSAGE_SELF) {
 				user_time = stats.userTime;
-			}else if(req.mode() == RUSAGE_CHILDREN) {
+			}else if(mode == RUSAGE_CHILDREN) {
 				user_time = self->accumulatedUsage().userTime;
 			}else{
 				std::cout << "\e[31mposix: GET_RESOURCE_USAGE mode is not supported\e[39m"

--- a/posix/subsystem/src/sysfs.cpp
+++ b/posix/subsystem/src/sysfs.cpp
@@ -381,7 +381,7 @@ Attribute::Attribute(std::string name, bool writable)
 : _name{std::move(name)}, _writable{writable} { }
 
 Attribute::Attribute(std::string name, bool writable, size_t size)
-: _name{std::move(name)}, _writable{writable}, _size{size} { }
+: _size{size}, _name{std::move(name)}, _writable{writable} { }
 
 // ----------------------------------------------------------------------------
 // Object implementation

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -590,7 +590,7 @@ async::result<frg::expected<Error, size_t>>
 MemoryFile::pread(Process *, int64_t offset, void *buffer, size_t length) {
 	auto node = static_cast<MemoryNode *>(associatedLink()->getTarget().get());
 
-	if(!(offset <= node->_fileSize))
+	if(static_cast<size_t>(offset) >= node->_fileSize)
 		co_return 0;
 	auto chunk = std::min(node->_fileSize - offset, length);
 

--- a/testsuites/posix-tests/src/faults.cpp
+++ b/testsuites/posix-tests/src/faults.cpp
@@ -23,6 +23,7 @@ namespace {
 		}
 
 		volatile int result = a / b;
+		(void) result;
 
 		return false;
 	}

--- a/testsuites/virt-test/main.cpp
+++ b/testsuites/virt-test/main.cpp
@@ -55,16 +55,18 @@ int main() {
 
 	HelVmexitReason reason;
 	HEL_CHECK(helRunVirtualizedCpu(vcpu, &reason));
-	if(reason.exitReason == kHelVmexitHlt)
+
+	int32_t exitReason = static_cast<int32_t>(reason.exitReason);
+	if(exitReason == kHelVmexitHlt)
 		std::cout << "HLT Instruction" << std::endl;
-	else if(reason.exitReason == kHelVmexitError)
+	else if(exitReason == kHelVmexitError)
 		std::cout << "VMExit error" << std::endl;
-	else if(reason.exitReason == kHelVmexitUnknownPlatformSpecificExitCode)
+	else if(exitReason == kHelVmexitUnknownPlatformSpecificExitCode)
 		std::cout << "Unknown platform specific exit code: 0x" << std::hex << reason.code << std::dec << std::endl;
-	else if(reason.exitReason == kHelVmexitTranslationFault)
+	else if(exitReason == kHelVmexitTranslationFault)
 		std::cout << "Translation fault: 0x" << std::hex << reason.address << std::dec << std::endl;
 	else
-		std::cout << "Unknown reason: " << reason.exitReason << std::endl;
+		std::cout << "Unknown reason: " << exitReason << std::endl;
 
 	helCloseDescriptor(kHelThisUniverse, vcpu);
 	helCloseDescriptor(kHelThisUniverse, vspace);


### PR DESCRIPTION
Fix initialization order and properly cast variables between signed/unsigned when doing compares.