### PR TITLE
[WIP]: Add better cpuinfo support

### DIFF
--- a/kernel/thor/arch/x86/cpu.cpp
+++ b/kernel/thor/arch/x86/cpu.cpp
@@ -398,7 +398,7 @@ bool handleUserAccessFault(uintptr_t address, bool write, FaultImageAccessor acc
 // --------------------------------------------------------
 
 constinit bool cpuFeaturesKnown = false;
-constinit CpuFeatures globalCpuFeatures{};
+constinit OldCpuFeatures globalCpuFeatures{};
 
 initgraph::Stage *getCpuFeaturesKnownStage() {
 	static initgraph::Stage s{&globalInitEngine, "x86.cpu-features-known"};
@@ -456,13 +456,13 @@ static initgraph::Task enumerateCpuFeaturesTask{&globalInitEngine, "x86.enumerat
 		if(intelPmLeaf & 0xFF) {
 			debugLogger() << "thor: CPUs support Intel performance counters"
 					<< frg::endlog;
-			globalCpuFeatures.profileFlags |= CpuFeatures::profileIntelSupported;
+			globalCpuFeatures.profileFlags |= OldCpuFeatures::profileIntelSupported;
 		}
 		auto amdPmLeaf = common::x86::cpuid(0x8000'0001)[2];
 		if(amdPmLeaf & (1 << 23)) {
 			debugLogger() << "thor: CPUs support AMD performance counters"
 					<< frg::endlog;
-			globalCpuFeatures.profileFlags |= CpuFeatures::profileAmdSupported;
+			globalCpuFeatures.profileFlags |= OldCpuFeatures::profileAmdSupported;
 		}
 
 		// Check that both VMX and EPT are supported.

--- a/kernel/thor/arch/x86/cpu.cpp
+++ b/kernel/thor/arch/x86/cpu.cpp
@@ -405,9 +405,589 @@ initgraph::Stage *getCpuFeaturesKnownStage() {
 	return &s;
 }
 
+void getNewCpuFeatures() {
+	auto cpuData = getCpuData();
+	// EAX = 1, ECX
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 0)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SSE3);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 1)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PCLMULQDQ);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 2)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::DTES64);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 3)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MONITOR);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 4)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::DS_CPL);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 5)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::VMX);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 6)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SMX);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 7)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::EST);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 8)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TM2);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 9)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SSSE3);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 10)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CNXT_ID);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 11)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SDBG);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 12)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::FMA);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 13)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CX16);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 14)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::XTPR);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 15)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PDCM);
+	}
+	// ECX Bit 16 is reserved
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 17)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PCID);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 18)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::DCA);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 19)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SSE4_1);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 20)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SSE4_2);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 21)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::X2APIC);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 22)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MOVBE);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 23)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::POPCNT);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 24)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TSC_DEADLINE);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 25)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AES);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 26)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::XSAVE);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 27)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::OSXSAVE);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 28)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 29)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::F16C);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 30)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::RDRAND);
+	}
+	if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 31)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::HYPERVISOR);
+	}
+	// EAX = 1, EDX
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 0)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::FPU);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 1)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::VME);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 2)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::DE);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 3)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PSE);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 4)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TSC);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 5)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MSR);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 6)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PAE);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 7)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MCE);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 8)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CX8);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 9)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::APIC);
+	}
+	// EDX Bit 16 is reserved
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 11)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SEP);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 12)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MTRR);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 13)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PGE);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 14)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MCA);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 15)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CMOV);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 16)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PAT);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 17)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PSE36);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 18)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PSN);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 19)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CLFLUSH);
+	}
+	// EDX Bit 20 is reserved
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 21)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::DS);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 22)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::ACPI);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 23)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MMX);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 24)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::FXSR);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 25)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SSE);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 26)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SSE2);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 27)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SS);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 28)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::HTT);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 29)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TM);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 30)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::IA64);
+	}
+	if(common::x86::cpuid(0x1)[3] & (uint32_t(1) << 31)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PBE);
+	}
+	// EAX = 7, EBX
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 0)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::FSGSBASE);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 1)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TSC_ADJUST);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 2)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SGX);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 3)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::BMI1);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 4)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::HLE);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 5)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX2);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 6)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::FDP_EXCPTN_ONLY);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 7)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SMEP);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 8)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::BMI2);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 9)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::ERMS);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 10)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::INVPCID);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 11)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::RTM);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 12)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PQM);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 13)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::ZERO_FCS_FDS);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 14)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MPX);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 15)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PQE);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 16)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_F);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 17)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_DQ);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 18)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::RDSEED);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 19)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::ADX);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 20)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SMAP);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 21)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_IFMA);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 22)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PCOMMIT);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 23)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CLFLUSHOPT);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 24)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CLWB);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 25)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::INTEL_PT);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 26)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_PF);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 27)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_ER);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 28)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_CD);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 29)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SHA);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 30)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_BW);
+	}
+	if(common::x86::cpuid(0x7)[1] & (uint32_t(1) << 31)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_VL);
+	}
+	// EAX = 7, ECX
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 0)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PREFETCHWT1);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 1)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_VBMI);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 2)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::UMIP);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 3)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PKU);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 4)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::OSPKE);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 5)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::WAITPKG);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 6)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_VBMI2);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 7)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CET_SS);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 8)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::GFNI);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 9)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::VAES);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 10)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::VPCLMULQDQ);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 11)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_VNNI);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 12)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_BITALG);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 13)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TME_EN);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 14)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_VPOPCNTDQ);
+	}
+	// ECX bit 15 is reserved
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 16)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::INTEL_5_LEVEL_PAGING);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 17)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::RDPID);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 18)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::KL);
+	}
+	// ECX bits 19-24 are reserved
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 25)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CLDEMOTE);
+	}
+	// ECX bit 26 is reserved
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 27)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MOVDIRI);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 28)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MOVDIR64B);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 29)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::ENQCMD);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 30)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SGX_LC);
+	}
+	if(common::x86::cpuid(0x7)[2] & (uint32_t(1) << 31)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PKS);
+	}
+	// EAX = 7, EDX
+	// EDX bits 0-1 are reserved
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 2)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_4VNNIW);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 3)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_4FMAPS);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 4)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::FSRM);
+	}
+	// EDX bits 5-7 are reserved
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 8)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_VP2INTERSECT);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 9)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SRBDS_CTRL);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 10)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MD_CLEAR);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 11)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::RTM_ALWAYS_ABORT);
+	}
+	// EDX bit 12 is reserved
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 13)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TSX_FORCE_ABORT);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 14)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SERIALIZE);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 15)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::HYBRID);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 16)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TSXLDTRK);
+	}
+	// EDX bit 17 is reserved
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 18)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PCONFIG);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 19)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::LBR);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 20)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CET_IBT);
+	}
+	// EDX bit 21 is reserved
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 22)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AMX_BF16);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 23)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AVX512_FP16);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 24)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AMX_TILE);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 25)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::AMX_INT8);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 26)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SPEC_CTRL);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 27)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::STIBP);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 28)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::L1D_FLUSH);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 29)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::IA32_ARCH_CAPABILITIES);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 30)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::IA32_CORE_CAPABILITIES);
+	}
+	if(common::x86::cpuid(0x7)[3] & (uint32_t(1) << 31)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SSBD);
+	}
+	// EAX = 80000001h, ECX
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 0)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::LAHF_LM);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 1)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CMP_LEGACY);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 2)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SVM);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 3)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::EXTAPIC);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 4)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CR8_LEGACY);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 5)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::ABM);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 6)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SSE4A);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 7)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MISALIGNSSE);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 8)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::_3DNOWPREFETCH);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 9)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::OSVW);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 10)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::IBS);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 11)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::XOP);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 12)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SKINIT);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 13)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::WDT);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 14)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::LWP);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 15)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::FMA4);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 16)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TCE);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 17)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::NODEID_MSR);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 18)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TBM);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 19)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::TOPOEXT);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 20)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PERFCTR_CORE);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 21)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PERFCTR_NB);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 22)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::DBX);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 23)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PERFTSC);
+	}
+	if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 24)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PCX_L2I);
+	}
+	// RESERVED?
+	// if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 25)) {
+	// 	cpuData->cpuFeatures |= uint32_t(CpuFeatures::AMX_INT8);
+	// }
+	// if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 26)) {
+	// 	cpuData->cpuFeatures |= uint32_t(CpuFeatures::SPEC_CTRL);
+	// }
+	// if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 27)) {
+	// 	cpuData->cpuFeatures |= uint32_t(CpuFeatures::STIBP);
+	// }
+	// if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 28)) {
+	// 	cpuData->cpuFeatures |= uint32_t(CpuFeatures::L1D_FLUSH);
+	// }
+	// if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 29)) {
+	// 	cpuData->cpuFeatures |= uint32_t(CpuFeatures::IA32_ARCH_CAPABILITIES);
+	// }
+	// if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 30)) {
+	// 	cpuData->cpuFeatures |= uint32_t(CpuFeatures::IA32_CORE_CAPABILITIES);
+	// }
+	// if(common::x86::cpuid(0x80000001)[2] & (uint32_t(1) << 31)) {
+	// 	cpuData->cpuFeatures |= uint32_t(CpuFeatures::SSBD);
+	// }
+	// EAX = 80000001h, EDX
+	if(common::x86::cpuid(0x80000001)[3] & (uint32_t(1) << 0)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::SYSCALL);
+	}
+	if(common::x86::cpuid(0x80000001)[3] & (uint32_t(1) << 1)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MP);
+	}
+	if(common::x86::cpuid(0x80000001)[3] & (uint32_t(1) << 2)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::NX);
+	}
+	if(common::x86::cpuid(0x80000001)[3] & (uint32_t(1) << 3)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::MMXEXT);
+	}
+	if(common::x86::cpuid(0x80000001)[3] & (uint32_t(1) << 4)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::FXSR_OPT);
+	}
+	if(common::x86::cpuid(0x80000001)[3] & (uint32_t(1) << 5)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::PDPE1GB);
+	}
+	if(common::x86::cpuid(0x80000001)[3] & (uint32_t(1) << 6)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::RDTSCP);
+	}
+	if(common::x86::cpuid(0x80000001)[3] & (uint32_t(1) << 7)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::LM);
+	}
+	if(common::x86::cpuid(0x80000001)[3] & (uint32_t(1) << 8)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::_3DNOWEXT);
+	}
+	if(common::x86::cpuid(0x80000001)[3] & (uint32_t(1) << 9)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::_3DNOW);
+	}
+	// EAX = 80000007h, EDX
+	if(common::x86::cpuid(0x80000007)[3] & (uint32_t(1) << 0)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::CONSTANT_TSC);
+	}
+	if(common::x86::cpuid(0x80000007)[3] & (uint32_t(1) << 1)) {
+		cpuData->cpuFeatures |= uint32_t(CpuFeatures::NONSTOP_TSC);
+	}
+}
+
 static initgraph::Task enumerateCpuFeaturesTask{&globalInitEngine, "x86.enumerate-cpu-features",
 	initgraph::Entails{getCpuFeaturesKnownStage()},
 	[] {
+		getNewCpuFeatures();
 		// Enable the XSAVE instruction set and child features
 		if(common::x86::cpuid(0x1)[2] & (uint32_t(1) << 26)) {
 			debugLogger() << "thor: CPUs support XSAVE" << frg::endlog;

--- a/kernel/thor/arch/x86/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/cpu.hpp
@@ -513,7 +513,7 @@ void scrubStack(IrqImageAccessor accessor, Continuation cont);
 void scrubStack(SyscallImageAccessor accessor, Continuation cont);
 void scrubStack(Executor *executor, Continuation cont);
 
-struct CpuFeatures {
+struct OldCpuFeatures {
 	static constexpr uint32_t profileIntelSupported = 1;
 	static constexpr uint32_t profileAmdSupported = 2;
 
@@ -528,10 +528,213 @@ struct CpuFeatures {
 	size_t xsaveRegionSize;
 };
 
-extern bool cpuFeaturesKnown;
-extern CpuFeatures globalCpuFeatures;
+enum class CpuFeatures : uint32_t {
+	// EAX=1, ECX
+    SSE3 = 0,						// Streaming SIMD Extensions 3
+    PCLMULQDQ = 1,					// PCLMULDQ Instruction
+    DTES64 = 2,						// 64-Bit Debug Store
+    MONITOR = 3,					// MONITOR/MWAIT Instructions
+    DS_CPL = 4,						// CPL Qualified Debug Store
+    VMX = 5,						// Virtual Machine Extensions
+    SMX = 6,						// Safer Mode Extensions
+    EST = 7,						// Enhanced Intel SpeedStep® Technology
+    TM2 = 8,						// Thermal Monitor 2
+    SSSE3 = 9,						// Supplemental Streaming SIMD Extensions 3
+    CNXT_ID = 10,					// L1 Context ID
+    SDBG = 11,						// Silicon Debug (IA32_DEBUG_INTERFACE MSR)
+    FMA = 12,						// Fused Multiply Add
+    CX16 = 13,						// CMPXCHG16B Instruction
+    XTPR = 14,						// xTPR Update Control
+    PDCM = 15,						// Perfmon and Debug Capability (IA32_PERF_CAPABILITIES MSR)
+    /* ECX Bit 16 */				// Reserved
+    PCID = 17,						// Process Context Identifiers
+    DCA = 18,						// Direct Cache Access
+    SSE4_1 = 19,					// Streaming SIMD Extensions 4.1
+    SSE4_2 = 20,					// Streaming SIMD Extensions 4.2
+    X2APIC = 21,					// Extended xAPIC Support
+    MOVBE = 22,						// MOVBE Instruction
+    POPCNT = 23,					// POPCNT Instruction
+    TSC_DEADLINE = 24,				// Time Stamp Counter Deadline
+    AES = 25,						// AES Instruction Extensions
+    XSAVE = 26,						// XSAVE/XSTOR States
+    OSXSAVE = 27,					// OS-Enabled Extended State Management
+    AVX = 28,						// Advanced Vector Extensions
+    F16C = 29,						// 16-bit floating-point conversion instructions
+    RDRAND = 30,					// RDRAND Instruction
+    HYPERVISOR = 31,				// Hypervisor present (always zero on physical CPUs)
+    // EAX=1, EDX
+    FPU = 32,						// Floating-point Unit On-Chip
+    VME = 33,						// Virtual Mode Extension
+    DE = 34,						// Debugging Extension
+    PSE = 35,						// Page Size Extension
+    TSC = 36,						// Time Stamp Counter
+    MSR = 37,						// Model Specific Registers
+    PAE = 38,						// Physical Address Extension
+    MCE = 39,						// Machine-Check Exception
+    CX8 = 40,						// CMPXCHG8 Instruction
+    APIC = 41,						// On-chip APIC Hardware
+    /* EDX Bit 10 */				// Reserved
+    SEP = 43,						// Fast System Call
+    MTRR = 44,						// Memory Type Range Registers
+    PGE = 45,						// Page Global Enable
+    MCA = 46,						// Machine-Check Architecture
+    CMOV = 47,						// Conditional Move Instruction
+    PAT = 48,						// Page Attribute Table
+    PSE36 = 49,						// 36-bit Page Size Extension
+    PSN = 50,						// Processor serial number is present and enabled
+    CLFLUSH = 51,					// CLFLUSH Instruction
+    /* EDX Bit 20 */				// Reserved
+    DS = 53,						// CLFLUSH Instruction
+    ACPI = 54,						// CLFLUSH Instruction
+    MMX = 55,						// CLFLUSH Instruction
+    FXSR = 56,						// CLFLUSH Instruction
+    SSE = 57,						// Streaming SIMD Extensions
+    SSE2 = 58,						// Streaming SIMD Extensions 2
+    SS = 59,						// Self-Snoop
+    HTT = 60,						// Multi-Threading
+    TM = 61,						// Thermal Monitor
+    IA64 = 62,						// IA64 processor emulating x86
+    PBE = 63,						// Pending Break Enable
+    // EAX=7, EBX
+    FSGSBASE = 64,					// Access to base of %fs and %gs
+    TSC_ADJUST = 65,				// IA32_TSC_ADJUST MSR
+    SGX = 66,						// Software Guard Extensions
+    BMI1 = 67,						// Bit Manipulation Instruction Set 1
+    HLE = 68,						// TSX Hardware Lock Elision
+    AVX2 = 69,						// Advanced Vector Extensions 2
+    FDP_EXCPTN_ONLY = 70,			// FDP_EXCPTN_ONLY
+    SMEP = 71,						// Supervisor Mode Execution Protection
+    BMI2 = 72,						// Bit Manipulation Instruction Set 2
+    ERMS = 73,						// Enhanced REP MOVSB/STOSB
+    INVPCID = 74,					// INVPCID Instruction
+    RTM = 75,						// TSX Restricted Transactional Memory
+    PQM = 76,						// Platform Quality of Service Monitoring
+    ZERO_FCS_FDS = 77,				// FPU CS and FPU DS deprecated
+    MPX = 78,						// Intel MPX (Memory Protection Extensions)
+    PQE = 79,						// Platform Quality of Service Enforcement
+    AVX512_F = 80,					// AVX-512 Foundation
+    AVX512_DQ = 81,					// AVX-512 Doubleword and Quadword Instructions
+    RDSEED = 82,					// RDSEED Instruction
+    ADX = 83,						// Intel ADX (Multi-Precision Add-Carry Instruction Extensions)
+    SMAP = 84,						// Supervisor Mode Access Prevention
+    AVX512_IFMA = 85,				// AVX-512 Integer Fused Multiply-Add Instructions
+    PCOMMIT = 86,					// PCOMMIT Instruction
+    CLFLUSHOPT = 87,				// CLFLUSHOPT Instruction
+    CLWB = 88,						// CLWB Instruction
+    INTEL_PT = 89,					// Intel Processor Tracing
+    AVX512_PF = 90,					// AVX-512 Prefetch Instructions
+    AVX512_ER = 91,					// AVX-512 Exponential and Reciprocal Instructions
+    AVX512_CD = 92,					// AVX-512 Conflict Detection Instructions
+    SHA = 93,						// Intel SHA Extensions
+    AVX512_BW = 94,					// AVX-512 Byte and Word Instructions
+    AVX512_VL = 95,					// AVX-512 Vector Length Extensions
+    // EAX=7, ECX
+    PREFETCHWT1 = 96,				// PREFETCHWT1 Instruction
+    AVX512_VBMI = 97,				// AVX-512 Vector Bit Manipulation Instructions
+    UMIP = 98,						// UMIP
+    PKU = 99,						// Memory Protection Keys for User-mode pages
+    OSPKE = 100,					// PKU enabled by OS
+    WAITPKG = 101,					// Timed pause and user-level monitor/wait
+    AVX512_VBMI2 = 102,				// AVX-512 Vector Bit Manipulation Instructions 2
+    CET_SS = 103,					// Control Flow Enforcement (CET) Shadow Stack
+    GFNI = 104,						// Galois Field Instructions
+    VAES = 105,						// Vector AES instruction set (VEX-256/EVEX)
+    VPCLMULQDQ = 106,				// CLMUL instruction set (VEX-256/EVEX)
+    AVX512_VNNI = 107,				// AVX-512 Vector Neural Network Instructions
+    AVX512_BITALG = 108,			// AVX-512 BITALG Instructions
+    TME_EN = 109,					// IA32_TME related MSRs are supported
+    AVX512_VPOPCNTDQ = 110,			// AVX-512 Vector Population Count Double and Quad-word
+    // ECX Bit 15					// Reserved
+    INTEL_5_LEVEL_PAGING = 112,		// Intel 5-Level Paging
+    RDPID = 113,					// RDPID Instruction
+    KL = 114,						// Key Locker
+    // ECX Bit 24					// Reserved
+    CLDEMOTE = 116,					// Cache Line Demote
+    // ECX Bit 26					// Reserved
+    MOVDIRI = 118,					// MOVDIRI Instruction
+    MOVDIR64B = 119,				// MOVDIR64B Instruction
+    ENQCMD = 120,					// ENQCMD Instruction
+    SGX_LC = 121,					// SGX Launch Configuration
+    PKS = 122,						// Protection Keys for Supervisor-Mode Pages
+    // EAX=7, EDX
+    // ECX Bit 0-1					// Reserved
+    AVX512_4VNNIW = 125,			// AVX-512 4-register Neural Network Instructions
+    AVX512_4FMAPS = 126,			// AVX-512 4-register Multiply Accumulation Single precision
+    FSRM = 127,						// Fast Short REP MOVSB
+    // ECX Bit 5-7					// Reserved
+    AVX512_VP2INTERSECT = 131,		// AVX-512 VP2INTERSECT Doubleword and Quadword Instructions
+    SRBDS_CTRL = 132,				// Special Register Buffer Data Sampling Mitigations
+    MD_CLEAR = 133,					// VERW instruction clears CPU buffers
+    RTM_ALWAYS_ABORT = 134,			// All TSX transactions are aborted
+    // ECX Bit 12 					// Reserved
+    TSX_FORCE_ABORT = 136,			// TSX_FORCE_ABORT MSR
+    SERIALIZE = 137,				// Serialize instruction execution
+    HYBRID = 138,					// Mixture of CPU types in processor topology
+    TSXLDTRK = 139,					// TSX suspend load address tracking
+    // ECX Bit 17					// Reserved
+    PCONFIG = 141,					// Platform configuration (Memory Encryption Technologies Instructions)
+    LBR = 142,						// Architectural Last Branch Records
+    CET_IBT = 143,					// Control flow enforcement (CET) indirect branch tracking
+    // ECX Bit 21 					// Reserved
+    AMX_BF16 = 145,					// Tile computation on bfloat16 numbers
+    AVX512_FP16 = 146,				// AVX512-FP16 half-precision floating-point instructions
+    AMX_TILE = 147,					// Tile architecture
+    AMX_INT8 = 148,					// Tile computation on 8-bit integers
+    SPEC_CTRL = 149,				// Speculation Control
+    STIBP = 150,					// Single Thread Indirect Branch Predictor
+    L1D_FLUSH = 151,				// IA32_FLUSH_CMD MSR
+    IA32_ARCH_CAPABILITIES = 152,	// IA32_ARCH_CAPABILITIES MSR
+    IA32_CORE_CAPABILITIES = 153,	// IA32_CORE_CAPABILITIES MSR
+    SSBD = 154,						// Speculative Store Bypass Disable
+    // EAX=80000001h, ECX
+    LAHF_LM = 155,					// LAHF/SAHF in long mode
+    CMP_LEGACY = 156,				// Hyperthreading not valid
+    SVM = 157,						// Secure Virtual Machine
+    EXTAPIC = 158,					// Extended APIC Space
+    CR8_LEGACY = 159,				// CR8 in 32-bit mode
+    ABM = 160,						// Advanced Bit Manipulation
+    SSE4A = 161,					// SSE4a
+    MISALIGNSSE = 162,				// Misaligned SSE Mode
+    _3DNOWPREFETCH = 163,			// PREFETCH and PREFETCHW Instructions
+    OSVW = 164,						// OS Visible Workaround
+    IBS = 165,						// Instruction Based Sampling
+    XOP = 166,						// XOP instruction set
+    SKINIT = 167,					// SKINIT/STGI Instructions
+    WDT = 168,						// Watchdog timer
+    LWP = 169,						// Light Weight Profiling
+    FMA4 = 170,						// FMA4 instruction set
+    TCE = 171,						// Translation Cache Extension
+    NODEID_MSR = 172,				// NodeID MSR
+    TBM = 173,						// Trailing Bit Manipulation
+    TOPOEXT = 174,					// Topology Extensions
+    PERFCTR_CORE = 175,				// Core Performance Counter Extensions
+    PERFCTR_NB = 176,				// NB Performance Counter Extensions
+    DBX = 177,						// Data Breakpoint Extensions
+    PERFTSC = 178,					// Performance TSC
+    PCX_L2I = 179,					// L2I Performance Counter Extensions
+    // EAX=80000001h, EDX
+    SYSCALL = 180,					// SYSCALL/SYSRET Instructions
+    MP = 181,						// Multiprocessor Capable
+    NX = 182,						// NX bit
+    MMXEXT = 183,					// Extended MMX
+    FXSR_OPT = 184,					// FXSAVE/FXRSTOR Optimizations
+    PDPE1GB = 185,					// Gigabyte Pages
+    RDTSCP = 186,					// RDTSCP Instruction
+    LM = 187,						// Long Mode
+    _3DNOWEXT = 188,				// Extended 3DNow!
+    _3DNOW = 189,					// 3DNow!
+    // EAX=80000007h, EDX
+    CONSTANT_TSC = 190,				// Invariant TSC
+    NONSTOP_TSC = 191,				// Invariant TSC
+    __End = 255,					// Special marker, should never be set ever
+};
 
-[[gnu::const]] inline CpuFeatures *getGlobalCpuFeatures() {
+extern bool cpuFeaturesKnown;
+// This should probably go into the per cpu struct
+// As different cores can have different features.
+extern OldCpuFeatures globalCpuFeatures;
+
+[[gnu::const]] inline OldCpuFeatures *getGlobalCpuFeatures() {
 	assert(cpuFeaturesKnown);
 	return &globalCpuFeatures;
 }

--- a/kernel/thor/arch/x86/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/cpu.hpp
@@ -796,6 +796,8 @@ struct PlatformCpuData : public AssemblyCpuData {
 
 	// TODO: This is not really arch-specific!
 	smarter::borrowed_ptr<Thread> activeExecutor;
+
+	uint32_t cpuFeatures;
 };
 
 inline PlatformCpuData *getPlatformCpuData() {

--- a/kernel/thor/generic/profile.cpp
+++ b/kernel/thor/generic/profile.cpp
@@ -37,8 +37,8 @@ void initializeProfile() {
 	if(!wantKernelProfile)
 		return;
 
-	if(!(getGlobalCpuFeatures()->profileFlags & CpuFeatures::profileIntelSupported)
-			&& !(getGlobalCpuFeatures()->profileFlags & CpuFeatures::profileAmdSupported)) {
+	if(!(getGlobalCpuFeatures()->profileFlags & OldCpuFeatures::profileIntelSupported)
+			&& !(getGlobalCpuFeatures()->profileFlags & OldCpuFeatures::profileAmdSupported)) {
 		urgentLogger() << "thor: Kernel profiling was requested but"
 				" no hardware support is available" << frg::endlog;
 		return;
@@ -52,13 +52,13 @@ void initializeProfile() {
 	KernelFiber::run([=] {
 		getCpuData()->localProfileRing = frg::construct<SingleContextRecordRing>(*kernelAlloc);
 
-		if(getGlobalCpuFeatures()->profileFlags & CpuFeatures::profileIntelSupported) {
+		if(getGlobalCpuFeatures()->profileFlags & OldCpuFeatures::profileIntelSupported) {
 			initializeIntelPmc();
 			getCpuData()->profileMechanism.store(ProfileMechanism::intelPmc,
 					std::memory_order_release);
 			setIntelPmc();
 		}else{
-			assert(getGlobalCpuFeatures()->profileFlags & CpuFeatures::profileAmdSupported);
+			assert(getGlobalCpuFeatures()->profileFlags & OldCpuFeatures::profileAmdSupported);
 			getCpuData()->profileMechanism.store(ProfileMechanism::amdPmc,
 					std::memory_order_release);
 			setAmdPmc();


### PR DESCRIPTION
Massive draft, formatting will be wrong.
This PR will implement parts of `/proc/cpuinfo` and aims to rework parts of the CPU bringup code alongside it, mainly related to the globalCpuFeatures part. With big.LITTLE cores, having one global set of features will at best reduce the better cores in what they can do and will otherwise touch potentially reserved bits for the LITTLE cores.