### PR TITLE
protocols/usb: Support large configuration descriptors

### DIFF
--- a/protocols/usb/src/server.cpp
+++ b/protocols/usb/src/server.cpp
@@ -327,6 +327,7 @@ async::detached serve(Device device, helix::UniqueLane lane) {
 
 			managarm::usb::SvrResponse resp;
 			resp.set_error(managarm::usb::Errors::SUCCESS);
+			resp.set_size(data.size());
 
 			auto [sendResp, sendData] = co_await helix_ng::exchangeMsgs(
 				conversation,


### PR DESCRIPTION
Send the buffer size in the response to support larger descriptors than recvInline() can handle.