### PR TITLE
thor: Rework LogHandler to use single emit() call

### DIFF
--- a/kernel/thor/arch/arm/debug.cpp
+++ b/kernel/thor/arch/arm/debug.cpp
@@ -27,6 +27,13 @@ namespace {
 
 } // namespace anonymous
 
+void UartLogHandler::emit(Severity severity, frg::string_view msg) {
+	(void)severity;
+	for (size_t i = 0; i < msg.size(); ++i)
+		printChar(msg[i]);
+	printChar('\n');
+}
+
 void UartLogHandler::printChar(char c) {
 	// Here we depend on a few things:
 	// 1. Eir has mapped the UART to 0xFFFF000000000000
@@ -37,13 +44,6 @@ void UartLogHandler::printChar(char c) {
 		;
 
 	space.store(reg::data, c);
-}
-
-void UartLogHandler::setPriority(Severity prio) {
-	(void)prio;
-}
-
-void UartLogHandler::resetPriority() {
 }
 
 } // namespace thor

--- a/kernel/thor/arch/arm/thor-internal/arch/debug.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/debug.hpp
@@ -5,9 +5,9 @@
 namespace thor {
 
 struct UartLogHandler : public LogHandler {
-	void printChar(char c) override;
-	void setPriority(Severity prio) override;
-	void resetPriority() override;
+	void emit(Severity severity, frg::string_view msg) override;
+
+	void printChar(char c);
 };
 
 } // namespace thor

--- a/kernel/thor/arch/x86/debug.cpp
+++ b/kernel/thor/arch/x86/debug.cpp
@@ -39,6 +39,14 @@ void setupDebugging() {
 	enableLogHandler(&pioLogHandler);
 }
 
+void PIOLogHandler::emit(Severity severity, frg::string_view msg) {
+	setPriority(severity);
+	for (size_t i = 0; i < msg.size(); ++i)
+		printChar(msg[i]);
+	resetPriority();
+	printChar('\n');
+}
+
 void PIOLogHandler::printChar(char c) {
 	auto sendByteSerial = [this](uint8_t val) {
 		auto base = arch::global_io.subspace(0x3F8);

--- a/kernel/thor/arch/x86/thor-internal/arch/debug.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/debug.hpp
@@ -55,9 +55,11 @@ struct PIOLogHandler final : public LogHandler {
 	constexpr PIOLogHandler()
 	: serialBufferIndex{0}, serialBuffer{0} {}
 
-	void printChar(char c) override;
-	void setPriority(Severity prio) override;
-	void resetPriority() override;
+	void emit(Severity severity, frg::string_view msg) override;
+
+	void printChar(char c);
+	void setPriority(Severity severity);
+	void resetPriority();
 
 private:
 	int serialBufferIndex;

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -120,16 +120,16 @@ HelError translateError(Error error) {
 namespace {
 
 template<typename Sink>
-std::optional<size_t> printLog(Sink &p, LogMessage &log, size_t chunk) {
-	for(size_t i = 0; i < chunk && log.text[i]; i++) {
-		if(log.text[i] == '\n') {
+std::optional<size_t> printLog(Sink &p, const char *log, size_t chunk) {
+	for(size_t i = 0; i < chunk && log[i]; i++) {
+		if(log[i] == '\n') {
 			p << frg::endlog;
 			return i + 1;
-		} else if(log.text[i] == '\0') {
+		} else if(log[i] == '\0') {
 			p << frg::endlog;
 			return std::nullopt;
 		} else {
-			p << frg::char_fmt(log.text[i]);
+			p << frg::char_fmt(log[i]);
 		}
 	}
 	p << frg::endlog;
@@ -141,10 +141,10 @@ std::optional<size_t> printLog(Sink &p, LogMessage &log, size_t chunk) {
 HelError helLog(HelLogSeverity severity, const char *string, size_t length) {
 	size_t offset = 0;
 	while(offset < length) {
-		LogMessage log;
+		char log[logLineLength];
 		auto chunk = frg::min(length - offset, size_t{logLineLength});
 
-		if(!readUserArray(string + offset, log.text, chunk))
+		if(!readUserArray(string + offset, log, chunk))
 			return kHelErrFault;
 
 		switch(severity) {

--- a/kernel/thor/generic/thor-internal/debug.hpp
+++ b/kernel/thor/generic/thor-internal/debug.hpp
@@ -13,10 +13,6 @@ void panic();
 
 constexpr size_t logLineLength = 256;
 
-struct LogMessage {
-	char text[logLineLength];
-};
-
 // see RFC 5424
 enum class Severity : uint8_t {
 	emergency,
@@ -30,17 +26,12 @@ enum class Severity : uint8_t {
 };
 
 struct LogHandler {
-	constexpr LogHandler() : context(nullptr) {}
-
-	LogHandler(void *ct) : context{ct} {}
-
-	virtual void printChar(char c) = 0;
-	virtual void setPriority(Severity) = 0;
-	virtual void resetPriority() = 0;
+	// Writes a log message to this handler.
+	// Note that the message is _not_ null-terminated, the handler has to respect the length.
+	// Also note that the message does not end with a newline.
+	virtual void emit(Severity severity, frg::string_view msg) = 0;
 
 	frg::default_list_hook<LogHandler> hook;
-
-	void *context;
 
 protected:
 	~LogHandler() = default;
@@ -48,9 +39,6 @@ protected:
 
 void enableLogHandler(LogHandler *sink);
 void disableLogHandler(LogHandler *sink);
-
-size_t currentLogSequence();
-void copyLogMessage(size_t sequence, LogMessage &msg);
 
 // --------------------------------------------------------
 // Loggers.

--- a/kernel/thor/system/framebuffer/thor-internal/framebuffer/boot-screen.hpp
+++ b/kernel/thor/system/framebuffer/thor-internal/framebuffer/boot-screen.hpp
@@ -21,6 +21,7 @@ struct BootScreen final : public LogHandler {
 		Formatter(BootScreen *screen, size_t x, size_t y);
 
 		void print(const char *c);
+		void print(const char *c, size_t n);
 
 	private:
 		BootScreen *_screen;
@@ -38,19 +39,25 @@ struct BootScreen final : public LogHandler {
 
 	BootScreen(TextDisplay *display);
 
-	void printChar(char c) override;
-	void setPriority(Severity prio) override;
-	void resetPriority() override;
+	void emit(Severity severity, frg::string_view msg) override;
 
-	void printString(const char *string);
+	void redraw();
 
 private:
+	struct Line {
+		Severity severity;
+		size_t length{0};
+		char msg[logLineLength]{};
+	};
+
+	// Number of lines that are kept in memory. Must be power of 2.
+	static constexpr size_t NUM_LINES = 128;
+
 	TextDisplay *_display;
 	size_t _width;
 	size_t _height;
-
-	uint64_t _bottomSequence;
-	Formatter _fmt;
+	Line _displayLines[NUM_LINES];
+	uint64_t _displaySeq{0};
 };
 
 } // namespace thor


### PR DESCRIPTION
This drastically reduces the number of virtual calls in the logging path. It is also makes it easier to make logging re-entrant (such that we can properly log from NMIs and MCEs).