### PR TITLE
posix: expose USB endpoints on sysfs

### DIFF
--- a/posix/subsystem/src/subsystem/usb/attributes.cpp
+++ b/posix/subsystem/src/subsystem/usb/attributes.cpp
@@ -1,3 +1,5 @@
+#include <format>
+
 #include "attributes.hpp"
 #include "devices.hpp"
 
@@ -174,8 +176,60 @@ async::result<frg::expected<Error, std::string>> InterfaceNumberAttribute::show(
 async::result<frg::expected<Error, std::string>> EndpointNumAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbInterface *>(object);
 	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->endpoints);
+	snprintf(buf, 4, "%02x\n", device->endpointCount);
 	co_return std::string{buf};
+}
+
+async::result<frg::expected<Error, std::string>> EndpointAddressAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbEndpoint *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->endpointAddress);
+	co_return std::string{buf};
+}
+
+async::result<frg::expected<Error, std::string>> PrettyIntervalAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbEndpoint *>(object);
+	co_return std::format("{}ms\n", 0);
+}
+
+async::result<frg::expected<Error, std::string>> IntervalAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbEndpoint *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->interval);
+	co_return std::string{buf};
+}
+
+async::result<frg::expected<Error, std::string>> LengthAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbEndpoint *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->length);
+	co_return std::string{buf};
+}
+
+async::result<frg::expected<Error, std::string>> EpAttributesAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbEndpoint *>(object);
+	char buf[4];
+	snprintf(buf, 4, "%02x\n", device->attributes);
+	co_return std::string{buf};
+}
+
+async::result<frg::expected<Error, std::string>> EpMaxPacketSizeAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbEndpoint *>(object);
+	char buf[6];
+	snprintf(buf, 6, "%04x\n", device->maxPacketSize);
+	co_return std::string{buf};
+}
+
+async::result<frg::expected<Error, std::string>> EpTypeAttribute::show(sysfs::Object *object) {
+	auto device = static_cast<UsbEndpoint *>(object);
+	switch(device->attributes & 0x03) {
+		case 0: co_return "Control";
+		case 1: co_return "Isochronous";
+		case 2: co_return "Bulk";
+		case 3: co_return "Interrupt";
+	}
+
+	__builtin_unreachable();
 }
 
 } // namespace usb_subsystem

--- a/posix/subsystem/src/subsystem/usb/attributes.hpp
+++ b/posix/subsystem/src/subsystem/usb/attributes.hpp
@@ -200,4 +200,53 @@ struct EndpointNumAttribute : sysfs::Attribute {
 	async::result<frg::expected<Error, std::string>> show(sysfs::Object *object) override;
 };
 
+struct EndpointAddressAttribute : sysfs::Attribute {
+	EndpointAddressAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<frg::expected<Error, std::string>> show(sysfs::Object *object) override;
+};
+
+struct PrettyIntervalAttribute : sysfs::Attribute {
+	PrettyIntervalAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<frg::expected<Error, std::string>> show(sysfs::Object *object) override;
+};
+
+struct IntervalAttribute : sysfs::Attribute {
+	IntervalAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<frg::expected<Error, std::string>> show(sysfs::Object *object) override;
+};
+
+struct LengthAttribute : sysfs::Attribute {
+	LengthAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<frg::expected<Error, std::string>> show(sysfs::Object *object) override;
+};
+
+struct EpAttributesAttribute : sysfs::Attribute {
+	EpAttributesAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<frg::expected<Error, std::string>> show(sysfs::Object *object) override;
+};
+
+struct EpMaxPacketSizeAttribute : sysfs::Attribute {
+	EpMaxPacketSizeAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<frg::expected<Error, std::string>> show(sysfs::Object *object) override;
+};
+
+struct EpTypeAttribute : sysfs::Attribute {
+	EpTypeAttribute(std::string name)
+	: sysfs::Attribute{std::move(name), false} { }
+
+	async::result<frg::expected<Error, std::string>> show(sysfs::Object *object) override;
+};
+
 } // namespace usb_subsystem

--- a/posix/subsystem/src/subsystem/usb/devices.hpp
+++ b/posix/subsystem/src/subsystem/usb/devices.hpp
@@ -52,6 +52,23 @@ struct UsbController final : UsbBase {
 	uint8_t numInterfaces = 0;
 };
 
+struct UsbEndpoint final : sysfs::Object {
+	UsbEndpoint(std::string sysfs_name, int64_t mbus_id, std::shared_ptr<drvcore::Device> parent)
+		: Object{parent, sysfs_name}, sysfs_name{sysfs_name} {
+
+	}
+
+	protocols::usb::Device &device();
+
+	uint8_t endpointAddress;
+	uint8_t attributes;
+	uint8_t interval;
+	uint8_t length;
+	uint16_t maxPacketSize;
+
+	std::string sysfs_name;
+};
+
 struct UsbInterface final : UsbBase {
 	UsbInterface(std::string sysfs_name, int64_t mbus_id, std::shared_ptr<drvcore::Device> parent)
 		: UsbBase{sysfs_name, mbus_id, parent}, sysfs_name{sysfs_name} {
@@ -75,8 +92,10 @@ struct UsbInterface final : UsbBase {
 	uint8_t interfaceSubClass;
 	uint8_t interfaceProtocol;
 	uint8_t alternateSetting;
+	uint8_t endpointCount;
 	uint8_t interfaceNumber;
-	uint8_t endpoints;
+
+	std::vector<std::shared_ptr<UsbEndpoint>> endpoints;
 
 	std::string sysfs_name;
 };


### PR DESCRIPTION
This allows for running `lsusb.py` with the `-e` flag.