### PR TITLE
thor: Add missing data/bss sections to linker scripts

### DIFF
--- a/kernel/thor/arch/arm/link.x
+++ b/kernel/thor/arch/arm/link.x
@@ -16,7 +16,7 @@ SECTIONS {
 		PROVIDE_HIDDEN (__init_array_end = .);
 	}
 
-	.data ALIGN(0x1000) : { *(.data) }
-	.bss : { *(.bss) }
+	.data ALIGN(0x1000) : { *(.data .data.*) }
+	.bss : { *(.bss .bss.*) }
 }
 

--- a/kernel/thor/arch/x86/link.x
+++ b/kernel/thor/arch/x86/link.x
@@ -24,7 +24,7 @@ SECTIONS {
 		KEEP (*(.init_array .ctors))
 		PROVIDE_HIDDEN (__init_array_end = .);
 	}
-	.data : { *(.data) }
-	.bss : { *(.bss) }
+	.data : { *(.data .data.*) }
+	.bss : { *(.bss .bss.*) }
 }
 


### PR DESCRIPTION
Add .data.* and .bss.* sections to some linker scripts.