### PR TITLE
thor: Move out common arch/cpu.hpp definitions to a shared file

### DIFF
--- a/kernel/thor/arch/arm/cpu.cpp
+++ b/kernel/thor/arch/arm/cpu.cpp
@@ -1,4 +1,4 @@
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <generic/thor-internal/cpu-data.hpp>
 #include <frg/manual_box.hpp>
 #include <thor-internal/main.hpp>

--- a/kernel/thor/arch/arm/gic_v2.cpp
+++ b/kernel/thor/arch/arm/gic_v2.cpp
@@ -1,5 +1,5 @@
 #include <thor-internal/arch/gic_v2.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/arch/system.hpp>
 #include <arch/bits.hpp>
 #include <arch/mem_space.hpp>

--- a/kernel/thor/arch/arm/ints.cpp
+++ b/kernel/thor/arch/arm/ints.cpp
@@ -1,4 +1,4 @@
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/arch/ints.hpp>
 #include <thor-internal/arch/gic.hpp>
 #include <thor-internal/debug.hpp>

--- a/kernel/thor/arch/arm/smp.cpp
+++ b/kernel/thor/arch/arm/smp.cpp
@@ -5,7 +5,7 @@
 #include <initgraph.hpp>
 #include <thor-internal/cpu-data.hpp>
 #include <thor-internal/physical.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/fiber.hpp>
 
 namespace thor {

--- a/kernel/thor/arch/arm/system.cpp
+++ b/kernel/thor/arch/arm/system.cpp
@@ -1,5 +1,5 @@
 #include <thor-internal/arch/system.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/arch/timer.hpp>
 
 namespace thor {

--- a/kernel/thor/arch/arm/thor-internal/arch/gic.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <initgraph.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/irq.hpp>
 #include <arch/mem_space.hpp>
 

--- a/kernel/thor/arch/arm/thor-internal/arch/gic_v2.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic_v2.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <initgraph.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/arch/gic.hpp>
 #include <thor-internal/irq.hpp>
 #include <arch/mem_space.hpp>

--- a/kernel/thor/arch/arm/timer.cpp
+++ b/kernel/thor/arch/arm/timer.cpp
@@ -1,5 +1,5 @@
 #include <thor-internal/arch/timer.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/cpu-data.hpp>
 #include <thor-internal/timer.hpp>
 #include <thor-internal/schedule.hpp>

--- a/kernel/thor/arch/x86/hpet.cpp
+++ b/kernel/thor/arch/x86/hpet.cpp
@@ -9,7 +9,7 @@
 #include <thor-internal/arch/hpet.hpp>
 #include <thor-internal/arch/paging.hpp>
 #include <thor-internal/arch/pic.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/debug.hpp>
 #include <thor-internal/main.hpp>
 #include <thor-internal/irq.hpp>

--- a/kernel/thor/arch/x86/ints.cpp
+++ b/kernel/thor/arch/x86/ints.cpp
@@ -2,7 +2,7 @@
 #include <thor-internal/cpu-data.hpp>
 #include <thor-internal/profile.hpp>
 #include <thor-internal/thread.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/arch/pmc-amd.hpp>
 #include <thor-internal/arch/pmc-intel.hpp>
 

--- a/kernel/thor/arch/x86/svm.cpp
+++ b/kernel/thor/arch/x86/svm.cpp
@@ -1,6 +1,6 @@
 #include <thor-internal/arch/svm.hpp>
 #include <thor-internal/address-space.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/physical.hpp>
 #include <thor-internal/cpu-data.hpp>
 #include <thor-internal/thread.hpp>

--- a/kernel/thor/arch/x86/system.cpp
+++ b/kernel/thor/arch/x86/system.cpp
@@ -1,4 +1,4 @@
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/arch/ints.hpp>
 #include <thor-internal/arch/system.hpp>
 

--- a/kernel/thor/arch/x86/vmx.cpp
+++ b/kernel/thor/arch/x86/vmx.cpp
@@ -1,7 +1,7 @@
 #include <thor-internal/arch/vmx.hpp>
 #include <thor-internal/address-space.hpp>
 #include <thor-internal/arch/ept.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/physical.hpp>
 #include <thor-internal/cpu-data.hpp>
 #include <thor-internal/thread.hpp>

--- a/kernel/thor/generic/fiber.cpp
+++ b/kernel/thor/generic/fiber.cpp
@@ -1,6 +1,7 @@
 #include <thor-internal/debug.hpp>
 #include <thor-internal/fiber.hpp>
 #include <thor-internal/main.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 
 namespace thor {
 

--- a/kernel/thor/generic/kasan.cpp
+++ b/kernel/thor/generic/kasan.cpp
@@ -1,6 +1,6 @@
 #include <stddef.h>
 #include <stdint.h>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/arch/paging.hpp>
 #include <thor-internal/debug.hpp>
 

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -21,6 +21,8 @@
 #include <thor-internal/servers.hpp>
 #include <thor-internal/thread.hpp>
 
+#include <thor-internal/arch-generic/cpu.hpp>
+
 namespace thor {
 
 static constexpr bool logInitialization = false;

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -347,55 +347,10 @@ extern "C" void thorMain() {
 	localScheduler()->commitReschedule();
 }
 
-extern "C" void handleStubInterrupt() {
-	panicLogger() << "Fault or IRQ from stub" << frg::endlog;
-}
-extern "C" void handleBadDomain() {
-	panicLogger() << "Fault or IRQ from bad domain" << frg::endlog;
-}
-
-extern "C" void handleDivideByZeroFault(FaultImageAccessor image) {
-	(void)image;
-
-	panicLogger() << "Divide by zero" << frg::endlog;
-}
-
-extern "C" void handleDebugFault(FaultImageAccessor image) {
-	infoLogger() << "Debug fault at "
-			<< (void *)*image.ip() << frg::endlog;
-}
-
-extern "C" void handleOpcodeFault(FaultImageAccessor image) {
-	(void)image;
-
-	panicLogger() << "Invalid opcode" << frg::endlog;
-}
-
-extern "C" void handleNoFpuFault(FaultImageAccessor image) {
-	panicLogger() << "FPU invoked at "
-			<< (void *)*image.ip() << frg::endlog;
-}
-
-extern "C" void handleDoubleFault(FaultImageAccessor image) {
-	panicLogger() << "Double fault at "
-			<< (void *)*image.ip() << frg::endlog;
-}
-
-extern "C" void handleProtectionFault(FaultImageAccessor image) {
-	panicLogger() << "General protection fault\n"
-			<< "    Faulting IP: " << (void *)*image.ip() << "\n"
-			<< "    Faulting segment: " << (void *)*image.code() << frg::endlog;
-}
-
 void handlePageFault(FaultImageAccessor image, uintptr_t address, Word errorCode) {
 	smarter::borrowed_ptr<Thread> this_thread = getCurrentThread();
 	auto address_space = this_thread->getAddressSpace();
 
-	const Word kPfAccess = 1;
-	const Word kPfWrite = 2;
-	const Word kPfUser = 4;
-	const Word kPfBadTable = 8;
-	const Word kPfInstruction = 16;
 	assert(!(errorCode & kPfBadTable));
 
 	auto logFault = [&] {
@@ -543,10 +498,6 @@ void handlePreemption(IrqImageAccessor image) {
 
 	assert(image.inPreemptibleDomain());
 	localScheduler()->currentRunnable()->handlePreemption(image);
-}
-
-extern "C" void thorImplementNoThreadIrqs() {
-	assert(!"Implement no-thread IRQ stubs");
 }
 
 void handleSyscall(SyscallImageAccessor image) {

--- a/kernel/thor/generic/random.cpp
+++ b/kernel/thor/generic/random.cpp
@@ -3,7 +3,7 @@
 #include <frg/manual_box.hpp>
 #include <cralgo/aes.hpp>
 #include <cralgo/sha2_32.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/kernel_heap.hpp>
 #include <thor-internal/random.hpp>
 #include <thor-internal/debug.hpp>

--- a/kernel/thor/generic/schedule.cpp
+++ b/kernel/thor/generic/schedule.cpp
@@ -1,7 +1,7 @@
 #include <assert.h>
 
 #include <thor-internal/arch/ints.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/cpu-data.hpp>
 #include <thor-internal/debug.hpp>
 #include <thor-internal/schedule.hpp>

--- a/kernel/thor/generic/thor-internal/arch-generic/cpu.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/cpu.hpp
@@ -19,8 +19,6 @@ template <typename T>
 concept ValidFaultImageAccessor = requires(T acc) {
 	{ acc.ip() } -> std::same_as<Word *>;
 	{ acc.sp() } -> std::same_as<Word *>;
-	// TODO(qookie): This is only used by handleGeneralProtectionFault in main.cpp
-	{ acc.code() } -> std::same_as<Word *>;
 
 	{ acc.inKernelDomain() } -> std::same_as<bool>;
 	{ acc.allowUserPages() } -> std::same_as<bool>;

--- a/kernel/thor/generic/thor-internal/arch-generic/cpu.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/cpu.hpp
@@ -1,0 +1,211 @@
+#pragma once
+
+#include <thor-internal/arch/cpu.hpp>
+
+#include <concepts>
+
+namespace thor {
+
+// Make sure that Continuation provides all the generic members.
+template <typename T>
+concept ValidContinuation = requires(T cont) {
+	{ cont.sp } -> std::same_as<void *&>;
+};
+static_assert(ValidContinuation<Continuation>);
+
+
+// Make sure that FaultImageAccessor provides all the generic methods.
+template <typename T>
+concept ValidFaultImageAccessor = requires(T acc) {
+	{ acc.ip() } -> std::same_as<Word *>;
+	{ acc.sp() } -> std::same_as<Word *>;
+	// TODO(qookie): This is only used by handleGeneralProtectionFault in main.cpp
+	{ acc.code() } -> std::same_as<Word *>;
+
+	{ acc.inKernelDomain() } -> std::same_as<bool>;
+	{ acc.allowUserPages() } -> std::same_as<bool>;
+};
+static_assert(ValidFaultImageAccessor<FaultImageAccessor>);
+
+
+// Make sure that IrqImageAccessor provides all the generic methods.
+template <typename T>
+concept ValidIrqImageAccessor = requires(T acc) {
+	{ acc.inPreemptibleDomain() } -> std::same_as<bool>;
+	{ acc.inThreadDomain() } -> std::same_as<bool>;
+	{ acc.inManipulableDomain() } -> std::same_as<bool>;
+	{ acc.inFiberDomain() } -> std::same_as<bool>;
+	{ acc.inIdleDomain() } -> std::same_as<bool>;
+};
+static_assert(ValidIrqImageAccessor<IrqImageAccessor>);
+
+
+// Make sure that SyscallImageAccessor provides all the generic methods.
+template <typename T>
+concept ValidSyscallImageAccessor = requires(T acc) {
+	{ acc.number() } -> std::same_as<Word *>;
+	{ acc.in0() } -> std::same_as<Word *>;
+	{ acc.in1() } -> std::same_as<Word *>;
+	{ acc.in2() } -> std::same_as<Word *>;
+	{ acc.in3() } -> std::same_as<Word *>;
+	{ acc.in4() } -> std::same_as<Word *>;
+	{ acc.in5() } -> std::same_as<Word *>;
+	{ acc.in6() } -> std::same_as<Word *>;
+	{ acc.in7() } -> std::same_as<Word *>;
+	{ acc.in8() } -> std::same_as<Word *>;
+
+	{ acc.error() } -> std::same_as<Word *>;
+	{ acc.out0() } -> std::same_as<Word *>;
+	{ acc.out1() } -> std::same_as<Word *>;
+};
+static_assert(ValidSyscallImageAccessor<SyscallImageAccessor>);
+
+
+// Make sure that UserContext provides all the generic methods.
+template <typename T>
+concept ValidUserContext = requires(T ctx, CpuData *data) {
+	{ T::deactivate() } -> std::same_as<void>;
+	{ ctx.migrate(data) } -> std::same_as<void>;
+};
+static_assert(ValidUserContext<UserContext>);
+
+
+// Make sure that FiberContext provides all the generic methods.
+template <typename T>
+concept ValidFiberContext = requires(T ctx, UniqueKernelStack stack) {
+	T{std::move(stack)};
+};
+static_assert(ValidFiberContext<FiberContext>);
+
+
+// Make sure that Executor provides all the generic methods.
+template <typename T>
+concept ValidExecutor = requires(T *ex,
+		FaultImageAccessor f, IrqImageAccessor i, SyscallImageAccessor s,
+		AbiParameters abi, UserContext *user, FiberContext *fiber) {
+	// Constructors
+	T{user, abi};
+	T{fiber, abi};
+	// Register state accessors
+	{ ex->arg0() } -> std::same_as<Word *>;
+	{ ex->arg1() } -> std::same_as<Word *>;
+	{ ex->result0() } -> std::same_as<Word *>;
+	{ ex->result1() } -> std::same_as<Word *>;
+	// Save/restore/work
+	{ saveExecutor(ex, f) } -> std::same_as<void>;
+	{ saveExecutor(ex, i) } -> std::same_as<void>;
+	{ saveExecutor(ex, s) } -> std::same_as<void>;
+	{ workOnExecutor(ex) } -> std::same_as<void>;
+	{ restoreExecutor(ex) } -> std::same_as<void>;
+};
+static_assert(ValidExecutor<Executor>);
+
+
+// Clean KASAN shadow for stack space before the continuation.
+void scrubStack(FaultImageAccessor accessor, Continuation cont);
+void scrubStack(IrqImageAccessor accessor, Continuation cont);
+void scrubStack(SyscallImageAccessor accessor, Continuation cont);
+void scrubStack(Executor *executor, Continuation cont);
+
+// Restores the current executor from its saved image.
+// This is functions does the heavy lifting during task switch.
+[[noreturn]] void restoreExecutor(Executor *executor);
+
+// Save state from the given image into the given executor.
+void saveExecutor(Executor *executor, FaultImageAccessor accessor);
+void saveExecutor(Executor *executor, IrqImageAccessor accessor);
+void saveExecutor(Executor *executor, SyscallImageAccessor accessor);
+
+// Schedule the executor to run its thread's work queue before resuming.
+void workOnExecutor(Executor *executor);
+
+
+// TODO(qookie): These two functions should probably be renamed
+// and moved out of here.
+struct Thread;
+
+// Set the current thread on this CPU.
+// Note: This does not invoke restoreExecutor!
+void switchExecutor(smarter::borrowed_ptr<Thread> executor);
+
+// Get the current thread on this CPU.
+smarter::borrowed_ptr<Thread> activeExecutor();
+
+
+// Validate AssemblyCpuData and PlatformCpuData definitions.
+static_assert(offsetof(AssemblyCpuData, selfPointer) == 0);
+static_assert(std::derived_from<PlatformCpuData, AssemblyCpuData>);
+
+
+// Make sure that inHigherHalf works as expected.
+static_assert(!inHigherHalf(0));
+static_assert(inHigherHalf(~0));
+
+
+// Determine whether the fault is an UAR fault, and handle it appropriately if so.
+bool handleUserAccessFault(uintptr_t address, bool write, FaultImageAccessor accessor);
+
+// Permit kernel access to user pages.
+void enableUserAccess();
+
+// Deny kernel access to user pages.
+void disableUserAccess();
+
+
+// Calls the given function on the given stack.
+void doRunOnStack(void (*function) (void *, void *), void *sp, void *argument);
+
+// Calls the given functor with the given arguments on the given stack.
+template<typename F, typename... Args>
+void runOnStack(F functor, StackBase stack, Args... args) {
+	struct Context {
+		Context(F functor, Args... args)
+		: functor(std::move(functor)), args(std::move(args)...) { }
+
+		F functor;
+		frg::tuple<Args...> args;
+	};
+
+	Context original(std::move(functor), std::forward<Args>(args)...);
+	doRunOnStack([] (void *context, void *previousSp) {
+		Context stolen = std::move(*static_cast<Context *>(context));
+		frg::apply(std::move(stolen.functor),
+				frg::tuple_cat(frg::make_tuple(Continuation{previousSp}),
+						std::move(stolen.args)));
+	}, stack.sp, &original);
+}
+
+
+// Copies the current state into the executor and calls the supplied function.
+extern "C" void doForkExecutor(Executor *executor, void (*functor)(void *), void *context);
+
+// Copies the current state into the executor and calls the supplied functor.
+template<typename F>
+void forkExecutor(F functor, Executor *executor) {
+	auto delegate = [] (void *p) {
+		auto fp = static_cast<F *>(p);
+		(*fp)();
+	};
+
+	saveCurrentSimdState(executor);
+	doForkExecutor(executor, delegate, &functor);
+}
+
+
+// Fill buffer with entropy obtained from the CPU.
+Error getEntropyFromCpu(void *buffer, size_t size);
+
+
+// Arm the preemption timer to fire in nanos nanoseconds.
+void armPreemption(uint64_t nanos);
+
+// Disarm the preemption timer.
+void disarmPreemption();
+
+// Check whether the preemption timer is armed.
+bool preemptionIsArmed();
+
+// Get the raw timestamp in preemption timer ticks.
+uint64_t getRawTimestampCounter();
+
+} // namespace thor

--- a/kernel/thor/generic/thor-internal/cpu-data.hpp
+++ b/kernel/thor/generic/thor-internal/cpu-data.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/executor-context.hpp>
 #include <thor-internal/kernel-locks.hpp>
 #include <thor-internal/schedule.hpp>

--- a/kernel/thor/generic/thor-internal/fiber.hpp
+++ b/kernel/thor/generic/thor-internal/fiber.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <frg/container_of.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/cpu-data.hpp>
 #include <thor-internal/schedule.hpp>
 #include <initgraph.hpp>

--- a/kernel/thor/generic/thor-internal/kasan.hpp
+++ b/kernel/thor/generic/thor-internal/kasan.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 
 namespace thor {
 

--- a/kernel/thor/generic/thread.cpp
+++ b/kernel/thor/generic/thread.cpp
@@ -7,6 +7,7 @@
 #include <thor-internal/cpu-data.hpp>
 #include <thor-internal/stream.hpp>
 #include <thor-internal/thread.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 
 namespace thor {
 

--- a/kernel/thor/system/acpi/madt.cpp
+++ b/kernel/thor/system/acpi/madt.cpp
@@ -3,7 +3,7 @@
 #include <frg/manual_box.hpp>
 #include <frg/vector.hpp>
 #include <eir/interface.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/fiber.hpp>
 #include <thor-internal/kernel_heap.hpp>
 #include <thor-internal/main.hpp>

--- a/kernel/thor/system/framebuffer/fb.cpp
+++ b/kernel/thor/system/framebuffer/fb.cpp
@@ -1,6 +1,6 @@
 
 #include <render-text.hpp>
-#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/fiber.hpp>
 #include <thor-internal/io.hpp>
 #include <thor-internal/kernel_heap.hpp>


### PR DESCRIPTION
arch-generic/cpu.hpp provides the interface between the generic and architecture-specific code, and validates that structures defined in arch/cpu.hpp meet the requirements of the generic code.