### PR TITLE
hel: Install arch-specific syscall stub headers

### DIFF
--- a/hel/meson.build
+++ b/hel/meson.build
@@ -7,6 +7,12 @@ headers = [
 	'include/helix/memory.hpp'
 ]
 
+if arch == 'aarch64'
+	headers += 'include/hel-stubs-aarch64.h'
+elif arch == 'x86_64'
+	headers += 'include/hel-stubs-x86_64.h'
+endif
+
 deps = [ coroutines, bragi_dep, frigg ]
 inc = [ 'include' ]
 


### PR DESCRIPTION
These are needed by the generic hel-stubs.h which is used in hel-syscalls.h.