### PR TITLE
HID: fixes and improvements for better touchscreen support

### DIFF
--- a/core/include/core/logging.hpp
+++ b/core/include/core/logging.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <format>
+
+template<class... Args>
+void logPanic(std::format_string<Args...> fmt, Args&&... args) {
+	std::cerr << std::format(fmt, args...) << std::endl;
+	__builtin_trap();
+}

--- a/core/meson.build
+++ b/core/meson.build
@@ -2,6 +2,7 @@ inc = [ 'include' ]
 
 headers = [
 	'include/core/bpf.hpp',
+	'include/core/logging.hpp',
 	'include/core/id-allocator.hpp',
 	'include/core/queue.hpp',
 ]

--- a/drivers/kbd/src/main.cpp
+++ b/drivers/kbd/src/main.cpp
@@ -102,6 +102,17 @@ constexpr std::array<const char *, 38> mousePnpIds = {{
 } // namespace
 
 // --------------------------------------------------------------------
+// EventDevice
+// --------------------------------------------------------------------
+
+struct EventDevice final : libevbackend::EventDevice {
+	EventDevice(std::string name)
+	: libevbackend::EventDevice(std::move(name), BUS_I8042, 0, 0) {
+
+	}
+};
+
+// --------------------------------------------------------------------
 // Controller
 // --------------------------------------------------------------------
 
@@ -380,7 +391,7 @@ async::result<void> Controller::KbdDevice::run() {
 	}
 
 	//setup evdev stuff
-	_evDev = std::make_shared<libevbackend::EventDevice>();
+	_evDev = std::make_shared<EventDevice>("PS/2 keyboard");
 
 	_evDev->enableEvent(EV_KEY, KEY_A);
 	_evDev->enableEvent(EV_KEY, KEY_B);
@@ -546,7 +557,7 @@ async::result<void> Controller::MouseDevice::run() {
 	assert(res1);
 
 	// setup evdev stuff
-	_evDev = std::make_shared<libevbackend::EventDevice>();
+	_evDev = std::make_shared<EventDevice>("PS/2 mouse");
 
 	_evDev->enableEvent(EV_REL, REL_X);
 	_evDev->enableEvent(EV_REL, REL_Y);

--- a/drivers/libevbackend/include/libevbackend.hpp
+++ b/drivers/libevbackend/include/libevbackend.hpp
@@ -97,7 +97,7 @@ public:
 	friend struct File;
 	friend async::detached serveDevice(std::shared_ptr<EventDevice>, helix::UniqueLane);
 
-	EventDevice();
+	EventDevice(std::string name, uint16_t bustype, uint16_t vendor, uint16_t product);
 
 	void setAbsoluteDetails(int code, int minimum, int maximum);
 
@@ -130,6 +130,11 @@ private:
 	> _files;
 
 	std::vector<StagedEvent> _staged;
+
+	std::string name_;
+	uint16_t busType_;
+	uint16_t vendor_;
+	uint16_t product_;
 };
 
 // --------------------------------------------

--- a/drivers/libevbackend/include/libevbackend.hpp
+++ b/drivers/libevbackend/include/libevbackend.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <queue>
+#include <map>
 #include <vector>
 
 #include <async/result.hpp>
 #include <async/recurring-event.hpp>
 #include <boost/intrusive/list.hpp>
 #include <helix/ipc.hpp>
+#include <linux/input.h>
 #include <protocols/fs/server.hpp>
 #include <protocols/mbus/client.hpp>
 
@@ -34,6 +35,10 @@ struct PendingEvent {
 // --------------------------------------------
 // EventDevice
 // --------------------------------------------
+
+constexpr int ABS_MT_FIRST = ABS_MT_SLOT;
+constexpr int ABS_MT_LAST = ABS_MT_TOOL_Y;
+constexpr size_t maxMultitouchSlots = 10;
 
 struct File {
 	friend struct EventDevice;
@@ -107,6 +112,20 @@ public:
 
 	void notify();
 
+	struct multitouchInfo {
+		// the multitouch tracking ID exposed to userspace
+		int userTrackingId = -1;
+
+		// the current values of multitouch codes
+		// only multitouch codes are stored, therefore indices are offset by the lowest code
+		// index 0 is ABS_MT_FIRST, 1 is (ABS_MT_FIRST + 1), ...
+		std::array<int, (ABS_MT_LAST - ABS_MT_FIRST + 1)> abs = {};
+	};
+
+	const std::map<int, multitouchInfo> &currentMultitouchState() {
+		return _mtState;
+	}
+
 private:
 	// Supported event bits.
 	// The array sizes come from Linux' EV_CNT, KEY_CNT, REL_CNT etc. macros (divided by 8)
@@ -118,7 +137,10 @@ private:
 
 	// Input details and current input state.
 	std::array<uint8_t, 96> _currentKeys;
-	std::array<AbsoluteSlot, 8> _absoluteSlots;
+	std::array<AbsoluteSlot, 64> _absoluteSlots;
+
+	// current multitouch state, keyed by slot ID
+	std::map<int, multitouchInfo> _mtState;
 
 	boost::intrusive::list<
 		File,

--- a/drivers/usb/devices/hid/meson.build
+++ b/drivers/usb/devices/hid/meson.build
@@ -1,5 +1,12 @@
-executable('hid', 'src/main.cpp',
-	dependencies : evbackend_dep,
+src = files(
+	'src/main.cpp',
+	'src/quirks.cpp',
+	'src/handler/multitouch.cpp',
+	'src/quirks/wacom.cpp',
+)
+
+executable('hid', src,
+	dependencies : [evbackend_dep, core_dep],
 	install : true
 )
 

--- a/drivers/usb/devices/hid/src/handler/multitouch.cpp
+++ b/drivers/usb/devices/hid/src/handler/multitouch.cpp
@@ -1,0 +1,264 @@
+#include <core/id-allocator.hpp>
+#include <format>
+#include <libevbackend.hpp>
+#include <linux/input.h>
+
+#include "../spec.hpp"
+#include "multitouch.hpp"
+
+namespace {
+
+constexpr bool debugTouches = false;
+
+std::map<std::weak_ptr<libevbackend::EventDevice>, id_allocator<size_t>,
+	std::owner_less<std::weak_ptr<libevbackend::EventDevice>>> trackingIdAllocators{};
+
+/* maps a HID tracking ID to a evdev userspace-visible tracking ID */
+std::map<std::weak_ptr<libevbackend::EventDevice>, std::map<size_t, size_t>,
+	std::owner_less<std::weak_ptr<libevbackend::EventDevice>>> userTrackingIds{};
+
+std::map<std::weak_ptr<libevbackend::EventDevice>, id_allocator<size_t>,
+	std::owner_less<std::weak_ptr<libevbackend::EventDevice>>> slotIdAllocators{};
+
+/* maps a HID tracking ID to a evdev userspace-visible slot ID */
+std::map<std::weak_ptr<libevbackend::EventDevice>, std::map<size_t, size_t>,
+	std::owner_less<std::weak_ptr<libevbackend::EventDevice>>> hidIdSlotMaps{};
+
+constexpr uint32_t usageID(uint16_t page, uint16_t id) {
+	return (page << 16) | id;
+}
+
+} // namespace
+
+namespace handler::multitouch {
+
+void MultitouchHandler::setupElement(std::shared_ptr<libevbackend::EventDevice> _eventDev, Element *e) {
+	if(e->parent->type() != CollectionType::Collection)
+		return;
+
+	auto c = static_cast<Collection *>(e->parent);
+
+	if(c->usageId() != usageID(pages::digitizers, usage::digitizers::finger))
+		return;
+
+	if(e->usagePage == pages::digitizers) {
+		if(e->usageId == usage::digitizers::tipSwitch) {
+			e->inputType = EV_KEY;
+			e->inputCode = BTN_TOUCH;
+		} else if(e->usageId == usage::digitizers::contactIdentifier) {
+			_eventDev->setAbsoluteDetails(ABS_MT_SLOT, 0, libevbackend::maxMultitouchSlots - 1);
+			_eventDev->enableEvent(EV_ABS, ABS_MT_SLOT);
+
+			e->inputType = EV_ABS;
+			e->inputCode = ABS_MT_TRACKING_ID;
+			e->logicalMin = 0;
+			e->logicalMax = UINT16_MAX;
+		}
+	} else if(e->usagePage == pages::genericDesktop) {
+		if(e->usageId == usage::genericDesktop::x) {
+			_eventDev->setAbsoluteDetails(ABS_MT_POSITION_X, e->logicalMin, e->logicalMax);
+			_eventDev->enableEvent(EV_ABS, ABS_MT_POSITION_X);
+		} else if(e->usageId == usage::genericDesktop::y) {
+			_eventDev->setAbsoluteDetails(ABS_MT_POSITION_Y, e->logicalMin, e->logicalMax);
+			_eventDev->enableEvent(EV_ABS, ABS_MT_POSITION_Y);
+		}
+	}
+};
+
+void MultitouchHandler::handleReport(std::shared_ptr<libevbackend::EventDevice> eventDev,
+		std::vector<Element> &elements,
+		std::vector<std::pair<bool, int32_t>> &values) {
+	struct touchInfo {
+		Collection *c;
+		size_t slot;
+		std::optional<size_t> hidTrackingId = std::nullopt;
+		size_t userTrackingId;
+		size_t x;
+		size_t y;
+		bool touching;
+		bool valid;
+		size_t xElementId;
+		size_t yElementId;
+	};
+
+	std::vector<std::shared_ptr<touchInfo>> touches;
+
+	auto is_touch = [&touches](Collection *c) -> bool {
+		return std::find_if(touches.cbegin(), touches.cend(), [&](auto e) {
+			return e->c == c;
+		}) != touches.cend();
+	};
+
+	auto touch = [&](Collection *c) -> std::shared_ptr<touchInfo> {
+		if(!is_touch(c)) {
+			touches.push_back(std::make_shared<touchInfo>(c));
+		}
+
+		return *std::find_if(touches.cbegin(), touches.cend(), [&](auto e) {
+			return e->c == c;
+		});
+	};
+
+	for(size_t i = 0; i < elements.size(); i++) {
+		auto &e = elements[i];
+		auto &v = values[i];
+
+		if(e.parent->type() != CollectionType::Collection)
+			continue;
+
+		auto c = static_cast<Collection *>(e.parent);
+
+		if(c->usageId() != usageID(pages::digitizers, usage::digitizers::finger))
+			continue;
+
+		if(e.usagePage == pages::digitizers) {
+			if(e.usageId == usage::digitizers::contactIdentifier) {
+				v.first = false;
+				touch(c)->hidTrackingId = v.second;
+
+				if(v.second == 0) {
+					touch(c)->valid = false;
+					continue;
+				}
+
+				if(!hidIdSlotMaps.contains(eventDev))
+					hidIdSlotMaps.insert({eventDev, {}});
+				if(!slotIdAllocators.contains(eventDev))
+					slotIdAllocators.insert({eventDev, {0, libevbackend::maxMultitouchSlots - 1}});
+
+				if(!hidIdSlotMaps.at(eventDev).contains(v.second)) {
+					auto slot_id = slotIdAllocators.at(eventDev).allocate();
+					hidIdSlotMaps.at(eventDev).insert({v.second, slot_id});
+					touch(c)->slot = slot_id;
+				} else {
+					assert(hidIdSlotMaps.at(eventDev).contains(v.second));
+					touch(c)->slot = hidIdSlotMaps.at(eventDev).at(v.second);
+				}
+			} else if(e.usageId == usage::digitizers::touchValid) {
+				touch(c)->valid = v.second;
+			}
+		}
+	}
+
+	for(size_t i = 0; i < elements.size(); i++) {
+		auto &e = elements[i];
+		auto &v = values[i];
+
+		if(e.parent->type() != CollectionType::Collection)
+			continue;
+
+		auto c = static_cast<Collection *>(e.parent);
+
+		if(!is_touch(c))
+			continue;
+
+		if(e.usagePage == pages::genericDesktop) {
+			if(e.usageId == usage::genericDesktop::x) {
+				touch(c)->xElementId = i;
+				touch(c)->x = v.second;
+				v.first = false;
+			} else if(e.usageId == usage::genericDesktop::y) {
+				touch(c)->yElementId = i;
+				touch(c)->y = v.second;
+				v.first = false;
+			}
+		} else if(e.usagePage == pages::digitizers) {
+			if(e.usageId == usage::digitizers::tipSwitch) {
+				auto t = touch(c);
+
+				t->touching = v.second;
+				v.first = false;
+
+				if(!userTrackingIds.contains(eventDev)) {
+					userTrackingIds.insert({eventDev, {}});
+				}
+
+				if(t->touching && t->hidTrackingId && !userTrackingIds.at(eventDev).contains(*t->hidTrackingId)) {
+					if(!trackingIdAllocators.contains(eventDev))
+						trackingIdAllocators.insert({eventDev, {1}});
+
+					auto allocated_id = trackingIdAllocators.at(eventDev).allocate();
+
+					userTrackingIds
+						.at(eventDev)
+						.insert({*t->hidTrackingId, allocated_id});
+				}
+
+				if(t->touching) {
+					assert(t->hidTrackingId);
+					assert(userTrackingIds.at(eventDev).contains(*t->hidTrackingId));
+
+					t->userTrackingId = userTrackingIds
+						.at(eventDev)
+						.at(*t->hidTrackingId);
+				}
+			}
+		}
+	}
+
+	auto current_touches = std::find_if(touches.cbegin(), touches.cend(), [](auto t) {
+		return t->valid;
+	});
+
+	bool abs_x_y_enabled = false;
+
+	for(auto t : touches) {
+		if(!t->valid || !t->hidTrackingId) {
+			continue;
+		}
+
+		int trackingId = t->touching ? t->userTrackingId : -1;
+
+		if(debugTouches)
+			std::cout << std::format("hid: touch slot={} tracking={} x={} y={}\n", t->slot, trackingId, t->x, t->y);
+
+		// first, check whether any of the values even changed; if not, we need to also suppress
+		// emitting ABS_MT_SLOT.
+		auto &mtState = eventDev->currentMultitouchState();
+
+		if(mtState.contains(t->slot)) {
+			auto &slot = mtState.at(t->slot);
+			if(static_cast<size_t>(slot.abs[ABS_MT_POSITION_X - libevbackend::ABS_MT_FIRST]) == t->x
+			&& static_cast<size_t>(slot.abs[ABS_MT_POSITION_Y - libevbackend::ABS_MT_FIRST]) == t->y
+			&& slot.abs[ABS_MT_TRACKING_ID - libevbackend::ABS_MT_FIRST] == trackingId)
+				continue;
+		}
+
+		eventDev->emitEvent(EV_ABS, ABS_MT_SLOT, t->slot);
+		eventDev->emitEvent(EV_ABS, ABS_MT_TRACKING_ID, trackingId);
+
+		if(t->touching) {
+			eventDev->emitEvent(EV_ABS, ABS_MT_POSITION_X, t->x);
+			eventDev->emitEvent(EV_ABS, ABS_MT_POSITION_Y, t->y);
+
+			if(!abs_x_y_enabled) {
+				values[t->xElementId].first = true;
+				values[t->yElementId].first = true;
+				abs_x_y_enabled = true;
+			}
+		}
+	}
+
+	if(current_touches != touches.cend()) {
+		eventDev->emitEvent(EV_KEY, BTN_TOUCH, 1);
+	} else {
+		eventDev->emitEvent(EV_KEY, BTN_TOUCH, 0);
+	}
+
+	/* free IDs and erase touch events where needed */
+	for(auto t : touches) {
+		if(t->valid && !t->touching) {
+			assert(userTrackingIds.contains(eventDev));
+			userTrackingIds
+				.at(eventDev)
+				.erase(*t->hidTrackingId);
+
+			assert(slotIdAllocators.contains(eventDev));
+			slotIdAllocators.at(eventDev).free(t->slot);
+			assert(hidIdSlotMaps.contains(eventDev));
+			hidIdSlotMaps.at(eventDev).erase(*t->hidTrackingId);
+		}
+	}
+}
+
+} // namespace handler::multitouch

--- a/drivers/usb/devices/hid/src/handler/multitouch.hpp
+++ b/drivers/usb/devices/hid/src/handler/multitouch.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../hid.hpp"
+
+namespace handler::multitouch {
+
+struct MultitouchHandler final : public Handler {
+	void handleReport(std::shared_ptr<libevbackend::EventDevice> eventDev,
+		std::vector<Element> &elements,
+		std::vector<std::pair<bool, int32_t>> &values) override;
+	void setupElement(std::shared_ptr<libevbackend::EventDevice> eventDev, Element *) override;
+};
+
+} // namespace handler::multitouch

--- a/drivers/usb/devices/hid/src/hid.hpp
+++ b/drivers/usb/devices/hid/src/hid.hpp
@@ -133,6 +133,10 @@ struct HidDevice {
 	void parseReportDescriptor(protocols::usb::Device device, uint8_t* p, uint8_t* limit);
 	async::detached run(protocols::usb::Device device, int intf_num, int config_num);
 
+	std::pair<uint16_t, uint16_t> getDeviceId() {
+		return {_vendorId, _deviceId};
+	}
+
 	std::unordered_map<uint8_t, std::vector<Field>> fields{
 		{0, {}}
 	};
@@ -145,4 +149,7 @@ struct HidDevice {
 
 private:
 	std::shared_ptr<libevbackend::EventDevice> _eventDev;
+
+	uint16_t _vendorId = 0xFFFF;
+	uint16_t _deviceId = 0xFFFF;
 };

--- a/drivers/usb/devices/hid/src/hid.hpp
+++ b/drivers/usb/devices/hid/src/hid.hpp
@@ -16,7 +16,7 @@ enum class FieldType {
 
 struct Field {
 	FieldType type;
-	int bitSize;
+	unsigned int bitSize;
 	int dataMin;
 	int dataMax;
 	bool isSigned;
@@ -36,6 +36,7 @@ struct Element {
 	uint16_t usagePage;
 	int32_t logicalMin;
 	int32_t logicalMax;
+	uint8_t reportId;
 	bool isAbsolute;
 
 	int inputType;
@@ -53,8 +54,15 @@ struct HidDevice {
 	void parseReportDescriptor(protocols::usb::Device device, uint8_t* p, uint8_t* limit);
 	async::detached run(protocols::usb::Device device, int intf_num, int config_num);
 
-	std::vector<Field> fields;
-	std::vector<Element> elements;
+	std::unordered_map<uint8_t, std::vector<Field>> fields{
+		{0, {}}
+	};
+
+	std::unordered_map<uint8_t, std::vector<Element>> elements{
+		{0, {}}
+	};
+
+	bool usesReportIds = false;
 
 private:
 	std::shared_ptr<libevbackend::EventDevice> _eventDev;

--- a/drivers/usb/devices/hid/src/hid.hpp
+++ b/drivers/usb/devices/hid/src/hid.hpp
@@ -4,6 +4,69 @@
 #include <protocols/usb/client.hpp>
 #include <libevbackend.hpp>
 
+enum class CollectionType {
+	Root,
+	Collection,
+};
+
+struct Collection;
+
+struct Hierarchy {
+	Hierarchy(Hierarchy *parent)
+	: parent_{std::move(parent)} {
+
+	}
+
+	~Hierarchy();
+
+	Hierarchy(const Hierarchy &) = delete;
+	Hierarchy &operator= (const Hierarchy &) = delete;
+
+	virtual CollectionType type() = 0;
+
+	Hierarchy *parent() {
+		return parent_;
+	}
+
+	std::vector<Collection *> children;
+
+private:
+	Hierarchy *parent_ = {};
+};
+
+struct Collection final : public Hierarchy {
+	Collection(Hierarchy *parent, uint8_t type, uint32_t usage)
+	: Hierarchy{std::move(parent)}, type_{type}, usageId_{usage} {
+
+	}
+
+	CollectionType type() override {
+		return CollectionType::Collection;
+	}
+
+	uint8_t collectionType() {
+		return type_;
+	}
+
+	uint32_t usageId() {
+		return usageId_;
+	}
+
+private:
+	uint8_t type_;
+	uint32_t usageId_;
+};
+
+struct Root final : public Hierarchy {
+	Root() : Hierarchy{{}} {
+
+	}
+
+	CollectionType type() override {
+		return CollectionType::Root;
+	}
+};
+
 // -----------------------------------------------------
 // Fields.
 // -----------------------------------------------------
@@ -32,6 +95,7 @@ struct Element {
 	Element()
 	: usageId{0}, usagePage{0}, isAbsolute{false},
 			inputType{-1}, inputCode{-1} { }
+	Hierarchy *parent;
 
 	uint32_t usageId;
 	uint16_t usagePage;

--- a/drivers/usb/devices/hid/src/hid.hpp
+++ b/drivers/usb/devices/hid/src/hid.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <async/result.hpp>
+#include <protocols/usb/client.hpp>
 #include <libevbackend.hpp>
 
 // -----------------------------------------------------
@@ -50,7 +51,7 @@ struct Element {
 // -----------------------------------------------------
 
 struct HidDevice {
-	HidDevice();
+	HidDevice() = default;
 	void parseReportDescriptor(protocols::usb::Device device, uint8_t* p, uint8_t* limit);
 	async::detached run(protocols::usb::Device device, int intf_num, int config_num);
 

--- a/drivers/usb/devices/hid/src/hid.hpp
+++ b/drivers/usb/devices/hid/src/hid.hpp
@@ -107,7 +107,21 @@ struct Element {
 	int inputType;
 	int inputCode;
 
-	bool disabled;
+	size_t elementNum;
+};
+
+// -----------------------------------------------------
+// Handler.
+// -----------------------------------------------------
+
+// Used for implementing specific Handler for devices that need special logic, like touchscreens.
+struct Handler {
+	// called for handling a HID report with the given elements and values
+	virtual void handleReport(std::shared_ptr<libevbackend::EventDevice> eventDev,
+		std::vector<Element> &elements, std::vector<std::pair<bool, int32_t>> &values) = 0;
+
+	// called for setting up evdev events for that Element
+	virtual void setupElement(std::shared_ptr<libevbackend::EventDevice> eventDev, Element *) = 0;
 };
 
 // -----------------------------------------------------

--- a/drivers/usb/devices/hid/src/main.cpp
+++ b/drivers/usb/devices/hid/src/main.cpp
@@ -532,6 +532,16 @@ void HidDevice::parseReportDescriptor(proto::Device, uint8_t *p, uint8_t* limit)
 			usesReportIds = true;
 			break;
 
+		case 0x54:
+			if(logDescriptorParser)
+				printf("usb-hid:     Unit exponent: %d\n", data);
+			break;
+
+		case 0x64:
+			if(logDescriptorParser)
+				printf("usb-hid:     Units: 0x%02x\n", data);
+			break;
+
 		// Local items
 		case 0x28:
 			if(logDescriptorParser)

--- a/drivers/usb/devices/hid/src/main.cpp
+++ b/drivers/usb/devices/hid/src/main.cpp
@@ -765,10 +765,9 @@ async::detached HidDevice::run(proto::Device device, int config_num, int intf_nu
 			std::cout << "usb-hid: Report size: " << length
 					<< " (packet size is " << in_endp_pktsize << ")" << std::endl;
 			std::cout << "usb-hid: Packet:";
-			std::cout << std::hex;
-			for(size_t i = 0; i < 4; i++)
-				std::cout << " " << (int)reinterpret_cast<uint8_t *>(report.data())[i];
-			std::cout << std::dec << std::endl;
+			for(size_t i = 0; i < length; i++)
+				std::cout << std::format(" {:02x}", reinterpret_cast<uint8_t *>(report.data())[i]);
+			std::cout << std::endl;
 		}
 
 		std::fill(values.begin(), values.end(), std::pair<bool, int32_t>{false, 0});

--- a/drivers/usb/devices/hid/src/main.cpp
+++ b/drivers/usb/devices/hid/src/main.cpp
@@ -184,6 +184,13 @@ void setupInputTranslation(Element *element) {
 					std::cout << "usb-hid: Unknown usage " << element->usageId
 							<< " in Button Page" << std::endl;
 		}
+	}else if(element->usagePage == pages::digitizers) {
+		switch(element->usageId) {
+			default:
+				if(logUnknownCodes)
+					std::cout << std::format("usb-hid: Unknown usage 0x{:02x} in Digitizers Page\n",
+						element->usageId);
+		}
 	}else if(element->usagePage >= pages::firstVendorDefined && element->usagePage <= pages::lastVendorDefined) {
 		if(logUnknownCodes)
 			std::cout << std::format("usb-hid: Ignoring vendor-defined usage page 0x{:04x}\n", element->usagePage);

--- a/drivers/usb/devices/hid/src/main.cpp
+++ b/drivers/usb/devices/hid/src/main.cpp
@@ -181,9 +181,12 @@ void setupInputTranslation(Element *element) {
 					std::cout << "usb-hid: Unknown usage " << element->usageId
 							<< " in Button Page" << std::endl;
 		}
+	}else if(element->usagePage >= pages::firstVendorDefined && element->usagePage <= pages::lastVendorDefined) {
+		if(logUnknownCodes)
+			std::cout << std::format("usb-hid: Ignoring vendor-defined usage page 0x{:04x}\n", element->usagePage);
 	}else{
 		if(logUnknownCodes)
-			std::cout << "usb-hid: Unkown usage page " << element->usagePage << std::endl;
+			std::cout << std::format("usb-hid: Unkown usage page 0x{:02x}\n", element->usagePage);
 	}
 }
 

--- a/drivers/usb/devices/hid/src/main.cpp
+++ b/drivers/usb/devices/hid/src/main.cpp
@@ -43,9 +43,9 @@ void setupInputTranslation(Element *element) {
 		// TODO: Distinguish between absolute and relative controls.
 		if(element->isAbsolute) {
 			switch(element->usageId) {
-				case 0x30: setInput(EV_ABS, ABS_X); break;
-				case 0x31: setInput(EV_ABS, ABS_Y); break;
-				case 0x38: setInput(EV_ABS, ABS_WHEEL); break;
+				case usage::genericDesktop::x: setInput(EV_ABS, ABS_X); break;
+				case usage::genericDesktop::y: setInput(EV_ABS, ABS_Y); break;
+				case usage::genericDesktop::wheel: setInput(EV_ABS, ABS_WHEEL); break;
 				default:
 					if(logUnknownCodes)
 						std::cout << "usb-hid: Unknown usage " << element->usageId
@@ -53,9 +53,9 @@ void setupInputTranslation(Element *element) {
 			}
 		}else{
 			switch(element->usageId) {
-				case 0x30: setInput(EV_REL, REL_X); break;
-				case 0x31: setInput(EV_REL, REL_Y); break;
-				case 0x38: setInput(EV_REL, REL_WHEEL); break;
+				case usage::genericDesktop::x: setInput(EV_REL, REL_X); break;
+				case usage::genericDesktop::y: setInput(EV_REL, REL_Y); break;
+				case usage::genericDesktop::wheel: setInput(EV_REL, REL_WHEEL); break;
 				default:
 					if(logUnknownCodes)
 						std::cout << "usb-hid: Unknown usage " << element->usageId

--- a/drivers/usb/devices/hid/src/quirks.cpp
+++ b/drivers/usb/devices/hid/src/quirks.cpp
@@ -1,0 +1,49 @@
+#include "quirks.hpp"
+#include "quirks/wacom.hpp"
+#include "spec.hpp"
+
+#include <format>
+
+namespace {
+
+constexpr bool logQuirks = false;
+
+struct hidDescriptor {
+	uint16_t idVendor;
+	uint16_t idProduct;
+	std::optional<uint16_t> usagePage;
+	std::optional<uint16_t> usageId;
+	void (*handler)(uint16_t usagePage, uint16_t usageId, Field &f);
+	std::string desc;
+};
+
+// HID quirks that operate by modifying Fields parsed from report descriptors
+std::array<struct hidDescriptor, 1> report_descriptor = {{
+	{0x056a, 0x509c, pages::digitizers, usage::digitizers::contactIdentifier, quirks::wacom::touchHidLimits, "Wacom touchscreen contact ID fix"},
+}};
+
+} // namespace
+
+namespace quirks {
+
+void processField(HidDevice *dev, uint16_t usagePage, uint16_t usageId, Field &f) {
+	for(auto &e : report_descriptor) {
+		auto [vendor, product] = dev->getDeviceId();
+
+		if(e.idVendor != vendor || e.idProduct != product)
+			continue;
+
+		if(e.usagePage && e.usagePage.value() != usagePage)
+			continue;
+
+		if(e.usageId && e.usageId.value() != usageId)
+			continue;
+
+		if(logQuirks)
+			std::cout << std::format("hid: matched HID quirk '{}' for device {:04x}:{:04x}\n", e.desc, vendor, product);
+
+		e.handler(usagePage, usageId, f);
+	}
+}
+
+} // namespace quirks

--- a/drivers/usb/devices/hid/src/quirks.hpp
+++ b/drivers/usb/devices/hid/src/quirks.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "hid.hpp"
+
+namespace quirks {
+
+void processField(HidDevice *dev, uint16_t usagePage, uint16_t usageId, Field &f);
+
+} // namespace quirks

--- a/drivers/usb/devices/hid/src/quirks/wacom.cpp
+++ b/drivers/usb/devices/hid/src/quirks/wacom.cpp
@@ -1,0 +1,19 @@
+#include "../spec.hpp"
+#include "wacom.hpp"
+
+namespace quirks::wacom {
+
+void touchHidLimits(uint16_t usagePage, uint16_t usageId, Field &f) {
+	assert(usagePage == pages::digitizers && usageId == usage::digitizers::contactIdentifier);
+	// on at least my Wacom touchscreen device (056a:509c), the HID report descriptor fails to
+	// update the logical limits for Contact Identifier usages, which breaks multitouch input.
+
+	// https://github.com/linuxwacom/wacom-hid-descriptors/blob/490ce1ccc1767531d269dac9f4d562425f22661a/Lenovo%20ThinkPad%20Yoga%20370/sysinfo.Mc7vuWOv8R/0003%3A056A%3A509F.0001.hid.txt
+
+	// We fix this by overriding the limits for the affected usage without changing the global
+	// parsing state.
+	f.dataMin = 0;
+	f.dataMax = UINT16_MAX;
+}
+
+} // namespace quirks::wacom

--- a/drivers/usb/devices/hid/src/quirks/wacom.hpp
+++ b/drivers/usb/devices/hid/src/quirks/wacom.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "../hid.hpp"
+
+namespace quirks::wacom {
+
+void touchHidLimits(uint16_t usagePage, uint16_t usageId, Field &f);
+
+} // namespace quirks::wacom

--- a/drivers/usb/devices/hid/src/spec.hpp
+++ b/drivers/usb/devices/hid/src/spec.hpp
@@ -23,12 +23,22 @@ namespace pages {
 	constexpr int firstVendorDefined = 0xFF00;
 	constexpr int lastVendorDefined = 0xFFFF;
 
-}
+} // namespace pages
+
+namespace usage {
+
+namespace genericDesktop {
+	constexpr int x = 0x30;
+	constexpr int y = 0x31;
+	constexpr int wheel = 0x38;
+} // namespace genericDesktop
+
+} // namespace usage
 
 namespace item {
 	constexpr uint32_t variable = (1 << 1);
 	constexpr uint32_t relative = (1 << 2);
-}
+} // namespace item
 
 struct HidDescriptor : public protocols::usb::DescriptorBase {
 	struct [[ gnu::packed ]] Entry {

--- a/drivers/usb/devices/hid/src/spec.hpp
+++ b/drivers/usb/devices/hid/src/spec.hpp
@@ -33,6 +33,14 @@ namespace genericDesktop {
 	constexpr int wheel = 0x38;
 } // namespace genericDesktop
 
+namespace digitizers {
+	constexpr int finger = 0x22;
+	constexpr int tipSwitch = 0x42;
+	constexpr int touchValid = 0x47;
+	constexpr int contactIdentifier = 0x51;
+	constexpr int contactCount = 0x54;
+} // namespace digitizers
+
 } // namespace usage
 
 namespace item {

--- a/drivers/usb/devices/hid/src/spec.hpp
+++ b/drivers/usb/devices/hid/src/spec.hpp
@@ -20,6 +20,8 @@ namespace pages {
 	constexpr int unicode = 0x10;
 	constexpr int alphanumericalDisplay = 0x14;
 	constexpr int medicalInstrument = 0x40;
+	constexpr int firstVendorDefined = 0xFF00;
+	constexpr int lastVendorDefined = 0xFFFF;
 
 }
 

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -760,3 +760,15 @@ head(128):
 	uint16 product;
 	uint16 version;
 }
+
+message EvioGetMultitouchSlotsRequest 25 {
+head(128):
+	uint32 code;
+}
+
+message EvioGetMultitouchSlotsReply 26 {
+head(128):
+	Errors error;
+tail:
+	uint32[] values;
+}

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -736,3 +736,27 @@ head(128):
 tail:
 	Ifconf[] ifconf;
 }
+
+message EvioGetNameRequest 21 {
+head(128):
+}
+
+message EvioGetNameReply 22 {
+head(128):
+	Errors error;
+tail:
+	string name;
+}
+
+message EvioGetIdRequest 23 {
+head(128):
+}
+
+message EvioGetIdReply 24 {
+head(128):
+	Errors error;
+	uint16 bustype;
+	uint16 vendor;
+	uint16 product;
+	uint16 version;
+}


### PR DESCRIPTION
Before this, HID assertions prevented my test laptop from booting managarm; these commits handle the missing bits in the report descriptors and improve the information given to userspace by the `EVIOCGID` and `EVIOCGNAME` ioctls.