### PR TITLE
Make logging re-entrant

### DIFF
--- a/kernel/thor/arch/arm/cpu.cpp
+++ b/kernel/thor/arch/arm/cpu.cpp
@@ -194,6 +194,18 @@ bool handleUserAccessFault(uintptr_t address, bool write, FaultImageAccessor acc
 	return true;
 }
 
+bool iseqStore64(uint64_t *p, uint64_t v) {
+	// TODO: This is a shim. A proper implementation is needed for NMIs on ARM.
+	std::atomic_ref{*p}.store(v, std::memory_order_relaxed);
+	return true;
+}
+
+bool iseqCopyWeak(void *dst, const void *src, size_t size) {
+	// TODO: This is a shim. A proper implementation is needed for NMIs on ARM.
+	memcpy(dst, src, size);
+	return true;
+}
+
 void doRunOnStack(void (*function) (void *, void *), void *sp, void *argument) {
 	assert(!intsAreEnabled());
 

--- a/kernel/thor/arch/arm/debug.cpp
+++ b/kernel/thor/arch/arm/debug.cpp
@@ -34,6 +34,16 @@ void UartLogHandler::emit(Severity severity, frg::string_view msg) {
 	printChar('\n');
 }
 
+void UartLogHandler::emitUrgent(Severity severity, frg::string_view msg) {
+	(void)severity;
+	const char *prefix = "URGENT: ";
+	while(*prefix)
+		printChar(*(prefix++));
+	for (size_t i = 0; i < msg.size(); ++i)
+		printChar(msg[i]);
+	printChar('\n');
+}
+
 void UartLogHandler::printChar(char c) {
 	// Here we depend on a few things:
 	// 1. Eir has mapped the UART to 0xFFFF000000000000

--- a/kernel/thor/arch/arm/smp.cpp
+++ b/kernel/thor/arch/arm/smp.cpp
@@ -8,6 +8,7 @@
 #include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/arch-generic/paging.hpp>
 #include <thor-internal/fiber.hpp>
+#include <thor-internal/ring-buffer.hpp>
 
 namespace thor {
 
@@ -103,6 +104,7 @@ bool bootSecondary(DeviceTreeNode *node) {
 	void *stackPtr = kernelAlloc->allocate(stackSize);
 
 	auto context = frg::construct<CpuData>(*kernelAlloc);
+	context->localLogRing = frg::construct<ReentrantRecordRing>(*kernelAlloc);
 
 	// Participate in global TLB invalidation *before* paging is used by the target CPU.
 	initializeAsidContext(context);

--- a/kernel/thor/arch/arm/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/cpu.hpp
@@ -276,6 +276,8 @@ struct UserAccessRegion {
 	unsigned int flags;
 };
 
+struct IseqContext;
+
 // Note: This struct is accessed from assembly.
 // Do not change the field offsets!
 struct AssemblyCpuData {
@@ -284,6 +286,9 @@ struct AssemblyCpuData {
 	void *exceptionStackPtr;
 	void *irqStackPtr;
 	UserAccessRegion *currentUar;
+	// TODO: This is unused for now but required to be in PlatformCpuData by generic code.
+	// 		 We need to make use of this once we use NMIs on ARM.
+	IseqContext *iseqPtr{nullptr};
 };
 
 struct GicCpuInterfaceV2;

--- a/kernel/thor/arch/arm/thor-internal/arch/debug.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/debug.hpp
@@ -5,7 +5,12 @@
 namespace thor {
 
 struct UartLogHandler : public LogHandler {
+	constexpr UartLogHandler() {
+		takesUrgentLogs = true;
+	}
+
 	void emit(Severity severity, frg::string_view msg) override;
+	void emitUrgent(Severity severity, frg::string_view msg) override;
 
 	void printChar(char c);
 };

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -233,6 +233,8 @@ struct UserAccessRegion {
 	unsigned int flags;
 };
 
+struct IseqContext;
+
 // Note: This struct is accessed from assembly.
 // Do not change the field offsets!
 struct AssemblyCpuData {
@@ -241,6 +243,7 @@ struct AssemblyCpuData {
 	void *exceptionStackPtr;
 	void *irqStackPtr;
 	UserAccessRegion *currentUar;
+	IseqContext *iseqPtr;
 };
 
 struct Thread;

--- a/kernel/thor/arch/x86/debug.cpp
+++ b/kernel/thor/arch/x86/debug.cpp
@@ -47,6 +47,17 @@ void PIOLogHandler::emit(Severity severity, frg::string_view msg) {
 	printChar('\n');
 }
 
+void PIOLogHandler::emitUrgent(Severity severity, frg::string_view msg) {
+	setPriority(severity);
+	const char *prefix = "URGENT: ";
+	while(*prefix)
+		printChar(*(prefix++));
+	for (size_t i = 0; i < msg.size(); ++i)
+		printChar(msg[i]);
+	resetPriority();
+	printChar('\n');
+}
+
 void PIOLogHandler::printChar(char c) {
 	auto sendByteSerial = [this](uint8_t val) {
 		auto base = arch::global_io.subspace(0x3F8);

--- a/kernel/thor/arch/x86/iseq.S
+++ b/kernel/thor/arch/x86/iseq.S
@@ -1,0 +1,75 @@
+# Kernel GS segment fields.
+.set .L_gsIseqPtr, 0x18
+
+.global iseqStore64
+
+.data
+1: # IseqRegions struct.
+	.quad 2f
+	.quad 3f
+	.quad 4f
+
+.text
+# rdi: Destination pointer
+# rsi: Destination word
+iseqStore64:
+	mov %gs:.L_gsIseqPtr, %r8 # Obtain the IseqContext.
+	mov $1b, %rax
+	mov %rax, (%r8)
+
+2: # startIp.
+	# Exit if transaction was interrupted.
+	testb $2, 8(%r8)
+	jnz 4f
+
+	# Do the store.
+	mov %rsi, (%rdi)
+
+3: # commitIp.
+	movq $0, (%r8)
+	mov $1, %rax
+	ret
+
+4: # interruptIp.
+	movq $0, (%r8)
+	xor %rax, %rax
+	ret
+
+.global iseqCopyWeak
+
+.data
+1: # IseqRegions struct.
+	.quad 2f
+	.quad 3f
+	.quad 4f
+
+.text
+# rdi: Destination pointer
+# rsi: Source pointer
+# rdx: Size
+iseqCopyWeak:
+	mov %gs:.L_gsIseqPtr, %r8 # Obtain the IseqContext.
+	mov $1b, %rax
+	mov %rax, (%r8)
+
+2: # startIp.
+	# Exit if transaction was interrupted.
+	testb $2, 8(%r8)
+	jnz 4f
+
+	# Do the copy.
+	# DF is clear due to the calling convention.
+	mov %rdx, %rcx
+	rep movsb
+
+3: # commitIp.
+	movq $0, (%r8)
+	mov $1, %rax
+	ret
+
+4: # interruptIp.
+	movq $0, (%r8)
+	xor %rax, %rax
+	ret
+
+	.section .note.GNU-stack,"",%progbits

--- a/kernel/thor/arch/x86/meson.build
+++ b/kernel/thor/arch/x86/meson.build
@@ -2,6 +2,7 @@ src += files(
 	'../../system/legacy-pc/ata.cpp',
 	'early_stubs.S',
 	'entry.S',
+	'iseq.S',
 	'stubs.S',
 	'user-access.S',
 	'vmx_stubs.S',

--- a/kernel/thor/arch/x86/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/cpu.hpp
@@ -543,12 +543,15 @@ struct UserAccessRegion {
 	unsigned int flags;
 };
 
+struct IseqContext;
+
 // Note: This struct is accessed from assembly.
 // Do not change the field offsets!
 struct AssemblyCpuData {
 	AssemblyCpuData *selfPointer;
 	void *syscallStack;
 	UserAccessRegion *currentUar;
+	IseqContext *iseqPtr{nullptr};
 };
 
 struct Thread;

--- a/kernel/thor/arch/x86/thor-internal/arch/debug.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/debug.hpp
@@ -53,9 +53,12 @@ namespace thor {
 
 struct PIOLogHandler final : public LogHandler {
 	constexpr PIOLogHandler()
-	: serialBufferIndex{0}, serialBuffer{0} {}
+	: serialBufferIndex{0}, serialBuffer{0} {
+		takesUrgentLogs = true;
+	}
 
 	void emit(Severity severity, frg::string_view msg) override;
+	void emitUrgent(Severity severity, frg::string_view msg) override;
 
 	void printChar(char c);
 	void setPriority(Severity severity);

--- a/kernel/thor/generic/core.cpp
+++ b/kernel/thor/generic/core.cpp
@@ -328,6 +328,8 @@ constinit frg::manual_box<KernelAlloc> kernelAlloc = {};
 ExecutorContext::ExecutorContext() { }
 
 CpuData::CpuData()
-: scheduler{this}, activeFiber{nullptr}, heartbeat{0} { }
+: scheduler{this}, activeFiber{nullptr}, heartbeat{0} {
+	iseqPtr = &regularIseq;
+}
 
 } // namespace thor

--- a/kernel/thor/generic/thor-internal/arch-generic/cpu.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/cpu.hpp
@@ -150,6 +150,75 @@ void enableUserAccess();
 void disableUserAccess();
 
 
+struct IseqRegion;
+
+// Note: This struct is accessed from assembly.
+// Do not change the field offsets!
+struct IseqContext {
+	// Bits for state.
+	static constexpr uint8_t STATE_TX = 1; // Currently inside transaction.
+	static constexpr uint8_t STATE_INTERRUPTED = 2; // Transaction was interrupted.
+
+	IseqRegion *region{nullptr};
+	// state can be changed by interrupt contexts. Access through std::atomic_ref.
+	uint8_t state{0};
+};
+
+// Note: This struct is accessed from assembly.
+// Do not change the field offsets!
+struct IseqRegion {
+	void *startIp;
+	void *commitIp;
+	// IP that is restored on interrupt.
+	// Must be outside [startIp, commitIp).
+	void *interruptIp;
+};
+
+// RAII class to enclose a transaction on an IseqContext.
+// All iseq* functions below must be called within an IseqTransaction.
+struct IseqTransaction {
+	IseqTransaction()
+	: _ctx{getPlatformCpuData()->iseqPtr} {
+		std::atomic_ref state_ref{_ctx->state};
+
+		auto state = state_ref.load(std::memory_order_relaxed);
+		assert(!(state & IseqContext::STATE_TX));
+		assert(!(state & IseqContext::STATE_INTERRUPTED));
+		state_ref.store(IseqContext::STATE_TX, std::memory_order_relaxed);
+	}
+
+	IseqTransaction(const IseqTransaction &) = delete;
+
+	~IseqTransaction() {
+		assert(_ctx == getPlatformCpuData()->iseqPtr);
+		std::atomic_ref state_ref{_ctx->state};
+
+		auto state = state_ref.load(std::memory_order_relaxed);
+		assert(state & IseqContext::STATE_TX);
+		state_ref.store(0, std::memory_order_relaxed);
+	}
+
+	IseqTransaction &operator= (const IseqTransaction &) = delete;
+
+private:
+	IseqContext *_ctx;
+};
+
+// The following iseq* functions return true on success and false if the transaction was interrupted.
+//
+// Note that the transactional semantics differ among these function.
+//
+// * iseqStore64() is transactional; i.e., it performs a write only if it succeeds.
+//
+// * iseqCopyWeak() has weaker transactional semantics.
+//   In particular, some bytes may have already been written even in the failure case.
+//   However, in contrast to a plain memcpy(), it is still guaranteed that no bytes
+//   are written after the transaction is interrupted.
+
+extern "C" bool iseqStore64(uint64_t *p, uint64_t v);
+extern "C" bool iseqCopyWeak(void *dest, const void *src, size_t size);
+
+
 // Calls the given function on the given stack.
 void doRunOnStack(void (*function) (void *, void *), void *sp, void *argument);
 

--- a/kernel/thor/generic/thor-internal/cpu-data.hpp
+++ b/kernel/thor/generic/thor-internal/cpu-data.hpp
@@ -39,6 +39,8 @@ struct CpuData : public PlatformCpuData {
 	smarter::shared_ptr<WorkQueue> generalWorkQueue;
 	std::atomic<uint64_t> heartbeat;
 
+	IseqContext regularIseq;
+
 	unsigned int irqEntropySeq = 0;
 	std::atomic<ProfileMechanism> profileMechanism{};
 	// TODO: This should be a unique_ptr instead.

--- a/kernel/thor/generic/thor-internal/cpu-data.hpp
+++ b/kernel/thor/generic/thor-internal/cpu-data.hpp
@@ -10,6 +10,7 @@ namespace thor {
 // Forward defined for pointers that are part of CpuData.
 struct KernelFiber;
 struct SingleContextRecordRing;
+struct ReentrantRecordRing;
 struct WorkQueue;
 
 enum class ProfileMechanism {
@@ -19,6 +20,9 @@ enum class ProfileMechanism {
 };
 
 struct CpuData : public PlatformCpuData {
+	static constexpr unsigned int RS_EMITTING = 1;
+	static constexpr unsigned int RS_PENDING = 2;
+
 	CpuData();
 
 	CpuData(const CpuData &) = delete;
@@ -40,6 +44,17 @@ struct CpuData : public PlatformCpuData {
 	std::atomic<uint64_t> heartbeat;
 
 	IseqContext regularIseq;
+
+	// Ring buffer that stores log records that are produced on this CPU.
+	// This is reentrant, i.e., it allows non-maskable interrupts / exceptions to log data.
+	// The ring buffer is drained to the global logging sinks.
+	ReentrantRecordRing *localLogRing;
+	// Current dequeue sequence for localLogRing.
+	uint64_t localLogSeq{0};
+	// Whether we should avoid emittings logs due to latency overhead (e.g., in IRQ/NMI context).
+	std::atomic<bool> avoidEmittingLogs{false};
+	// Bitmask of {RS_EMITTING, RS_PENDING} to determine whether we are currently emitting logs.
+	std::atomic<unsigned int> reentrantLogState{0};
 
 	unsigned int irqEntropySeq = 0;
 	std::atomic<ProfileMechanism> profileMechanism{};

--- a/kernel/thor/generic/thor-internal/ring-buffer.hpp
+++ b/kernel/thor/generic/thor-internal/ring-buffer.hpp
@@ -229,4 +229,123 @@ private:
 	std::atomic<uint64_t> headPtr_{0};
 };
 
+struct ReentrantRecordRing {
+	void enqueue(const void *data, size_t recordSize) {
+		auto ringSize = size_t{1} << shift_;
+		auto p = reinterpret_cast<const char *>(data);
+		auto tailRef = std::atomic_ref{tailPtr_};
+		auto headRef = std::atomic_ref{headPtr_};
+		assert(effectiveSize(recordSize) <= ringSize);
+
+		auto tryEnqueue = [&] () -> bool {
+			IseqTransaction iseqTx;
+
+			auto enqPtr = headRef.load(std::memory_order_relaxed);
+
+			// Compute the invalidated part of the ring buffer.
+			auto invalPtr = tailRef.load(std::memory_order_relaxed);
+			while(invalPtr + ringSize < enqPtr + headerSize + recordSize) {
+				assert(invalPtr < enqPtr);
+				auto tailOffset = invalPtr & (ringSize - 1);
+				// Alignment guarantees that the header fits contiguously.
+				assert(!(tailOffset > ringSize - headerSize));
+
+				size_t tailSize;
+				// TODO: This does not necessarily need iseq semantics,
+				//       but we need to validate the data by checking that the transaction was not interrupted
+				//       (otherwise, it could have been overwritten by garbage).
+				if(!iseqCopyWeak(&tailSize, buffer_ + tailOffset, sizeof(size_t)))
+					return false;
+				assert(tailSize <= ringSize);
+
+				invalPtr += effectiveSize(tailSize);
+			}
+
+			// Invalidate the ring *before* writing to it.
+			assert(!(invalPtr & (recordAlign - 1)));
+			if (!iseqStore64(&tailPtr_, invalPtr))
+				return false;
+
+			// Copy to the ring.
+			auto recordOffset = enqPtr & (ringSize - 1);
+			// Alignment guarantees that the header fits contiguously.
+			assert(!(recordOffset > ringSize - headerSize));
+
+			if(!iseqCopyWeak(buffer_ + recordOffset, &recordSize, sizeof(size_t)))
+				return false;
+			auto preWrapSize = frg::min(ringSize - (recordOffset + headerSize), recordSize);
+			if(!iseqCopyWeak(buffer_ + recordOffset + sizeof(size_t), p, preWrapSize))
+				return false;
+			if(!iseqCopyWeak(buffer_, p + preWrapSize, recordSize - preWrapSize))
+				return false;
+
+			// Commit the operation *after* writing to the ring.
+			auto commitPtr = enqPtr + effectiveSize(recordSize);
+			if (!iseqStore64(&headPtr_, commitPtr))
+				return false;
+
+			return true;
+		};
+
+		while(!tryEnqueue())
+			;
+	}
+
+	frg::tuple<bool, uint64_t, uint64_t, size_t>
+	dequeueAt(uint64_t deqPtr, void *data, size_t maxSize) {
+		auto ringSize = size_t{1} << shift_;
+		auto p = reinterpret_cast<char *>(data);
+		auto tailRef = std::atomic_ref{tailPtr_};
+		auto headRef = std::atomic_ref{headPtr_};
+
+	tryAgain:
+		// Find a valid position to dequeue from.
+		auto beforePtr = tailRef.load(std::memory_order_relaxed);
+		if(deqPtr < beforePtr)
+			deqPtr = beforePtr;
+
+		auto validPtr = headRef.load(std::memory_order_acquire);
+		if(deqPtr == validPtr)
+			return {false, deqPtr, deqPtr, 0};
+		assert(deqPtr < validPtr);
+
+		// Copy from the ring.
+		auto recordOffset = deqPtr & (ringSize - 1);
+		// Alignment guarantees that the header fits contiguously.
+		assert(!(recordOffset > ringSize - headerSize));
+
+		size_t recordSize;
+		memcpy(&recordSize, buffer_ + recordOffset, sizeof(size_t));
+		// Alignment guarantees that the header fits contiguously.
+		if(recordSize > ringSize - headerSize)
+			goto tryAgain;
+		auto chunkSize = frg::min(recordSize, maxSize);
+		auto preWrapSize = frg::min(ringSize - (recordOffset + headerSize), chunkSize);
+		memcpy(p, buffer_ + recordOffset + sizeof(size_t), preWrapSize);
+		memcpy(p + preWrapSize, buffer_, chunkSize - preWrapSize);
+
+		// Validate the data *after* copying.
+		auto afterPtr = tailRef.load(std::memory_order_acquire);
+		if(deqPtr < afterPtr)
+			goto tryAgain;
+
+		size_t newPtr = deqPtr + effectiveSize(recordSize);
+		return {true, deqPtr, newPtr, chunkSize};
+	}
+
+private:
+	static constexpr size_t headerSize = sizeof(size_t);
+	static constexpr size_t recordAlign = sizeof(size_t);
+
+	size_t effectiveSize(size_t recordSize) {
+		return (headerSize + recordSize + recordAlign - 1) & ~(recordAlign - 1);
+	}
+
+	int shift_ = 16;
+	char buffer_[1 << 16];
+	// tailPtr_ and headPtr_ may be modified by reentrant contexts. Access through atomic_ref.
+	uint64_t tailPtr_{0};
+	uint64_t headPtr_{0};
+};
+
 } // namespace thor


### PR DESCRIPTION
This overhauls the logging infrastructure to allow re-entrant logging. In particular, this enables logging from NMI, MCE and other contexts that cannot be masked. To achieve this, we add a mechanism for code sequences that can be interrupted (and cancelled) by NMIs and similar exceptions. The new mechanism is similar to the existing user access region (UAR) infrastructure. We use the new mechanism to implement an interruptible memcpy() to a per-CPU logging ring buffer.