### PR TITLE
eir: add UEFI boot protocol

### DIFF
--- a/docs/src/contributing/lsp.md
+++ b/docs/src/contributing/lsp.md
@@ -46,6 +46,11 @@ If:
   PathMatch: kernel/.*
 CompileFlags:
   CompilationDatabase: /var/lib/managarm-buildenv/build/pkg-builds/managarm-kernel
+---
+If:
+  PathMatch: kernel/eir/protos/uefi/.*
+CompileFlags:
+  CompilationDatabase: /var/lib/managarm-buildenv/build/pkg-builds/managarm-kernel-uefi
 
 # vim: set ft=yaml :
 ```

--- a/hel/meson.build
+++ b/hel/meson.build
@@ -22,7 +22,7 @@ endif
 inc = [ 'include' ]
 
 if not provide_deps and not build_kernel
-	deps = [ coroutines, bragi_dep, frigg, posix_extra_dep ]
+	deps = [ bragi_dep, frigg, posix_extra_dep ]
 
 	helix = shared_library('helix', src,
 		dependencies : deps,

--- a/kernel/eir/arch/arm/load64.S
+++ b/kernel/eir/arch/arm/load64.S
@@ -30,4 +30,6 @@ eirEnterKernel:
 	mov x0, x4
 	br x2
 
+#ifndef __clang__
 	.section .note.GNU-stack,"",%progbits
+#endif

--- a/kernel/eir/arch/riscv/entry64.S
+++ b/kernel/eir/arch/riscv/entry64.S
@@ -13,4 +13,6 @@ eirStackBase:
 	.space 0x10000
 eirStackTop:
 
+#ifndef __clang__
 	.section .note.GNU-stack,"",%progbits
+#endif

--- a/kernel/eir/arch/x86/load64.S
+++ b/kernel/eir/arch/x86/load64.S
@@ -26,4 +26,6 @@ eirEnterKernel:
 	movabs $0xFFFFFE8000010000, %rdi
 	jmp *%rsi
 
+#ifndef __clang__
 	.section .note.GNU-stack,"",%progbits
+#endif

--- a/kernel/eir/arch/x86/meson.build
+++ b/kernel/eir/arch/x86/meson.build
@@ -30,5 +30,7 @@ eir64_dependencies = eir_dependencies
 eir64_extra_objects = []
 eir64_link_depends = files('generic64_link.x')
 
-subdir('multiboot1')
-subdir('multiboot2')
+if not build_uefi
+	subdir('multiboot1')
+	subdir('multiboot2')
+endif

--- a/kernel/eir/generic/eir-internal/debug.hpp
+++ b/kernel/eir/generic/eir-internal/debug.hpp
@@ -16,9 +16,13 @@ struct LogSink {
 
 struct PanicSink {
 	void operator()(const char *c);
+	void finalize(bool);
 };
 
-extern frg::stack_buffer_logger<LogSink> infoLogger;
-extern frg::stack_buffer_logger<PanicSink> panicLogger;
+extern bool log_e9;
+extern void (*logHandler)(const char c);
+
+extern frg::stack_buffer_logger<LogSink, 128> infoLogger;
+extern frg::stack_buffer_logger<PanicSink, 128> panicLogger;
 
 } // namespace eir

--- a/kernel/eir/meson.build
+++ b/kernel/eir/meson.build
@@ -21,7 +21,7 @@ libgcc = cxx.find_library('gcc', required: not build_uefi)
 eir_c_args = []
 eir_cpp_args = ['-fno-threadsafe-statics', '-DFRG_DONT_USE_LONG_DOUBLE']
 eir_link_args = ['-nostdlib']
-eir_dependencies = [libgcc, cxxshim_dep, frigg, libarch]
+eir_dependencies = [libgcc, frigg, libarch]
 
 if get_option('kernel_kasan')
 	eir_c_args += [

--- a/kernel/eir/meson.build
+++ b/kernel/eir/meson.build
@@ -16,7 +16,7 @@ eir_includes = [include_directories(
 eir_includes += uacpi_includes
 
 cxx = meson.get_compiler('cpp')
-libgcc = cxx.find_library('gcc')
+libgcc = cxx.find_library('gcc', required: not build_uefi)
 
 eir_c_args = []
 eir_cpp_args = ['-fno-threadsafe-statics', '-DFRG_DONT_USE_LONG_DOUBLE']
@@ -41,4 +41,9 @@ elif arch == 'riscv64'
 	subdir('arch/riscv')
 elif arch == 'x86_64'
 	subdir('arch/x86')
+endif
+
+if build_uefi
+	eir_cpp_args = []
+	subdir('protos/uefi')
 endif

--- a/kernel/eir/protos/uefi/efi.hpp
+++ b/kernel/eir/protos/uefi/efi.hpp
@@ -1,0 +1,357 @@
+#pragma once
+
+// based on UEFI 2.10 Errata A
+
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// 2.3.1 Data Types
+using efi_status = size_t;
+using efi_handle = void *;
+
+struct alignas(8) efi_guid {
+	uint32_t data1;
+	uint16_t data2;
+	uint16_t data3;
+	uint8_t data4[8];
+};
+
+// 4.2.1 EFI_TABLE_HEADER
+
+struct efi_table_header {
+	uint64_t signature;
+	uint32_t revision;
+	uint32_t header_size;
+	uint32_t crc32;
+	uint32_t reserved;
+};
+
+// 4.3.1 EFI_SYSTEM_TABLE
+
+struct efi_boot_services;
+struct efi_configuration_table;
+struct efi_simple_text_output_protocol;
+
+struct efi_system_table {
+	efi_table_header hdr;
+	char16_t *firmware_vendor;
+	uint32_t firmware_revision;
+	efi_handle console_in_handle;
+	void *con_in;
+	efi_handle console_out_handle;
+	struct efi_simple_text_output_protocol *con_out;
+	efi_handle standard_error_handle;
+	void *std_err;
+	void *runtime_services;
+	efi_boot_services *boot_services;
+	size_t number_of_table_entries;
+	efi_configuration_table *configuration_table;
+};
+
+// 4.6.1 EFI_CONFIGURATION_TABLE
+struct efi_configuration_table {
+	efi_guid vendor_guid;
+	void *vendor_table;
+};
+
+constexpr efi_guid ACPI_20_TABLE_GUID = { 0x8868e871, 0xe4f1, 0x11d3, { 0xbc, 0x22, 0x00, 0x80, 0xc7, 0x3c, 0x88, 0x81 } };
+
+// 7.2.1 EFI_BOOT_SERVICES.AllocatePages()
+enum efi_allocate_type {
+	AllocateAnyPages,
+	AllocateMaxAddress,
+	AllocateAddress,
+	MaxAllocateType
+};
+
+enum efi_memory_type {
+	EfiReservedMemoryType,
+	EfiLoaderCode,
+	EfiLoaderData,
+	EfiBootServicesCode,
+	EfiBootServicesData,
+	EfiRuntimeServicesCode,
+	EfiRuntimeServicesData,
+	EfiConventionalMemory,
+	EfiUnusableMemory,
+	EfiACPIReclaimMemory,
+	EfiACPIMemoryNVS,
+	EfiMemoryMappedIO,
+	EfiMemoryMappedIOPortSpace,
+	EfiPalCode,
+	EfiPersistentMemory,
+	EfiUnacceptedMemoryType,
+	EfiMaxMemoryType
+};
+
+using efi_physical_addr = uint64_t;
+
+// 7.2.3 EFI_BOOT_SERVICES.GetMemoryMap()
+
+using efi_virtual_addr = uint64_t;
+
+struct efi_memory_descriptor {
+	uint32_t type;
+	efi_physical_addr physical_start;
+	efi_virtual_addr virtual_start;
+	uint64_t number_of_pages;
+	uint64_t attribute;
+};
+
+// 8.3.1 GetTime()
+
+struct efi_time {
+	uint16_t year;
+	uint8_t month;
+	uint8_t day;
+	uint8_t hour;
+	uint8_t minute;
+	uint8_t second;
+	uint8_t pad1;
+	uint32_t nanosecond;
+	int16_t time_zone;
+	uint8_t daylight;
+	uint8_t pad2;
+};
+
+// 9.1.1 EFI_LOADED_IMAGE_PROTOCOL
+
+constexpr efi_guid EFI_LOADED_IMAGE_PROTOCOL_GUID = {0x5B1B31A1, 0x9562, 0x11d2, {0x8E, 0x3F, 0x00, 0xA0, 0xC9, 0x69, 0x72, 0x3B}};
+
+struct efi_loaded_image_protocol {
+	uint32_t revision;
+	efi_handle parent_handle;
+	efi_system_table *system_table;
+	efi_handle device_handle;
+	void *file_path;
+	void *reserved;
+	uint32_t load_options_size;
+	void *load_options;
+	void *image_base;
+	uint64_t image_size;
+	efi_memory_type image_code_type;
+	efi_memory_type image_data_type;
+	void *unload;
+};
+
+// 12.4.1 EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL
+
+struct efi_simple_text_output_protocol {
+	void *reset;
+	efi_status (*output_string)(struct efi_simple_text_output_protocol *self, char16_t *string);
+	void *test_string;
+	void *query_mode;
+	void *set_mode;
+	void *set_attribute;
+	efi_status (*clear_screen)(struct efi_simple_text_output_protocol *self);
+	void *set_cursor_position;
+	void *enable_cursor;
+	void *mode;
+};
+
+// 12.9.2 EFI_GRAPHICS_OUTPUT_PROTOCOL
+
+constexpr efi_guid EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID = { 0x9042a9de, 0x23dc, 0x4a38, { 0x96, 0xfb, 0x7a, 0xde, 0xd0, 0x80, 0x51, 0x6a } };
+
+struct efi_graphics_output_protocol_mode;
+
+struct efi_graphics_output_protocol {
+	void *query_mode;
+	void *set_mode;
+	void *blt;
+	struct efi_graphics_output_protocol_mode *mode;
+};
+
+struct efi_pixel_bitmask {
+	uint32_t red_mask;
+	uint32_t green_mask;
+	uint32_t blue_mask;
+	uint32_t reserved_mask;
+};
+
+enum efi_graphics_pixel_format {
+	PixelRedGreenBlueReserved8BitPerColor,
+	PixelBlueGreenRedReserved8BitPerColor,
+	PixelBitMask,
+	PixelBltOnly,
+	PixelFormatMax
+};
+
+struct efi_graphics_output_mode_information {
+	uint32_t version;
+	uint32_t horizontal_resolution;
+	uint32_t vertical_resolution;
+	efi_graphics_pixel_format pixel_format;
+	efi_pixel_bitmask pixel_information;
+	uint32_t pixels_per_scan_line;
+};
+
+struct efi_graphics_output_protocol_mode {
+	uint32_t max_mode;
+	uint32_t mode;
+	efi_graphics_output_mode_information *info;
+	size_t size_of_info;
+	efi_physical_addr framebuffer_base;
+	size_t framebuffer_size;
+};
+
+// 13.4.1 EFI_SIMPLE_FILE_SYSTEM_PROTOCOL
+
+constexpr efi_guid EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_GUID = { 0x0964e5b22, 0x6459, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+struct efi_file_protocol;
+
+struct efi_simple_file_system_protocol {
+	uint64_t revision;
+	efi_status (*open_volume)(struct efi_simple_file_system_protocol *self, struct efi_file_protocol **root);
+};
+
+// 13.5.1 EFI_FILE_PROTOCOL
+
+struct efi_file_protocol {
+	uint64_t revision;
+	efi_status (*open)(struct efi_file_protocol *self, struct efi_file_protocol **new_handle, char16_t *file_name, uint64_t open_mode, uint64_t attributes);
+	void *close;
+	void *del;
+	efi_status (*read)(struct efi_file_protocol *self, size_t *buffer_size, void *buffer);
+	void *write;
+	efi_status (*get_position)(struct efi_file_protocol *self, uint64_t *position);
+	efi_status (*set_position)(struct efi_file_protocol *self, uint64_t position);
+	efi_status (*get_info)(struct efi_file_protocol *self, efi_guid *information_type, size_t *buffer_size, void *buffer);
+	void *set_info;
+	void *flush;
+	void *open_ex;
+	void *read_ex;
+	void *write_ex;
+	void *flush_ex;
+};
+
+// 13.5.2 EFI_FILE_PROTOCOL.Open()
+
+constexpr uint64_t EFI_FILE_MODE_READ = 0x0000000000000001;
+constexpr uint64_t EFI_FILE_MODE_WRITE = 0x0000000000000002;
+constexpr uint64_t EFI_FILE_MODE_CREATE = 0x8000000000000000;
+
+constexpr uint64_t EFI_FILE_READ_ONLY = 0x0000000000000001;
+constexpr uint64_t EFI_FILE_HIDDEN = 0x0000000000000002;
+constexpr uint64_t EFI_FILE_SYSTEM = 0x0000000000000004;
+constexpr uint64_t EFI_FILE_RESERVED = 0x0000000000000008;
+constexpr uint64_t EFI_FILE_DIRECTORY = 0x0000000000000010;
+constexpr uint64_t EFI_FILE_ARCHIVE = 0x0000000000000020;
+constexpr uint64_t EFI_FILE_VALID_ATTR = 0x0000000000000037;
+
+// 13.5.16 EFI_FILE_INFO
+
+constexpr efi_guid EFI_FILE_INFO_GUID = { 0x09576e92, 0x6d3f, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+struct efi_file_info {
+	uint64_t size;
+	uint64_t file_size;
+	uint64_t physical_size;
+	efi_time create_time;
+	efi_time last_access_time;
+	efi_time modification_time;
+	uint64_t attribute;
+	char16_t file_name[];
+};
+
+// Appendix D
+
+constexpr efi_status EFI_SUCCESS = 0;
+
+constexpr efi_status EFI_WARN_UNKNOWN_GLYPH = 1;
+constexpr efi_status EFI_WARN_DELETE_FAILURE = 2;
+constexpr efi_status EFI_WARN_WRITE_FAILURE = 3;
+constexpr efi_status EFI_WARN_BUFFER_TOO_SMALL = 4;
+constexpr efi_status EFI_WARN_STALE_DATA = 5;
+constexpr efi_status EFI_WARN_FILE_SYSTEM = 6;
+constexpr efi_status EFI_WARN_RESET_REQUIRED = 7;
+
+constexpr efi_status EFI_LOAD_ERROR = (INTPTR_MAX + 1ULL) + 1;
+constexpr efi_status EFI_INVALID_PARAMETER = (INTPTR_MAX + 1ULL) + 2;
+constexpr efi_status EFI_UNSUPPORTED = (INTPTR_MAX + 1ULL) + 3;
+constexpr efi_status EFI_BAD_BUFFER_SIZE = (INTPTR_MAX + 1ULL) + 4;
+constexpr efi_status EFI_BUFFER_TOO_SMALL = (INTPTR_MAX + 1ULL) + 5;
+constexpr efi_status EFI_NOT_READY = (INTPTR_MAX + 1ULL) + 6;
+constexpr efi_status EFI_DEVICE_ERROR = (INTPTR_MAX + 1ULL) + 7;
+constexpr efi_status EFI_WRITE_PROTECTED = (INTPTR_MAX + 1ULL) + 8;
+constexpr efi_status EFI_OUT_OF_RESOURCES = (INTPTR_MAX + 1ULL) + 9;
+constexpr efi_status EFI_VOLUME_CORRUPTED = (INTPTR_MAX + 1ULL) + 10;
+constexpr efi_status EFI_VOLUME_FULL = (INTPTR_MAX + 1ULL) + 11;
+constexpr efi_status EFI_NO_MEDIA = (INTPTR_MAX + 1ULL) + 12;
+constexpr efi_status EFI_MEDIA_CHANGED = (INTPTR_MAX + 1ULL) + 13;
+constexpr efi_status EFI_NOT_FOUND = (INTPTR_MAX + 1ULL) + 14;
+constexpr efi_status EFI_ACCESS_DENIED = (INTPTR_MAX + 1ULL) + 15;
+constexpr efi_status EFI_NO_RESPONSE = (INTPTR_MAX + 1ULL) + 16;
+constexpr efi_status EFI_NO_MAPPING = (INTPTR_MAX + 1ULL) + 17;
+constexpr efi_status EFI_TIMEOUT = (INTPTR_MAX + 1ULL) + 18;
+constexpr efi_status EFI_NOT_STARTED = (INTPTR_MAX + 1ULL) + 19;
+constexpr efi_status EFI_ALREADY_STARTED = (INTPTR_MAX + 1ULL) + 20;
+constexpr efi_status EFI_ABORTED = (INTPTR_MAX + 1ULL) + 21;
+constexpr efi_status EFI_ICMP_ERROR = (INTPTR_MAX + 1ULL) + 22;
+constexpr efi_status EFI_TFTP_ERROR = (INTPTR_MAX + 1ULL) + 23;
+constexpr efi_status EFI_PROTOCOL_ERROR = (INTPTR_MAX + 1ULL) + 24;
+constexpr efi_status EFI_INCOMPATIBLE_VERSION = (INTPTR_MAX + 1ULL) + 25;
+constexpr efi_status EFI_SECURITY_VIOLATION = (INTPTR_MAX + 1ULL) + 26;
+constexpr efi_status EFI_CRC_ERROR = (INTPTR_MAX + 1ULL) + 27;
+constexpr efi_status EFI_END_OF_MEDIA = (INTPTR_MAX + 1ULL) + 28;
+constexpr efi_status EFI_END_OF_FILE = (INTPTR_MAX + 1ULL) + 31;
+constexpr efi_status EFI_INVALID_LANGUAGE = (INTPTR_MAX + 1ULL) + 32;
+constexpr efi_status EFI_COMPROMISED_DATA = (INTPTR_MAX + 1ULL) + 33;
+constexpr efi_status EFI_IP_ADDRESS_CONFLICT = (INTPTR_MAX + 1ULL) + 34;
+constexpr efi_status EFI_HTTP_ERROR = (INTPTR_MAX + 1ULL) + 35;
+
+// ------------------------------------------------------------------------------------------------
+// Some things heavily rely on declarations later in the spec, so place them last.
+// ------------------------------------------------------------------------------------------------
+
+// 4.4.1 EFI_BOOT_SERVICES
+
+struct efi_boot_services {
+	efi_table_header hdr;
+	void *raise_tpl;
+	void *restore_tpl;
+	efi_status (*allocate_pages)(efi_allocate_type type, efi_memory_type memory_type, size_t pages, efi_physical_addr *memory);
+	void *free_pages;
+	efi_status (*get_memory_map)(size_t *memory_map_size, efi_memory_descriptor *memory_map, size_t *map_key, size_t *descriptor_size, uint32_t *descriptor_version);
+	efi_status (*allocate_pool)(efi_memory_type pool_type, size_t size, void **buffer);
+	void *free_pool;
+	void *create_event;
+	void *set_timer;
+	void *wait_for_event;
+	void *signal_event;
+	void *close_event;
+	void *check_event;
+	void *install_protocol_interface;
+	void *reinstall_protocol_interface;
+	void *uninstall_protocol_interface;
+	efi_status (*handle_protocol)(efi_handle handle, efi_guid *protocol, void **interface);
+	void *reserved;
+	void *register_protocol_notify;
+	void *locate_handle;
+	void *locate_device_path;
+	void *install_configuration_table;
+	void *load_image;
+	void *start_image;
+	void *exit;
+	void *unload_image;
+	efi_status (*exit_boot_services)(efi_handle image_handle, size_t map_key);
+	void *get_next_monotonic_count;
+	void *stall;
+	efi_status (*set_watchdog_timer)(size_t timeout, uint64_t watchdog_code, size_t data_size, char16_t *watchdog_data);
+	void *connect_controller;
+	void *disconnect_controller;
+	void *open_protocol;
+	void *close_protocol;
+	void *open_protocol_information;
+	void *protocols_per_handle;
+	void *locate_handle_buffer;
+	efi_status (*locate_protocol)(efi_guid *protocol, void *registration, void **interface);
+	void *install_multiple_protocol_interface;
+	void *uninstall_multiple_protocol_interface;
+	void *calculate_crc32;
+	void *copy_mem;
+	void *set_mem;
+	void *create_event_ex;
+};

--- a/kernel/eir/protos/uefi/entry.cpp
+++ b/kernel/eir/protos/uefi/entry.cpp
@@ -1,0 +1,351 @@
+#include <arch/io_space.hpp>
+#include <assert.h>
+#include <eir-internal/arch.hpp>
+#include <eir-internal/debug.hpp>
+#include <eir-internal/generic.hpp>
+#include <frg/array.hpp>
+#include <frg/cmdline.hpp>
+#include <stdbool.h>
+
+#include "efi.hpp"
+#include "helpers.hpp"
+
+static_assert(sizeof(char16_t) == sizeof(wchar_t), "Strings are not UTF-16-ish, are you missing -fshort-wchar?");
+extern "C" void eirEnterKernel(uintptr_t, uint64_t, uint64_t) __attribute__((sysv_abi));
+
+namespace eir {
+
+const efi_system_table *st = nullptr;
+const efi_boot_services *bs = nullptr;
+efi_handle handle = nullptr;
+
+namespace {
+
+void uefiBootServicesLogHandler(const char c) {
+	if(bs) {
+		if(c == '\n') {
+			frg::array<char16_t, 3> newline = {u"\r\n"};
+			st->con_out->output_string(st->con_out, newline.data());
+			return;
+		}
+
+		frg::array<char16_t, 2> converted = {static_cast<char16_t>(c), 0};
+		st->con_out->output_string(st->con_out, converted.data());
+	}
+}
+
+} // namespace
+
+extern "C" efi_status eirUefiMain(const efi_handle h, const efi_system_table *system_table) {
+	// Set the system table so we can use loggers early on.
+	st = system_table;
+	bs = st->boot_services;
+	handle = h;
+
+	logHandler = uefiBootServicesLogHandler;
+
+	// Reset the watchdog timer.
+	EFI_CHECK(bs->set_watchdog_timer(0, 0, 0, nullptr));
+	EFI_CHECK(st->con_out->clear_screen(st->con_out));
+
+	// Get a handle to this binary in order to get the command line.
+	efi_guid protocol = EFI_LOADED_IMAGE_PROTOCOL_GUID;
+	efi_loaded_image_protocol *loadedImage = nullptr;
+	EFI_CHECK(bs->handle_protocol(handle, &protocol, reinterpret_cast<void **>(&loadedImage)));
+
+	// Convert the command line to ASCII.
+	char *cmdLine = nullptr;
+	{
+		EFI_CHECK(bs->allocate_pool(EfiLoaderData,
+			(loadedImage->load_options_size / sizeof(uint16_t)) + 1,
+			reinterpret_cast<void **>(&cmdLine)));
+		size_t i = 0;
+		for(; i < loadedImage->load_options_size / sizeof(char16_t); i++) {
+			auto c = reinterpret_cast<char16_t *>(loadedImage->load_options)[i];
+			// we only use printable ASCII characters, everything else gets discarded
+			if(c >= 0x20 && c <= 0x7E) {
+				cmdLine[i] = c;
+			} else {
+				cmdLine[i] = '\0';
+			}
+		}
+		// Null-terminate the buffer.
+		cmdLine[i] = '\0';
+	}
+	assert(cmdLine);
+
+	bool eir_gdb_ready_val = true;
+	frg::string_view thor_path = "managarm\\thor";
+	frg::string_view initrd_path = "managarm\\initrd.cpio";
+
+	frg::array args = {
+		// allow for attaching GDB to eir
+		frg::option{"eir.efidebug", frg::store_false(eir_gdb_ready_val)},
+		frg::option{"bochs", frg::store_true(log_e9)},
+		frg::option{"eir.thor", frg::as_string_view(thor_path)},
+		frg::option{"eir.initrd", frg::as_string_view(initrd_path)},
+	};
+	frg::parse_arguments(cmdLine, args);
+
+	eir::infoLogger() << "eir: command line='" << cmdLine << "'" << frg::endlog;
+
+	// this needs to be volatile as GDB sets this to true on attach
+	volatile bool eir_gdb_ready = eir_gdb_ready_val;
+
+	if(!eir_gdb_ready_val) {
+		// exfiltrate our base address for use with gdb
+		constexpr arch::scalar_register<uint8_t> offset{0};
+		auto port = arch::global_io.subspace(0xCB7);
+
+		for(size_t i = 0; i < sizeof(uintptr_t); i++) {
+			uint8_t b = reinterpret_cast<uintptr_t>(loadedImage->image_base) >> (i * 8);
+			port.store(offset, b);
+		}
+
+		eir::infoLogger() << "eir: Waiting for GDB to attach" << frg::endlog;
+	}
+
+	while(!eir_gdb_ready);
+
+	// acquire ACPI table info
+	efi_guid acpi_guid = ACPI_20_TABLE_GUID;
+	const efi_configuration_table *t = st->configuration_table;
+	uintptr_t rsdp = 0;
+	for(size_t i = 0; i < st->number_of_table_entries && t; i++, t++)
+		if(!memcmp(&acpi_guid, &t->vendor_guid, sizeof(acpi_guid)))
+			rsdp = reinterpret_cast<uintptr_t>(t->vendor_table);
+
+	// Load the kernel and initrd.
+	efi_file_protocol *kernelFile = nullptr;
+	EFI_CHECK(fsOpen(&kernelFile, asciiToUcs2(thor_path)));
+	auto kernel_info = fsGetInfo(kernelFile);
+	efi_physical_addr thor = 0;
+	EFI_CHECK(bs->allocate_pages(AllocateAnyPages, EfiLoaderData, (kernel_info->file_size >> 12) + 1, &thor));
+	fsRead(kernelFile, kernel_info->file_size, 0, thor);
+
+	efi_file_protocol *initrdFile = nullptr;
+	EFI_CHECK(fsOpen(&initrdFile, asciiToUcs2(initrd_path)));
+	efi_file_info *initrdInfo = fsGetInfo(initrdFile);
+
+	// Read initrd.
+	efi_physical_addr initrd = 0;
+	EFI_CHECK(bs->allocate_pages(AllocateAnyPages, EfiLoaderData, (initrdInfo->file_size >> 12) + 1, &initrd));
+	EFI_CHECK(fsRead(initrdFile, initrdInfo->file_size, 0, initrd));
+
+	// Get the frame buffer.
+	efi_graphics_output_protocol *gop = nullptr;
+
+	{
+		efi_guid gop_protocol = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
+		EFI_CHECK(bs->locate_protocol(&gop_protocol, nullptr, reinterpret_cast<void **>(&gop)));
+		if(gop->mode->info->version != 0)
+			eir::panicLogger() << "error: unsupported EFI_GRAPHICS_OUTPUT_MODE_INFORMATION version!" << frg::endlog;
+
+		eir::infoLogger() << "eir: framebuffer "
+			<< gop->mode->info->horizontal_resolution << "x"
+			<< gop->mode->info->vertical_resolution << " address=0x"
+			<< frg::hex_fmt{gop->mode->framebuffer_base}
+			<< frg::endlog;
+	}
+
+	size_t memMapSize = sizeof(efi_memory_descriptor);
+	size_t mapKey = 0;
+	size_t descriptorSize = 0;
+	uint32_t descriptorVersion = 0;
+	void *memMap = nullptr;
+	efi_memory_descriptor dummy;
+
+	// First get the size of the memory map buffer to allocate.
+	efi_status status = bs->get_memory_map(&memMapSize, &dummy, &mapKey, &descriptorSize, &descriptorVersion);
+	assert(status == EFI_BUFFER_TOO_SMALL);
+
+	// over-allocate a bit to accomodate the allocation we have to make here
+	// we only get one shot(tm) to allocate an appropriately-sized buffer, as the spec does not
+	// allow for calling any boot services other than GetMemoryMap and ExitBootServices after
+	// a call to ExitBootServices fails
+	memMapSize += 8 * descriptorSize;
+	EFI_CHECK(bs->allocate_pool(EfiLoaderData, memMapSize, &memMap));
+
+	// Now, get the actual memory map.
+	EFI_CHECK(bs->get_memory_map(&memMapSize,
+		reinterpret_cast<efi_memory_descriptor*>(memMap),
+		&mapKey, &descriptorSize, &descriptorVersion));
+
+	// Exit boot services.
+	EFI_CHECK(bs->exit_boot_services(handle, mapKey));
+	bs = nullptr;
+#if defined(__x86_64__)
+	asm volatile ("cli");
+#else
+#error "Unsupported architecture!"
+#endif
+
+	frg::array<InitialRegion, 4> reservedRegions = {};
+	size_t nReservedRegions = 0;
+
+	reservedRegions[nReservedRegions++] = {reinterpret_cast<uintptr_t>(loadedImage->image_base), loadedImage->image_size};
+	reservedRegions[nReservedRegions++] = {thor, kernel_info->file_size};
+	reservedRegions[nReservedRegions++] = {initrd, initrdInfo->file_size};
+
+	auto entries = memMapSize / descriptorSize;
+
+	auto endAddr = [](const efi_memory_descriptor *e) -> efi_physical_addr {
+		return e->physical_start + (e->number_of_pages * eir::pageSize);
+	};
+
+	auto nextEntry = [&](efi_physical_addr addr) {
+		const efi_memory_descriptor *lowest = nullptr;
+
+		for(size_t i = 0; i < entries; i++) {
+			auto e = reinterpret_cast<const efi_memory_descriptor *>(uintptr_t(memMap) + (i * descriptorSize));
+			if(e->physical_start >= addr) {
+				if(!lowest || e->physical_start < lowest->physical_start) {
+					lowest = e;
+				}
+			}
+		}
+
+		return lowest;
+	};
+
+	auto isContiguous = [](const efi_memory_descriptor *a, const efi_memory_descriptor *b) {
+		if(a->physical_start + (a->number_of_pages * eir::pageSize) == b->physical_start)
+			return true;
+		return false;
+	};
+
+	auto isUsable = [](const efi_memory_descriptor *e) {
+		switch(e->type) {
+			case EfiConventionalMemory:
+			case EfiBootServicesCode:
+			case EfiBootServicesData:
+				return true;
+			default:
+				return false;
+		}
+	};
+
+	eir::infoLogger() << "Memory map:" << frg::endlog;
+	auto entry = nextEntry(0);
+
+	while(entry) {
+		auto lastContiguousEntry = entry;
+
+		while(true) {
+			auto next = nextEntry(endAddr(lastContiguousEntry));
+
+			if(!next || !isContiguous(lastContiguousEntry, next))
+				break;
+
+			if(isUsable(lastContiguousEntry) != isUsable(next))
+				break;
+
+			lastContiguousEntry = next;
+		}
+
+		eir::infoLogger()
+			<< "\tbase=0x" << frg::hex_fmt{entry->physical_start}
+			<< " length=0x" << frg::hex_fmt{endAddr(lastContiguousEntry) - entry->physical_start}
+			<< " usable=" << (isUsable(entry) ? "true" : "false")
+			<< frg::endlog;
+
+		if(isUsable(entry)) {
+			createInitialRegions(
+				{entry->physical_start, endAddr(lastContiguousEntry) - entry->physical_start},
+				{reservedRegions.data(), nReservedRegions}
+			);
+		}
+
+		entry = nextEntry(endAddr(lastContiguousEntry));
+	}
+
+	initProcessorEarly();
+	setupRegionStructs();
+
+	uint64_t kernel_entry = 0;
+	initProcessorPaging(reinterpret_cast<void *>(thor), kernel_entry);
+
+	EirInfo *info_ptr = generateInfo(cmdLine);
+
+	auto initrd_module = bootAlloc<EirModule>(1);
+	initrd_module->physicalBase = reinterpret_cast<EirPtr>(initrd);
+	initrd_module->length = initrdInfo->file_size;
+	const char *initrd_mod_name = "initrd.cpio";
+	size_t name_length = strlen(initrd_mod_name);
+	char *name_ptr = bootAlloc<char>(name_length);
+	memcpy(name_ptr, initrd_mod_name, name_length);
+	initrd_module->namePtr = mapBootstrapData(name_ptr);
+	initrd_module->nameLength = name_length;
+
+	info_ptr->numModules = 1;
+	info_ptr->moduleInfo = mapBootstrapData(initrd_module);
+
+	info_ptr->acpiRsdp = rsdp;
+
+	auto base = reinterpret_cast<uintptr_t>(loadedImage->image_base);
+	auto pages = (loadedImage->image_size >> 12) + 1;
+
+	for(size_t i = 0; i < pages; i++) {
+		mapSingle4kPage(base + (i << 12), base + (i << 12), PageFlags::write | PageFlags::execute);
+	}
+
+	if(gop && gop->mode->info->pixel_format != PixelBltOnly) {
+		auto fb = &info_ptr->frameBuffer;
+
+		switch(gop->mode->info->pixel_format) {
+			case PixelBlueGreenRedReserved8BitPerColor:
+				fb->fbBpp = 32;
+				break;
+			case PixelRedGreenBlueReserved8BitPerColor:
+				fb->fbBpp = 32;
+				break;
+			case PixelBitMask: {
+				assert(gop->mode->info->pixel_information.red_mask);
+				assert(gop->mode->info->pixel_information.green_mask);
+				assert(gop->mode->info->pixel_information.blue_mask);
+
+				size_t hbred = (sizeof(uint32_t) * 8) - __builtin_clz(gop->mode->info->pixel_information.red_mask);
+				size_t hbgreen = (sizeof(uint32_t) * 8) - __builtin_clz(gop->mode->info->pixel_information.green_mask);
+				size_t hbblue = (sizeof(uint32_t) * 8) - __builtin_clz(gop->mode->info->pixel_information.blue_mask);
+
+				frg::optional<size_t> hbres = {};
+				if(gop->mode->info->pixel_information.reserved_mask)
+					hbres = (sizeof(uint32_t) * 8) - __builtin_clz(gop->mode->info->pixel_information.reserved_mask);
+
+				size_t highest_bit = frg::max(hbred, hbgreen);
+				highest_bit = frg::max(highest_bit, hbblue);
+				if(hbres)
+					highest_bit = frg::max(highest_bit, hbres.value());
+
+				assert(highest_bit % 8 == 0);
+				fb->fbBpp = highest_bit;
+				break;
+			}
+			default:
+				eir::panicLogger() << "eir: unhandled GOP pixel format" << frg::endlog;
+		}
+
+		fb->fbAddress = gop->mode->framebuffer_base;
+		fb->fbPitch = gop->mode->info->pixels_per_scan_line * (fb->fbBpp / 8);
+		fb->fbWidth = gop->mode->info->horizontal_resolution;
+		fb->fbHeight = gop->mode->info->vertical_resolution;
+		fb->fbType = 1; // linear framebuffer
+
+		// Map the framebuffer.
+		assert(fb->fbAddress & ~static_cast<EirPtr>(pageSize - 1));
+		for(address_t pg = 0; pg < gop->mode->framebuffer_size; pg += 0x1000)
+			mapSingle4kPage(0xFFFF'FE00'4000'0000 + pg, fb->fbAddress + pg,
+					PageFlags::write, CachingMode::writeCombine);
+		mapKasanShadow(0xFFFF'FE00'4000'0000, fb->fbPitch * fb->fbHeight);
+		unpoisonKasanShadow(0xFFFF'FE00'4000'0000, fb->fbPitch * fb->fbHeight);
+		fb->fbEarlyWindow = 0xFFFF'FE00'4000'0000;
+	}
+
+	// Hand-off to thor
+	eir::infoLogger() << "Leaving Eir and entering the real kernel" << frg::endlog;
+	eirEnterKernel(eirPml4Pointer, kernel_entry, 0xFFFF'FE80'0001'0000); // TODO
+
+	return EFI_SUCCESS;
+}
+
+} // namespace eir

--- a/kernel/eir/protos/uefi/helpers.cpp
+++ b/kernel/eir/protos/uefi/helpers.cpp
@@ -1,0 +1,71 @@
+#include "efi.hpp"
+#include "helpers.hpp"
+
+void EFI_CHECK(efi_status s, std::source_location loc) {
+	if(s == EFI_SUCCESS)
+		return;
+
+	eir::panicLogger() << "eir: unexpected EFI error 0x"
+	<< frg::hex_fmt {s}
+	<< " in " << loc.function_name()
+	<< " at " << loc.file_name() << ":" << loc.line()
+	<< frg::endlog;
+}
+
+namespace eir {
+
+efi_status fsOpen(efi_file_protocol **file, char16_t *path) {
+	efi_guid loadedImageGuid = EFI_LOADED_IMAGE_PROTOCOL_GUID;
+	efi_guid simpleFsGuid = EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_GUID;
+
+	efi_loaded_image_protocol *loadedImage = nullptr;
+	EFI_CHECK(bs->handle_protocol(handle, &loadedImageGuid, reinterpret_cast<void **>(&loadedImage)));
+
+	efi_simple_file_system_protocol *fileSystem = nullptr;
+	EFI_CHECK(bs->handle_protocol(loadedImage->device_handle, &simpleFsGuid, reinterpret_cast<void **>(&fileSystem)));
+
+	efi_file_protocol *root = nullptr;
+	EFI_CHECK(fileSystem->open_volume(fileSystem, &root));
+
+	EFI_CHECK(root->open(root, file, path, EFI_FILE_MODE_READ, EFI_FILE_READ_ONLY));
+
+	return EFI_SUCCESS;
+}
+
+efi_status fsRead(efi_file_protocol *file, size_t len, size_t offset, efi_physical_addr buf) {
+	EFI_CHECK(file->set_position(file, offset));
+	EFI_CHECK(file->read(file, &len, reinterpret_cast<void *>(buf)));
+	EFI_CHECK(file->set_position(file, 0));
+
+	return EFI_SUCCESS;
+}
+
+efi_file_info *fsGetInfo(efi_file_protocol *file) {
+	efi_file_info *fileInfo = nullptr;
+	efi_guid guid = EFI_FILE_INFO_GUID;
+	uintptr_t infoLen = 0x1;
+
+	efi_status stat = file->get_info(file, &guid, &infoLen, fileInfo);
+	assert(stat == EFI_SUCCESS || stat == EFI_BUFFER_TOO_SMALL);
+	EFI_CHECK(bs->allocate_pool(EfiLoaderData, infoLen, reinterpret_cast<void **>(&fileInfo)));
+	EFI_CHECK(file->get_info(file, &guid, &infoLen, fileInfo));
+
+	return fileInfo;
+}
+
+char16_t *asciiToUcs2(frg::string_view &s) {
+	assert(bs);
+
+	char16_t *ucs2 = nullptr;
+	EFI_CHECK(bs->allocate_pool(EfiLoaderData, (s.size() + 1) * 2, reinterpret_cast<void **>(&ucs2)));
+
+	for(size_t i = 0; i < s.size(); i++) {
+		ucs2[i] = static_cast<char16_t>(s[i]);
+	}
+
+	ucs2[s.size()] = '\0';
+
+	return ucs2;
+}
+
+} // namespace eir

--- a/kernel/eir/protos/uefi/helpers.hpp
+++ b/kernel/eir/protos/uefi/helpers.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <assert.h>
+#include <eir-internal/debug.hpp>
+#include <frg/logging.hpp>
+#include <frg/string.hpp>
+#include <source_location>
+
+#include "efi.hpp"
+
+void EFI_CHECK(efi_status s, std::source_location loc = std::source_location::current());
+
+namespace eir {
+
+extern const efi_system_table *st;
+extern const efi_boot_services *bs;
+extern efi_handle handle;
+
+efi_status fsOpen(efi_file_protocol **file, char16_t *path);
+efi_status fsRead(efi_file_protocol *file, size_t len, size_t offset, efi_physical_addr buf);
+efi_file_info *fsGetInfo(efi_file_protocol *file);
+
+char16_t *asciiToUcs2(frg::string_view &s);
+
+} // namespace eir

--- a/kernel/eir/protos/uefi/meson.build
+++ b/kernel/eir/protos/uefi/meson.build
@@ -1,0 +1,12 @@
+eir_uefi_sources = [
+	'entry.cpp',
+	'helpers.cpp',
+]
+
+executable('eir-uefi', eir_uefi_sources + eir64_sources,
+	include_directories : [eir_includes],
+	dependencies : [freestnd_cxx_hdrs_dep, eir_dependencies],
+	c_args: eir_c_args,
+	cpp_args: eir_cpp_args,
+	install : true
+)

--- a/kernel/memory.txt
+++ b/kernel/memory.txt
@@ -31,11 +31,6 @@ FFFF'F000'0000'0000
 	Log ring buffer memory
 	Referenced in eir/main.cpp, thor/generic/core.cpp
 
-FFFF'F000'0000'0000
-	Length: 256MiB
-	Log ring buffer memory
-	Referenced in eir/main.cpp, thor/generic/core.cpp
-
 FFFF'FE00'0000'0000
 	Length: 0x1'0000 bytes
 	Initial stack for thor

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -1,3 +1,7 @@
+if build_uefi
+	subdir_done()
+endif
+
 libsmarter = subproject('libsmarter').get_variable('libsmarter_dep')
 link_args = [ '-nostdlib' ]
 

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -156,11 +156,10 @@ endif
 link_with += static_library('cralgo', cralgo_sources,
 	include_directories : [klibc_inc, cralgo_includes],
 	cpp_args : cpp_args + args,
-	dependencies : cxxshim_dep,
 	pic : false
 )
 
-deps = [ libgcc, coroutines, cxxshim_dep, frigg, libsmarter, bragi_dep, libasync_dep, libarch, hel_dep ]
+deps = [ libgcc, frigg, libsmarter, bragi_dep, libasync_dep, libarch, hel_dep ]
 
 # TODO: also build thor on RISC-V.
 if arch != 'riscv64'

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,7 @@ if get_option('build_docs')
 endif
 
 build_kernel = get_option('build_kernel')
+build_uefi = get_option('build_uefi')
 build_drivers = get_option('build_drivers')
 build_tools = get_option('build_tools')
 provide_deps = get_option('provide_deps')
@@ -126,6 +127,18 @@ frgbragi = generator(bragi,
 	arguments : [ '-l', 'frigg', '--protobuf', '@INPUT@', '@OUTPUT@' ]
 )
 
+freestnd_c_hdrs_dep = dependency(
+	'freestnd-c-hdrs-' + host_machine.cpu_family(),
+	required: build_uefi,
+	method: 'pkg-config'
+)
+
+freestnd_cxx_hdrs_dep = dependency(
+	'freestnd-cxx-hdrs-' + host_machine.cpu_family(),
+	required: build_uefi,
+	method: 'pkg-config'
+)
+
 # declare dependencies that subdirs are going to use
 bragi_dep = subproject('bragi', default_options: ['install_headers=false']).get_variable('bragi_dep')
 
@@ -136,7 +149,7 @@ elif flavor == 'userspace'
 	libarch_opts = [ 'install_headers=false' ]
 endif
 
-if build_kernel or build_drivers or provide_deps
+if build_kernel or build_uefi or build_drivers or provide_deps
 	cxxshim_dep = dependency('cxxshim',
 				 required: false,
 				 fallback: ['cxxshim', 'cxxshim_dep'])

--- a/meson.build
+++ b/meson.build
@@ -149,15 +149,6 @@ elif flavor == 'userspace'
 	libarch_opts = [ 'install_headers=false' ]
 endif
 
-if build_kernel or build_uefi or build_drivers or provide_deps
-	cxxshim_dep = dependency('cxxshim',
-				 required: false,
-				 fallback: ['cxxshim', 'cxxshim_dep'])
-	coroutines = dependency('cxxshim-coroutine-std',
-				 required: false,
-				 fallback: ['cxxshim', 'std_coroutine_dep'])
-endif
-
 if build_kernel or build_drivers
 	libarch = subproject('libarch',
 		default_options : libarch_opts

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,15 +1,20 @@
-option('build_kernel', 
-    type : 'boolean', 
+option('build_kernel',
+    type : 'boolean',
     value : false
 )
 
-option('build_drivers', 
-    type : 'boolean', 
+option('build_uefi',
+    type : 'boolean',
     value : false
 )
 
-option('build_tools', 
-    type : 'boolean', 
+option('build_drivers',
+    type : 'boolean',
+    value : false
+)
+
+option('build_tools',
+    type : 'boolean',
     value : false
 )
 
@@ -18,26 +23,26 @@ option('provide_deps',
     value : false
 )
 
-option('kernel_ubsan', 
-    type : 'boolean', 
+option('kernel_ubsan',
+    type : 'boolean',
     value : false,
     description : 'enable ubsanitizer in the kernel'
 )
 
-option('kernel_kasan', 
-    type : 'boolean', 
+option('kernel_kasan',
+    type : 'boolean',
     value : false,
     description : 'enable kasan in the kernel'
 )
 
-option('kernel_log_allocations', 
-    type : 'boolean', 
+option('kernel_log_allocations',
+    type : 'boolean',
     value : false,
     description : 'enable memory allocation logging in kernel'
 )
 
-option('build_docs', 
-    type : 'boolean', 
+option('build_docs',
+    type : 'boolean',
     value : false,
     description : 'build only the mdbook and doxygen docs'
 )

--- a/testsuites/kernel-bench/meson.build
+++ b/testsuites/kernel-bench/meson.build
@@ -1,6 +1,5 @@
 executable('kernel-bench', 'src/main.cpp',
 	dependencies : [
-		coroutines,
 		helix_dep,
 	],
 	install : true)


### PR DESCRIPTION
This PR adds UEFI as a boot protocol to eir. It's architecture independent and introduces a "protos" directory for future independent protocols.