### PR TITLE
PS/2 driver rework for ACPI detection support

### DIFF
--- a/drivers/kbd/meson.build
+++ b/drivers/kbd/meson.build
@@ -3,7 +3,7 @@ if host_machine.cpu_family() != 'x86_64'
 endif
 
 executable('ps2-hid', 'src/main.cpp',
-	dependencies : evbackend_dep,
+	dependencies : [ evbackend_dep, hw_proto_dep ],
 	install : true
 )
 

--- a/drivers/kbd/src/ps2.hpp
+++ b/drivers/kbd/src/ps2.hpp
@@ -5,6 +5,7 @@
 #include <libevbackend.hpp>
 #include <array>
 #include <memory>
+#include <protocols/hw/client.hpp>
 
 struct stl_allocator {
 	void *allocate(size_t size) {
@@ -67,7 +68,9 @@ struct DeviceType {
 };
 
 struct Controller {
-	Controller();
+	Controller(std::shared_ptr<protocols::hw::Device> device, std::array<uintptr_t, 2> ports,
+		std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> primaryIrq,
+		std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> secondaryIrq);
 	async::detached init();
 
 	struct Device {
@@ -173,15 +176,20 @@ private:
 	std::optional<uint8_t> recvResponseByte(uint64_t timeout = 0);
 
 	std::array<Port *, 2> _ports{};
-	bool _hasSecondPort;
+	bool _hasSecondPort = true;
 	bool _portsOwnData = false;
 
-	arch::io_space _space;
+	std::shared_ptr<protocols::hw::Device> _hwDevice;
+	std::array<uintptr_t, 2> _ioPorts;
 
-	HelHandle _irq1Handle;
-	HelHandle _irq12Handle;
-	helix::UniqueIrq _irq1;
-	helix::UniqueIrq _irq12;
+	arch::io_space _dataSpace;
+	arch::io_space _commandSpace;
+
+	std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> _primaryIrq;
+	std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> _secondaryIrq;
+
+	helix::UniqueIrq _port1Irq;
+	std::optional<helix::UniqueIrq> _port2Irq;
 
 };
 

--- a/drivers/kbd/src/spec.hpp
+++ b/drivers/kbd/src/spec.hpp
@@ -13,9 +13,12 @@ constexpr int enable1stPort = 0xAE;
 constexpr int write2ndNextByte = 0xD4;
 
 namespace kbd_register {
+	// R/W on the first (data) port
 	arch::scalar_register<uint8_t> data(0);
-	arch::bit_register<uint8_t> status(4);
-	arch::scalar_register<uint8_t> command(4);
+	// RO on the second (command/status) port
+	arch::bit_register<uint8_t> status(0);
+	// WO on the second (command/status) port
+	arch::scalar_register<uint8_t> command(0);
 }
 
 namespace status_bits {

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -133,6 +133,7 @@ if want_acpi
 		'system/acpi/ec.cpp',
 		'system/acpi/pm-interface.cpp',
 		'system/acpi/battery.cpp',
+		'system/acpi/ps2.cpp',
 		'system/pci/pci_acpi.cpp'
 	)
 

--- a/kernel/thor/system/acpi/battery.cpp
+++ b/kernel/thor/system/acpi/battery.cpp
@@ -115,7 +115,7 @@ namespace BST {
 namespace thor::acpi {
 
 coroutine<void> BatteryBusObject::run() {
-	auto obj = frg::construct<AcpiObject>(*kernelAlloc, _node, ACPI_HID_BATTERY, _id);
+	auto obj = frg::construct<AcpiObject>(*kernelAlloc, _node, _id);
 	co_await obj->run();
 	auto acpi_object = obj->mbus_id;
 

--- a/kernel/thor/system/acpi/ps2.cpp
+++ b/kernel/thor/system/acpi/ps2.cpp
@@ -1,0 +1,101 @@
+#include <bragi/helpers-all.hpp>
+#include <bragi/helpers-frigg.hpp>
+#include <thor-internal/acpi/acpi.hpp>
+#include <thor-internal/main.hpp>
+#include <thor-internal/fiber.hpp>
+#include <uacpi/utilities.h>
+
+namespace {
+
+size_t next_keyboard_id = 0;
+size_t next_mouse_id = 0;
+
+struct AcpiStatus final : public thor::KernelBusObject {
+	AcpiStatus(const char *status)
+	: status_{frg::string<thor::KernelAlloc>(*thor::kernelAlloc, status)} {}
+
+	coroutine<void> run() {
+		thor::Properties props;
+		props.stringProperty("unix.subsystem", frg::string<thor::KernelAlloc>(*thor::kernelAlloc, "acpi"));
+		props.stringProperty("acpi.status", frg::string<thor::KernelAlloc>("ps2.init_complete", *thor::kernelAlloc));
+
+		(co_await createObject("acpi-status", std::move(props))).unwrap();
+	}
+
+	coroutine<frg::expected<thor::Error>> handleRequest(thor::LaneHandle lane) override {
+		auto [acceptError, conversation] = co_await thor::AcceptSender{lane};
+		if(acceptError != thor::Error::success)
+			co_return acceptError;
+
+		auto [reqError, reqBuffer] = co_await thor::RecvBufferSender{conversation};
+		if(reqError != thor::Error::success)
+			co_return reqError;
+
+		auto preamble = bragi::read_preamble(reqBuffer);
+
+		if(preamble.error())
+			co_return thor::Error::protocolViolation;
+
+		thor::infoLogger() << "thor: dismissing conversation due to illegal HW request." << frg::endlog;
+		co_await thor::DismissSender{conversation};
+
+		co_return frg::success;
+	};
+
+private:
+	frg::string<thor::KernelAlloc> status_;
+};
+
+
+} // namespace
+
+namespace thor::acpi {
+
+void initializePS2() {
+	// Create a fiber to manage requests to the ACPI mbus objects.
+	async::detach_with_allocator(*kernelAlloc, []() -> coroutine<void> {
+		co_await acpiFiber->associatedWorkQueue()->schedule();
+
+		frg::vector<async::oneshot_event *, thor::KernelAlloc> events{*thor::kernelAlloc};
+
+		uacpi_find_devices_at(uacpi_namespace_root(), ACPI_HID_PS2_KEYBOARDS.data(), [](void *ctx, uacpi_namespace_node *node) {
+			auto events = reinterpret_cast<frg::vector<async::oneshot_event *, KernelAlloc> *>(ctx);
+
+			auto obj = frg::construct<AcpiObject>(*kernelAlloc, node, next_keyboard_id++);
+			events->push_back(&obj->completion);
+			async::detach_with_allocator(*kernelAlloc, obj->run());
+
+			return UACPI_NS_ITERATION_DECISION_CONTINUE;
+		}, &events);
+
+		uacpi_find_devices_at(uacpi_namespace_root(), ACPI_HID_PS2_MICE.data(), [](void *ctx, uacpi_namespace_node *node) {
+			auto events = reinterpret_cast<frg::vector<async::oneshot_event *, KernelAlloc> *>(ctx);
+
+			auto obj = frg::construct<AcpiObject>(
+				*kernelAlloc, node, next_mouse_id++);
+			events->push_back(&obj->completion);
+			async::detach_with_allocator(*kernelAlloc, obj->run());
+
+			return UACPI_NS_ITERATION_DECISION_CONTINUE;
+		}, &events);
+
+		for(auto ev : events) {
+			co_await ev->wait();
+		}
+
+		// This object is published to notify listeners about the fact that ACPI parsing
+		// and publishing of PS/2 objects from there has finished, so as to avoid running mbus
+		// filters indefinitely.
+		AcpiStatus status{"ps2.init-complete"};
+		co_await status.run();
+	}());
+}
+
+static initgraph::Task initPS2Task{&globalInitEngine, "acpi.init-ps2",
+	initgraph::Requires{getNsAvailableStage(), getAcpiWorkqueueAvailableStage()},
+	[] {
+		initializePS2();
+	}
+};
+
+} // namespace thor::acpi

--- a/kernel/thor/system/acpi/thor-internal/acpi/acpi.hpp
+++ b/kernel/thor/system/acpi/thor-internal/acpi/acpi.hpp
@@ -3,7 +3,9 @@
 #include <thor-internal/irq.hpp>
 #include <thor-internal/stream.hpp>
 #include <thor-internal/mbus.hpp>
+#include <smarter.hpp>
 #include <uacpi/uacpi.h>
+#include <uacpi/utilities.h>
 #include <initgraph.hpp>
 
 namespace thor {
@@ -25,6 +27,78 @@ namespace thor::acpi {
 
 extern KernelFiber *acpiFiber;
 
+constexpr std::array<const uacpi_char *, 27> ACPI_HID_PS2_KEYBOARDS = {{
+	"PNP0300",
+	"PNP0301",
+	"PNP0302",
+	"PNP0303",
+	"PNP0304",
+	"PNP0305",
+	"PNP0306",
+	"PNP0307",
+	"PNP0308",
+	"PNP0309",
+	"PNP030A",
+	"PNP030B",
+	"PNP0320",
+	"PNP0321",
+	"PNP0322",
+	"PNP0323",
+	"PNP0324",
+	"PNP0325",
+	"PNP0326",
+	"PNP0327",
+	"PNP0340",
+	"PNP0341",
+	"PNP0342",
+	"PNP0343",
+	"PNP0343",
+	"PNP0344",
+	UACPI_NULL,
+}};
+
+constexpr std::array<const uacpi_char *, 39> ACPI_HID_PS2_MICE = {{
+	"PNP0F00",
+	"PNP0F01",
+	"PNP0F02",
+	"PNP0F03",
+	"PNP0F04",
+	"PNP0F05",
+	"PNP0F06",
+	"PNP0F07",
+	"PNP0F08",
+	"PNP0F09",
+	"PNP0F0A",
+	"PNP0F0B",
+	"PNP0F0C",
+	"PNP0F0D",
+	"PNP0F0E",
+	"PNP0F0F",
+	"PNP0F10",
+	"PNP0F11",
+	"PNP0F12",
+	"PNP0F13",
+	"PNP0F14",
+	"PNP0F15",
+	"PNP0F16",
+	"PNP0F17",
+	"PNP0F18",
+	"PNP0F19",
+	"PNP0F1A",
+	"PNP0F1B",
+	"PNP0F1C",
+	"PNP0F1D",
+	"PNP0F1E",
+	"PNP0F1F",
+	"PNP0F20",
+	"PNP0F21",
+	"PNP0F22",
+	"PNP0F23",
+	"PNP0FFC",
+	"PNP0FFF",
+	UACPI_NULL,
+}};
+
 constexpr const uacpi_char *ACPI_HID_PCI = "PNP0A03";
 constexpr const uacpi_char *ACPI_HID_PCIE = "PNP0A08";
 constexpr const uacpi_char *ACPI_HID_EC = "PNP0C09";
@@ -40,16 +114,30 @@ void initEc();
 void initEvents();
 
 struct AcpiObject final : public KernelBusObject {
-	AcpiObject(uacpi_namespace_node *node, const char *hid, unsigned int id)
-	: node{node}, hid_name{hid}, instance{id} {}
+	AcpiObject(uacpi_namespace_node *node, unsigned int id)
+	: node{node}, instance{id} {
+		if(node) {
+			uacpi_eval_hid(node, &hid_name);
+			uacpi_eval_cid(node, &cid_name);
+		}
+	}
+
+	~AcpiObject() {
+		if(hid_name)
+			uacpi_free_id_string(hid_name);
+		if(cid_name)
+			uacpi_free_pnp_id_list(cid_name);
+	}
 
 	coroutine<void> run();
 	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override;
 
 	size_t mbus_id;
 	uacpi_namespace_node *node;
-	const char *hid_name;
+	uacpi_id_string *hid_name = nullptr;
+	uacpi_pnp_id_list *cid_name = nullptr;
 	unsigned int instance;
+	async::oneshot_event completion = {};
 };
 
 } // namespace thor::acpi

--- a/kernel/thor/system/acpi/thor-internal/acpi/ps2.hpp
+++ b/kernel/thor/system/acpi/thor-internal/acpi/ps2.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace thor::acpi {
+
+void initializePS2();
+
+} // namespace thor::acpi

--- a/kernel/thor/system/legacy-pc/ata.cpp
+++ b/kernel/thor/system/legacy-pc/ata.cpp
@@ -126,6 +126,12 @@ private:
 			managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 			resp.set_error(managarm::hw::Errors::SUCCESS);
 
+			if(req->index() != 0) {
+				resp.set_error(managarm::hw::Errors::OUT_OF_BOUNDS);
+				FRG_CO_TRY(co_await sendResponse(lane, std::move(resp)));
+				co_return frg::success;
+			}
+
 			auto object = smarter::allocate_shared<GenericIrqObject>(*kernelAlloc,
 					frg::string<KernelAlloc>{*kernelAlloc, "isa-irq.ata"});
 #ifdef __x86_64__

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -333,11 +333,16 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(LaneHandle lane) {
 			co_return Error::protocolViolation;
 		}
 
-
-		auto object = static_cast<PciDevice *>(this)->obtainIrqObject();
-
 		managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 		resp.set_error(managarm::hw::Errors::SUCCESS);
+
+		if(req->index() != 0) {
+			resp.set_error(managarm::hw::Errors::OUT_OF_BOUNDS);
+			FRG_CO_TRY(co_await sendResponse(lane, std::move(resp)));
+			co_return frg::success;
+		}
+
+		auto object = static_cast<PciDevice *>(this)->obtainIrqObject();
 
 		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 

--- a/posix/subsystem/src/subsystem/acpi.cpp
+++ b/posix/subsystem/src/subsystem/acpi.cpp
@@ -91,7 +91,8 @@ async::detached run() {
 
 			auto entity = co_await mbus_ng::Instance::global().getEntity(event.id);
 
-			bind(std::move(entity), std::move(event.properties));
+			if(event.properties.contains("acpi.hid"))
+				bind(std::move(entity), std::move(event.properties));
 		}
 	}
 }

--- a/protocols/hw/hw.bragi
+++ b/protocols/hw/hw.bragi
@@ -4,7 +4,8 @@ enum Errors {
 	SUCCESS = 0,
 	OUT_OF_BOUNDS,
 	ILLEGAL_ARGUMENTS,
-	RESOURCE_EXHAUSTION
+	RESOURCE_EXHAUSTION,
+	DEVICE_ERROR
 }
 
 enum IoType {
@@ -152,4 +153,17 @@ tail:
 		tag(7) uint64 voltage_now;
 		tag(8) uint64 voltage_min_design;
 	}
+}
+
+message AcpiGetResourcesRequest 19 {
+head(16):
+}
+
+message AcpiGetResourcesReply 20 {
+head(16):
+	Errors error;
+tail:
+	uint16[] io_ports;
+	uint16[] fixed_io_ports;
+	uint8[] irqs;
 }

--- a/protocols/hw/hw.bragi
+++ b/protocols/hw/hw.bragi
@@ -43,6 +43,7 @@ head(128):
 
 message AccessIrqRequest 3 {
 head(128):
+	uint64 index;
 }
 
 message AccessExpansionRomRequest 16 {

--- a/protocols/hw/include/protocols/hw/client.hpp
+++ b/protocols/hw/include/protocols/hw/client.hpp
@@ -64,7 +64,7 @@ struct Device {
 	async::result<PciInfo> getPciInfo();
 	async::result<helix::UniqueDescriptor> accessBar(int index);
 	async::result<helix::UniqueDescriptor> accessExpansionRom();
-	async::result<helix::UniqueDescriptor> accessIrq();
+	async::result<helix::UniqueDescriptor> accessIrq(size_t index = 0);
 	async::result<helix::UniqueDescriptor> installMsi(int index);
 
 	async::result<void> claimDevice();

--- a/protocols/hw/include/protocols/hw/client.hpp
+++ b/protocols/hw/include/protocols/hw/client.hpp
@@ -57,6 +57,11 @@ struct BatteryState {
 	std::optional<uint64_t> voltage_min_design = std::nullopt;
 };
 
+struct AcpiResources {
+	std::vector<uint16_t> io_ports;
+	std::vector<uint8_t> irqs;
+};
+
 struct Device {
 	Device(helix::UniqueLane lane)
 	:_lane(std::move(lane)) { };
@@ -80,6 +85,8 @@ struct Device {
 	async::result<helix::UniqueDescriptor> accessFbMemory();
 
 	async::result<void> getBatteryState(BatteryState &state, bool block = false);
+
+	async::result<std::shared_ptr<AcpiResources>> getResources();
 
 private:
 	helix::UniqueLane _lane;

--- a/protocols/hw/src/client.cpp
+++ b/protocols/hw/src/client.cpp
@@ -169,8 +169,9 @@ async::result<helix::UniqueDescriptor> Device::accessExpansionRom() {
 	co_return std::move(expansion_rom);
 }
 
-async::result<helix::UniqueDescriptor> Device::accessIrq() {
+async::result<helix::UniqueDescriptor> Device::accessIrq(size_t index) {
 	managarm::hw::AccessIrqRequest req;
+	req.set_index(index);
 
 	auto [offer, send_req, recv_head] = co_await helix_ng::exchangeMsgs(
 			_lane,

--- a/protocols/mbus/include/protocols/mbus/client.hpp
+++ b/protocols/mbus/include/protocols/mbus/client.hpp
@@ -53,6 +53,7 @@ private:
 struct Conjunction {
 	Conjunction(std::vector<AnyFilter> &&operands);
 
+	std::vector<AnyFilter> &operands() &;
 	const std::vector<AnyFilter> &operands() const &;
 
 private:
@@ -62,6 +63,7 @@ private:
 struct Disjunction {
 	Disjunction(std::vector<AnyFilter> &&operands);
 
+	std::vector<AnyFilter> &operands() &;
 	const std::vector<AnyFilter> &operands() const &;
 
 private:

--- a/protocols/mbus/src/client_ng.cpp
+++ b/protocols/mbus/src/client_ng.cpp
@@ -398,6 +398,10 @@ Conjunction::Conjunction(std::vector<AnyFilter> &&operands)
 
 }
 
+std::vector<AnyFilter> &Conjunction::operands() & {
+	return operands_;
+}
+
 const std::vector<AnyFilter> &Conjunction::operands() const & {
 	return operands_;
 }
@@ -409,6 +413,10 @@ const std::vector<AnyFilter> &Conjunction::operands() const & {
 Disjunction::Disjunction(std::vector<AnyFilter> &&operands)
 	: operands_{std::move(operands)} {
 
+}
+
+std::vector<AnyFilter> &Disjunction::operands() & {
+	return operands_;
 }
 
 const std::vector<AnyFilter> &Disjunction::operands() const & {


### PR DESCRIPTION
This PR enables detection of i8042 parameters (I/O ports, IRQ numbers) via ACPI.