### PR TITLE
posix: Fix order of operations in epoll handleClose

### DIFF
--- a/posix/subsystem/src/epoll.cpp
+++ b/posix/subsystem/src/epoll.cpp
@@ -346,14 +346,14 @@ public:
 			it = _fileMap.erase(it);
 			item->state &= ~stateActive;
 
-			if(item->state & statePolling)
-				item->cancelPoll.cancel();
-
 			if(item->state & statePending) {
 				auto qit = _pendingQueue.iterator_to(*item);
 				_pendingQueue.erase(qit);
 				item->state &= ~statePending;
 			}
+
+			if(item->state & statePolling)
+				item->cancelPoll.cancel();
 		}
 
 		_statusBell.raise();


### PR DESCRIPTION
If the item is pending, we need to remove it from the pending queue before we cancel polling, as that's what the logic in _awaitPoll expects.