### PR TITLE
libblockfs and init-stage1 improvements

### DIFF
--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -21,10 +21,7 @@
 
 namespace blockfs {
 
-// TODO: Support more than one table.
-gpt::Table *table;
-ext2fs::FileSystem *fs;
-raw::RawFs *rawFs;
+bool tracingInitialized = false;
 
 protocols::ostrace::Context ostContext;
 protocols::ostrace::EventId ostReadEvent;
@@ -268,7 +265,7 @@ getLink(std::shared_ptr<void> object,
 	}
 
 	assert(entry->inode);
-	co_return protocols::fs::GetLinkResult{fs->accessInode(entry->inode), entry->inode, type};
+	co_return protocols::fs::GetLinkResult{self->fs.accessInode(entry->inode), entry->inode, type};
 }
 
 async::result<protocols::fs::GetLinkResult> link(std::shared_ptr<void> object,
@@ -295,7 +292,7 @@ async::result<protocols::fs::GetLinkResult> link(std::shared_ptr<void> object,
 	}
 
 	assert(entry->inode);
-	co_return protocols::fs::GetLinkResult{fs->accessInode(entry->inode), entry->inode, type};
+	co_return protocols::fs::GetLinkResult{self->fs.accessInode(entry->inode), entry->inode, type};
 }
 
 async::result<frg::expected<protocols::fs::Error>> unlink(std::shared_ptr<void> object, std::string name) {
@@ -393,7 +390,7 @@ mkdir(std::shared_ptr<void> object, std::string name) {
 		co_return protocols::fs::MkdirResult{nullptr, -1};
 
 	assert(entry->inode);
-	co_return protocols::fs::MkdirResult{fs->accessInode(entry->inode), entry->inode};
+	co_return protocols::fs::MkdirResult{self->fs.accessInode(entry->inode), entry->inode};
 }
 
 async::result<protocols::fs::SymlinkResult>
@@ -405,7 +402,7 @@ symlink(std::shared_ptr<void> object, std::string name, std::string target) {
 		co_return protocols::fs::SymlinkResult{nullptr, -1};
 
 	assert(entry->inode);
-	co_return protocols::fs::SymlinkResult{fs->accessInode(entry->inode), entry->inode};
+	co_return protocols::fs::SymlinkResult{self->fs.accessInode(entry->inode), entry->inode};
 }
 
 async::result<protocols::fs::Error> chmod(std::shared_ptr<void> object, int mode) {
@@ -611,8 +608,11 @@ constexpr protocols::fs::FileOperations rawOperations {
 BlockDevice::BlockDevice(size_t sector_size, int64_t parent_id)
 : size(0), sectorSize(sector_size), parentId(parent_id) { }
 
-async::detached servePartition(helix::UniqueLane lane) {
+async::detached servePartition(helix::UniqueLane lane, gpt::Partition *partition, std::unique_ptr<raw::RawFs> rawFs) {
 	std::cout << "unix device: Connection" << std::endl;
+
+	// TODO(qookie): Generic file system type
+	std::unique_ptr<ext2fs::FileSystem> fs;
 
 	while(true) {
 		auto [accept, recv_head] = co_await helix_ng::exchangeMsgs(
@@ -640,6 +640,11 @@ async::detached servePartition(helix::UniqueLane lane) {
 		recv_head.reset();
 
 		if(req.req_type() == managarm::fs::CntReqType::DEV_MOUNT) {
+			// Mount the actual file system
+			fs = std::make_unique<ext2fs::FileSystem>(partition);
+			co_await fs->init();
+			printf("ext2fs is ready!\n");
+
 			helix::UniqueLane local_lane, remote_lane;
 			std::tie(local_lane, remote_lane) = helix::createStream();
 			protocols::fs::serveNode(std::move(local_lane), fs->accessRoot(),
@@ -769,7 +774,7 @@ async::detached servePartition(helix::UniqueLane lane) {
 		}else if(req.req_type() == managarm::fs::CntReqType::DEV_OPEN) {
 			helix::UniqueLane local_lane, remote_lane;
 			std::tie(local_lane, remote_lane) = helix::createStream();
-			auto file = smarter::make_shared<raw::OpenFile>(rawFs);
+			auto file = smarter::make_shared<raw::OpenFile>(rawFs.get());
 			async::detach(protocols::fs::servePassthrough(std::move(local_lane),
 					file,
 					&rawOperations));
@@ -796,7 +801,7 @@ async::detached servePartition(helix::UniqueLane lane) {
 			if(req->command() == BLKGETSIZE64) {
 				managarm::fs::GenericIoctlReply rsp;
 				rsp.set_error(managarm::fs::Errors::SUCCESS);
-				rsp.set_size(co_await fs->device->getSize());
+				rsp.set_size(co_await partition->getSize());
 
 				auto ser = rsp.SerializeAsString();
 				auto [send_resp] = co_await helix_ng::exchangeMsgs(
@@ -819,13 +824,20 @@ async::detached servePartition(helix::UniqueLane lane) {
 }
 
 async::detached runDevice(BlockDevice *device) {
-	ostContext = co_await protocols::ostrace::createContext();
-	ostReadEvent = co_await ostContext.announceEvent("libblockfs.read");
-	ostReaddirEvent = co_await ostContext.announceEvent("libblockfs.readdir");
-	ostByteCounter = co_await ostContext.announceItem("numBytes");
-	ostTimeCounter = co_await ostContext.announceItem("time");
+	if (!tracingInitialized) {
+		ostContext = co_await protocols::ostrace::createContext();
+		ostReadEvent = co_await ostContext.announceEvent("libblockfs.read");
+		ostReaddirEvent = co_await ostContext.announceEvent("libblockfs.readdir");
+		ostByteCounter = co_await ostContext.announceItem("numBytes");
+		ostTimeCounter = co_await ostContext.announceItem("time");
 
-	table = new gpt::Table(device);
+		tracingInitialized = true;
+	}
+
+	// TODO(qookie): Don't leak the table.
+	// Currently it should be fine to leak it since neither it nor
+	// the device gets deleted anyway.
+	auto table = new gpt::Table(device);
 	co_await table->parse();
 
 	int64_t diskId = 0;
@@ -865,11 +877,9 @@ async::detached runDevice(BlockDevice *device) {
 			continue;
 		printf("It's a Managarm root partition!\n");
 
-		fs = new ext2fs::FileSystem(&table->getPartition(i));
-		co_await fs->init();
-		printf("ext2fs is ready!\n");
+		auto device = &table->getPartition(i);
 
-		rawFs = new raw::RawFs(fs->device);
+		auto rawFs = std::make_unique<raw::RawFs>(device);
 		co_await rawFs->init();
 		printf("rawfs is ready!\n");
 
@@ -886,16 +896,16 @@ async::detached runDevice(BlockDevice *device) {
 		auto entity = (co_await mbus_ng::Instance::global().createEntity(
 					"partition", descriptor)).unwrap();
 
-		[] (mbus_ng::EntityManager entity) -> async::detached {
+		[] (mbus_ng::EntityManager entity, gpt::Partition *partition, std::unique_ptr<raw::RawFs> rawFs) -> async::detached {
 			while (true) {
 				auto [localLane, remoteLane] = helix::createStream();
 
 				// If this fails, too bad!
 				(void)(co_await entity.serveRemoteLane(std::move(remoteLane)));
 
-				servePartition(std::move(localLane));
+				servePartition(std::move(localLane), partition, std::move(rawFs));
 			}
-		}(std::move(entity));
+		}(std::move(entity), device, std::move(rawFs));
 	}
 }
 

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -873,9 +873,8 @@ async::detached runDevice(BlockDevice *device) {
 				i, type.a, type.b, type.c, type.d[0], type.d[1],
 				type.e[0], type.e[1], type.e[2], type.e[3], type.e[4], type.e[5]);
 
-		if(type != gpt::type_guids::managarmRootPartition)
-			continue;
-		printf("It's a Managarm root partition!\n");
+		if(type == gpt::type_guids::managarmRootPartition)
+			printf("  It's a Managarm root partition!\n");
 
 		auto device = &table->getPartition(i);
 

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -879,7 +879,8 @@ async::detached runDevice(BlockDevice *device) {
 			{"unix.blocktype", mbus_ng::StringItem{"partition"}},
 			{"unix.partid", mbus_ng::StringItem{std::to_string(partId++)}},
 			{"unix.diskid", mbus_ng::StringItem{std::to_string(diskId)}},
-			{"drvcore.mbus-parent", mbus_ng::StringItem{std::to_string(device->parentId)}}
+			{"drvcore.mbus-parent", mbus_ng::StringItem{std::to_string(device->parentId)}},
+			{"unix.is-managarm-root", mbus_ng::StringItem{std::to_string(type == gpt::type_guids::managarmRootPartition)}}
 		};
 
 		auto entity = (co_await mbus_ng::Instance::global().createEntity(

--- a/posix/init/src/stage1.cpp
+++ b/posix/init/src/stage1.cpp
@@ -7,8 +7,149 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <sys/socket.h>
+#include <sys/sysmacros.h>
+#include <linux/netlink.h>
 #include <unistd.h>
+#include <string.h>
 #include <iostream>
+#include <string_view>
+#include <unordered_set>
+#include <ranges>
+#include <filesystem>
+#include <optional>
+#include <fstream>
+
+bool logDiscovery = false;
+
+std::string findRootDevice() {
+	std::cout << "init: Looking for the root partition" << std::endl;
+
+	int nlFd = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_KOBJECT_UEVENT);
+	if(nlFd < 0) {
+		std::cout << "init: socket(AF_NETLINK) failed! errno: " << strerror(errno) << std::endl;
+		return "";
+	}
+
+	struct sockaddr_nl sa;
+	sa.nl_family = AF_NETLINK;
+	sa.nl_pid = getpid();
+	sa.nl_groups = 1;
+
+	int ret = bind(nlFd, reinterpret_cast<struct sockaddr *>(&sa), sizeof(sa));
+	if(ret < 0) {
+		std::cout << "init: bind(nlFd) failed! errno: " << strerror(errno) << std::endl;
+		return "";
+	}
+
+	std::unordered_set<std::string> checkedDevices;
+
+	auto checkDevice = [&] (std::string device) -> std::optional<std::string> {
+		if (checkedDevices.contains(device))
+			return std::nullopt;
+
+		checkedDevices.insert(device);
+
+		if(logDiscovery)
+			std::cout << "init: Considering device " << device << std::endl;
+
+		auto rootAttr = device + "/managarm-root";
+
+		// Check if the managarm-root attribute exists
+		if(access(rootAttr.data(), R_OK)) {
+			assert(errno == ENOENT);
+			if(logDiscovery)
+				std::cout << "init:  Not the root filesystem" << std::endl;
+			return std::nullopt;
+		}
+
+		// Figure out the device's major:minor
+		std::ifstream ifs{device + "/dev"};
+		std::string dev;
+		std::getline(ifs, dev);
+
+		auto split = dev | std::views::split(':');
+		auto it = split.begin();
+
+		// TODO(qookie): C++23 would let us do std::string_view{*it}
+		std::string majorStr{(*it).begin(), (*it).end()};
+		it++;
+		std::string minorStr{(*it).begin(), (*it).end()};
+
+		int major = std::stoi(majorStr), minor = std::stoi(minorStr);
+
+		// Find the /dev node with the right major:minor numbers
+		for(auto node : std::filesystem::directory_iterator{"/dev/"}) {
+			struct stat st;
+			stat(node.path().c_str(), &st);
+
+			if(st.st_rdev == makedev(major, minor)) {
+				return node.path();
+			}
+		}
+
+		// This major:minor is not in /dev? Bail out...
+		std::cout << "init: Device " << device << " (maj:min " << major << ":" << minor << ")"
+			<< "is the root filesystem, but has no corresponding /dev node?" << std::endl;
+		return "";
+	};
+
+	// Check existing devices in /sys/class/block
+	// that appeared before we started listening
+	for(auto dev : std::filesystem::directory_iterator{"/sys/class/block"}) {
+		auto linkTarget = "/sys/class/block/" / std::filesystem::read_symlink(dev);
+
+		if(logDiscovery)
+			std::cout << "init: Candidate device " << linkTarget
+				<< " found via /sys/class/block" << std::endl;
+		if(auto device = checkDevice(linkTarget.generic_string()))
+			return device.value();
+	}
+
+	while(true) {
+		std::string buf;
+		buf.resize(16384);
+
+		ret = read(nlFd, buf.data(), buf.size());
+		if(ret < 0) {
+			std::cout << "init: read(nlFd) failed! errno: " << strerror(errno) << std::endl;
+			return "";
+		} else {
+			// Parse the uevent message
+			std::string_view action, subsystem;
+			std::string devpath;
+
+			const char *cur = buf.data();
+			while(cur < buf.data() + ret) {
+				std::string_view line{cur};
+				auto split = line | std::views::split('=');
+				auto it = split.begin();
+
+				// TODO(qookie): C++23 would let us do std::string_view{*it}
+				std::string_view name{(*it).begin(), (*it).end()};
+				it++;
+				std::string_view value{(*it).begin(), (*it).end()};
+
+				if(name == "ACTION")
+					action = value;
+				else if(name == "SUBSYSTEM")
+					subsystem = value;
+				else if(name == "DEVPATH")
+					devpath = "/sys" + std::string{value};
+
+				cur += line.size() + 1;
+			}
+
+			if(action == "add" && subsystem == "block") {
+				if(logDiscovery)
+					std::cout << "init: Candidate device " << devpath
+						<< " found via uevent" << std::endl;
+				if(auto device = checkDevice(devpath))
+					return device.value();
+			}
+		}
+	}
+}
 
 int main() {
 	int fd = open("/dev/helout", O_WRONLY);
@@ -62,12 +203,14 @@ int main() {
 		execl("/bin/runsvr", "/bin/runsvr", "runsvr", "/sbin/storage", nullptr);
 	}else assert(block_usb != -1);
 
-	// Spin until /dev/sda0 becomes available. Then mount the rootfs and prepare it.
-	while(access("/dev/sda1", F_OK)) {
-		assert(errno == ENOENT);
-		std::cout << "Waiting for /dev/sda1" << std::endl;
-		sleep(1);
-	}
+	std::string rootPath = "";
+	// TODO(qookie): Query /proc/cmdline to see if the user
+	// requested a different device.
+
+	if (!rootPath.size())
+		rootPath = findRootDevice();
+	if (!rootPath.size())
+		throw std::runtime_error("Can't determine root device");
 
 #if defined (__x86_64__)
 	// Hack: Start UHCI only after EHCI devices are ready.
@@ -77,8 +220,8 @@ int main() {
 	}else assert(uhci != -1);
 #endif
 
-	std::cout << "init: Mounting /dev/sda1" << std::endl;
-	if(mount("/dev/sda1", "/realfs", "ext2", 0, ""))
+	std::cout << "init: Mounting " << rootPath << std::endl;
+	if(mount(rootPath.data(), "/realfs", "ext2", 0, ""))
 		throw std::runtime_error("mount() failed");
 
 	if(mount("", "/realfs/proc", "procfs", 0, ""))

--- a/posix/init/src/stage1.cpp
+++ b/posix/init/src/stage1.cpp
@@ -63,9 +63,9 @@ int main() {
 	}else assert(block_usb != -1);
 
 	// Spin until /dev/sda0 becomes available. Then mount the rootfs and prepare it.
-	while(access("/dev/sda0", F_OK)) {
+	while(access("/dev/sda1", F_OK)) {
 		assert(errno == ENOENT);
-		std::cout << "Waiting for /dev/sda0" << std::endl;
+		std::cout << "Waiting for /dev/sda1" << std::endl;
 		sleep(1);
 	}
 
@@ -77,8 +77,8 @@ int main() {
 	}else assert(uhci != -1);
 #endif
 
-	std::cout << "init: Mounting /dev/sda0" << std::endl;
-	if(mount("/dev/sda0", "/realfs", "ext2", 0, ""))
+	std::cout << "init: Mounting /dev/sda1" << std::endl;
+	if(mount("/dev/sda1", "/realfs", "ext2", 0, ""))
 		throw std::runtime_error("mount() failed");
 
 	if(mount("", "/realfs/proc", "procfs", 0, ""))

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -11,6 +11,7 @@
 #include "device.hpp"
 #include "tmp_fs.hpp"
 #include "extern_fs.hpp"
+#include "sysfs.hpp"
 
 HelHandle __mlibc_getPassthrough(int fd);
 
@@ -71,6 +72,9 @@ async::result<void> populateRootView() {
 	// TODO: Check for errors from mkdir().
 	auto dev = std::get<std::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir("dev"));
 	co_await rootView->mount(std::move(dev), getDevtmpfs());
+
+	auto sys = std::get<std::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir("sys"));
+	co_await rootView->mount(std::move(sys), getSysfs());
 
 	// Populate the tmpfs from the fs we are running on.
 	std::vector<


### PR DESCRIPTION
Now all partitions are exposed in /dev and /sys, and init-stage1 finds the root partition by looking for one with the appropriate type in the partition table.