### PR TITLE
kernel/thor: Publish dtb nodes to mbus

### DIFF
--- a/kernel/thor/arch/arm/meson.build
+++ b/kernel/thor/arch/arm/meson.build
@@ -14,6 +14,7 @@ src += files(
 	'smp.cpp',
 	'timer.cpp',
 	'../../system/dtb/dtb.cpp',
+	'../../system/dtb/dtb_discover.cpp',
 	'../../system/pci/pci_dtb.cpp'
 )
 

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -15,6 +15,7 @@
 #include <thor-internal/main.hpp>
 #include <thor-internal/module.hpp>
 #include <thor-internal/pci/pci.hpp>
+#include <thor-internal/dtb/dtb.hpp>
 #include <thor-internal/physical.hpp>
 #include <thor-internal/profile.hpp>
 #include <thor-internal/random.hpp>
@@ -202,6 +203,10 @@ extern "C" void thorMain() {
 
 		pci::runAllBridges();
 		pci::runAllDevices();
+
+#if __aarch64__
+		dtb::publishNodes();
+#endif
 
 		// Parse the initrd image.
 		auto modules = reinterpret_cast<EirModule *>(thorBootInfoPtr->moduleInfo);

--- a/kernel/thor/generic/thor-internal/mbus.hpp
+++ b/kernel/thor/generic/thor-internal/mbus.hpp
@@ -11,24 +11,27 @@ struct Properties {
 	friend struct KernelBusObject;
 
 	void stringProperty(frg::string_view name, frg::string<KernelAlloc> &&value) {
-		properties_.emplace_back(name, std::move(value));
+		auto allocName = frg::string<KernelAlloc>(*kernelAlloc, name);
+		properties_.emplace_back(std::move(allocName), std::move(value));
 	}
 
 	void hexStringProperty(frg::string_view name, uint32_t value, int padding) {
-		stringProperty(name, frg::to_allocated_string(*kernelAlloc, value, 16, padding));
+		auto allocName = frg::string<KernelAlloc>(*kernelAlloc, name);
+		stringProperty(std::move(allocName), frg::to_allocated_string(*kernelAlloc, value, 16, padding));
 	}
 
 	void decStringProperty(frg::string_view name, uint32_t value, int padding) {
-		stringProperty(name, frg::to_allocated_string(*kernelAlloc, value, 10, padding));
+		auto allocName = frg::string<KernelAlloc>(*kernelAlloc, name);
+		stringProperty(std::move(allocName), frg::to_allocated_string(*kernelAlloc, value, 10, padding));
 	}
 
 private:
 	struct Property {
-		Property(frg::string_view name,
+		Property(frg::string<KernelAlloc> &&name,
 			frg::string<KernelAlloc> &&value)
-		: name{name}, value{std::move(value)} { }
+		: name{std::move(name)}, value{std::move(value)} { }
 
-		frg::string_view name;
+		frg::string<KernelAlloc> name;
 		frg::string<KernelAlloc> value;
 	};
 

--- a/kernel/thor/system/dtb/dtb_discover.cpp
+++ b/kernel/thor/system/dtb/dtb_discover.cpp
@@ -1,0 +1,256 @@
+#include <thor-internal/fiber.hpp>
+#include <thor-internal/main.hpp>
+#include <thor-internal/dtb/dtb.hpp>
+#include <thor-internal/mbus.hpp>
+
+#include <hw.frigg_bragi.hpp>
+
+#include <bragi/helpers-all.hpp>
+#include <bragi/helpers-frigg.hpp>
+
+#ifdef __aarch64__
+#include <thor-internal/arch/gic.hpp>
+#endif
+
+namespace thor::dtb {
+
+struct DtbRegister {
+	uintptr_t address;
+	uintptr_t length;
+	uintptr_t offset;
+	smarter::shared_ptr<MemoryView> memory;
+};
+
+struct DtbIrqObject final : IrqObject {
+	DtbIrqObject(frg::string<KernelAlloc> name, DeviceTreeNode::DeviceIrq deviceIrq, IrqPin *pin)
+	: IrqObject{name}, deviceIrq{deviceIrq}, pin{pin} { }
+
+	void dumpHardwareState() override {
+		infoLogger() << "thor: DTB IRQ " << name() << frg::endlog;
+	}
+
+	DeviceTreeNode::DeviceIrq deviceIrq;
+	IrqPin *pin;
+};
+
+struct DtbNode final : private KernelBusObject {
+	DtbNode(DeviceTreeNode *node)
+		: node{node}, regs{*kernelAlloc}, irqs{*kernelAlloc} {
+		for(auto &reg : node->reg()) {
+			auto offset = reg.addr & (kPageSize - 1);
+
+			regs.emplace_back(
+				reg.addr,
+				reg.size,
+				offset,
+				smarter::allocate_shared<HardwareMemory>(*kernelAlloc,
+					reg.addr & ~(kPageSize - 1),
+					(reg.size + (kPageSize - 1)) & ~(kPageSize - 1),
+					CachingMode::mmioNonPosted)
+			);
+		}
+	}
+
+	smarter::shared_ptr<IrqObject> obtainIrqObject(uint32_t index) {
+		auto deviceIrq = node->irqs()[index];
+#ifdef __aarch64__
+		auto *pin = gic->getPin(deviceIrq.id);
+#else
+#error Missing architecture specific code
+#endif
+
+		auto object = smarter::allocate_shared<DtbIrqObject>(*kernelAlloc,
+				frg::string<KernelAlloc>{*kernelAlloc, "dtb-irq."} + node->name(),
+				deviceIrq,
+				pin);
+
+		IrqPin::attachSink(pin, object.get());
+
+		irqs.push_back(object);
+		return object;
+	}
+
+	void run(enable_detached_coroutine = {}) {
+		Properties properties;
+
+		properties.stringProperty("unix.subsystem", frg::string<KernelAlloc>(*kernelAlloc, "dtb"));
+		for(auto &compatible : node->compatible()) {
+			frg::string<KernelAlloc> prop{*kernelAlloc, "dtb.compatible="};
+			prop += compatible;
+			properties.stringProperty(prop, frg::string<KernelAlloc>{*kernelAlloc, ""});
+		}
+
+		auto ret = co_await createObject("dtb-node", std::move(properties));
+		assert(ret);
+		mbusId = ret.value();
+	}
+
+	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override {
+		auto [acceptError, conversation] = co_await AcceptSender{lane};
+		if(acceptError != Error::success)
+			co_return acceptError;
+
+		auto [reqError, reqBuffer] = co_await RecvBufferSender{conversation};
+		if(reqError != Error::success)
+			co_return reqError;
+
+		auto preamble = bragi::read_preamble(reqBuffer);
+		if(preamble.error())
+			co_return Error::protocolViolation;
+
+		auto sendResponse = [] (LaneHandle &conversation,
+				managarm::hw::SvrResponse<KernelAlloc> &&resp) -> coroutine<frg::expected<Error>> {
+			frg::unique_memory<KernelAlloc> respHeadBuffer{*kernelAlloc,
+				resp.head_size};
+
+			frg::unique_memory<KernelAlloc> respTailBuffer{*kernelAlloc,
+				resp.size_of_tail()};
+
+			bragi::write_head_tail(resp, respHeadBuffer, respTailBuffer);
+
+			auto respHeadError = co_await SendBufferSender{conversation, std::move(respHeadBuffer)};
+
+			if(respHeadError != Error::success)
+				co_return respHeadError;
+
+			auto respTailError = co_await SendBufferSender{conversation, std::move(respTailBuffer)};
+
+			if(respTailError != Error::success)
+				co_return respTailError;
+
+			co_return frg::success;
+		};
+
+		if(preamble.id() == bragi::message_id<managarm::hw::GetDtbInfoRequest>) {
+			auto req = bragi::parse_head_only<managarm::hw::GetDtbInfoRequest>(reqBuffer, *kernelAlloc);
+
+			if(!req) {
+				infoLogger() << "thor: Closing lane due to illegal HW request." << frg::endlog;
+				co_return Error::protocolViolation;
+			}
+
+			managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
+			resp.set_error(managarm::hw::Errors::SUCCESS);
+
+			resp.set_num_dtb_irqs(node->irqs().size());
+
+			for(const auto &reg : regs) {
+				managarm::hw::DtbRegister<KernelAlloc> msg(*kernelAlloc);
+				msg.set_address(reg.address);
+				msg.set_length(reg.length);
+				msg.set_offset(reg.offset);
+				resp.add_dtb_regs(std::move(msg));
+			}
+
+			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
+		}else if(preamble.id() == bragi::message_id<managarm::hw::AccessDtbRegisterRequest>) {
+			auto req = bragi::parse_head_only<managarm::hw::AccessDtbRegisterRequest>(reqBuffer, *kernelAlloc);
+
+			if(!req) {
+				infoLogger() << "thor: Closing lane due to illegal HW request." << frg::endlog;
+				co_return Error::protocolViolation;
+			}
+
+			auto index = req->index();
+
+			if(index >= regs.size()) {
+				infoLogger() << "thor: Closing lane due to out-ouf-bounds DTB register " << index << " in HW request." << frg::endlog;
+				co_return Error::illegalArgs;
+			}
+
+			MemoryViewDescriptor descriptor{regs[index].memory};
+
+			managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
+			resp.set_error(managarm::hw::Errors::SUCCESS);
+
+			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
+
+			auto descError = co_await PushDescriptorSender{conversation, std::move(descriptor)};
+
+			if(descError != Error::success)
+				co_return descError;
+		}else if(preamble.id() == bragi::message_id<managarm::hw::InstallDtbIrqRequest>) {
+			auto req = bragi::parse_head_only<managarm::hw::InstallDtbIrqRequest>(reqBuffer, *kernelAlloc);
+
+			if(!req) {
+				infoLogger() << "thor: Closing lane due to illegal HW request." << frg::endlog;
+				co_return Error::protocolViolation;
+			}
+
+			auto index = req->index();
+
+			if(index >= node->irqs().size()) {
+				infoLogger() << "thor: Closing lane due to out-ouf-bounds DTB irq " << index << " in HW request." << frg::endlog;
+				co_return Error::illegalArgs;
+			}
+
+			auto object = obtainIrqObject(index);
+
+			managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
+			resp.set_error(managarm::hw::Errors::SUCCESS);
+
+			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
+
+			auto descError = co_await PushDescriptorSender{conversation, IrqDescriptor{object}};
+
+			if(descError != Error::success)
+				co_return descError;
+		}else if(preamble.id() == bragi::message_id<managarm::hw::EnableBusIrqRequest>) {
+			auto req = bragi::parse_head_only<managarm::hw::EnableBusIrqRequest>(reqBuffer, *kernelAlloc);
+
+			if(!req) {
+				infoLogger() << "thor: Closing lane due to illegal HW request." << frg::endlog;
+				co_return Error::protocolViolation;
+			}
+
+			for(auto &irq : irqs) {
+				irq->pin->configure({irq->deviceIrq.trigger, irq->deviceIrq.polarity});
+			}
+
+			managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
+			resp.set_error(managarm::hw::Errors::SUCCESS);
+
+			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
+		}else{
+			infoLogger() << "thor: Dismissing conversation due to illegal HW request." << frg::endlog;
+			co_await DismissSender{conversation};
+		}
+
+		co_return frg::success;
+	}
+
+	DeviceTreeNode *node;
+	frg::vector<DtbRegister, KernelAlloc> regs;
+	frg::vector<smarter::shared_ptr<DtbIrqObject>, KernelAlloc> irqs;
+	uint64_t mbusId;
+};
+
+frg::manual_box<
+	frg::vector<
+		smarter::shared_ptr<DtbNode>,
+		KernelAlloc
+	>
+> allNodes;
+
+static initgraph::Task discoverDtbNodes{&globalInitEngine, "dtb.discover-nodes",
+	initgraph::Requires{getDeviceTreeParsedStage()},
+	[] {
+		allNodes.initialize(*kernelAlloc);
+
+		getDeviceTreeRoot()->forEach([&](DeviceTreeNode *node) -> bool {
+			allNodes->emplace_back(smarter::allocate_shared<DtbNode>(*kernelAlloc, node));
+			return false;
+		});
+
+		infoLogger() << "thor: Found " << allNodes->size() << " DTB nodes in total." << frg::endlog;
+	}
+};
+
+void publishNodes() {
+	KernelFiber::run([=] {
+		for(auto& node : *allNodes)
+			node->run();
+	});
+}
+
+} // namespace thor::pci

--- a/kernel/thor/system/dtb/thor-internal/dtb/dtb.hpp
+++ b/kernel/thor/system/dtb/thor-internal/dtb/dtb.hpp
@@ -50,6 +50,10 @@ struct DeviceTreeNode {
 		return model_;
 	}
 
+	const frg::vector<frg::string_view, KernelAlloc>& compatible() const {
+		return compatible_;
+	}
+
 	template <size_t N>
 	bool isCompatible(frg::array<frg::string_view, N> with) const {
 		for (const auto &c : compatible_) {
@@ -233,6 +237,10 @@ DeviceTreeNode *getDeviceTreeNodeByPath(frg::string_view path);
 DeviceTreeNode *getDeviceTreeRoot();
 
 initgraph::Stage *getDeviceTreeParsedStage();
+
+namespace dtb {
+	void publishNodes();
+} // namespace thor::dtb
 
 static inline frg::array<frg::string_view, 12> dtGicV2Compatible = {
 	"arm,arm11mp-gic",

--- a/protocols/hw/hw.bragi
+++ b/protocols/hw/hw.bragi
@@ -33,6 +33,12 @@ struct PciCapability {
 	uint64 length;
 }
 
+struct DtbRegister {
+	uint64 address;
+	uint64 length;
+	uint32 offset;
+}
+
 message GetPciInfoRequest 1 {
 head(128):
 }
@@ -105,6 +111,20 @@ head(128):
 	int64 cmd;
 }
 
+message GetDtbInfoRequest 21 {
+head(128):
+}
+
+message AccessDtbRegisterRequest 22 {
+head(128):
+	uint32 index;
+}
+
+message InstallDtbIrqRequest 23 {
+head(128):
+	uint32 index;
+}
+
 message SvrResponse 13 {
 head(128):
 	Errors error;
@@ -122,6 +142,9 @@ tail:
 		tag(6) uint32 fb_height;
 		tag(7) uint32 fb_bpp;
 		tag(8) uint32 fb_type;
+
+		tag(11) DtbRegister[] dtb_regs;
+		tag(12) uint32 num_dtb_irqs;
 	}
 }
 

--- a/protocols/hw/include/protocols/hw/client.hpp
+++ b/protocols/hw/include/protocols/hw/client.hpp
@@ -62,6 +62,17 @@ struct AcpiResources {
 	std::vector<uint8_t> irqs;
 };
 
+struct DtbRegister {
+	uintptr_t address;
+	size_t length;
+	ptrdiff_t offset;
+};
+
+struct DtbInfo {
+	std::vector<DtbRegister> regs;
+	uint32_t numIrqs;
+};
+
 struct Device {
 	Device(helix::UniqueLane lane)
 	:_lane(std::move(lane)) { };
@@ -71,6 +82,10 @@ struct Device {
 	async::result<helix::UniqueDescriptor> accessExpansionRom();
 	async::result<helix::UniqueDescriptor> accessIrq(size_t index = 0);
 	async::result<helix::UniqueDescriptor> installMsi(int index);
+
+	async::result<DtbInfo> getDtbInfo();
+	async::result<helix::UniqueDescriptor> accessDtbRegister(uint32_t index);
+	async::result<helix::UniqueDescriptor> installDtbIrq(uint32_t index);
 
 	async::result<void> claimDevice();
 	async::result<void> enableBusIrq();


### PR DESCRIPTION
Publish dtb nodes to mbus. This is a draft because I am not sure if the mbus refactor should get merged first and also it would be nice to get #617 merged so AccessIrqRequest could be supported too.