### PR TITLE
More aarch64 fixes

### DIFF
--- a/kernel/eir/arch/arm/generic.cpp
+++ b/kernel/eir/arch/arm/generic.cpp
@@ -57,7 +57,7 @@ void eirRelocate() {
 
 	dt.rootNode().discoverSubnodes(
 		[](DeviceTreeNode &node) {
-			return !memcmp("memory@", node.name(), 7)
+			return !memcmp("memory", node.name(), 6)
 				|| !memcmp("chosen", node.name(), 7)
 				|| !memcmp("reserved-memory", node.name(), 15);
 		},

--- a/kernel/eir/generic/debug.cpp
+++ b/kernel/eir/generic/debug.cpp
@@ -63,7 +63,8 @@ void LogSink::operator()(const char *c) {
 void PanicSink::operator()(const char *c) {
 	infoSink.print(c);
 	infoSink.print('\n');
-	while(true);
+	while(true)
+		asm volatile("" : : : "memory");
 }
 
 } // namespace eir

--- a/kernel/thor/system/dtb/dtb.cpp
+++ b/kernel/thor/system/dtb/dtb.cpp
@@ -9,7 +9,7 @@
 
 namespace thor {
 
-static inline constexpr bool logNodeInfo = true;
+static inline constexpr bool logNodeInfo = false;
 
 initgraph::Stage *getDeviceTreeParsedStage() {
 	static initgraph::Stage s{&globalInitEngine, "dtb.tree-parsed"};
@@ -78,6 +78,8 @@ void DeviceTreeNode::initializeWith(::DeviceTreeNode dtNode) {
 			hasInterruptCells_ = true;
 		} else if (pn == "interrupt-parent") {
 			interruptParentId_ = prop.asU32();
+		} else if (pn == "interrupt-controller") {
+			interruptController_ = true;
 		} else if (pn == "reg") {
 			auto addrCells = parent_->addressCells_;
 			auto sizeCells = parent_->sizeCells_;


### PR DESCRIPTION
I am not sure if `logNodeInfo` should be kept enabled, I disabled it because it slows the boot significantly when there are ~1k nodes.