### PR TITLE
`dmesg` improvements

### DIFF
--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -6,9 +6,9 @@
 #include <hel-types.h>
 #include <hel-stubs.h>
 
-extern inline __attribute__ (( always_inline )) HelError helLog(const char *string,
+extern inline __attribute__ (( always_inline )) HelError helLog(const HelLogSeverity severity, const char *string,
 		size_t length) {
-	return helSyscall2(kHelCallLog, (HelWord)string, length);
+	return helSyscall3(kHelCallLog, severity, (HelWord)string, length);
 };
 
 extern inline __attribute__ (( always_inline )) void helPanic(const char *string,

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -528,15 +528,29 @@ struct HelVmexitReason {
 	size_t flags;
 };
 
+// see RFC 5424
+enum HelLogSeverity {
+	kHelLogSeverityEmergency,
+	kHelLogSeverityAlert,
+	kHelLogSeverityCritical,
+	kHelLogSeverityError,
+	kHelLogSeverityWarning,
+	kHelLogSeverityNotice,
+	kHelLogSeverityInfo,
+	kHelLogSeverityDebug,
+};
+
 //! @name Logging
 //! @{
 
 //! Writes a text message (e.g., a line of text) to the kernel's log.
+//! @param[in] severity
+//!    	The RFC 5424 priority of the log message.
 //! @param[in] string
 //!    	Text to be written.
 //! @param[in] length
 //! 	Size of the text in bytes.
-HEL_C_LINKAGE HelError helLog(const char *string, size_t length);
+HEL_C_LINKAGE HelError helLog(const HelLogSeverity severity, const char *string, size_t length);
 
 //! Kills the current thread and writes an error message to the kernel's log.
 //! @param[in] string
@@ -1147,13 +1161,13 @@ extern inline __attribute__ (( always_inline )) const char *_helErrorString(HelE
 
 extern inline __attribute__ (( always_inline )) void _helCheckFailed(HelError err_code,
 		const char *string, int fatal) {
-	helLog(string, strlen(string));
+	helLog(kHelLogSeverityError, string, strlen(string));
 
 	const char *err_string = _helErrorString(err_code);
 	if(err_string == 0)
 		err_string = "(Unexpected error code)";
-	helLog(err_string, strlen(err_string));
-	helLog("\n", 1);
+	helLog(kHelLogSeverityError, err_string, strlen(err_string));
+	helLog(kHelLogSeverityError, "\n", 1);
 
 	if(fatal)
 		helPanic(0, 0);

--- a/kernel/thor/arch/arm/thor-internal/arch/debug.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/debug.hpp
@@ -6,6 +6,8 @@ namespace thor {
 
 struct UartLogHandler : public LogHandler {
 	void printChar(char c) override;
+	void setPriority(Severity prio) override;
+	void resetPriority() override;
 };
 
 } // namespace thor

--- a/kernel/thor/arch/x86/cpu.cpp
+++ b/kernel/thor/arch/x86/cpu.cpp
@@ -410,57 +410,57 @@ static initgraph::Task enumerateCpuFeaturesTask{&globalInitEngine, "x86.enumerat
 	[] {
 		// Enable the XSAVE instruction set and child features
 		if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 26)) {
-			infoLogger() << "\e[37mthor: CPUs support XSAVE\e[39m" << frg::endlog;
+			debugLogger() << "thor: CPUs support XSAVE" << frg::endlog;
 			globalCpuFeatures.haveXsave = true;
 
 			auto xsaveCpuid = common::x86::cpuid(0xD);
 			globalCpuFeatures.xsaveRegionSize = xsaveCpuid[2];
 		}else{
-			infoLogger() << "\e[37mthor: CPUs do not support XSAVE!\e[39m" << frg::endlog;
+			debugLogger() << "thor: CPUs do not support XSAVE!" << frg::endlog;
 		}
 
 		if(globalCpuFeatures.haveXsave) {
 			if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 28)) {
-				infoLogger() << "\e[37mthor: CPUs support AVX\e[39m" << frg::endlog;
+				debugLogger() << "thor: CPUs support AVX" << frg::endlog;
 				globalCpuFeatures.haveAvx = true;
 			}else{
-				infoLogger() << "\e[37mthor: CPUs do not support AVX!\e[39m" << frg::endlog;
+				debugLogger() << "thor: CPUs do not support AVX!" << frg::endlog;
 			}
 
 			if(common::x86::cpuid(0x07)[1] & (uint32_t(1) << 16)) {
-				infoLogger() << "\e[37mthor: CPUs support AVX-512\e[39m" << frg::endlog;
+				debugLogger() << "thor: CPUs support AVX-512" << frg::endlog;
 				globalCpuFeatures.haveZmm = true;
 			}else{
-				infoLogger() << "\e[37mthor: CPUs do not support AVX-512!\e[39m" << frg::endlog;
+				debugLogger() << "thor: CPUs do not support AVX-512!" << frg::endlog;
 			}
 		}
 
 		if(common::x86::cpuid(0x80000007)[3] & (1 << 8)) {
-			infoLogger() << "\e[37mthor: CPUs support invariant TSC\e[39m"
+			debugLogger() << "thor: CPUs support invariant TSC"
 					<< frg::endlog;
 			globalCpuFeatures.haveInvariantTsc = true;
 		}else{
-			infoLogger() << "\e[37mthor: CPUs do not support invariant TSC!\e[39m" << frg::endlog;
+			debugLogger() << "thor: CPUs do not support invariant TSC!" << frg::endlog;
 		}
 
 		if(common::x86::cpuid(0x01)[2] & (1 << 24)) {
-			infoLogger() << "\e[37mthor: CPUs support TSC deadline mode\e[39m"
+			debugLogger() << "thor: CPUs support TSC deadline mode"
 					<< frg::endlog;
 			globalCpuFeatures.haveTscDeadline = true;
 		}else{
-			infoLogger() << "\e[37mthor: CPUs do not support TSC deadline mode!\e[39m"
+			debugLogger() << "thor: CPUs do not support TSC deadline mode!"
 					<< frg::endlog;
 		}
 
 		auto intelPmLeaf = common::x86::cpuid(0xA)[0];
 		if(intelPmLeaf & 0xFF) {
-			infoLogger() << "\e[37mthor: CPUs support Intel performance counters\e[39m"
+			debugLogger() << "thor: CPUs support Intel performance counters"
 					<< frg::endlog;
 			globalCpuFeatures.profileFlags |= CpuFeatures::profileIntelSupported;
 		}
 		auto amdPmLeaf = common::x86::cpuid(0x8000'0001)[2];
 		if(amdPmLeaf & (1 << 23)) {
-			infoLogger() << "\e[37mthor: CPUs support AMD performance counters\e[39m"
+			debugLogger() << "thor: CPUs support AMD performance counters"
 					<< frg::endlog;
 			globalCpuFeatures.profileFlags |= CpuFeatures::profileAmdSupported;
 		}
@@ -494,10 +494,10 @@ static initgraph::Task enumerateCpuFeaturesTask{&globalInitEngine, "x86.enumerat
 			auto vm_cr = common::x86::rdmsr(common::x86::kMsrIndexVmCr);
 			if(vm_cr & (1 << 4)) {
 				if(leaf[3] & (1 << 2)) {
-					infoLogger() << "\e[37mthor: SVM Locked with Key\e[39m" << frg::endlog;
+					debugLogger() << "thor: SVM Locked with Key" << frg::endlog;
 					return false;
 				} else {
-					infoLogger() << "\e[37mthor: SVM Disabled in BIOS\e[39m" << frg::endlog;
+					debugLogger() << "thor: SVM Disabled in BIOS" << frg::endlog;
 					return false;
 				}
 			}
@@ -508,19 +508,19 @@ static initgraph::Task enumerateCpuFeaturesTask{&globalInitEngine, "x86.enumerat
 		}();
 
 		if(vmxSupported) {
-			infoLogger() << "\e[37mthor: CPUs support VMX\e[39m"
+			debugLogger() << "thor: CPUs support VMX"
 					<< frg::endlog;
 			globalCpuFeatures.haveVmx = true;
 		}else{
-			infoLogger() << "\e[37mthor: CPUs do not support VMX!\e[39m" << frg::endlog;
+			debugLogger() << "thor: CPUs do not support VMX!" << frg::endlog;
 		}
 
 		if(svmSupported) {
-			infoLogger() << "\e[37mthor: CPUs support SVM\e[39m"
+			debugLogger() << "thor: CPUs support SVM"
 					<< frg::endlog;
 			globalCpuFeatures.haveSvm = true;
 		}else{
-			infoLogger() << "\e[37mthor: CPUs do not support SVM!\e[39m" << frg::endlog;
+			debugLogger() << "thor: CPUs do not support SVM!" << frg::endlog;
 		}
 
 		cpuFeaturesKnown = true;
@@ -583,7 +583,7 @@ static initgraph::Task initBootProcessorTask{&globalInitEngine, "x86.init-boot-p
 		// We need to fill in the boot APIC ID.
 		// This cannot be done in setupBootCpuContext() as we need the APIC base first.
 		staticBootCpuContext->localApicId = getLocalApicId();
-		infoLogger() << "Booting on CPU #" << staticBootCpuContext->localApicId
+		debugLogger() << "Booting on CPU #" << staticBootCpuContext->localApicId
 				<< frg::endlog;
 
 		initializeThisProcessor();
@@ -686,7 +686,7 @@ void initializeThisProcessor() {
 
 	// Enable the SMAP extension.
 	if(common::x86::cpuid(0x07)[1] & (uint32_t(1) << 20)) {
-		infoLogger() << "\e[37mthor: CPU supports SMAP\e[39m" << frg::endlog;
+		debugLogger() << "thor: CPU supports SMAP" << frg::endlog;
 
 		uint64_t cr4;
 		asm volatile ("mov %%cr4, %0" : "=r" (cr4));
@@ -697,38 +697,38 @@ void initializeThisProcessor() {
 
 		cpuData->haveSmap = true;
 	}else{
-		infoLogger() << "\e[37mthor: CPU does not support SMAP!\e[39m" << frg::endlog;
+		debugLogger() << "thor: CPU does not support SMAP!" << frg::endlog;
 	}
 
 	// Enable the SMEP extension.
 	if(common::x86::cpuid(0x07)[1] & (uint32_t(1) << 6)) {
-		infoLogger() << "\e[37mthor: CPU supports SMEP\e[39m" << frg::endlog;
+		debugLogger() << "thor: CPU supports SMEP" << frg::endlog;
 
 		uint64_t cr4;
 		asm volatile ("mov %%cr4, %0" : "=r" (cr4));
 		cr4 |= uint32_t(1) << 20;
 		asm volatile ("mov %0, %%cr4" : : "r" (cr4));
 	}else{
-		infoLogger() << "\e[37mthor: CPU does not support SMEP!\e[39m" << frg::endlog;
+		debugLogger() << "thor: CPU does not support SMEP!" << frg::endlog;
 	}
 
 	// Enable the UMIP extension.
 	if(common::x86::cpuid(0x07)[2] & (uint32_t(1) << 2)) {
-		infoLogger() << "\e[37mthor: CPU supports UMIP\e[39m" << frg::endlog;
+		debugLogger() << "thor: CPU supports UMIP" << frg::endlog;
 
 		uint64_t cr4;
 		asm volatile ("mov %%cr4, %0" : "=r" (cr4));
 		cr4 |= uint32_t(1) << 11;
 		asm volatile ("mov %0, %%cr4" : : "r" (cr4));
 	}else{
-		infoLogger() << "\e[37mthor: CPU does not support UMIP!\e[39m" << frg::endlog;
+		debugLogger() << "thor: CPU does not support UMIP!" << frg::endlog;
 	}
 
 	// Enable the PCID extension.
 	bool pcidBit = common::x86::cpuid(0x01)[2] & (uint32_t(1) << 17);
 	bool invpcidBit = common::x86::cpuid(0x07)[1] & (uint32_t(1) << 10);
 	if(pcidBit && invpcidBit) {
-		infoLogger() << "\e[37mthor: CPU supports PCIDs\e[39m" << frg::endlog;
+		debugLogger() << "thor: CPU supports PCIDs" << frg::endlog;
 
 		uint64_t cr4;
 		asm volatile ("mov %%cr4, %0" : "=r" (cr4));
@@ -737,10 +737,10 @@ void initializeThisProcessor() {
 
 		cpuData->havePcids = true;
 	}else if(pcidBit) {
-		infoLogger() << "\e[37mthor: CPU supports PCIDs but no INVPCID;"
-				" will not use PCIDs!\e[39m" << frg::endlog;
+		debugLogger() << "thor: CPU supports PCIDs but no INVPCID;"
+				" will not use PCIDs!" << frg::endlog;
 	}else{
-		infoLogger() << "\e[37mthor: CPU does not support PCIDs!\e[39m" << frg::endlog;
+		debugLogger() << "thor: CPU does not support PCIDs!" << frg::endlog;
 	}
 
 	// Enable SVM or VMX if it is supported.
@@ -800,7 +800,7 @@ void secondaryMain(StatusBlock *statusBlock) {
 	initializeThisProcessor();
 	__atomic_store_n(&statusBlock->targetStage, 2, __ATOMIC_RELEASE);
 
-	infoLogger() << "Hello world from CPU #" << getLocalApicId() << frg::endlog;
+	debugLogger() << "Hello world from CPU #" << getLocalApicId() << frg::endlog;
 
 	Scheduler::resume(cpuContext->wqFiber);
 
@@ -841,7 +841,7 @@ void bootSecondary(unsigned int apic_id) {
 	// Setup a status block to communicate information to the AP.
 	auto statusBlock = reinterpret_cast<StatusBlock *>(reinterpret_cast<char *>(accessor.get())
 			+ (kPageSize - sizeof(StatusBlock)));
-	infoLogger() << "status block accessed via: " << statusBlock << frg::endlog;
+	debugLogger() << "status block accessed via: " << statusBlock << frg::endlog;
 
 	statusBlock->self = statusBlock;
 	statusBlock->targetStage = 0;
@@ -869,7 +869,7 @@ void bootSecondary(unsigned int apic_id) {
 	while(__atomic_load_n(&statusBlock->targetStage, __ATOMIC_ACQUIRE) < 1) {
 		pause();
 	}
-	infoLogger() << "thor: AP did wake up." << frg::endlog;
+	debugLogger() << "thor: AP did wake up." << frg::endlog;
 
 	// We only let the AP proceed after all IPIs have been sent.
 	// This ensures that the AP does not execute boot code twice (e.g. in case
@@ -880,7 +880,7 @@ void bootSecondary(unsigned int apic_id) {
 	while(__atomic_load_n(&statusBlock->targetStage, __ATOMIC_ACQUIRE) < 2) {
 		pause();
 	}
-	infoLogger() << "thor: AP finished booting." << frg::endlog;
+	debugLogger() << "thor: AP finished booting." << frg::endlog;
 }
 
 Error getEntropyFromCpu(void *buffer, size_t size) {

--- a/kernel/thor/arch/x86/debug.cpp
+++ b/kernel/thor/arch/x86/debug.cpp
@@ -67,4 +67,41 @@ void PIOLogHandler::printChar(char c) {
 	}
 }
 
+void PIOLogHandler::setPriority(Severity prio) {
+	int c = 9;
+
+	switch(prio) {
+		case Severity::emergency:
+		case Severity::alert:
+		case Severity::critical:
+		case Severity::error:
+			c = 1;
+			break;
+		case Severity::warning:
+			c = 3;
+			break;
+		case Severity::notice:
+		case Severity::info:
+			c = 9;
+			break;
+		case Severity::debug:
+			c = 5;
+			break;
+	}
+
+	printChar('\e');
+	printChar('[');
+	printChar('3');
+	printChar('0' + c);
+	printChar('m');
+}
+
+void PIOLogHandler::resetPriority() {
+	printChar('\e');
+	printChar('[');
+	printChar('3');
+	printChar('9');
+	printChar('m');
+}
+
 } // namespace thor

--- a/kernel/thor/arch/x86/hpet.cpp
+++ b/kernel/thor/arch/x86/hpet.cpp
@@ -114,8 +114,7 @@ public:
 			//         everything works as expected; we do not need to warn.
 			//       - Adjust this code one we count the number of overflows.
 			if(ticks & ~uint64_t{0xFFFFFFFF})
-				infoLogger() << "\e[31m" "thor: HPET comparator overflow" "\e[39m"
-						<< frg::endlog;
+				urgentLogger() << "thor: HPET comparator overflow" << frg::endlog;
 			ticks &= ~uint64_t(0xFFFFFFFF);
 		}
 		hpetBase.store(timerComparator0, ticks);
@@ -234,12 +233,11 @@ static initgraph::Task initHpetTask{&globalInitEngine, "x86.init-hpet",
 
 		auto ret = uacpi_table_find_by_signature("HPET", &hpetTbl);
 		if(ret != UACPI_STATUS_OK) {
-			infoLogger() << "\e[31m" "thor: No HPET table!" "\e[39m" << frg::endlog;
+			urgentLogger() << "thor: No HPET table!" << frg::endlog;
 			return;
 		}
 		if(hpetTbl->hdr->length < sizeof(acpi_sdt_hdr) + sizeof(HpetEntry)) {
-			infoLogger() << "\e[31m" "thor: HPET table has no entries!" "\e[39m"
-					<< frg::endlog;
+			urgentLogger() << "thor: HPET table has no entries!" << frg::endlog;
 			return;
 		}
 		auto hpetEntry = (HpetEntry *)(hpetTbl->virt_addr + sizeof(acpi_sdt_hdr));

--- a/kernel/thor/arch/x86/ints.cpp
+++ b/kernel/thor/arch/x86/ints.cpp
@@ -295,8 +295,7 @@ void handlePreemption(IrqImageAccessor image);
 void handleSyscall(SyscallImageAccessor image);
 
 void handleDebugFault(FaultImageAccessor image) {
-	infoLogger() << "\e[35mthor: Debug fault "
-			<< "at ip: " << (void *)*image.ip() << "\e[39m" << frg::endlog;
+	debugLogger() << "thor: Debug fault at ip: " << (void *)*image.ip() << frg::endlog;
 }
 
 extern "C" void onPlatformFault(FaultImageAccessor image, int number) {
@@ -397,11 +396,11 @@ extern "C" void onPlatformLegacyIrq(IrqImageAccessor image, int number) {
 	disableUserAccess();
 
 	if(checkLegacyPicIsr(number)) {
-		infoLogger() << "\e[31m" "thor: Spurious IRQ " << number
-				<< " of legacy PIC" "\e[39m" << frg::endlog;
+		urgentLogger() << "thor: Spurious IRQ " << number
+				<< " of legacy PIC" << frg::endlog;
 	}else{
-		infoLogger() << "\e[31m" "thor: Ignoring non-spurious IRQ " << number
-				<< " of legacy PIC" "\e[39m" << frg::endlog;
+		urgentLogger() << "thor: Ignoring non-spurious IRQ " << number
+				<< " of legacy PIC" << frg::endlog;
 	}
 }
 

--- a/kernel/thor/arch/x86/pic.cpp
+++ b/kernel/thor/arch/x86/pic.cpp
@@ -257,11 +257,11 @@ static initgraph::Task discoverApicTask{&globalInitEngine, "x86.discover-apic",
 
 		bool haveX2apic = false;
 		if(common::x86::cpuid(0x01)[2] & (uint32_t(1) << 21)){
-			infoLogger() << "\e[37mthor: CPU supports x2apic\e[39m" << frg::endlog;
+			debugLogger() << "thor: CPU supports x2apic" << frg::endlog;
 			msr |= (1 << 10);
 			haveX2apic = true;
 		} else {
-			infoLogger() << "\e[37mthor: CPU does not support x2apic\e[39m" << frg::endlog;
+			debugLogger() << "thor: CPU does not support x2apic" << frg::endlog;
 		}
 
 		common::x86::wrmsr(common::x86::kMsrLocalApicBase, msr);
@@ -528,8 +528,7 @@ namespace {
 
 		void mask() override {
 			// TODO: Support this.
-			infoLogger() << "\e[31m" "thor: Masking of APIC-MSIs is not implemented" "\e[39m"
-					<< frg::endlog;
+			warningLogger() << "thor: Masking of APIC-MSIs is not implemented" << frg::endlog;
 		}
 
 		void unmask() override {
@@ -679,11 +678,11 @@ namespace {
 				<< ((word1 & pin_word1::activeLow) ? "low" : "high")
 				<< frg::endlog;
 		if(_levelTriggered != (word1 & pin_word1::levelTriggered))
-			infoLogger() << "\e[31m" "thor: Trigger mode does not match software state!"
-					"\e[39m" << frg::endlog;
+			urgentLogger() << "thor: Trigger mode does not match software state!"
+					<< frg::endlog;
 		if(_activeLow != (word1 & pin_word1::activeLow))
-			infoLogger() << "\e[31m" "thor: Trigger mode does not match software state!"
-					"\e[39m" << frg::endlog;
+			urgentLogger() << "thor: Trigger mode does not match software state!"
+					<< frg::endlog;
 		infoLogger() << "thor: I/O APIC state:"
 				<< " mask: " << (int)(word1 & pin_word1::masked)
 				<< ", delivery status: " << (int)(word1 & pin_word1::deliveryStatus)

--- a/kernel/thor/arch/x86/thor-internal/arch/debug.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/debug.hpp
@@ -56,6 +56,8 @@ struct PIOLogHandler final : public LogHandler {
 	: serialBufferIndex{0}, serialBuffer{0} {}
 
 	void printChar(char c) override;
+	void setPriority(Severity prio) override;
+	void resetPriority() override;
 
 private:
 	int serialBufferIndex;

--- a/kernel/thor/arch/x86/vmx.cpp
+++ b/kernel/thor/arch/x86/vmx.cpp
@@ -112,8 +112,8 @@ namespace thor::vmx {
 		if(successful) {
 			infoLogger() << "thor: CPU entered vmxon operation" << frg::endlog;
 		} else {
-			infoLogger() << "\e[31m" "thor: vmxon failed; this will be a hard error in the future"
-					"\e[39m" << frg::endlog;
+			urgentLogger() << "thor: vmxon failed; this will be a hard error in the future"
+					<< frg::endlog;
 		}
 
 		return successful;

--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -218,7 +218,7 @@ Mapping::Mapping(size_t length, MappingFlags flags,
 
 Mapping::~Mapping() {
 	assert(state == MappingState::retired);
-	//infoLogger() << "\e[31mthor: Mapping is destructed\e[39m" << frg::endlog;
+	//debugLogger() << "thor: Mapping is destructed" << frg::endlog;
 }
 
 void Mapping::tie(smarter::shared_ptr<VirtualSpace> newOwner, VirtualAddr address) {
@@ -355,7 +355,7 @@ void VirtualSpace::setupInitialHole(VirtualAddr address, size_t size) {
 
 VirtualSpace::~VirtualSpace() {
 	if(logCleanup)
-		infoLogger() << "\e[31mthor: VirtualSpace is destructed\e[39m" << frg::endlog;
+		debugLogger() << "thor: VirtualSpace is destructed" << frg::endlog;
 
 	while(_holes.get_root()) {
 		auto hole = _holes.get_root();
@@ -366,7 +366,7 @@ VirtualSpace::~VirtualSpace() {
 
 void VirtualSpace::retire() {
 	if(logCleanup)
-		infoLogger() << "\e[31mthor: VirtualSpace is cleared\e[39m" << frg::endlog;
+		debugLogger() << "thor: VirtualSpace is cleared" << frg::endlog;
 
 	// TODO: Set some flag to make sure that no mappings are added/deleted.
 	auto mapping = _mappings.first();
@@ -678,11 +678,11 @@ VirtualSpace::handleFault(VirtualAddr address, uint32_t faultFlags,
 			if(remapOutcome.error() == Error::spuriousOperation) {
 				// Spurious page faults are the result of race conditions.
 				// They should be rare. If they happen too often, something is probably wrong!
-				infoLogger() << "\e[33m" "thor: Spurious page fault" "\e[39m" << frg::endlog;
+				warningLogger() << "thor: Spurious page fault" << frg::endlog;
 			}else{
 				assert(remapOutcome.error() == Error::fault);
-				infoLogger() << "\e[33m" "thor: Page still not available after"
-						" fetchRange()" "\e[39m" << frg::endlog;
+				warningLogger() << "thor: Page still not available after fetchRange()"
+					<< frg::endlog;
 				continue;
 			}
 		}
@@ -718,8 +718,7 @@ VirtualSpace::retrievePhysical(VirtualAddr address, smarter::shared_ptr<WorkQueu
 
 		auto physicalRange = mapping->view->peekRange(mapping->viewOffset + offset);
 		if(physicalRange.get<0>() == PhysicalAddr(-1)) {
-			infoLogger() << "\e[33m" "thor: Page still not available after"
-					" fetchRange()" "\e[39m" << frg::endlog;
+			warningLogger() << "thor: Page still not available after fetchRange()" << frg::endlog;
 			continue;
 		}
 

--- a/kernel/thor/generic/core.cpp
+++ b/kernel/thor/generic/core.cpp
@@ -145,8 +145,7 @@ void *KernelVirtualMemory::allocate(size_t size) {
 					" kernel VM: " << (kernelVirtualUsage / 1024) << " KiB"
 					" kernel RSS: " << (kernelMemoryUsage / 1024) << " KiB"
 					<< frg::endlog;
-			panicLogger() << "\e[31m" "thor: Out of kernel virtual memory" "\e[39m"
-					<< frg::endlog;
+			panicLogger() << "thor: Out of kernel virtual memory" << frg::endlog;
 		}
 
 		auto current = virtualTree->get_root();

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -381,7 +381,7 @@ HelError helAllocateMemory(size_t size, uint32_t flags,
 	}else if(flags & kHelAllocOnDemand) {
 		memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, size, effective.addressBits);
 	}else{
-		// TODO: 
+		// TODO:
 		memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, size, effective.addressBits);
 	}
 	memory->selfPtr = memory;
@@ -839,7 +839,7 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 	if(!isVspace) {
 		if(map_flags & AddressSpace::kMapFixed && !pointer)
 			return kHelErrIllegalArgs; // Non-vspaces aren't allowed to map at NULL
-		
+
 		mapResult = Thread::asyncBlockCurrent(space->map(slice,
 				(VirtualAddr)pointer, offset, length, map_flags));
 	} else {

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -176,8 +176,6 @@ extern "C" void thorMain() {
 	kernelCommandLine.initialize(*kernelAlloc,
 			reinterpret_cast<const char *>(thorBootInfoPtr->commandLine));
 
-	initializeLog();
-
 	for(int i = 0; i < numIrqSlots; i++)
 		globalIrqSlots[i].initialize();
 
@@ -306,7 +304,7 @@ extern "C" void thorMain() {
 				}else{
 					assert((mode & type_mask) == regular_type);
 	//				if(logInitialization)
-						infoLogger() << "thor: initrd file " << path << frg::endlog;
+						debugLogger() << "thor: initrd file " << path << frg::endlog;
 
 					auto memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc,
 							(file_size + (kPageSize - 1)) & ~size_t{kPageSize - 1});

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -73,11 +73,9 @@ extern "C" void thorInitialize() {
 	infoLogger() << "Starting Thor" << frg::endlog;
 
 	if(thorBootInfoPtr->signature == eirSignatureValue) {
-		infoLogger() << "\e[37mthor: Bootstrap information signature matches\e[39m"
-				<< frg::endlog;
+		infoLogger() << "thor: Bootstrap information signature matches" << frg::endlog;
 	}else{
-		panicLogger() << "\e[31mthor: Bootstrap information signature mismatch!\e[39m"
-				<< frg::endlog;
+		panicLogger() << "thor: Bootstrap information signature mismatch!" << frg::endlog;
 	}
 
 	KernelPageSpace::initialize();
@@ -96,7 +94,7 @@ extern "C" void thorInitialize() {
 	kernelHeap.initialize(*kernelVirtualAlloc);
 	kernelAlloc.initialize(kernelHeap.get());
 
-	infoLogger() << "\e[37mthor: Basic memory management is ready\e[39m" << frg::endlog;
+	infoLogger() << "thor: Basic memory management is ready" << frg::endlog;
 }
 
 extern "C" void thorRunConstructors() {
@@ -434,7 +432,7 @@ void handlePageFault(FaultImageAccessor image, uintptr_t address, Word errorCode
 		if(!image.allowUserPages()) {
 			if(!logEveryPageFault)
 				logFault();
-			panicLogger() << "\e[31mthor: SMAP fault.\e[39m" << frg::endlog;
+			panicLogger() << "thor: SMAP fault." << frg::endlog;
 		}
 	}else{
 		assert(errorCode & kPfUser);
@@ -469,7 +467,7 @@ void handlePageFault(FaultImageAccessor image, uintptr_t address, Word errorCode
 
 		if(!logEveryPageFault)
 			logFault();
-		panicLogger() << "\e[31m" "thor: Page fault in kernel, at " << (void *)address
+		panicLogger() << "thor: Page fault in kernel, at " << (void *)address
 				<< ", faulting ip: " << (void *)*image.ip() << frg::endlog;
 	}
 
@@ -477,7 +475,7 @@ void handlePageFault(FaultImageAccessor image, uintptr_t address, Word errorCode
 	if(this_thread->flags & Thread::kFlagServer) {
 		if(!logEveryPageFault)
 			logFault();
-		infoLogger() << "\e[31m" "thor: Page fault in server, at " << (void *)address
+		urgentLogger() << "thor: Page fault in server, at " << (void *)address
 				<< ", faulting ip: " << (void *)*image.ip() << frg::endlog;
 	}
 	Thread::interruptCurrent(Interrupt::kIntrPageFault, image);
@@ -501,8 +499,8 @@ void handleOtherFault(FaultImageAccessor image, Interrupt fault) {
 				<< ", faulting ip: " << (void *)*image.ip() << frg::endlog;
 
 	if(this_thread->flags & Thread::kFlagServer) {
-		infoLogger() << "\e[31m" "thor: " << name << " fault in server.\n"
-				<< "Last ip: " << (void *)*image.ip() << "\e[39m" << frg::endlog;
+		urgentLogger() << "thor: " << name << " fault in server.\n"
+				<< "Last ip: " << (void *)*image.ip() << frg::endlog;
 		// TODO: Trigger a more-specific interrupt.
 		Thread::interruptCurrent(kIntrPanic, image);
 	}else{

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -575,7 +575,7 @@ void handleSyscall(SyscallImageAccessor image) {
 
 	switch(*image.number()) {
 	case kHelCallLog: {
-		*image.error() = helLog((const char *)arg0, (size_t)arg1);
+		*image.error() = helLog((HelLogSeverity)arg0, (const char *)arg1, (size_t)arg2);
 	} break;
 	case kHelCallPanic: {
 		Thread::interruptCurrent(kIntrPanic, image);

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -404,8 +404,7 @@ struct ZeroMemory final : MemoryView, GlobalFutexSpace {
 	}
 
 	void markDirty(uintptr_t, size_t) override {
-		infoLogger() << "\e[31m" "thor: ZeroMemory::markDirty() called,"
-				"" "\e[39m" << frg::endlog;
+		urgentLogger() << "thor: ZeroMemory::markDirty() called," << frg::endlog;
 	}
 
 	coroutine<frg::expected<Error, PhysicalAddr>> takeGlobalFutex(uintptr_t,
@@ -601,14 +600,14 @@ AllocatedMemory::AllocatedMemory(size_t desiredLngth,
 	static_assert(sizeof(unsigned long) == sizeof(uint64_t), "Fix use of __builtin_clzl");
 	_chunkSize = size_t(1) << (64 - __builtin_clzl(desiredChunkSize - 1));
 	if(_chunkSize != desiredChunkSize)
-		infoLogger() << "\e[31mPhysical allocation of size " << (void *)desiredChunkSize
-				<< " rounded up to power of 2\e[39m" << frg::endlog;
+		urgentLogger() << "Physical allocation of size " << (void *)desiredChunkSize
+				<< " rounded up to power of 2" << frg::endlog;
 
 	size_t length = (desiredLngth + (_chunkSize - 1)) & ~(_chunkSize - 1);
 	if(length != desiredLngth)
-		infoLogger() << "\e[31mMemory length " << (void *)desiredLngth
+		urgentLogger() << "Memory length " << (void *)desiredLngth
 				<< " rounded up to chunk size " << (void *)_chunkSize
-				<< "\e[39m" << frg::endlog;
+				<< frg::endlog;
 
 	assert(_chunkSize % kPageSize == 0);
 	assert(_chunkAlign % kPageSize == 0);
@@ -772,7 +771,7 @@ ManagedSpace::ManagedSpace(size_t length, bool readahead)
 			}
 
 			if(logUncaching)
-				infoLogger() << "\e[33mEvicting physical page\e[39m" << frg::endlog;
+				warningLogger() << "Evicting physical page" << frg::endlog;
 			physicalAllocator->free(physical, kPageSize);
 		}
 	}(this);
@@ -1218,8 +1217,7 @@ FrontalMemory::fetchRange(uintptr_t offset, FetchFlags flags, smarter::shared_pt
 		}
 
 		if(flags & fetchDisallowBacking) {
-			infoLogger() << "\e[31m" "thor: Backing of page is disallowed" "\e[39m"
-					<< frg::endlog;
+			urgentLogger() << "thor: Backing of page is disallowed" << frg::endlog;
 			co_return Error::fault;
 		}
 

--- a/kernel/thor/generic/profile.cpp
+++ b/kernel/thor/generic/profile.cpp
@@ -39,8 +39,8 @@ void initializeProfile() {
 
 	if(!(getGlobalCpuFeatures()->profileFlags & CpuFeatures::profileIntelSupported)
 			&& !(getGlobalCpuFeatures()->profileFlags & CpuFeatures::profileAmdSupported)) {
-		infoLogger() << "\e[31m" "thor: Kernel profiling was requested but"
-				" no hardware support is available" "\e[39m" << frg::endlog;
+		urgentLogger() << "thor: Kernel profiling was requested but"
+				" no hardware support is available" << frg::endlog;
 		return;
 	}
 

--- a/kernel/thor/generic/random.cpp
+++ b/kernel/thor/generic/random.cpp
@@ -199,18 +199,15 @@ void initializeRandom() {
 		csprng->forceReseed(seed, 32);
 		return;
 	}else if(e == Error::noHardwareSupport) {
-		infoLogger() << "\e[31m" "thor: CPU-based hardware PRNG not available"
-				"\e[39m" << frg::endlog;
+		urgentLogger() << "thor: CPU-based hardware PRNG not available" << frg::endlog;
 	}else{
 		assert(e == Error::hardwareBroken);
-		infoLogger() << "\e[31m" "thor: CPU-based hardware PRNG is broken"
-				"\e[39m" << frg::endlog;
+		urgentLogger() << "thor: CPU-based hardware PRNG is broken" << frg::endlog;
 	}
 
 	// TODO: we can do something *much* better here, this case is highly insecure!
 	//       Use jitter-based entropy (e.g., HAVEGE) instead.
-	infoLogger() << "\e[31m" "thor: Falling back to entropy from CPU clock"
-			"\e[39m" << frg::endlog;
+	urgentLogger() << "thor: Falling back to entropy from CPU clock" << frg::endlog;
 	uint64_t tsc = getRawTimestampCounter();
 	csprng->forceReseed(&tsc, sizeof(uint64_t));
 }

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -101,8 +101,8 @@ namespace stdio {
 				// TODO: improve error handling here.
 				assert(respError == Error::success);
 			}else{
-				infoLogger() << "\e[31m" "thor: Illegal request type " << (int32_t)req.req_type()
-						<< " for kernel provided stdio file" "\e[39m" << frg::endlog;
+				urgentLogger() << "thor: Illegal request type " << (int32_t)req.req_type()
+						<< " for kernel provided stdio file" << frg::endlog;
 
 				auto dismissError = co_await DismissSender{conversation};
 				// TODO: improve error handling here.
@@ -211,8 +211,8 @@ namespace initrd {
 				// TODO: improve error handling here.
 				assert(memoryError == Error::success);
 			}else{
-				infoLogger() << "\e[31m" "thor: Illegal request type " << (int32_t)req.req_type()
-						<< " for kernel provided regular file" "\e[39m" << frg::endlog;
+				urgentLogger() << "thor: Illegal request type " << (int32_t)req.req_type()
+						<< " for kernel provided regular file" << frg::endlog;
 
 				auto dismissError = co_await DismissSender{conversation};
 				// TODO: improve error handling here.
@@ -276,8 +276,8 @@ namespace initrd {
 					assert(respError == Error::success);
 				}
 			}else{
-				infoLogger() << "\e[31m" "thor: Illegal request type " << (int32_t)req.req_type()
-						<< " for kernel provided directory file" "\e[39m" << frg::endlog;
+				urgentLogger() << "thor: Illegal request type " << (int32_t)req.req_type()
+						<< " for kernel provided directory file" << frg::endlog;
 
 				auto dismissError = co_await DismissSender{conversation};
 				// TODO: improve error handling here.
@@ -651,15 +651,15 @@ namespace posix {
 			if(interrupt == kIntrPanic) {
 				// Do nothing and stop observing.
 				// TODO: Make sure the server is destructed here.
-				infoLogger() << "\e[31m" "thor: Panic in server "
-						<< name().data() << "\e[39m" << frg::endlog;
+				urgentLogger() << "thor: Panic in server "
+						<< name().data() << frg::endlog;
 				launchGdbServer(_thread, _name, WorkQueue::generalQueue()->take());
 				break;
 			}else if(interrupt == kIntrPageFault) {
 				// Do nothing and stop observing.
 				// TODO: Make sure the server is destructed here.
-				infoLogger() << "\e[31m" "thor: Fault in server "
-						<< name().data() << "\e[39m" << frg::endlog;
+				urgentLogger() << "thor: Fault in server "
+						<< name().data() << frg::endlog;
 				launchGdbServer(_thread, _name, WorkQueue::generalQueue()->take());
 				break;
 			}else if(interrupt == kIntrSuperCall + ::posix::superAnonAllocate) { // ANON_ALLOCATE.

--- a/kernel/thor/generic/stream.cpp
+++ b/kernel/thor/generic/stream.cpp
@@ -289,7 +289,7 @@ Stream::Stream(bool withCredentials)
 
 Stream::~Stream() {
 // TODO: remove debugging messages?
-//	infoLogger() << "\e[31mClosing stream\e[0m" << frg::endlog;
+//	infoLogger() << "Closing stream" << frg::endlog;
 }
 
 void Stream::shutdownLane(int lane) {

--- a/kernel/thor/generic/thor-internal/debug.hpp
+++ b/kernel/thor/generic/thor-internal/debug.hpp
@@ -17,8 +17,22 @@ struct LogMessage {
 	char text[logLineLength];
 };
 
+// see RFC 5424
+enum class Severity : uint8_t {
+	emergency,
+	alert,
+	critical,
+	error,
+	warning,
+	notice,
+	info,
+	debug,
+};
+
 struct LogHandler {
 	virtual void printChar(char c) = 0;
+	virtual void setPriority(Severity) = 0;
+	virtual void resetPriority() = 0;
 
 	frg::default_list_hook<LogHandler> hook;
 
@@ -35,6 +49,18 @@ void copyLogMessage(size_t sequence, LogMessage &msg);
 // --------------------------------------------------------
 // Loggers.
 // --------------------------------------------------------
+
+struct DebugSink {
+	constexpr DebugSink() = default;
+
+	void operator() (const char *msg);
+};
+
+struct WarningSink {
+	constexpr WarningSink() = default;
+
+	void operator() (const char *msg);
+};
 
 struct InfoSink {
 	constexpr InfoSink() = default;
@@ -55,6 +81,8 @@ struct PanicSink {
 	void finalize(bool);
 };
 
+extern frg::stack_buffer_logger<DebugSink, logLineLength> debugLogger;
+extern frg::stack_buffer_logger<WarningSink, logLineLength> warningLogger;
 extern frg::stack_buffer_logger<InfoSink, logLineLength> infoLogger;
 // Similar in spirit as infoLogger(), but avoids the use of sophisticated kernel infrastructure.
 // This can be used to debug low-level kernel infrastructure, e.g., irqMutex().

--- a/kernel/thor/generic/thor-internal/debug.hpp
+++ b/kernel/thor/generic/thor-internal/debug.hpp
@@ -30,11 +30,17 @@ enum class Severity : uint8_t {
 };
 
 struct LogHandler {
+	constexpr LogHandler() : context(nullptr) {}
+
+	LogHandler(void *ct) : context{ct} {}
+
 	virtual void printChar(char c) = 0;
 	virtual void setPriority(Severity) = 0;
 	virtual void resetPriority() = 0;
 
 	frg::default_list_hook<LogHandler> hook;
+
+	void *context;
 
 protected:
 	~LogHandler() = default;

--- a/kernel/thor/generic/thor-internal/virtualization.hpp
+++ b/kernel/thor/generic/thor-internal/virtualization.hpp
@@ -66,8 +66,8 @@ namespace thor {
 			}
 
 			PageStatus cleanSingle4k(VirtualAddr) override {
-				infoLogger() << "\e[31m" "thor: VirtualizedPageSpace::cleanSingle4k()"
-						" is not properly supported" "\e[39m" << frg::endlog;
+				urgentLogger() << "thor: VirtualizedPageSpace::cleanSingle4k()"
+						" is not properly supported" << frg::endlog;
 				return 0;
 			}
 

--- a/kernel/thor/generic/thread.cpp
+++ b/kernel/thor/generic/thread.cpp
@@ -392,8 +392,7 @@ Thread::~Thread() {
 // This function has to initiate the thread's shutdown.
 void Thread::dispose(ActiveHandle) {
 	if(logCleanup)
-		infoLogger() << "\e[31mthor: Killing thread due to destruction\e[39m"
-				<< frg::endlog;
+		urgentLogger() << "thor: Killing thread due to destruction" << frg::endlog;
 	_kill();
 	_mainWorkQueue.selfPtr = {};
 	_pagingWorkQueue.selfPtr = {};

--- a/kernel/thor/generic/universe.cpp
+++ b/kernel/thor/generic/universe.cpp
@@ -11,7 +11,7 @@ Universe::Universe()
 
 Universe::~Universe() {
 	if(logCleanup)
-		infoLogger() << "\e[31mthor: Universe is deallocated\e[39m" << frg::endlog;
+		debugLogger() << "thor: Universe is deallocated" << frg::endlog;
 }
 
 Handle Universe::attachDescriptor(Guard &guard, AnyDescriptor descriptor) {

--- a/kernel/thor/system/framebuffer/boot-screen.cpp
+++ b/kernel/thor/system/framebuffer/boot-screen.cpp
@@ -54,7 +54,7 @@ void BootScreen::Formatter::print(const char *c) {
 			// This is _csiState == 2.
 			if(*c >= '0' && *c <= '9') {
 				_modeStack[_modeCount] *= 10;
-				_modeStack[_modeCount] += *c - '0'; 
+				_modeStack[_modeCount] += *c - '0';
 				c++;
 			}else if(*c == ';') {
 				_modeCount++;
@@ -63,19 +63,19 @@ void BootScreen::Formatter::print(const char *c) {
 				if(*c == 'm') {
 					for(int i = 0; i <= _modeCount; i++) {
 						if(!_modeStack[i]) {
-							_fg = 15;
+							_fg = _initialFg;
 						}else if(_modeStack[i] >= 30 && _modeStack[i] <= 37) {
 							_fg = _modeStack[i] - 30;
 						}else if(_modeStack[i] == 39) {
-							_fg = 15;
+							_fg = _initialFg;
 						}
 					}
 				}
-		
+
 				for(int i = 0; i < 4; i++)
 					_modeStack[i] = 0;
 				_modeCount = 0;
-				
+
 				_csiState = 0;
 				c++;
 			}
@@ -86,7 +86,8 @@ void BootScreen::Formatter::print(const char *c) {
 }
 
 BootScreen::BootScreen(TextDisplay *display)
-: _display{display}, _bottomSequence{0}, _fmt{this, 0, 0} {
+: _display{display}, _bottomSequence{0},
+		_fmt{this, 0, 0} {
 	_width = _display->getWidth();
 	_height = _display->getHeight();
 }
@@ -117,6 +118,34 @@ void BootScreen::printChar(char) {
 //  LogMessage log;
 //	copyLogMessage(_bottomSequence, log);
 //	_fmt.print(text + _x);
+}
+
+void BootScreen::setPriority(Severity prio) {
+	switch(prio) {
+		case Severity::emergency:
+		case Severity::alert:
+		case Severity::critical:
+		case Severity::error:
+			_fmt.print("\e[31m");
+			break;
+		case Severity::warning:
+			_fmt.print("\e[33m");
+			break;
+		case Severity::notice:
+		case Severity::info:
+			_fmt.print("\e[37m");
+			break;
+		case Severity::debug:
+			_fmt.print("\e[35m");
+			break;
+		default:
+			_fmt.print("\e[39m");
+			break;
+	}
+}
+
+void BootScreen::resetPriority() {
+	_fmt.print("\e[39m");
 }
 
 void BootScreen::printString(const char *string) {

--- a/kernel/thor/system/framebuffer/fb.cpp
+++ b/kernel/thor/system/framebuffer/fb.cpp
@@ -34,7 +34,7 @@ struct FbDisplay final : TextDisplay {
 
 	int getWidth() override;
 	int getHeight() override;
-	
+
 	void setChars(unsigned int x, unsigned int y,
 			const char *c, int count, int fg, int bg) override;
 	void setBlanks(unsigned int x, unsigned int y, int count, int bg) override;
@@ -64,7 +64,7 @@ void FbDisplay::setChars(unsigned int x, unsigned int y,
 }
 
 void FbDisplay::setBlanks(unsigned int x, unsigned int y, int count, int bg) {
-	auto bg_rgb = (bg < 0) ? defaultBg : rgbColor[bg]; 
+	auto bg_rgb = (bg < 0) ? defaultBg : rgbColor[bg];
 
 	auto dest_line = _window + y * fontHeight * _pitch + x * fontWidth;
 	for(size_t i = 0; i < fontHeight; i++) {
@@ -147,7 +147,7 @@ void transitionBootFb() {
 						&& bootInfo->address + bootInfo->height * bootInfo->pitch <= bar_end)
 					return true;
 			}
-			
+
 			return false;
 		};
 

--- a/kernel/thor/system/framebuffer/thor-internal/framebuffer/boot-screen.hpp
+++ b/kernel/thor/system/framebuffer/thor-internal/framebuffer/boot-screen.hpp
@@ -16,7 +16,7 @@ protected:
 	~TextDisplay() = default;
 };
 
-struct BootScreen final : LogHandler {
+struct BootScreen final : public LogHandler {
 	struct Formatter {
 		Formatter(BootScreen *screen, int x, int y);
 
@@ -24,20 +24,24 @@ struct BootScreen final : LogHandler {
 
 	private:
 		BootScreen *_screen;
-		
+
 		int _csiState;
 		int _modeStack[4];
 		int _modeCount;
-		
+
 		int _x;
 		int _y;
 		int _fg = 15;
 		int _bg = -1;
+		int _initialFg = _fg;
 	};
 
 	BootScreen(TextDisplay *display);
 
 	void printChar(char c) override;
+	void setPriority(Severity prio) override;
+	void resetPriority() override;
+
 	void printString(const char *string);
 
 private:

--- a/kernel/thor/system/pci/pci_acpi.cpp
+++ b/kernel/thor/system/pci/pci_acpi.cpp
@@ -205,13 +205,13 @@ static initgraph::Task discoverConfigIoSpaces{&globalInitEngine, "pci.discover-a
 
 		auto ret = uacpi_table_find_by_signature("MCFG", &mcfgTbl);
 		if(ret == UACPI_STATUS_NOT_FOUND) {
-			infoLogger() << "\e[31m" "thor: No MCFG table!" "\e[39m" << frg::endlog;
+			urgentLogger() << "thor: No MCFG table!" << frg::endlog;
 			addLegacyConfigIo();
 			return;
 		}
 
 		if(mcfgTbl->hdr->length < sizeof(acpi_sdt_hdr) + 8 + sizeof(McfgEntry)) {
-			infoLogger() << "\e[31m" "thor: MCFG table has no entries, assuming legacy PCI!" "\e[39m"
+			urgentLogger() << "thor: MCFG table has no entries, assuming legacy PCI!"
 					<< frg::endlog;
 			addLegacyConfigIo();
 			return;

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -1184,7 +1184,7 @@ void checkPciFunction(PciBus *bus, uint32_t slot, uint32_t function,
 		auto status = io->readConfigHalf(bus, slot, function, kPciStatus);
 
 		if(status & 0x08)
-			infoLogger() << "\e[35m                IRQ is asserted!\e[39m" << frg::endlog;
+			debugLogger() << "                IRQ is asserted!" << frg::endlog;
 
 		auto device = smarter::allocate_shared<PciDevice>(*kernelAlloc, bus, bus->segId, bus->busId, slot, function,
 				vendor, device_id, revision, class_code, sub_class, interface, subsystem_vendor, subsystem_device);
@@ -1212,8 +1212,7 @@ void checkPciFunction(PciBus *bus, uint32_t slot, uint32_t function,
 						<< " (routed to " << irq_pin->name() << ")" << frg::endlog;
 				device->interrupt = irq_pin;
 			}else{
-				infoLogger() << "\e[31m" "            Interrupt routing not available!"
-					"\e[39m" << frg::endlog;
+				urgentLogger() << "            Interrupt routing not available!" << frg::endlog;
 			}
 		}
 

--- a/kernel/thor/system/pci/pci_quirks.cpp
+++ b/kernel/thor/system/pci/pci_quirks.cpp
@@ -9,12 +9,12 @@ namespace thor::pci {
 namespace {
 
 void uhciSmiDisable(smarter::shared_ptr<pci::PciDevice> dev) {
-	infoLogger() << "            \e[32mDisabling UHCI SMI generation!\e[39m" << frg::endlog;
+	debugLogger() << "            Disabling UHCI SMI generation!" << frg::endlog;
 	dev->parentBus->io->writeConfigHalf(dev->parentBus, dev->slot, dev->function, 0xC0, 0x2000);
 }
 
 void switchUsbPortsToXhci(smarter::shared_ptr<pci::PciDevice> dev) {
-	infoLogger() << "            \e[32mSwitching USB ports to XHCI!\e[39m" << frg::endlog;
+	debugLogger() << "            Switching USB ports to XHCI!" << frg::endlog;
 	auto io = dev->parentBus->io;
 
 	auto usb3PortsAvail = io->readConfigWord(dev->parentBus, dev->slot, dev->function, 0xDC);

--- a/posix/subsystem/src/devices/kmsg.cpp
+++ b/posix/subsystem/src/devices/kmsg.cpp
@@ -57,7 +57,48 @@ private:
 
 	async::result<frg::expected<Error, size_t>> writeAll(Process *, const void *data, size_t length) override {
 		auto msg = reinterpret_cast<const char *>(data);
-		std::cout << msg;
+
+		HelLogSeverity s = kHelLogSeverityInfo;
+
+		auto handlePrefix = [&](size_t digits) {
+			assert(digits > 0 && digits <= 3);
+
+			char *endptr = 0;
+			auto val = std::strtoul(&msg[1], &endptr, 10);
+			assert(endptr == &msg[1 + digits]);
+			auto level = val & 0x7;
+
+			if(level >= kHelLogSeverityEmergency && level <= kHelLogSeverityDebug) {
+				s = HelLogSeverity(level);
+			}
+
+			msg += digits + 2;
+		};
+
+		if(msg && length >= 1 && msg[0] == '<') {
+			if(length >= 2 && isdigit(msg[1])) {
+				if(length >= 3 && isdigit(msg[2])) {
+					if(length >= 4 && isdigit(msg[3])) {
+						if(length >= 5 && msg[4] == '>') {
+							handlePrefix(3);
+						}
+					} else if(length >= 4 && msg[3] == '>') {
+						handlePrefix(2);
+					}
+				} else if(length >= 3 && msg[2] == '>') {
+					handlePrefix(1);
+				}
+			}
+		}
+
+		auto line_len = strlen(msg);
+		auto newline = strchr(msg, '\n');
+		if(newline) {
+			assert(newline > msg);
+			line_len = frg::min(static_cast<size_t>(newline - msg), line_len);
+		}
+
+		helLog(s, msg, line_len);
 
 		co_return length;
 	}

--- a/posix/subsystem/src/devices/kmsg.cpp
+++ b/posix/subsystem/src/devices/kmsg.cpp
@@ -47,7 +47,7 @@ private:
 		assert(resp.error() == managarm::kerncfg::Error::SUCCESS);
 
 		int ret_len = snprintf(reinterpret_cast<char *>(data), length,
-			"%u,%lu,%u,-;%s", 0, resp.effective_dequeue(), 0, reinterpret_cast<char *>(buffer.data()));
+			"%s", reinterpret_cast<char *>(buffer.data()));
 
 		assert(offset_ == resp.effective_dequeue());
 		offset_ = resp.new_dequeue();

--- a/testsuites/kernel-tests/src/faults.cpp
+++ b/testsuites/kernel-tests/src/faults.cpp
@@ -9,12 +9,12 @@ void *const nonCanonicalPtr = reinterpret_cast<void *>(INT64_C(-16384));
 void *const illegalPtr = reinterpret_cast<void *>(0xBAD'0000'BEEF);
 
 DEFINE_TEST(nonCanonical, ([] {
-	HelError ret = helLog(static_cast<char *>(nonCanonicalPtr), 4096);
+	HelError ret = helLog(kHelLogSeverityInfo, static_cast<char *>(nonCanonicalPtr), 4096);
 	assert(ret == kHelErrFault);
 }))
 
 DEFINE_TEST(helLog_fault, ([] {
-	HelError ret = helLog(static_cast<char *>(illegalPtr), 4096);
+	HelError ret = helLog(kHelLogSeverityInfo, static_cast<char *>(illegalPtr), 4096);
 	assert(ret == kHelErrFault);
 }))
 


### PR DESCRIPTION
This PR ensures that logging to dmesg is pretty (by using priorities and stripping CSI sequences) and works as expected. This includes eudev's logging to `/dev/kmsg`, which uses prefixes as defined in RFC 5424.

Needs to be merged along with managarm/mlibc#1090.