### PR TITLE
helix: add handleForFd function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,18 @@ jobs:
                   - pkg: managarm-kernel
                     tool_deps: >-
                         cross-binutils
+                        host-autoconf-v2.69
+                        host-automake-v1.11
+                        host-automake-v1.15
+                        host-libtool
                         host-llvm-toolchain
                         host-managarm-tools
+                        host-pkg-config
                         kernel-gcc
                         system-gcc
                     pkg_deps: >-
+                        libdrm-headers
+                        linux-headers
                         mlibc
                         mlibc-headers
                   - pkg: managarm-system
@@ -26,13 +33,15 @@ jobs:
                         host-libtool
                         host-llvm-toolchain
                         host-managarm-tools
+                        host-mold
                         host-pkg-config
                         host-xorg-macros
-                        host-mold
                         system-gcc
                     pkg_deps: >-
                         boost
                         eudev
+                        libdrm-headers
+                        linux-headers
                         mlibc
                         mlibc-headers
         name: Build ${{ matrix.pkg }}

--- a/hel/include/helix/passthrough-fd.hpp
+++ b/hel/include/helix/passthrough-fd.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <hel.h>
+
+namespace helix {
+
+HelHandle handleForFd(int fd);
+
+} // namespace helix

--- a/hel/meson.build
+++ b/hel/meson.build
@@ -4,8 +4,14 @@ headers = [
 	'include/hel-syscalls.h',
 	'include/hel-types.h',
 	'include/helix/ipc.hpp',
-	'include/helix/memory.hpp'
+	'include/helix/memory.hpp',
+	'include/helix/passthrough-fd.hpp'
 ]
+
+src = files(
+	'src/globals.cpp',
+	'src/passthrough-fd.cpp',
+)
 
 if arch == 'aarch64'
 	headers += 'include/hel-stubs-aarch64.h'
@@ -16,9 +22,9 @@ endif
 inc = [ 'include' ]
 
 if not provide_deps and not build_kernel
-	deps = [ coroutines, bragi_dep, frigg ]
+	deps = [ coroutines, bragi_dep, frigg, posix_extra_dep ]
 
-	helix = shared_library('helix', 'src/globals.cpp',
+	helix = shared_library('helix', src,
 		dependencies : deps,
 		include_directories : inc,
 		install : true

--- a/hel/src/passthrough-fd.cpp
+++ b/hel/src/passthrough-fd.cpp
@@ -1,0 +1,19 @@
+#include <hel.h>
+#include <hel-syscalls.h>
+#include <helix/passthrough-fd.hpp>
+#include <protocols/posix/data.hpp>
+#include <protocols/posix/supercalls.hpp>
+
+namespace helix {
+
+HelHandle handleForFd(int fd) {
+	if (fd >= 512)
+		return 0;
+
+	posix::ManagarmProcessData data;
+	HEL_CHECK(helSyscall1(kHelCallSuper + posix::superGetProcessData, reinterpret_cast<HelWord>(&data)));
+
+	return reinterpret_cast<HelHandle *>(data.fileTable)[fd];
+}
+
+} // namespace helix

--- a/meson.build
+++ b/meson.build
@@ -174,11 +174,13 @@ if build_drivers
 endif
 
 if build_drivers or provide_deps
+	subdir('protocols/posix')
+
 	# this produces the helix dependency which
-	# all protocols depend on
+	# all other protocols depend on
 	subdir('hel')
 
-	protocols = [ 'posix', 'clock', 'fs', 'hw', 'mbus', 'usb', 'svrctl', 'kerncfg', 'kernlet', 'ostrace' ]
+	protocols = [ 'clock', 'fs', 'hw', 'mbus', 'usb', 'svrctl', 'kerncfg', 'kernlet', 'ostrace' ]
 	core = [ 'core', 'core/drm', 'core/virtio', 'mbus' ]
 	posix = [ 'subsystem', 'init' ]
 	drivers = [

--- a/posix/subsystem/src/devices/helout.cpp
+++ b/posix/subsystem/src/devices/helout.cpp
@@ -1,3 +1,4 @@
+#include <helix/passthrough-fd.hpp>
 #include <string.h>
 #include <sys/epoll.h>
 
@@ -6,8 +7,6 @@
 
 #include <bitset>
 #include <coroutine>
-
-HelHandle __mlibc_getPassthrough(int fd);
 
 namespace {
 
@@ -40,7 +39,7 @@ private:
 	}
 
 	helix::BorrowedDescriptor getPassthroughLane() override {
-		return helix::BorrowedDescriptor(__mlibc_getPassthrough(1));
+		return helix::BorrowedDescriptor(helix::handleForFd(1));
 	}
 
 public:

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -3,6 +3,7 @@
 #include <set>
 
 #include <helix/memory.hpp>
+#include <helix/passthrough-fd.hpp>
 #include <protocols/fs/client.hpp>
 #include <protocols/fs/server.hpp>
 #include "common.hpp"
@@ -16,7 +17,6 @@
 
 // TODO: Remove dependency on those functions.
 #include "extern_fs.hpp"
-HelHandle __mlibc_getPassthrough(int fd);
 HelHandle __raw_map(int fd);
 
 namespace tmp_fs {
@@ -378,7 +378,7 @@ private:
 		auto fd = ::open(_path.c_str(), O_RDONLY);
 		assert(fd != -1);
 
-		helix::UniqueDescriptor passthrough(__mlibc_getPassthrough(fd));
+		helix::UniqueDescriptor passthrough(helix::handleForFd(fd));
 		co_return extern_fs::createFile(std::move(passthrough), std::move(mount), std::move(link));
 	}
 

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <coroutine>
 #include <future>
+#include <helix/passthrough-fd.hpp>
 
 #include "common.hpp"
 #include "fs.bragi.hpp"
@@ -12,8 +13,6 @@
 #include "tmp_fs.hpp"
 #include "extern_fs.hpp"
 #include "sysfs.hpp"
-
-HelHandle __mlibc_getPassthrough(int fd);
 
 static bool debugResolve = false;
 
@@ -94,7 +93,7 @@ async::result<void> populateRootView() {
 		auto dir_fd = open(dir_path.c_str(), O_RDONLY);
 		assert(dir_fd != -1);
 
-		auto lane = helix::BorrowedLane{__mlibc_getPassthrough(dir_fd)};
+		auto lane = helix::BorrowedLane{helix::handleForFd(dir_fd)};
 		while(true) {
 			managarm::fs::CntRequest req;
 			req.set_req_type(managarm::fs::CntReqType::PT_READ_ENTRIES);


### PR DESCRIPTION
This avoids having to (hackily) rely on `__mlibc_getPassthrough`.