### PR TITLE
meson: fix warning for boolean option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -44,6 +44,6 @@ option('build_docs',
 
 option('kernel_frame_pointers',
     type : 'boolean',
-    value : 'false',
+    value : false,
     description : 'include frame pointers for stack traces'
 )


### PR DESCRIPTION
Removed the quotes around a boolean value, which causes a warning when building.