### PR TITLE
kernel/eir: Merge common aarch64 init code and make virt eir pie

### DIFF
--- a/kernel/eir/arch/arm/fault.S
+++ b/kernel/eir/arch/arm/fault.S
@@ -50,7 +50,8 @@ eirCommonHandler:
 	and x1, x1, #0xFFFFFFFFFFFFFFFE
 	msr sctlr_el1, x1
 
-	ldr x1, =eirStackTop
+	adrp x1, eirStackTop
+	add x1, x1, :lo12:eirStackTop
 	mov sp, x1
 	mrs x1, esr_el1
 	mrs x2, elr_el1

--- a/kernel/eir/arch/arm/generic.cpp
+++ b/kernel/eir/arch/arm/generic.cpp
@@ -1,0 +1,276 @@
+#include <dtb.hpp>
+#include <elf.h>
+#include <cpio.hpp>
+#include <eir-internal/arch.hpp>
+#include <eir-internal/debug.hpp>
+#include <eir-internal/generic.hpp>
+
+namespace eir {
+
+#if PIE
+
+extern "C" [[gnu::visibility("hidden")]] Elf64_Dyn _DYNAMIC[];
+
+void eirRelocate() {
+	auto base = reinterpret_cast<uintptr_t>(&eirImageFloor);
+	uintptr_t relaAddr = 0;
+	uintptr_t relaSize = 0;
+
+	for(auto *dyn = _DYNAMIC; dyn->d_tag != DT_NULL; ++dyn) {
+		switch(dyn->d_tag) {
+		case DT_RELA:
+			relaAddr = dyn->d_ptr + base;
+			break;
+		case DT_RELASZ:
+			relaSize = dyn->d_val;
+			break;
+		default:
+			break;
+		}
+	}
+
+	for(uintptr_t i = 0; i < relaSize; i += sizeof(Elf64_Rela)) {
+		auto *rela = reinterpret_cast<const Elf64_Rela *>(relaAddr + i);
+		assert(ELF64_R_TYPE(rela->r_info) == R_AARCH64_RELATIVE);
+		*reinterpret_cast<Elf64_Addr *>(rela->r_offset + base) = base + rela->r_addend;
+	}
+}
+
+#endif // PIE
+
+[[noreturn]] void eirGenericMain(const GenericInfo &genericInfo) {
+	initProcessorEarly();
+
+	DeviceTree dt{reinterpret_cast<void *>(genericInfo.deviceTreePtr)};
+
+	eir::infoLogger() << "DTB pointer " << dt.data() << frg::endlog;
+	eir::infoLogger() << "DTB size: 0x" << frg::hex_fmt{dt.size()} << frg::endlog;
+
+	DeviceTreeNode chosenNode;
+	bool hasChosenNode = false;
+
+	DeviceTreeNode reservedMemoryNode;
+	bool hasReservedMemoryNode = false;
+
+	DeviceTreeNode memoryNodes[32];
+	size_t nMemoryNodes = 0;
+
+	dt.rootNode().discoverSubnodes(
+		[](DeviceTreeNode &node) {
+			return !memcmp("memory@", node.name(), 7)
+				|| !memcmp("chosen", node.name(), 7)
+				|| !memcmp("reserved-memory", node.name(), 15);
+		},
+		[&](DeviceTreeNode node) {
+			if(!memcmp("chosen", node.name(), 7)) {
+				assert(!hasChosenNode);
+
+				chosenNode = node;
+				hasChosenNode = true;
+			} else if(!memcmp("reserved-memory", node.name(), 15)) {
+				assert(!hasReservedMemoryNode);
+
+				reservedMemoryNode = node;
+				hasReservedMemoryNode = true;
+			} else {
+				assert(nMemoryNodes < 32);
+
+				memoryNodes[nMemoryNodes++] = node;
+			}
+			infoLogger() << "Node \"" << node.name() << "\" discovered" << frg::endlog;
+		});
+
+	uint32_t addressCells = 2, sizeCells = 1;
+
+	for(auto prop : dt.rootNode().properties()) {
+		if(!memcmp("#address-cells", prop.name(), 15)) {
+			addressCells = prop.asU32();
+		} else if(!memcmp("#size-cells", prop.name(), 12)) {
+			sizeCells = prop.asU32();
+		}
+	}
+
+	assert(nMemoryNodes && hasChosenNode);
+
+	InitialRegion reservedRegions[64];
+	size_t nReservedRegions = 0;
+
+	eir::infoLogger() << "Memory reservation entries:" << frg::endlog;
+
+	auto addReservedRegion = [&](address_t base, address_t size) {
+		assert(nReservedRegions < sizeof(reservedRegions) / sizeof(*reservedRegions));
+		reservedRegions[nReservedRegions++] = {base, size};
+	};
+
+	for(auto ent : dt.memoryReservations()) {
+		eir::infoLogger() << "At 0x" << frg::hex_fmt{ent.address}
+			<< ", ends at 0x" << frg::hex_fmt{ent.address + ent.size}
+			<< " (0x" << frg::hex_fmt{ent.size} << " bytes)" << frg::endlog;
+		addReservedRegion(ent.address, ent.size);
+	}
+
+	if(hasReservedMemoryNode) {
+		// reserved-memory should have same address-cells and size-cells as the root node.
+		for(auto prop : reservedMemoryNode.properties()) {
+			if(!memcmp("#address-cells", prop.name(), 15)) {
+				assert(prop.asU32() == addressCells);
+			} else if(!memcmp("#size-cells", prop.name(), 12)) {
+				assert(prop.asU32() == sizeCells);
+			}
+		}
+
+		reservedMemoryNode.discoverSubnodes(
+			[](DeviceTreeNode &) {
+				return true;
+			},
+			[&](DeviceTreeNode node) {
+			auto reg = node.findProperty("reg");
+			if(!reg) {
+				return;
+			}
+
+			size_t i = 0;
+			while(i < reg->size()) {
+				auto base = reg->asPropArrayEntry(addressCells, i);
+				i += addressCells * 4;
+
+				auto size = reg->asPropArrayEntry(sizeCells, i);
+				i += sizeCells * 4;
+
+				eir::infoLogger() << "At 0x" << frg::hex_fmt{base}
+					<< ", ends at 0x" << frg::hex_fmt{base + size}
+					<< " (0x" << frg::hex_fmt{size} << " bytes)" << frg::endlog;
+				addReservedRegion(base, size);
+			}
+		});
+	}
+
+	eir::infoLogger() << "End of memory reservation entries" << frg::endlog;
+
+	uintptr_t eirStart = reinterpret_cast<uintptr_t>(&eirImageFloor);
+	uintptr_t eirEnd = reinterpret_cast<uintptr_t>(&eirImageCeiling);
+	addReservedRegion(eirStart, eirEnd - eirStart);
+
+	uintptr_t initrd = 0;
+	if(auto p = chosenNode.findProperty("linux,initrd-start"); p) {
+		if (p->size() == 4)
+			initrd = p->asU32();
+		else if (p->size() == 8)
+			initrd = p->asU64();
+		else
+			assert(!"Invalid linux,initrd-start size");
+
+		eir::infoLogger() << "Initrd is at " << (void *)initrd << frg::endlog;
+	} else {
+		initrd = 0x48000000;
+		eir::infoLogger() << "Assuming initrd is at " << (void *)initrd << frg::endlog;
+	}
+
+	CpioRange cpio_range{reinterpret_cast<void *>(initrd)};
+
+	auto initrd_end = reinterpret_cast<uintptr_t>(cpio_range.eof());
+	eir::infoLogger() << "Initrd ends at " << (void *)initrd_end << frg::endlog;
+
+	addReservedRegion(initrd, initrd_end - initrd);
+	addReservedRegion(genericInfo.deviceTreePtr, dt.size());
+
+	for(size_t i = 0; i < nMemoryNodes; i++) {
+		auto reg = memoryNodes[i].findProperty("reg");
+		assert(reg);
+
+		size_t j = 0;
+		while(j < reg->size()) {
+			auto base = reg->asPropArrayEntry(addressCells, j);
+			j += addressCells * 4;
+
+			auto size = reg->asPropArrayEntry(sizeCells, j);
+			j += sizeCells * 4;
+
+			createInitialRegions({base, size}, {reservedRegions, nReservedRegions});
+		}
+	}
+
+	setupRegionStructs();
+
+	eir::infoLogger() << "Kernel memory regions:" << frg::endlog;
+	for(size_t i = 0; i < numRegions; ++i) {
+		if(regions[i].regionType == RegionType::null)
+			continue;
+		eir::infoLogger() << "    Memory region [" << i << "]."
+				<< " Base: 0x" << frg::hex_fmt{regions[i].address}
+				<< ", length: 0x" << frg::hex_fmt{regions[i].size} << frg::endlog;
+		if(regions[i].regionType == RegionType::allocatable)
+			eir::infoLogger() << "        Buddy tree at 0x" << frg::hex_fmt{regions[i].buddyTree}
+					<< ", overhead: 0x" << frg::hex_fmt{regions[i].buddyOverhead}
+					<< frg::endlog;
+	}
+
+	frg::span<uint8_t> kernel_image{nullptr, 0};
+
+	for(auto entry : cpio_range) {
+		if(entry.name == "thor") {
+			kernel_image = entry.data;
+		}
+	}
+
+	assert(kernel_image.data() && kernel_image.size());
+
+	uint64_t kernel_entry = 0;
+	initProcessorPaging(kernel_image.data(), kernel_entry);
+
+	const char *cmdline = "";
+	if(genericInfo.cmdline) {
+		cmdline = genericInfo.cmdline;
+	} else if(auto p = chosenNode.findProperty("bootargs"); p) {
+		cmdline = static_cast<const char *>(p->data());
+	}
+
+	auto info_ptr = generateInfo(cmdline);
+
+	auto module = bootAlloc<EirModule>();
+	module->physicalBase = initrd;
+	module->length = initrd_end - initrd;
+
+	char *name_ptr = bootAlloc<char>(11);
+	memcpy(name_ptr, "initrd.cpio", 11);
+	module->namePtr = mapBootstrapData(name_ptr);
+	module->nameLength = 11;
+
+	info_ptr->numModules = 1;
+	info_ptr->moduleInfo = mapBootstrapData(module);
+
+	info_ptr->dtbPtr = genericInfo.deviceTreePtr;
+	info_ptr->dtbSize = dt.size();
+
+	if(genericInfo.hasFb) {
+		info_ptr->frameBuffer = genericInfo.fb;
+		assert(genericInfo.fb.fbAddress & ~(pageSize - 1));
+		size_t fbSize = genericInfo.fb.fbPitch * genericInfo.fb.fbHeight;
+
+		for(address_t pg = 0; pg < fbSize; pg += 0x1000)
+			mapSingle4kPage(0xFFFF'FE00'4000'0000 + pg, genericInfo.fb.fbAddress + pg,
+					PageFlags::write, CachingMode::writeCombine);
+
+		mapKasanShadow(0xFFFF'FE00'4000'0000, fbSize);
+		unpoisonKasanShadow(0xFFFF'FE00'4000'0000, fbSize);
+		info_ptr->frameBuffer.fbEarlyWindow = 0xFFFF'FE00'4000'0000;
+	}
+
+	info_ptr->debugFlags = genericInfo.debugFlags;
+
+	mapSingle4kPage(0xFFFF'0000'0000'0000, 0x9000000,
+			PageFlags::write, CachingMode::mmio);
+	mapKasanShadow(0xFFFF'0000'0000'0000, 0x1000);
+	unpoisonKasanShadow(0xFFFF'0000'0000'0000, 0x1000);
+
+	eir::infoLogger() << "Leaving Eir and entering the real kernel" << frg::endlog;
+
+	eirEnterKernel(eirTTBR[0] + 1, eirTTBR[1] + 1, kernel_entry,
+			0xFFFF'FE80'0001'0000, 0xFFFF'FE80'0001'0000);
+
+	while(true) {
+		asm volatile("" : : : "memory");
+	}
+}
+
+} // namespace eir

--- a/kernel/eir/arch/arm/meson.build
+++ b/kernel/eir/arch/arm/meson.build
@@ -1,4 +1,4 @@
-eir_sources = [files('load64.S', 'arch.cpp', 'fault.S', 'fault.cpp'), eir_generic_sources]
+eir_sources = [files('load64.S', 'arch.cpp', 'fault.S', 'fault.cpp', 'generic.cpp'), eir_generic_sources]
 eir_includes += include_directories('.')
 eir_cpp_args += ['-mgeneral-regs-only', '-mno-unaligned-access']
 eir_c_args += ['-mgeneral-regs-only', '-mno-unaligned-access']

--- a/kernel/eir/arch/arm/raspi4/raspi4.S
+++ b/kernel/eir/arch/arm/raspi4/raspi4.S
@@ -16,7 +16,8 @@ eirEntry:
 	mov x7, x0
 
 	.extern eirStackTop
-	ldr x1, =eirStackTop
+	adrp x1, eirStackTop
+	add x1, x1, :lo12:eirStackTop
 	mov sp, x1
 
 	// Get current execution level
@@ -60,7 +61,8 @@ eirEntry:
 
 	// Load vector table
 	.extern eirExcVectors
-	ldr x0, =eirExcVectors
+	adrp x0, eirExcVectors
+	add x0, x0, :lo12:eirExcVectors
 	msr vbar_el1, x0
 
 	// "Return" into EL1
@@ -76,8 +78,10 @@ eirEntry:
 	// Zero out BSS
 	.extern eirBssStart
 	.extern eirBssEnd
-	ldr x5, =eirBssStart
-	ldr x6, =eirBssEnd
+	adrp x5, eirBssStart
+	adrp x6, eirBssEnd
+	add x5, x5, :lo12:eirBssStart
+	add x6, x6, :lo12:eirBssEnd
 .loop:
 	cmp x5, x6
 	b.eq .enter

--- a/kernel/eir/arch/arm/virt/link.x
+++ b/kernel/eir/arch/arm/virt/link.x
@@ -1,7 +1,7 @@
 ENTRY(eirEntry)
 
 SECTIONS {
-	. = 0x40080000;
+	. = 0;
 	eirImageFloor = .;
 
 	.text : ALIGN(0x1000) {
@@ -11,6 +11,10 @@ SECTIONS {
 
 	.rodata : ALIGN(0x1000) {
 		*(.rodata*)
+	}
+
+	.dynamic : {
+		*(.dynamic)
 	}
 
 	.data : ALIGN(0x1000) {

--- a/kernel/eir/arch/arm/virt/meson.build
+++ b/kernel/eir/arch/arm/virt/meson.build
@@ -3,10 +3,11 @@ objcopy = find_program('aarch64-managarm-objcopy')
 
 exe = executable('eir-virt', eir_sources, raspi4_sources,
 	include_directories : eir_includes,
-	cpp_args : eir_cpp_args,
-	link_args : [eir_link_args, '-Wl,-T,' + meson.current_source_dir() + '/link.x'],
+	cpp_args : [eir_cpp_args, '-DPIE'],
+	link_args : [eir_link_args, '-Wl,-T,' + meson.current_source_dir() + '/link.x', '-static-pie'],
 	dependencies : eir_dependencies,
 	link_depends : files('link.x'),
+	pie : true,
 	install : true
 )
 

--- a/kernel/eir/arch/arm/virt/virt.S
+++ b/kernel/eir/arch/arm/virt/virt.S
@@ -2,7 +2,8 @@
 .global eirEntry
 eirEntry:
 	.extern eirStackTop
-	ldr x1, =eirStackTop
+	adrp x1, eirStackTop
+	add x1, x1, :lo12:eirStackTop
 	mov sp, x1
 
 	mov x2, xzr
@@ -18,14 +19,17 @@ eirEntry:
 
 	// Load vector table
 	.extern eirExcVectors
-	ldr x1, =eirExcVectors
+	adrp x1, eirExcVectors
+	add x1, x1, :lo12:eirExcVectors
 	msr vbar_el1, x1
 
 	// Zero out BSS
 	.extern eirBssStart
 	.extern eirBssEnd
-	ldr x5, =eirBssStart
-	ldr x6, =eirBssEnd
+	adrp x5, eirBssStart
+	adrp x6, eirBssEnd
+	add x5, x5, :lo12:eirBssStart
+	add x6, x6, :lo12:eirBssEnd
 .loop:
 	cmp x5, x6
 	b.eq .enter

--- a/kernel/eir/arch/arm/virt/virt.cpp
+++ b/kernel/eir/arch/arm/virt/virt.cpp
@@ -1,12 +1,4 @@
-#include <stdint.h>
-#include <assert.h>
-#include <eir-internal/debug.hpp>
-#include <eir/interface.hpp>
-#include <render-text.hpp>
-#include <dtb.hpp>
-#include "../cpio.hpp"
 #include <frg/manual_box.hpp>
-#include <eir-internal/arch.hpp>
 #include <eir-internal/generic.hpp>
 #include <eir-internal/arch/pl011.hpp>
 
@@ -18,173 +10,18 @@ void debugPrintChar(char c) {
 	debugUart->send(c);
 }
 
-extern "C" void eirVirtMain(uintptr_t deviceTreePtr) {
+extern "C" [[noreturn]] void eirVirtMain(uintptr_t deviceTreePtr) {
+	eirRelocate();
 	debugUart.initialize(0x9000000, 24000000);
 	debugUart->init(115200);
-
-	initProcessorEarly();
-
-	DeviceTree dt{reinterpret_cast<void *>(deviceTreePtr)};
-
-	eir::infoLogger() << "DTB pointer " << dt.data() << frg::endlog;
-	eir::infoLogger() << "DTB size: 0x" << frg::hex_fmt{dt.size()} << frg::endlog;
-
-	DeviceTreeNode chosenNode;
-	bool hasChosenNode = false;
-
-	DeviceTreeNode memoryNodes[32];
-	size_t nMemoryNodes = 0;
-
-	dt.rootNode().discoverSubnodes(
-		[](DeviceTreeNode &node) {
-			return !memcmp("memory@", node.name(), 7)
-				|| !memcmp("chosen", node.name(), 7);
-		},
-		[&](DeviceTreeNode node) {
-			if (!memcmp("chosen", node.name(), 7)) {
-				assert(!hasChosenNode);
-
-				chosenNode = node;
-				hasChosenNode = true;
-			} else {
-				assert(nMemoryNodes < 32);
-
-				memoryNodes[nMemoryNodes++] = node;
-			}
-			infoLogger() << "Node \"" << node.name() << "\" discovered" << frg::endlog;
-		});
-
-	uint32_t addressCells = 2, sizeCells = 1;
-
-	for (auto prop : dt.rootNode().properties()) {
-		if (!memcmp("#address-cells", prop.name(), 15)) {
-			addressCells = prop.asU32();
-		} else if (!memcmp("#size-cells", prop.name(), 12)) {
-			sizeCells = prop.asU32();
-		}
-	}
-
-	assert(nMemoryNodes && hasChosenNode);
-
-	InitialRegion reservedRegions[32];
-	size_t nReservedRegions = 0;
-
-	eir::infoLogger() << "Memory reservation entries:" << frg::endlog;
-	for (auto ent : dt.memoryReservations()) {
-		eir::infoLogger() << "At 0x" << frg::hex_fmt{ent.address}
-			<< ", ends at 0x" << frg::hex_fmt{ent.address + ent.size}
-			<< " (0x" << frg::hex_fmt{ent.size} << " bytes)" << frg::endlog;
-
-		reservedRegions[nReservedRegions++] = {ent.address, ent.size};
-	}
-	eir::infoLogger() << "End of memory reservation entries" << frg::endlog;
-
-	uintptr_t eirStart = reinterpret_cast<uintptr_t>(&eirImageFloor);
-	uintptr_t eirEnd = reinterpret_cast<uintptr_t>(&eirImageCeiling);
-	reservedRegions[nReservedRegions++] = {eirStart, eirEnd - eirStart};
-
-	uintptr_t initrd = 0;
-	if (auto p = chosenNode.findProperty("linux,initrd-start"); p) {
-		if (p->size() == 4)
-			initrd = p->asU32();
-		else if (p->size() == 8)
-			initrd = p->asU64();
-		else
-			assert(!"Invalid linux,initrd-start size");
-
-		eir::infoLogger() << "Initrd is at " << (void *)initrd << frg::endlog;
-	} else {
-		initrd = 0x48000000;
-		eir::infoLogger() << "Assuming initrd is at " << (void *)initrd << frg::endlog;
-	}
-
-	CpioRange cpio_range{reinterpret_cast<void *>(initrd)};
-
-	auto initrd_end = reinterpret_cast<uintptr_t>(cpio_range.eof());
-	eir::infoLogger() << "Initrd ends at " << (void *)initrd_end << frg::endlog;
-
-	reservedRegions[nReservedRegions++] = {initrd, initrd_end - initrd};
-	reservedRegions[nReservedRegions++] = {deviceTreePtr, dt.size()};
-
-	for (int i = 0; i < nMemoryNodes; i++) {
-		auto reg = memoryNodes[i].findProperty("reg");
-		assert(reg);
-
-		size_t j = 0;
-		while (j < reg->size()) {
-			auto base = reg->asPropArrayEntry(addressCells, j);
-			j += addressCells * 4;
-
-			auto size = reg->asPropArrayEntry(sizeCells, j);
-			j += sizeCells * 4;
-
-			createInitialRegions({base, size}, {reservedRegions, nReservedRegions});
-		}
-	}
-
-	setupRegionStructs();
-
-	eir::infoLogger() << "Kernel memory regions:" << frg::endlog;
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType == RegionType::null)
-			continue;
-		eir::infoLogger() << "    Memory region [" << i << "]."
-				<< " Base: 0x" << frg::hex_fmt{regions[i].address}
-				<< ", length: 0x" << frg::hex_fmt{regions[i].size} << frg::endlog;
-		if(regions[i].regionType == RegionType::allocatable)
-			eir::infoLogger() << "        Buddy tree at 0x" << frg::hex_fmt{regions[i].buddyTree}
-					<< ", overhead: 0x" << frg::hex_fmt{regions[i].buddyOverhead}
-					<< frg::endlog;
-	}
-
-	frg::span<uint8_t> kernel_image{nullptr, 0};
-
-	for (auto entry : cpio_range) {
-		if (entry.name == "thor") {
-			kernel_image = entry.data;
-		}
-	}
-
-	assert(kernel_image.data() && kernel_image.size());
-
-	uint64_t kernel_entry = 0;
-	initProcessorPaging(kernel_image.data(), kernel_entry);
-
-	const char *cmdline = "";
-	if (auto p = chosenNode.findProperty("bootargs"); p) {
-		cmdline = static_cast<const char *>(p->data());
-	}
-
-	auto info_ptr = generateInfo(cmdline);
-
-	auto module = bootAlloc<EirModule>();
-	module->physicalBase = initrd;
-	module->length = initrd_end - initrd;
-
-	char *name_ptr = bootAlloc<char>(11);
-	memcpy(name_ptr, "initrd.cpio", 11);
-	module->namePtr = mapBootstrapData(name_ptr);
-	module->nameLength = 11;
-
-	info_ptr->numModules = 1;
-	info_ptr->moduleInfo = mapBootstrapData(module);
-
-	info_ptr->dtbPtr = deviceTreePtr;
-	info_ptr->dtbSize = dt.size();
-
-	info_ptr->debugFlags |= eirDebugSerial;
-
-	mapSingle4kPage(0xFFFF'0000'0000'0000, 0x9000000,
-			PageFlags::write, CachingMode::mmio);
-	mapKasanShadow(0xFFFF'0000'0000'0000, 0x1000);
-	unpoisonKasanShadow(0xFFFF'0000'0000'0000, 0x1000);
-
-	eir::infoLogger() << "Leaving Eir and entering the real kernel" << frg::endlog;
-
-	eirEnterKernel(eirTTBR[0] + 1, eirTTBR[1] + 1, kernel_entry,
-			0xFFFF'FE80'0001'0000, 0xFFFF'FE80'0001'0000);
-
-	while(true);
+	GenericInfo info{
+		.deviceTreePtr = deviceTreePtr,
+		.cmdline = nullptr,
+		.fb {},
+		.debugFlags = eirDebugSerial,
+		.hasFb = false
+	};
+	eirGenericMain(info);
 }
 
 } // namespace eir

--- a/kernel/eir/generic/eir-internal/arch.hpp
+++ b/kernel/eir/generic/eir-internal/arch.hpp
@@ -32,7 +32,8 @@ address_t getSingle4kPage(address_t address);
 void initProcessorEarly();
 void initProcessorPaging(void *kernel_start, uint64_t &kernel_entry);
 
-extern "C" char eirImageFloor;
-extern "C" char eirImageCeiling;
+// These need to be hidden because they are used in eirRelocate.
+extern "C" [[gnu::visibility("hidden")]] char eirImageFloor;
+extern "C" [[gnu::visibility("hidden")]] char eirImageCeiling;
 
 } // namespace eir

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -31,6 +31,17 @@ static constexpr size_t numRegions = 64;
 extern Region regions[numRegions];
 extern address_t allocatedMemory;
 
+struct GenericInfo {
+	uintptr_t deviceTreePtr;
+	const char *cmdline;
+	EirFramebuffer fb;
+	uint32_t debugFlags;
+	bool hasFb;
+};
+
+void eirRelocate();
+[[noreturn]] void eirGenericMain(const GenericInfo &genericInfo);
+
 uintptr_t bootReserve(size_t length, size_t alignment);
 uintptr_t allocPage();
 void allocLogRingBuffer();

--- a/kernel/klibc/elf.h
+++ b/kernel/klibc/elf.h
@@ -76,6 +76,10 @@ enum {
 	R_X86_64_TPOFF64 = 18,
 };
 
+enum {
+	R_AARCH64_RELATIVE = 1027
+};
+
 struct Elf64_Rela {
 	Elf64_Addr r_offset;
 	Elf64_Xword r_info;


### PR DESCRIPTION
Merge common duplicated aarch64 eir init code and make it a pie on virt platform. It would also likely be possible to do that on raspi4 but I don't really know how the bootloader handles images with base address zero (and if it would be non-zero it would need to be taken into account somehow in eirRelocate() or alternatively making sure there are no relocations at all but that requires some ugly hacks eg. around constexpr string arrays in fault.cpp).