### PR TITLE
Attach credentials to streams again

### DIFF
--- a/core/drm/src/ioctl.cpp
+++ b/core/drm/src/ioctl.cpp
@@ -1052,7 +1052,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			// Create the lane used for serving the PRIME fd
 			helix::UniqueLane local_lane, remote_lane;
-			std::tie(local_lane, remote_lane) = helix::createStream();
+			std::tie(local_lane, remote_lane) = helix::createStream(true);
 			auto file = smarter::make_shared<drm_core::PrimeFile>(bo->getMemory().first, bo->getSize());
 
 			// Start serving the file
@@ -1109,7 +1109,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			if(logDrmRequests)
 				std::cout << "core/drm: PRIME_FD_TO_HANDLE({can't resolve credentials yet})" << std::endl;
 
-			// extract the credentials of the land that served the PRIME fd, as this is keying our maps that keep track of it
+			// extract the credentials of the lane that served the PRIME fd, as this is keying our maps that keep track of it
 			auto [creds] = co_await helix_ng::exchangeMsgs(conversation, helix_ng::extractCredentials());
 			HEL_CHECK(creds.error());
 

--- a/hel/include/hel-stubs-aarch64.h
+++ b/hel/include/hel-stubs-aarch64.h
@@ -73,6 +73,23 @@ extern inline __attribute__ (( always_inline )) HelError helSyscall1_1(int numbe
 	return error;
 }
 
+extern inline __attribute__ (( always_inline )) HelError helSyscall1_2(int number,
+		HelWord arg0, HelWord *res0, HelWord *res1) {
+	register HelWord error asm("x0");
+	register HelWord code asm("x0") = number;
+	register HelWord in0 asm("x1") = arg0;
+	register HelWord out0 asm("x1");
+	register HelWord out1 asm("x2");
+
+	asm volatile ( "svc 0" : "=r" (error), "=r" (out0), "=r"(out1)
+			: "r" (code), "r" (in0)
+			: "memory" );
+
+	*res0 = out0;
+	*res1 = out1;
+	return error;
+}
+
 extern inline __attribute__ (( always_inline )) HelError helSyscall2(int number,
 		HelWord arg0, HelWord arg1) {
 	register HelWord error asm("x0");

--- a/hel/include/hel-stubs-x86_64.h
+++ b/hel/include/hel-stubs-x86_64.h
@@ -74,6 +74,23 @@ extern inline __attribute__ (( always_inline )) HelError helSyscall1_1(int numbe
 	return error;
 }
 
+extern inline __attribute__ (( always_inline )) HelError helSyscall1_2(int number,
+		HelWord arg0, HelWord *res0, HelWord *res1) {
+	register HelWord in0 asm("rsi") = arg0;
+
+	HelWord error;
+	register HelWord out0 asm("rsi");
+	register HelWord out1 asm("rdx");
+
+	asm volatile ( "syscall" : "=D" (error), "=r" (out0), "=r"(out1)
+			: "D" (number), "r" (in0)
+			: "rcx", "r11", "rbx", "memory" );
+
+	*res0 = out0;
+	*res1 = out1;
+	return error;
+}
+
 extern inline __attribute__ (( always_inline )) HelError helSyscall2(int number,
 		HelWord arg0, HelWord arg1) {
 	register HelWord in0 asm("rsi") = arg0;

--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -362,10 +362,10 @@ extern inline __attribute__ (( always_inline )) HelError helSubmitAwaitClock(uin
 };
 
 extern inline __attribute__ (( always_inline )) HelError helCreateStream(HelHandle *lane1,
-		HelHandle *lane2) {
+		HelHandle *lane2, uint32_t attach_credentials) {
 	HelWord out_lane1;
 	HelWord out_lane2;
-	HelError error = helSyscall0_2(kHelCallCreateStream, &out_lane1, &out_lane2);
+	HelError error = helSyscall1_2(kHelCallCreateStream, attach_credentials, &out_lane1, &out_lane2);
 	*lane1 = (HelHandle)out_lane1;
 	*lane2 = (HelHandle)out_lane2;
 	return error;

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -987,7 +987,9 @@ HEL_C_LINKAGE HelError helSetAffinity(HelHandle handle, uint8_t *mask, size_t si
 //!     Handle to the first lane of the new stream.
 //! @param[out] lane2
 //!     Handle to the second lane of the new stream.
-HEL_C_LINKAGE HelError helCreateStream(HelHandle *lane1, HelHandle *lane2);
+//! @param[in] attach_credentials
+//!     Enable or disable credentials for the new stream.
+HEL_C_LINKAGE HelError helCreateStream(HelHandle *lane1, HelHandle *lane2, uint32_t attach_credentials);
 
 //! Pass messages on a stream.
 //! @param[in] handle

--- a/hel/include/helix/ipc.hpp
+++ b/hel/include/helix/ipc.hpp
@@ -90,9 +90,9 @@ struct Lane { };
 using UniqueLane = UniqueResource<Lane>;
 using BorrowedLane = BorrowedResource<Lane>;
 
-inline std::pair<UniqueLane, UniqueLane> createStream() {
+inline std::pair<UniqueLane, UniqueLane> createStream(bool attach_credentials = false) {
 	HelHandle first_handle, second_handle;
-	HEL_CHECK(helCreateStream(&first_handle, &second_handle));
+	HEL_CHECK(helCreateStream(&first_handle, &second_handle, attach_credentials));
 	return { UniqueLane(first_handle), UniqueLane(second_handle) };
 }
 

--- a/kernel/thor/generic/credentials.cpp
+++ b/kernel/thor/generic/credentials.cpp
@@ -14,8 +14,8 @@ Credentials::Credentials() {
 	//              Although that seems like a waste of time...
 	while (progress < 16) {
 		progress += generateRandomBytes(
-			_credentials + progress,
-			16 - progress);
+			_credentials.data() + progress,
+			_credentials.size() - progress);
 	}
 
 	// Set the UUID to version 4 ...

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -264,7 +264,7 @@ HelError helGetCredentials(HelHandle handle, uint32_t flags, char *credentials) 
 		}
 	}
 
-	if(!writeUserMemory(credentials, creds->credentials(), 16))
+	if(!writeUserMemory(credentials, creds->credentials().data(), creds->credentials().size()))
 		return kHelErrFault;
 
 	return kHelErrNone;
@@ -2361,7 +2361,7 @@ HelError helSubmitAsync(HelHandle handle, const HelAction *actions, size_t count
 				}
 
 				node->_tag = kTagImbueCredentials;
-				memcpy(node->_inCredentials.data(), creds->credentials(), 16);
+				memcpy(node->_inCredentials.data(), creds->credentials().data(), creds->credentials().size());
 				ipcSize += ipcSourceSize(sizeof(HelSimpleResult));
 				break;
 			}

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -807,7 +807,7 @@ void handleSyscall(SyscallImageAccessor image) {
 	case kHelCallCreateStream: {
 		HelHandle lane1;
 		HelHandle lane2;
-		*image.error() = helCreateStream(&lane1, &lane2);
+		*image.error() = helCreateStream(&lane1, &lane2, (uint32_t) arg0);
 		*image.out0() = lane1;
 		*image.out1() = lane2;
 	} break;

--- a/kernel/thor/generic/stream.cpp
+++ b/kernel/thor/generic/stream.cpp
@@ -279,10 +279,12 @@ bool Stream::decrementPeers(Stream *stream, int lane) {
 	return true;
 }
 
-Stream::Stream()
-: _laneBroken{false, false}, _laneShutDown{false, false} {
+Stream::Stream(bool withCredentials)
+: _laneBroken{false, false}, _laneShutDown{false, false}, _withCredentials{withCredentials} {
 	_peerCount[0].store(1, std::memory_order_relaxed);
 	_peerCount[1].store(1, std::memory_order_relaxed);
+	if(withCredentials)
+		_creds = Credentials{};
 }
 
 Stream::~Stream() {
@@ -343,8 +345,8 @@ void Stream::_cancelItem(StreamNode *item, Error error) {
 	}
 }
 
-frg::tuple<LaneHandle, LaneHandle> createStream() {
-	auto stream = smarter::allocate_shared<Stream>(*kernelAlloc);
+frg::tuple<LaneHandle, LaneHandle> createStream(bool withCredentials) {
+	auto stream = smarter::allocate_shared<Stream>(*kernelAlloc, withCredentials);
 	assert(stream.ctr()->check_count() == 1);
 	stream.ctr()->increment();
 	LaneHandle handle1(adoptLane, stream, 0);

--- a/kernel/thor/generic/thor-internal/credentials.hpp
+++ b/kernel/thor/generic/thor-internal/credentials.hpp
@@ -1,15 +1,17 @@
 #pragma once
 
+#include <array>
+
 namespace thor {
 
 struct Credentials {
 	Credentials();
 
-	const char *credentials() {
+	std::array<char, 16> credentials() {
 		return _credentials;
 	}
 protected:
-	char _credentials[16];
+	std::array<char, 16> _credentials;
 };
 
 }


### PR DESCRIPTION
9278db8d27369933de57b0657d488604b3675d15 broke sway, so this PR attaches credentials to `Stream`s again. In order to keep the objective of that commit, these are only generated on demand.