### PR TITLE
libblockfs/ext2: Set uid/gid when creating new files

### DIFF
--- a/drivers/libblockfs/src/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2fs.cpp
@@ -598,7 +598,7 @@ auto FileSystem::accessInode(uint32_t number) -> std::shared_ptr<Inode> {
 	return new_inode;
 }
 
-async::result<std::shared_ptr<Inode>> FileSystem::createRegular() {
+async::result<std::shared_ptr<Inode>> FileSystem::createRegular(int uid, int gid) {
 	auto ino = co_await allocateInode();
 	assert(ino);
 
@@ -628,6 +628,8 @@ async::result<std::shared_ptr<Inode>> FileSystem::createRegular() {
 	disk_inode->atime = time.tv_sec;
 	disk_inode->ctime = time.tv_sec;
 	disk_inode->mtime = time.tv_sec;
+	disk_inode->uid = uid;
+	disk_inode->gid = gid;
 
 	co_return accessInode(ino);
 }

--- a/drivers/libblockfs/src/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2fs.hpp
@@ -252,7 +252,7 @@ struct FileSystem {
 
 	std::shared_ptr<Inode> accessRoot();
 	std::shared_ptr<Inode> accessInode(uint32_t number);
-	async::result<std::shared_ptr<Inode>> createRegular();
+	async::result<std::shared_ptr<Inode>> createRegular(int uid, int gid);
 	async::result<std::shared_ptr<Inode>> createDirectory();
 	async::result<std::shared_ptr<Inode>> createSymlink();
 

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -647,7 +647,7 @@ async::detached servePartition(helix::UniqueLane lane) {
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
 		}else if(req.req_type() == managarm::fs::CntReqType::SB_CREATE_REGULAR) {
-			auto inode = co_await fs->createRegular();
+			auto inode = co_await fs->createRegular(req.uid(), req.gid());
 
 			helix::UniqueLane local_lane, remote_lane;
 			std::tie(local_lane, remote_lane) = helix::createStream();

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -59,7 +59,7 @@ protected:
 	~FsSuperblock() = default;
 
 public:
-	virtual FutureMaybe<std::shared_ptr<FsNode>> createRegular() = 0;
+	virtual FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) = 0;
 	virtual FutureMaybe<std::shared_ptr<FsNode>> createSocket() = 0;
 
 	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>>

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -204,7 +204,7 @@ RegularNode::open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link
 	co_return File::constructHandle(std::move(file));
 }
 
-FutureMaybe<std::shared_ptr<FsNode>> SuperBlock::createRegular() {
+FutureMaybe<std::shared_ptr<FsNode>> SuperBlock::createRegular(Process *) {
 	co_return nullptr;
 }
 

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -110,7 +110,7 @@ struct SuperBlock final : FsSuperblock {
 public:
 	SuperBlock() = default;
 
-	FutureMaybe<std::shared_ptr<FsNode>> createRegular() override;
+	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override;
 	FutureMaybe<std::shared_ptr<FsNode>> createSocket() override;
 
 	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>

--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -1680,7 +1680,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					}
 				}else{
 					assert(directory->superblock());
-					auto node = co_await directory->superblock()->createRegular();
+					auto node = co_await directory->superblock()->createRegular(self.get());
 					if (!node) {
 						co_await sendErrorResponse(managarm::posix::Errors::FILE_NOT_FOUND);
 						continue;

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -495,7 +495,7 @@ private:
 };
 
 struct Superblock final : FsSuperblock {
-	FutureMaybe<std::shared_ptr<FsNode>> createRegular() override {
+	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override {
 		auto node = std::make_shared<MemoryNode>(this);
 		co_return std::move(node);
 	}

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -268,6 +268,10 @@ head(128):
 		tag(84) int32 seals;
 
 		tag(85) byte append;
+
+		// used by SB_CREATE_REGULAR
+		tag(86) int64 uid;
+		tag(87) int64 gid;
 	}
 }
 


### PR DESCRIPTION
We used to just initialize everything to zero, which is fine as long as we're root. I plan on adding more support for multiple users in the near future, so expect more fixes in this category.