### PR TITLE
Implement EISDIR for read

### DIFF
--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -73,6 +73,11 @@ async::result<protocols::fs::ReadResult> read(void *object, const char *,
 	HEL_CHECK(helGetClock(&start));
 
 	auto self = static_cast<ext2fs::OpenFile *>(object);
+
+	if(self->inode->fileType == FileType::kTypeDirectory) {
+		co_return protocols::fs::Error::isDirectory;
+	}
+
 	co_await self->inode->readyJump.wait();
 
 	if(self->offset >= self->inode->fileSize())


### PR DESCRIPTION
Depends on managarm/mlibc#1047.

Previously, running `cat` on a directory returned garbage. With this change, it correctly outputs `cat: <directory>: Is a directory`.