### PR TITLE
USB-to-ethernet adapter support

### DIFF
--- a/drivers/nic/usb_ecm/include/nic/usb_ecm/usb_ecm.hpp
+++ b/drivers/nic/usb_ecm/include/nic/usb_ecm/usb_ecm.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <netserver/nic.hpp>
+#include <protocols/usb/client.hpp>
+
+namespace nic::usb_ecm {
+
+std::shared_ptr<nic::Link> makeShared(protocols::usb::Device hw_device, MacAddress mac, protocols::usb::Endpoint in, protocols::usb::Endpoint out);
+
+} // namespace nic::usb_ecm

--- a/drivers/nic/usb_ecm/meson.build
+++ b/drivers/nic/usb_ecm/meson.build
@@ -1,0 +1,14 @@
+deps = [ libarch, frigg, helix_dep, usb_proto_dep ]
+inc = [ 'include' ]
+
+nic_usb_ecm_lib = static_library('nic-usb-ecm', 'src/usb-ecm.cpp',
+	include_directories : [ '../../../servers/netserver/include', inc ],
+	dependencies : deps,
+	install : true
+)
+
+nic_usb_ecm_dep = declare_dependency(
+	include_directories : inc,
+	dependencies : deps,
+	link_with : nic_usb_ecm_lib
+)

--- a/drivers/nic/usb_ecm/src/usb-ecm.cpp
+++ b/drivers/nic/usb_ecm/src/usb-ecm.cpp
@@ -1,0 +1,47 @@
+#include <helix/timer.hpp>
+#include <netserver/nic.hpp>
+#include <arch/dma_pool.hpp>
+#include <nic/usb_ecm/usb_ecm.hpp>
+
+struct UsbEcmNic : nic::Link {
+	UsbEcmNic(protocols::usb::Device hw_device, nic::MacAddress mac, protocols::usb::Endpoint in, protocols::usb::Endpoint out);
+
+	async::result<size_t> receive(arch::dma_buffer_view) override;
+	async::result<void> send(const arch::dma_buffer_view) override;
+
+	~UsbEcmNic() override = default;
+private:
+	arch::contiguous_pool dmaPool_;
+	protocols::usb::Device device_;
+
+	protocols::usb::Endpoint in_;
+	protocols::usb::Endpoint out_;
+};
+
+UsbEcmNic::UsbEcmNic(protocols::usb::Device hw_device, nic::MacAddress mac, protocols::usb::Endpoint in, protocols::usb::Endpoint out)
+	: nic::Link(1500, &dmaPool_), device_{std::move(hw_device)}, in_{std::move(in)}, out_{std::move(out)} {
+	mac_ = mac;
+}
+
+async::result<size_t> UsbEcmNic::receive(arch::dma_buffer_view frame) {
+	while(true) {
+		auto res = co_await in_.transfer(protocols::usb::BulkTransfer{protocols::usb::kXferToHost, frame});
+		assert(res);
+
+		if(res.value() != 0)
+			co_return res.value();
+	}
+}
+
+async::result<void> UsbEcmNic::send(const arch::dma_buffer_view payload) {
+	co_await out_.transfer(protocols::usb::BulkTransfer{protocols::usb::kXferToDevice, payload});
+	co_return;
+}
+
+namespace nic::usb_ecm {
+
+std::shared_ptr<nic::Link> makeShared(protocols::usb::Device hw_device, MacAddress mac, protocols::usb::Endpoint in, protocols::usb::Endpoint out) {
+	return std::make_shared<UsbEcmNic>(std::move(hw_device), mac, std::move(in), std::move(out));
+}
+
+} // namespace nic::usb_ecm

--- a/drivers/usb/90-managarm-usb.rules
+++ b/drivers/usb/90-managarm-usb.rules
@@ -3,4 +3,7 @@ SUBSYSTEM!="usb", GOTO="managarm_usb_end"
 
 ATTR{idVendor}=="10c4", ATTR{idProduct}=="ea60", RUN+="/usr/bin/runsvr --fork bind /usr/lib/managarm/server/usb-serial.bin", GOTO="managarm_usb_end"
 
+# match CDC devices
+ATTR{bDeviceClass}=="02", RUN+="/usr/bin/runsvr --fork bind /usr/lib/managarm/server/netserver.bin", GOTO="managarm_usb_end"
+
 LABEL="managarm_usb_end"

--- a/drivers/usb/hcds/ehci/src/ehci.hpp
+++ b/drivers/usb/hcds/ehci/src/ehci.hpp
@@ -114,7 +114,7 @@ struct Controller : std::enable_shared_from_this<Controller> {
 
 public:
 	async::result<frg::expected<proto::UsbError, std::string>> deviceDescriptor(int address);
-	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor(int address);
+	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor(int address, uint8_t configuration);
 
 	async::result<frg::expected<proto::UsbError>>
 	useConfiguration(int address, int configuration);
@@ -203,7 +203,7 @@ struct DeviceState final : proto::DeviceData {
 	arch::dma_pool *bufferPool() override;
 
 	async::result<frg::expected<proto::UsbError, std::string>> deviceDescriptor() override;
-	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor() override;
+	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor(uint8_t configuration) override;
 	async::result<frg::expected<proto::UsbError, proto::Configuration>> useConfiguration(int number) override;
 	async::result<frg::expected<proto::UsbError>> transfer(proto::ControlTransfer info) override;
 

--- a/drivers/usb/hcds/ehci/src/main.cpp
+++ b/drivers/usb/hcds/ehci/src/main.cpp
@@ -589,7 +589,7 @@ Controller::useConfiguration(int address, int configuration) {
 async::result<frg::expected<proto::UsbError>>
 Controller::useInterface(int address, int interface, int alternative) {
 	(void) interface;
-	(void) alternative;
+	assert(!alternative);
 
 	arch::dma_object<proto::SetupPacket> get{&schedulePool};
 	get->type = proto::setup_type::targetDevice | proto::setup_type::byStandard

--- a/drivers/usb/hcds/ehci/src/main.cpp
+++ b/drivers/usb/hcds/ehci/src/main.cpp
@@ -109,8 +109,8 @@ async::result<frg::expected<proto::UsbError, std::string>> DeviceState::deviceDe
 	return _controller->deviceDescriptor(_device);
 }
 
-async::result<frg::expected<proto::UsbError, std::string>> DeviceState::configurationDescriptor() {
-	return _controller->configurationDescriptor(_device);
+async::result<frg::expected<proto::UsbError, std::string>> DeviceState::configurationDescriptor(uint8_t configuration) {
+	return _controller->configurationDescriptor(_device, configuration);
 }
 
 async::result<frg::expected<proto::UsbError, proto::Configuration>> DeviceState::useConfiguration(int number) {
@@ -538,13 +538,13 @@ Controller::deviceDescriptor(int address) {
 }
 
 async::result<frg::expected<proto::UsbError, std::string>>
-Controller::configurationDescriptor(int address) {
+Controller::configurationDescriptor(int address, uint8_t configuration) {
 	// Read the descriptor header that contains the hierachy size.
 	arch::dma_object<proto::SetupPacket> get_header{&schedulePool};
 	get_header->type = proto::setup_type::targetDevice | proto::setup_type::byStandard
 			| proto::setup_type::toHost;
 	get_header->request = proto::request_type::getDescriptor;
-	get_header->value = proto::descriptor_type::configuration << 8;
+	get_header->value = proto::descriptor_type::configuration << 8 | configuration;
 	get_header->index = 0;
 	get_header->length = sizeof(proto::ConfigDescriptor);
 
@@ -558,7 +558,7 @@ Controller::configurationDescriptor(int address) {
 	get_descriptor->type = proto::setup_type::targetDevice | proto::setup_type::byStandard
 			| proto::setup_type::toHost;
 	get_descriptor->request = proto::request_type::getDescriptor;
-	get_descriptor->value = proto::descriptor_type::configuration << 8;
+	get_descriptor->value = proto::descriptor_type::configuration << 8 | configuration;
 	get_descriptor->index = 0;
 	get_descriptor->length = header->totalLength;
 
@@ -591,7 +591,19 @@ Controller::useInterface(int address, int interface, int alternative) {
 	(void) interface;
 	(void) alternative;
 
-	auto descriptor = FRG_CO_TRY(co_await configurationDescriptor(address));
+	arch::dma_object<proto::SetupPacket> get{&schedulePool};
+	get->type = proto::setup_type::targetDevice | proto::setup_type::byStandard
+			| proto::setup_type::toHost;
+	get->request = proto::request_type::getConfig;
+	get->value = 0;
+	get->index = 0;
+	get->length = 1;
+
+	arch::dma_object<uint8_t> get_conf_desc{&schedulePool};
+	FRG_CO_TRY(co_await transfer(address, 0, proto::ControlTransfer{proto::kXferToHost,
+			get, get_conf_desc.view_buffer()}));
+
+	auto descriptor = FRG_CO_TRY(co_await configurationDescriptor(address, *get_conf_desc.data()));
 	proto::walkConfiguration(descriptor, [&] (int type, size_t length, void *p, const auto &info) {
 		(void)length;
 

--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -76,8 +76,8 @@ async::result<frg::expected<proto::UsbError, std::string>> DeviceState::deviceDe
 	return _controller->deviceDescriptor(_device);
 }
 
-async::result<frg::expected<proto::UsbError, std::string>> DeviceState::configurationDescriptor() {
-	return _controller->configurationDescriptor(_device);
+async::result<frg::expected<proto::UsbError, std::string>> DeviceState::configurationDescriptor(uint8_t configuration) {
+	return _controller->configurationDescriptor(_device, configuration);
 }
 
 async::result<frg::expected<proto::UsbError, proto::Configuration>> DeviceState::useConfiguration(int number) {
@@ -559,13 +559,13 @@ Controller::deviceDescriptor(int address) {
 }
 
 async::result<frg::expected<proto::UsbError, std::string>>
-Controller::configurationDescriptor(int address) {
+Controller::configurationDescriptor(int address, uint8_t configuration) {
 	// Read the descriptor header that contains the hierachy size.
 	arch::dma_object<proto::SetupPacket> get_header{&schedulePool};
 	get_header->type = proto::setup_type::targetDevice | proto::setup_type::byStandard
 			| proto::setup_type::toHost;
 	get_header->request = proto::request_type::getDescriptor;
-	get_header->value = proto::descriptor_type::configuration << 8;
+	get_header->value = proto::descriptor_type::configuration << 8 | configuration;
 	get_header->index = 0;
 	get_header->length = sizeof(proto::ConfigDescriptor);
 
@@ -579,7 +579,7 @@ Controller::configurationDescriptor(int address) {
 	get_descriptor->type = proto::setup_type::targetDevice | proto::setup_type::byStandard
 			| proto::setup_type::toHost;
 	get_descriptor->request = proto::request_type::getDescriptor;
-	get_descriptor->value = proto::descriptor_type::configuration << 8;
+	get_descriptor->value = proto::descriptor_type::configuration << 8 | configuration;
 	get_descriptor->index = 0;
 	get_descriptor->length = header->totalLength;
 
@@ -612,7 +612,19 @@ Controller::useInterface(int address, int interface, int alternative) {
 	(void) interface;
 	(void) alternative;
 
-	auto descriptor = FRG_CO_TRY(co_await configurationDescriptor(address));
+	arch::dma_object<proto::SetupPacket> get{&schedulePool};
+	get->type = proto::setup_type::targetDevice | proto::setup_type::byStandard
+			| proto::setup_type::toHost;
+	get->request = proto::request_type::getConfig;
+	get->value = 0;
+	get->index = 0;
+	get->length = 1;
+
+	arch::dma_object<uint8_t> get_conf_desc{&schedulePool};
+	FRG_CO_TRY(co_await transfer(address, 0, proto::ControlTransfer{proto::kXferToHost,
+			get, get_conf_desc.view_buffer()}));
+
+	auto descriptor = FRG_CO_TRY(co_await configurationDescriptor(address, *get_conf_desc.data()));
 	bool fail = false;
 	proto::walkConfiguration(descriptor, [&] (int type, size_t length, void *p, const auto &info) {
 		(void)length;

--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -610,7 +610,7 @@ Controller::useConfiguration(int address, int configuration) {
 async::result<frg::expected<proto::UsbError>>
 Controller::useInterface(int address, int interface, int alternative) {
 	(void) interface;
-	(void) alternative;
+	assert(!alternative);
 
 	arch::dma_object<proto::SetupPacket> get{&schedulePool};
 	get->type = proto::setup_type::targetDevice | proto::setup_type::byStandard

--- a/drivers/usb/hcds/uhci/src/schedule.hpp
+++ b/drivers/usb/hcds/uhci/src/schedule.hpp
@@ -126,7 +126,7 @@ private:
 
 public:
 	async::result<frg::expected<proto::UsbError, std::string>> deviceDescriptor(int address);
-	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor(int address);
+	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor(int address, uint8_t configuration);
 
 	async::result<frg::expected<proto::UsbError>>
 	useConfiguration(int address, int configuration);
@@ -203,7 +203,7 @@ struct DeviceState final : proto::DeviceData {
 	arch::dma_pool *bufferPool() override;
 
 	async::result<frg::expected<proto::UsbError, std::string>> deviceDescriptor() override;
-	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor() override;
+	async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor(uint8_t configuration) override;
 	async::result<frg::expected<proto::UsbError, proto::Configuration>> useConfiguration(int number) override;
 	async::result<frg::expected<proto::UsbError>> transfer(proto::ControlTransfer info) override;
 

--- a/drivers/usb/hcds/xhci/src/main.cpp
+++ b/drivers/usb/hcds/xhci/src/main.cpp
@@ -747,12 +747,12 @@ Controller::Device::deviceDescriptor() {
 }
 
 async::result<frg::expected<proto::UsbError, std::string>>
-Controller::Device::configurationDescriptor() {
+Controller::Device::configurationDescriptor(uint8_t configuration) {
 	arch::dma_object<proto::ConfigDescriptor> header{&_controller->_memoryPool};
-	FRG_CO_TRY(co_await readDescriptor(header.view_buffer(), 0x0200));
+	FRG_CO_TRY(co_await readDescriptor(header.view_buffer(), 0x0200 | configuration));
 
 	arch::dma_buffer descriptor{&_controller->_memoryPool, header->totalLength};
-	FRG_CO_TRY(co_await readDescriptor(descriptor, 0x0200));
+	FRG_CO_TRY(co_await readDescriptor(descriptor, 0x0200 | configuration));
 	co_return std::string{(char *)descriptor.data(), descriptor.size()};
 }
 

--- a/drivers/usb/hcds/xhci/src/xhci.hpp
+++ b/drivers/usb/hcds/xhci/src/xhci.hpp
@@ -170,7 +170,7 @@ private:
 		arch::dma_pool *setupPool() override;
 		arch::dma_pool *bufferPool() override;
 		async::result<frg::expected<proto::UsbError, std::string>> deviceDescriptor() override;
-		async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor() override;
+		async::result<frg::expected<proto::UsbError, std::string>> configurationDescriptor(uint8_t configuration = 0) override;
 		async::result<frg::expected<proto::UsbError, proto::Configuration>> useConfiguration(int number) override;
 		async::result<frg::expected<proto::UsbError>> transfer(proto::ControlTransfer info) override;
 

--- a/meson.build
+++ b/meson.build
@@ -163,6 +163,8 @@ if build_drivers
 		'libblockfs', 'libevbackend',
 		# storage
 		'block/ata', 'block/virtio-blk', 'block/ahci', 'block/nvme',
+		# net
+		'nic/usb_ecm',
 		# gfx
 		'gfx/bochs', 'gfx/intel', 'gfx/virtio', 'gfx/plainfb', 'gfx/vmware',
 		# io

--- a/posix/subsystem/src/subsystem/usb/attributes.cpp
+++ b/posix/subsystem/src/subsystem/usb/attributes.cpp
@@ -6,67 +6,53 @@
 namespace usb_subsystem {
 
 async::result<frg::expected<Error, std::string>> VendorAttribute::show(sysfs::Object *object) {
-	char buffer[6]; // The format is 1234\n\0.
 	auto device = static_cast<UsbBase *>(object);
-	snprintf(buffer, 6, "%.4x\n", device->desc()->idVendor);
-	co_return std::string{buffer};
+	co_return std::format("{:0>4x}\n", device->desc()->idVendor);
 }
 
 async::result<frg::expected<Error, std::string>> DeviceAttribute::show(sysfs::Object *object) {
-	char buffer[6]; // The format is 1234\n\0.
 	auto device = static_cast<UsbBase *>(object);
-	snprintf(buffer, 6, "%.4x\n", device->desc()->idProduct);
-	co_return std::string{buffer};
+	co_return std::format("{:0>4x}\n", device->desc()->idProduct);
 }
 
 async::result<frg::expected<Error, std::string>> DeviceClassAttribute::show(sysfs::Object *object) {
-	char buffer[4]; // The format is 34\n\0.
 	auto device = static_cast<UsbBase *>(object);
-	snprintf(buffer, 4, "%.2x\n", device->desc()->deviceClass);
-	co_return std::string{buffer};
+	co_return std::format("{:0>2x}\n", device->desc()->deviceClass);
 }
 
 async::result<frg::expected<Error, std::string>> DeviceSubClassAttribute::show(sysfs::Object *object) {
-	char buffer[4]; // The format is 34\n\0.
 	auto device = static_cast<UsbBase *>(object);
-	snprintf(buffer, 4, "%.2x\n", device->desc()->deviceSubclass);
-	co_return std::string{buffer};
+	co_return std::format("{:0>2x}\n", device->desc()->deviceSubclass);
 }
 
 async::result<frg::expected<Error, std::string>> DeviceProtocolAttribute::show(sysfs::Object *object) {
-	char buffer[4]; // The format is 34\n\0.
 	auto device = static_cast<UsbBase *>(object);
-	snprintf(buffer, 4, "%.2x\n", device->desc()->deviceProtocol);
-	co_return std::string{buffer};
+	co_return std::format("{:0>2x}\n", device->desc()->deviceProtocol);
 }
 
 async::result<frg::expected<Error, std::string>> BcdDeviceAttribute::show(sysfs::Object *object) {
-	char buffer[6]; // The format is 34\n\0.
 	auto device = static_cast<UsbBase *>(object);
-	snprintf(buffer, 6, "%.4x\n", device->desc()->bcdDevice);
-	co_return std::string{buffer};
+	co_return std::format("{:0>4x}\n", device->desc()->bcdDevice);
 }
 
 async::result<frg::expected<Error, std::string>> VersionAttribute::show(sysfs::Object *object) {
-	char buffer[7]; // The format is " 2.00\n\0".
 	auto device = static_cast<UsbBase *>(object);
-	snprintf(buffer, 7, "%2x.%02x\n", device->desc()->bcdUsb >> 8, device->desc()->bcdUsb & 0xFF);
-	co_return std::string{buffer};
+	co_return std::format("{:>2x}.{:0>2x}\n", device->desc()->bcdUsb >> 8, device->desc()->bcdUsb & 0xFF);
 }
 
 async::result<frg::expected<Error, std::string>> SpeedAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbBase *>(object);
-	co_return device->speed + "\n";
+	co_return std::format("{}\n", device->speed);
 }
 
 async::result<frg::expected<Error, std::string>> DeviceMaxPowerAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbDevice *>(object);
-	co_return std::to_string(device->maxPower) + "mA\n";
+	co_return std::format("{}mA\n", device->maxPower);
 }
 
 async::result<frg::expected<Error, std::string>> ControllerMaxPowerAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbController *>(object);
-	co_return std::to_string(device->maxPower) + "mA\n";
+	co_return std::format("{}mA\n", device->maxPower);
 }
 
 async::result<frg::expected<Error, std::string>> MaxChildAttribute::show(sysfs::Object *object) {
@@ -76,19 +62,17 @@ async::result<frg::expected<Error, std::string>> MaxChildAttribute::show(sysfs::
 
 async::result<frg::expected<Error, std::string>> NumInterfacesAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbDevice *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%2x\n", device->numInterfaces);
-	co_return std::string{buf};
+	co_return std::format("{:>2}\n", device->numInterfaces);
 }
 
 async::result<frg::expected<Error, std::string>> BusNumAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbBase *>(object);
-	co_return std::to_string(device->busNum) + "\n";
+	co_return std::format("{}\n", device->busNum);
 }
 
 async::result<frg::expected<Error, std::string>> DevNumAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbBase *>(object);
-	co_return std::to_string(device->portNum) + "\n";
+	co_return std::format("{}\n", device->portNum);
 }
 
 async::result<frg::expected<Error, std::string>> DescriptorsAttribute::show(sysfs::Object *object) {
@@ -109,14 +93,12 @@ async::result<frg::expected<Error, std::string>> TxLanesAttribute::show(sysfs::O
 async::result<frg::expected<Error, std::string>> ConfigValueAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbDevice *>(object);
 	auto config_val = (co_await device->device().currentConfigurationValue()).value();
-
-	co_return std::to_string(config_val) + "\n";
+	co_return std::format("{}\n", config_val);
 }
 
 async::result<frg::expected<Error, std::string>> MaxPacketSize0Attribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbDevice *>(object);
-
-	co_return std::to_string(device->desc()->maxPacketSize) + "\n";
+	co_return std::format("{}\n", device->desc()->maxPacketSize);
 }
 
 async::result<frg::expected<Error, std::string>> ConfigurationAttribute::show(sysfs::Object *object) {
@@ -126,65 +108,47 @@ async::result<frg::expected<Error, std::string>> ConfigurationAttribute::show(sy
 
 async::result<frg::expected<Error, std::string>> BmAttributesAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbDevice *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->bmAttributes);
-	co_return std::string{buf};
+	co_return std::format("{:2x}\n", device->bmAttributes);
 }
 
 async::result<frg::expected<Error, std::string>> NumConfigurationsAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbDevice *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->desc()->numConfigs);
-	co_return std::string{buf};
+	co_return std::format("{}\n", device->desc()->numConfigs);
 }
 
 async::result<frg::expected<Error, std::string>> InterfaceClassAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbInterface *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->interfaceClass);
-	co_return std::string{buf};
+	co_return std::format("{:0>2x}\n", device->interfaceClass);
 }
 
 async::result<frg::expected<Error, std::string>> InterfaceSubClassAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbInterface *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->interfaceSubClass);
-	co_return std::string{buf};
+	co_return std::format("{:0>2x}\n", device->interfaceSubClass);
 }
 
 async::result<frg::expected<Error, std::string>> InterfaceProtocolAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbInterface *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->interfaceProtocol);
-	co_return std::string{buf};
+	co_return std::format("{:0>2x}\n", device->interfaceProtocol);
 }
 
 async::result<frg::expected<Error, std::string>> AlternateSettingAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbInterface *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%2x\n", device->alternateSetting);
-	co_return std::string{buf};
+	co_return std::format("{:>2x}\n", device->alternateSetting);
 }
 
 async::result<frg::expected<Error, std::string>> InterfaceNumberAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbInterface *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->interfaceNumber);
-	co_return std::string{buf};
+	co_return std::format("{:0>2x}\n", device->interfaceNumber);
 }
 
 async::result<frg::expected<Error, std::string>> EndpointNumAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbInterface *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->endpointCount);
-	co_return std::string{buf};
+	co_return std::format("{:0>2x}\n", device->endpointCount);
 }
 
 async::result<frg::expected<Error, std::string>> EndpointAddressAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbEndpoint *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->endpointAddress);
-	co_return std::string{buf};
+	co_return std::format("{:0>2x}\n", device->endpointAddress);
 }
 
 async::result<frg::expected<Error, std::string>> PrettyIntervalAttribute::show(sysfs::Object *object) {
@@ -194,30 +158,22 @@ async::result<frg::expected<Error, std::string>> PrettyIntervalAttribute::show(s
 
 async::result<frg::expected<Error, std::string>> IntervalAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbEndpoint *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->interval);
-	co_return std::string{buf};
+	co_return std::format("{:0>2x}\n", device->interval);
 }
 
 async::result<frg::expected<Error, std::string>> LengthAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbEndpoint *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->length);
-	co_return std::string{buf};
+	co_return std::format("{:0>2x}\n", device->length);
 }
 
 async::result<frg::expected<Error, std::string>> EpAttributesAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbEndpoint *>(object);
-	char buf[4];
-	snprintf(buf, 4, "%02x\n", device->attributes);
-	co_return std::string{buf};
+	co_return std::format("{:0>2x}\n", device->attributes);
 }
 
 async::result<frg::expected<Error, std::string>> EpMaxPacketSizeAttribute::show(sysfs::Object *object) {
 	auto device = static_cast<UsbEndpoint *>(object);
-	char buf[6];
-	snprintf(buf, 6, "%04x\n", device->maxPacketSize);
-	co_return std::string{buf};
+	co_return std::format("{:0>4x}\n", device->maxPacketSize);
 }
 
 async::result<frg::expected<Error, std::string>> EpTypeAttribute::show(sysfs::Object *object) {

--- a/posix/subsystem/src/subsystem/usb/devices.hpp
+++ b/posix/subsystem/src/subsystem/usb/devices.hpp
@@ -132,8 +132,8 @@ struct UsbDevice final : UsbBase {
 	std::vector<std::shared_ptr<UsbInterface>> interfaces;
 
 	size_t maxPower = 0;
-	uint8_t bmAttributes;
-	uint8_t numInterfaces;
+	uint8_t bmAttributes = 0;
+	uint8_t numInterfaces = 0;
 
 private:
 	protocols::usb::Device _device;

--- a/posix/subsystem/src/subsystem/usb/usb.cpp
+++ b/posix/subsystem/src/subsystem/usb/usb.cpp
@@ -202,10 +202,10 @@ async::result<void> bindDevice(mbus_ng::Entity entity, mbus_ng::Properties prope
 		if(type == protocols::usb::descriptor_type::configuration) {
 			auto desc = reinterpret_cast<protocols::usb::ConfigDescriptor *>(descriptor);
 			device->maxPower = desc->maxPower * 2;
+			device->numInterfaces = desc->numInterfaces;
 
 			if(info.configNumber == config_val) {
 				device->bmAttributes = desc->bmAttributes;
-				device->numInterfaces = reinterpret_cast<protocols::usb::ConfigDescriptor *>(descriptor)->numInterfaces;
 			}
 		} else if(type == protocols::usb::descriptor_type::interface) {
 			auto desc = reinterpret_cast<protocols::usb::InterfaceDescriptor *>(descriptor);

--- a/protocols/usb/include/protocols/usb/api.hpp
+++ b/protocols/usb/include/protocols/usb/api.hpp
@@ -153,7 +153,7 @@ public:
 	virtual arch::dma_pool *bufferPool() = 0;
 
 	virtual async::result<frg::expected<UsbError, std::string>> deviceDescriptor() = 0;
-	virtual async::result<frg::expected<UsbError, std::string>> configurationDescriptor() = 0;
+	virtual async::result<frg::expected<UsbError, std::string>> configurationDescriptor(uint8_t configuration = 0) = 0;
 	virtual async::result<frg::expected<UsbError, Configuration>> useConfiguration(int number) = 0;
 	virtual async::result<frg::expected<UsbError>> transfer(ControlTransfer info) = 0;
 };
@@ -165,7 +165,7 @@ struct Device {
 	arch::dma_pool *bufferPool() const;
 
 	async::result<frg::expected<UsbError, std::string>> deviceDescriptor() const;
-	async::result<frg::expected<UsbError, std::string>> configurationDescriptor() const;
+	async::result<frg::expected<UsbError, std::string>> configurationDescriptor(uint8_t configuration = 0) const;
 	async::result<frg::expected<UsbError, uint8_t>> currentConfigurationValue() const;
 	async::result<frg::expected<UsbError, Configuration>> useConfiguration(int number) const;
 	async::result<frg::expected<UsbError, std::string>> getString(size_t number) const;

--- a/protocols/usb/include/protocols/usb/api.hpp
+++ b/protocols/usb/include/protocols/usb/api.hpp
@@ -168,6 +168,7 @@ struct Device {
 	async::result<frg::expected<UsbError, std::string>> configurationDescriptor() const;
 	async::result<frg::expected<UsbError, uint8_t>> currentConfigurationValue() const;
 	async::result<frg::expected<UsbError, Configuration>> useConfiguration(int number) const;
+	async::result<frg::expected<UsbError, std::string>> getString(size_t number) const;
 	async::result<frg::expected<UsbError>> transfer(ControlTransfer info) const;
 
 	std::shared_ptr<DeviceData> state() const {

--- a/protocols/usb/include/protocols/usb/usb.hpp
+++ b/protocols/usb/include/protocols/usb/usb.hpp
@@ -66,7 +66,9 @@ namespace descriptor_type {
 
 		// TODO: Put non-standard descriptors somewhere else.
 		hid = 0x21,
-		report = 0x22
+		report = 0x22,
+		cs_interface = 0x24,
+		cs_endpoint = 0x25,
 	};
 }
 
@@ -113,6 +115,44 @@ struct InterfaceDescriptor : public DescriptorBase {
 	uint8_t interfaceSubClass;
 	uint8_t interfaceProtocol;
 	uint8_t iInterface;
+};
+
+struct [[gnu::packed]] CdcDescriptor : public DescriptorBase {
+	enum class CdcSubType : uint8_t {
+		Header = 0x00,
+		CallManagement = 0x01,
+		AbstractControl = 0x02,
+		Union = 0x06,
+		EthernetNetworking = 0x0F,
+	};
+
+	CdcSubType subtype;
+};
+
+struct [[gnu::packed]] CdcHeader : public CdcDescriptor {
+	uint16_t bcdCDC;
+};
+
+struct [[gnu::packed]] CdcCallManagement : public CdcDescriptor {
+	uint8_t bmCapabilities;
+	uint8_t bDataInterface;
+};
+
+struct [[gnu::packed]] CdcAbstractControl : public CdcDescriptor {
+	uint8_t bmCapabilities;
+};
+
+struct [[gnu::packed]] CdcUnion : public CdcDescriptor {
+	uint8_t bControlInterface;
+	uint8_t bSubordinateInterface[1];
+};
+
+struct [[gnu::packed]] CdcEthernetNetworking : public CdcDescriptor {
+	uint8_t iMACAddress;
+	uint32_t bmEthernetStatistics;
+	uint16_t wMaxSegmentSize;
+	uint16_t wNumberMCFilters;
+	uint8_t bNumberPowerFilters;
 };
 
 struct [[ gnu::packed ]] EndpointDescriptor : public DescriptorBase {

--- a/protocols/usb/include/protocols/usb/usb.hpp
+++ b/protocols/usb/include/protocols/usb/usb.hpp
@@ -74,6 +74,10 @@ struct DescriptorBase {
 	uint8_t descriptorType;
 };
 
+struct [[gnu::packed]] StringDescriptor : public DescriptorBase {
+	char16_t data[0];
+};
+
 struct DeviceDescriptor : public DescriptorBase {
 	uint16_t bcdUsb;
 	uint8_t deviceClass;

--- a/protocols/usb/include/protocols/usb/usb.hpp
+++ b/protocols/usb/include/protocols/usb/usb.hpp
@@ -49,6 +49,7 @@ namespace request_type {
 		setDescriptor = 0x07,
 		getConfig = 0x08,
 		setConfig = 0x09,
+		setInterface = 0x0B,
 
 		// TODO: Move non-standard features to some other location.
 		getReport = 0x01

--- a/protocols/usb/src/api.cpp
+++ b/protocols/usb/src/api.cpp
@@ -25,8 +25,8 @@ async::result<frg::expected<UsbError, std::string>> Device::deviceDescriptor() c
 	return _state->deviceDescriptor();
 }
 
-async::result<frg::expected<UsbError, std::string>> Device::configurationDescriptor() const {
-	return _state->configurationDescriptor();
+async::result<frg::expected<UsbError, std::string>> Device::configurationDescriptor(uint8_t configuration) const {
+	return _state->configurationDescriptor(configuration);
 }
 
 async::result<frg::expected<UsbError, uint8_t>> Device::currentConfigurationValue() const {

--- a/protocols/usb/src/api.cpp
+++ b/protocols/usb/src/api.cpp
@@ -1,3 +1,6 @@
+#include <string>
+#include <locale>
+#include <codecvt>
 
 #include "protocols/usb/api.hpp"
 
@@ -44,6 +47,27 @@ async::result<frg::expected<UsbError, uint8_t>> Device::currentConfigurationValu
 
 async::result<frg::expected<UsbError, Configuration>> Device::useConfiguration(int number) const {
 	return _state->useConfiguration(number);
+}
+
+async::result<frg::expected<UsbError, std::string>> Device::getString(size_t number) const {
+	arch::dma_object<SetupPacket> desc{setupPool()};
+	desc->type = setup_type::targetDevice | setup_type::byStandard | setup_type::toHost;
+	desc->request = request_type::getDescriptor;
+	desc->value = (descriptor_type::string << 8) | number;
+	desc->index = 0x0409; // en-us
+	desc->length = sizeof(StringDescriptor);
+
+	arch::dma_object<StringDescriptor> header{bufferPool()};
+
+	FRG_CO_TRY(co_await transfer(ControlTransfer(kXferToHost, desc, header.view_buffer())));
+
+	desc->length = header->length;
+	arch::dma_buffer buffer{bufferPool(), header->length};
+	FRG_CO_TRY(co_await transfer(ControlTransfer(kXferToHost, desc, buffer)));
+
+	std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> convert;
+	auto res = reinterpret_cast<StringDescriptor *>(buffer.data());
+	co_return convert.to_bytes(std::u16string{res->data, (res->length - sizeof(StringDescriptor) / 2)});
 }
 
 async::result<frg::expected<UsbError>> Device::transfer(ControlTransfer info) const {

--- a/protocols/usb/src/client.cpp
+++ b/protocols/usb/src/client.cpp
@@ -23,7 +23,7 @@ struct DeviceState final : DeviceData {
 	arch::dma_pool *bufferPool() override;
 
 	async::result<frg::expected<UsbError, std::string>> deviceDescriptor() override;
-	async::result<frg::expected<UsbError, std::string>> configurationDescriptor() override;
+	async::result<frg::expected<UsbError, std::string>> configurationDescriptor(uint8_t configuration) override;
 	async::result<frg::expected<UsbError, Configuration>> useConfiguration(int number) override;
 	async::result<frg::expected<UsbError>> transfer(ControlTransfer info) override;
 
@@ -119,8 +119,9 @@ async::result<frg::expected<UsbError, std::string>> DeviceState::deviceDescripto
 	co_return std::move(data);
 }
 
-async::result<frg::expected<UsbError, std::string>> DeviceState::configurationDescriptor() {
+async::result<frg::expected<UsbError, std::string>> DeviceState::configurationDescriptor(uint8_t configuration) {
 	managarm::usb::GetConfigurationDescriptorRequest req;
+	req.set_configuration(configuration);
 
 	auto [offer, sendReq, recvResp] = co_await helix_ng::exchangeMsgs(
 		_lane,

--- a/protocols/usb/src/server.cpp
+++ b/protocols/usb/src/server.cpp
@@ -316,7 +316,7 @@ async::detached serve(Device device, helix::UniqueLane lane) {
 				co_return;
 			}
 
-			auto outcome = co_await device.configurationDescriptor();
+			auto outcome = co_await device.configurationDescriptor(req->configuration());
 
 			if (!outcome) {
 				co_await respondWithError(conversation, outcome.error());

--- a/protocols/usb/usb.bragi
+++ b/protocols/usb/usb.bragi
@@ -34,6 +34,7 @@ group {
 
 message GetConfigurationDescriptorRequest 1 {
 head(128):
+	uint8 configuration;
 }
 
 message UseConfigurationRequest 2 {

--- a/servers/netserver/include/netserver/nic.hpp
+++ b/servers/netserver/include/netserver/nic.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <arch/dma_pool.hpp>
 #include <async/result.hpp>
 #include <cstdint>
@@ -9,13 +10,16 @@
 
 namespace nic {
 struct MacAddress {
+	MacAddress() = default;
+	explicit MacAddress(std::array<uint8_t, 6> data) : mac_{data} {}
+
 	uint8_t &operator[](size_t idx);
 	const uint8_t &operator[](size_t idx) const;
 	inline uint8_t *data() {
-		return mac_;
+		return mac_.data();
 	}
 	inline const uint8_t *data() const {
-		return mac_;
+		return mac_.data();
 	}
 
 	friend bool operator==(const MacAddress &l, const MacAddress &r);
@@ -26,14 +30,14 @@ struct MacAddress {
 	}
 
 	inline friend uint8_t *begin(MacAddress &m) {
-		return &m.mac_[0];
+		return m.mac_.begin();
 	}
 
 	inline friend uint8_t *end(MacAddress &m) {
-		return &m.mac_[6];
+		return m.mac_.end();
 	}
 private:
-	uint8_t mac_[6] = { 0 };
+	std::array<uint8_t, 6> mac_ = {};
 };
 
 enum EtherType : uint16_t {

--- a/servers/netserver/meson.build
+++ b/servers/netserver/meson.build
@@ -16,7 +16,7 @@ src = [
 inc = [ 'include', 'src' ]
 
 executable('netserver', src,
-	dependencies : [ fs_proto_dep, mbus_proto_dep, svrctl_proto_dep, nic_virtio_dep, core_dep ],
+	dependencies : [ fs_proto_dep, mbus_proto_dep, svrctl_proto_dep, nic_virtio_dep, nic_usb_ecm_dep, core_dep ],
 	include_directories : inc,
 	install : true
 )

--- a/servers/netserver/src/main.cpp
+++ b/servers/netserver/src/main.cpp
@@ -25,6 +25,8 @@
 
 #include <netserver/nic.hpp>
 #include <nic/virtio/virtio.hpp>
+#include <nic/usb_ecm/usb_ecm.hpp>
+#include <protocols/usb/client.hpp>
 
 // Maps mbus IDs to device objects
 std::unordered_map<int64_t, std::shared_ptr<nic::Link>> baseDeviceMap;
@@ -95,6 +97,97 @@ async::result<protocols::svrctl::Error> bindDevice(int64_t base_id) {
 		}
 
 		co_await doBind(std::move(baseEntity), discover_mode);
+	} else if(type->value == "usb") {
+		auto dev = protocols::usb::connect((co_await baseEntity.getRemoteLane()).unwrap());
+		std::optional<uint8_t> iMACAddress;
+		std::optional<uint8_t> data_if;
+
+		std::optional<int> in_endp_number;
+		std::optional<int> out_endp_number;
+
+		auto raw_descs = (co_await dev.configurationDescriptor(1)).value();
+		protocols::usb::walkConfiguration(raw_descs, [&] (int type, size_t, void *descriptor, const auto &info) {
+			if(type == protocols::usb::descriptor_type::cs_interface) {
+				auto desc = reinterpret_cast<protocols::usb::CdcDescriptor *>(descriptor);
+
+				switch(desc->subtype) {
+					using CdcSubType = protocols::usb::CdcDescriptor::CdcSubType;
+
+					case CdcSubType::Header: {
+						auto hdr = reinterpret_cast<protocols::usb::CdcHeader *>(descriptor);
+						printf("netserver: CDC version 0x%x\n", hdr->bcdCDC);
+						break;
+					}
+					case CdcSubType::AbstractControl: {
+						auto hdr = reinterpret_cast<protocols::usb::CdcAbstractControl *>(descriptor);
+						printf("netserver: ACM capabilities 0x%02x\n", hdr->bmCapabilities);
+						break;
+					}
+					case CdcSubType::Union: {
+						auto hdr = reinterpret_cast<protocols::usb::CdcUnion *>(descriptor);
+						assert(hdr->length >= 5);
+						printf("netserver: controller interface %u\n", hdr->bControlInterface);
+						for(size_t i = 0; i < hdr->length - offsetof(protocols::usb::CdcUnion, bSubordinateInterface); i++) {
+							printf("netserver: sub interface #%zu: IF %u\n", i, hdr->bSubordinateInterface[i]);
+						}
+
+						data_if = hdr->bSubordinateInterface[0];
+						break;
+					}
+					case CdcSubType::EthernetNetworking: {
+						auto hdr = reinterpret_cast<protocols::usb::CdcEthernetNetworking *>(descriptor);
+						printf("netserver: iMACAddress %u\n", hdr->iMACAddress);
+						iMACAddress = hdr->iMACAddress;
+						break;
+					}
+					default: {
+						printf("netserver: unhandled Function Descriptor SubType %hhu\n", desc->subtype);
+					}
+				}
+			} else if(type == protocols::usb::descriptor_type::endpoint) {
+				if(info.interfaceNumber && *info.interfaceNumber == data_if && info.endpointType == protocols::usb::EndpointType::bulk) {
+					if(info.endpointIn.value()) {
+						in_endp_number = info.endpointNumber;
+					} else {
+						out_endp_number = info.endpointNumber;
+					}
+				}
+			}
+		});
+
+		if(!iMACAddress || !data_if)
+			co_return protocols::svrctl::Error::deviceNotSupported;
+
+		auto str = (co_await dev.getString(*iMACAddress)).value();
+
+		auto decodeHexString = [](char c) -> uint8_t {
+			if(c >= 'A' && c <= 'F')
+				return c - 'A' + 0x0A;
+			if(c >= 'a' && c <= 'f')
+				return c - 'a' + 0x0A;
+			if(c >= '0' && c <= '9')
+				return c - '0';
+			__builtin_unreachable();
+		};
+
+		nic::MacAddress mac{{
+			static_cast<uint8_t>((decodeHexString(str[0]) << 4) | decodeHexString(str[1])),
+			static_cast<uint8_t>((decodeHexString(str[2]) << 4) | decodeHexString(str[3])),
+			static_cast<uint8_t>((decodeHexString(str[4]) << 4) | decodeHexString(str[5])),
+			static_cast<uint8_t>((decodeHexString(str[6]) << 4) | decodeHexString(str[7])),
+			static_cast<uint8_t>((decodeHexString(str[8]) << 4) | decodeHexString(str[9])),
+			static_cast<uint8_t>((decodeHexString(str[10]) << 4) | decodeHexString(str[11])),
+		}};
+
+		auto config = (co_await dev.useConfiguration(1)).unwrap();
+		auto intf = (co_await config.useInterface(*data_if, 1)).unwrap();
+		auto in = (co_await intf.getEndpoint(protocols::usb::PipeType::in, in_endp_number.value())).unwrap();
+		auto out = (co_await intf.getEndpoint(protocols::usb::PipeType::out, out_endp_number.value())).unwrap();
+
+		auto device = nic::usb_ecm::makeShared(std::move(dev), mac, std::move(in), std::move(out));
+
+		baseDeviceMap.insert({baseEntity.id(), device});
+		nic::runDevice(device);
 	}
 
 	co_return protocols::svrctl::Error::success;


### PR DESCRIPTION
This PR adds support for USB ethernet adapters that support ECM, and fixes some bugs along the way. In order to test this, qemu's `-device usb-net` can be used. A PR to wire this up in vm-util has already been made (managarm/bootstrap-managarm#343).