### PR TITLE
Add RISC-V support to thor

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,33 @@
+---
+BasedOnStyle: LLVM
+Language: Cpp
+
+ColumnLimit: 100
+IndentWidth: 4
+TabWidth: 4
+UseTab: ForIndentation
+
+ContinuationIndentWidth: 4
+ConstructorInitializerIndentWidth: 4
+# Do not indent "public", "private", etc.
+AccessModifierOffset: -4
+
+AlignAfterOpenBracket: BlockIndent
+
+# Put template<> on its own line.
+BreakTemplateDeclarations: Yes
+# Put long return types on their own line.
+BreakAfterReturnType: Automatic
+
+# Put all initializers onto their own lines.
+PackConstructorInitializers: CurrentLine
+
+# Put all function arguments on their own lines.
+BinPackArguments: false
+BinPackParameters: false
+
+# Format braces as {1, 2, 3}, not as { 1, 2, 3 }.
+Cpp11BracedListStyle: true
+
+# Force \n at EOF.
+InsertNewlineAtEOF: true

--- a/.clang-format-include
+++ b/.clang-format-include
@@ -1,0 +1,3 @@
+# This file is read by Meson to configure "ninja clang-format".
+
+kernel/thor/arch/riscv/**/*

--- a/hel/include/hel-stubs-riscv64.h
+++ b/hel/include/hel-stubs-riscv64.h
@@ -1,0 +1,265 @@
+#ifndef HEL_STUBS_H
+#	error Architecture header included directly, include hel-stubs.h instead
+#endif
+
+// Syscall convention:
+// a0: code / error
+
+typedef uint64_t HelWord;
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall0(int number) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+
+	asm volatile ( "ecall" : "=r" (error)
+			: "r" (code)
+			: "memory" );
+
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall0_1 (int number,
+		HelWord *res0) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord out0 asm("a1");
+
+	asm volatile ( "ecall" : "=r" (error), "=r" (out0)
+			: "r" (code)
+			: "memory" );
+
+	*res0 = out0;
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall0_2 (int number,
+		HelWord *res0, HelWord *res1) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord out0 asm("a1");
+	register HelWord out1 asm("a2");
+
+	asm volatile ( "ecall" : "=r" (error), "=r" (out0), "=r" (out1)
+			: "r" (code)
+			: "memory" );
+
+	*res0 = out0;
+	*res1 = out1;
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall1 (int number,
+		HelWord arg0) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+
+	asm volatile ( "ecall" : "=r" (error)
+			: "r" (code), "r" (in0)
+			: "memory" );
+
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall1_1 (int number,
+		HelWord arg0, HelWord *res0) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord out0 asm("a1");
+
+	asm volatile ( "ecall" : "=r" (error), "=r" (out0)
+			: "r" (code), "r" (in0)
+			: "memory" );
+
+	*res0 = out0;
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall1_2 (int number,
+		HelWord arg0, HelWord *res0, HelWord *res1) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord out0 asm("a1");
+	register HelWord out1 asm("a2");
+
+	asm volatile ( "ecall" : "=r" (error), "=r" (out0), "=r" (out1)
+			: "r" (code), "r" (in0)
+			: "memory" );
+
+	*res0 = out0;
+	*res1 = out1;
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall2 (int number,
+		HelWord arg0, HelWord arg1) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+
+	asm volatile ( "ecall" : "=r" (error)
+			: "r" (code), "r" (in0), "r" (in1)
+			: "memory" );
+
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall2_1 (int number,
+		HelWord arg0, HelWord arg1, HelWord *res0) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+	register HelWord out0 asm("a1");
+
+	asm volatile ( "ecall" : "=r" (error), "=r" (out0)
+			: "r" (code), "r" (in0), "r" (in1)
+			: "memory" );
+
+	*res0 = out0;
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall2_2 (int number,
+		HelWord arg0, HelWord arg1, HelWord *res0, HelWord *res1) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+	register HelWord out0 asm("a1");
+	register HelWord out1 asm("a2");
+
+	asm volatile ( "ecall" : "=r" (error), "=r" (out0), "=r" (out1)
+			: "r" (code), "r" (in0), "r" (in1)
+			: "memory" );
+
+	*res0 = out0;
+	*res1 = out1;
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall3 (int number,
+		HelWord arg0, HelWord arg1, HelWord arg2) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+	register HelWord in2 asm("a3") = arg2;
+
+	asm volatile ( "ecall" : "=r" (error)
+			: "r" (code), "r" (in0), "r" (in1), "r" (in2)
+			: "memory" );
+
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall3_1 (int number,
+		HelWord arg0, HelWord arg1, HelWord arg2, HelWord *res0) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+	register HelWord in2 asm("a3") = arg2;
+	register HelWord out0 asm("a1");
+
+	asm volatile ( "ecall" : "=r" (error), "=r" (out0)
+			: "r" (code), "r" (in0), "r" (in1), "r" (in2)
+			: "memory" );
+
+	*res0 = out0;
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall4 (int number,
+		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+	register HelWord in2 asm("a3") = arg2;
+	register HelWord in3 asm("a4") = arg3;
+
+	asm volatile ( "ecall" : "=r" (error)
+			: "r" (code), "r" (in0), "r" (in1), "r" (in2), "r" (in3)
+			: "memory" );
+
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall4_1 (int number,
+		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3, HelWord *res0) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+	register HelWord in2 asm("a3") = arg2;
+	register HelWord in3 asm("a4") = arg3;
+	register HelWord out0 asm("a1");
+
+	asm volatile ( "ecall" : "=r" (error), "=r" (out0)
+			: "r" (code), "r" (in0), "r" (in1), "r" (in2), "r" (in3)
+			: "memory" );
+
+	*res0 = out0;
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall5 (int number,
+		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3, HelWord arg4) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+	register HelWord in2 asm("a3") = arg2;
+	register HelWord in3 asm("a4") = arg3;
+	register HelWord in4 asm("a5") = arg4;
+
+	asm volatile ( "ecall" : "=r" (error)
+			: "r" (code), "r" (in0), "r" (in1), "r" (in2), "r" (in3), "r" (in4)
+			: "memory" );
+
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall6 (int number,
+		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3, HelWord arg4,
+		HelWord arg5) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+	register HelWord in2 asm("a3") = arg2;
+	register HelWord in3 asm("a4") = arg3;
+	register HelWord in4 asm("a5") = arg4;
+	register HelWord in5 asm("a6") = arg5;
+
+	asm volatile ( "ecall" : "=r" (error)
+			: "r" (code), "r" (in0), "r" (in1), "r" (in2), "r" (in3), "r" (in4), "r" (in5)
+			: "memory" );
+
+	return error;
+}
+
+extern inline __attribute__ (( always_inline )) HelError helSyscall6_1 (int number,
+		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3, HelWord arg4,
+		HelWord arg5, HelWord *res0) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+	register HelWord in2 asm("a3") = arg2;
+	register HelWord in3 asm("a4") = arg3;
+	register HelWord in4 asm("a5") = arg4;
+	register HelWord in5 asm("a6") = arg5;
+	register HelWord out0 asm("a1");
+
+	asm volatile ( "ecall" : "=r" (error), "=r" (out0)
+			: "r" (code), "r" (in0), "r" (in1), "r" (in2), "r" (in3), "r" (in4), "r" (in5)
+			: "memory" );
+
+	*res0 = out0;
+	return error;
+}

--- a/hel/include/hel-stubs.h
+++ b/hel/include/hel-stubs.h
@@ -5,6 +5,8 @@
 #	include "hel-stubs-x86_64.h"
 #elif defined(__aarch64__)
 #	include "hel-stubs-aarch64.h"
+#elif defined(__riscv) && __riscv_xlen == 64
+#	include "hel-stubs-riscv64.h"
 #else
 #	error Unsupported architecture
 #endif

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -388,6 +388,59 @@ enum HelSyscallArgs {
 	kHelRegOut0 = kHelRegX1,
 	kHelRegOut1 = kHelRegX2
 };
+
+#elif defined(__riscv) && __riscv_xlen == 64
+enum HelRegisterIndex {
+	kHelRegRa = 0,
+	kHelRegGp,
+	kHelRegTp,
+	kHelRegT0,
+	kHelRegT1,
+	kHelRegT2,
+	kHelRegS0,
+	kHelRegS1,
+	kHelRegA0,
+	kHelRegA1,
+	kHelRegA2,
+	kHelRegA3,
+	kHelRegA4,
+	kHelRegA5,
+	kHelRegA6,
+	kHelRegA7,
+	kHelRegS2,
+	kHelRegS3,
+	kHelRegS4,
+	kHelRegS5,
+	kHelRegS6,
+	kHelRegS7,
+	kHelRegS8,
+	kHelRegS9,
+	kHelRegS10,
+	kHelRegS11,
+	kHelRegT3,
+	kHelRegT4,
+	kHelRegT5,
+	kHelRegT6,
+	kHelNumGprs,
+	kHelRegIp = 0,
+	kHelRegSp = 1
+};
+enum HelSyscallArgs {
+	kHelRegNumber = kHelRegA0,
+	kHelRegError = kHelRegA0,
+	kHelRegArg0 = kHelRegA1,
+	kHelRegArg1 = kHelRegA2,
+	kHelRegArg2 = kHelRegA3,
+	kHelRegArg3 = kHelRegA4,
+	kHelRegArg4 = kHelRegA5,
+	kHelRegArg5 = kHelRegA6,
+	kHelRegArg6 = kHelRegA7,
+	kHelRegArg7 = kHelRegS2,
+	kHelRegArg8 = kHelRegS3,
+	kHelRegOut0 = kHelRegA1,
+	kHelRegOut1 = kHelRegA2
+};
+
 #endif
 
 struct HelQueueParameters {

--- a/hel/meson.build
+++ b/hel/meson.build
@@ -15,6 +15,8 @@ src = files(
 
 if arch == 'aarch64'
 	headers += 'include/hel-stubs-aarch64.h'
+elif arch == 'riscv64'
+	headers += 'include/hel-stubs-riscv64.h'
 elif arch == 'x86_64'
 	headers += 'include/hel-stubs-x86_64.h'
 endif

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -1,0 +1,24 @@
+#include <frg/manual_box.hpp>
+#include <generic/thor-internal/cpu-data.hpp>
+#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch/unimplemented.hpp>
+#include <thor-internal/fiber.hpp>
+#include <thor-internal/kasan.hpp>
+#include <thor-internal/main.hpp>
+
+namespace thor {
+
+void enableUserAccess() { unimplementedOnRiscv(); }
+void disableUserAccess() { unimplementedOnRiscv(); }
+
+void UserContext::deactivate() { unimplementedOnRiscv(); }
+
+smarter::borrowed_ptr<Thread> activeExecutor() { unimplementedOnRiscv(); }
+
+Error getEntropyFromCpu(void *buffer, size_t size) { unimplementedOnRiscv(); }
+
+void doRunOnStack(void (*function)(void *, void *), void *sp, void *argument) {
+	unimplementedOnRiscv();
+}
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/debug.cpp
+++ b/kernel/thor/arch/riscv/debug.cpp
@@ -1,0 +1,34 @@
+#include <arch/mem_space.hpp>
+#include <arch/register.hpp>
+#include <thor-internal/arch/debug.hpp>
+
+namespace thor {
+
+constinit FirmwareLogHandler firmwareLogHandler;
+
+void setupDebugging() { enableLogHandler(&firmwareLogHandler); }
+
+void FirmwareLogHandler::emit(Severity severity, frg::string_view msg) {
+	(void)severity;
+	for (size_t i = 0; i < msg.size(); ++i)
+		printChar(msg[i]);
+	printChar('\n');
+}
+
+void FirmwareLogHandler::sbiCall1(int ext, int func, SbiWord arg0) {
+	register SbiWord rExt asm("a7") = ext;
+	register SbiWord rFunc asm("a6") = func;
+	register SbiWord rArg0 asm("a0") = arg0;
+	register SbiWord rArg1 asm("a1");
+	asm volatile("ecall" : "+r"(rArg0), "=r"(rArg1) : "r"(rExt), "r"(rFunc));
+	if (rArg0)
+		__builtin_trap();
+}
+
+void FirmwareLogHandler::printChar(char c) {
+	// This firmware call is technically deprecated, but is still
+	// almost always supported
+	sbiCall1(1, 0, c);
+}
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/entry.S
+++ b/kernel/thor/arch/riscv/entry.S
@@ -1,0 +1,16 @@
+.data
+.global thorBootInfoPtr
+thorBootInfoPtr:
+	.quad 0
+
+.text
+.global thorRtEntry
+thorRtEntry:
+	la a0, thorBootInfoPtr
+
+	.extern thorInitialize
+	.extern thorRunConstructors
+	.extern thorMain
+	jal thorInitialize
+	jal thorRunConstructors
+	j thorMain

--- a/kernel/thor/arch/riscv/link.x
+++ b/kernel/thor/arch/riscv/link.x
@@ -1,0 +1,86 @@
+ENTRY(thorRtEntry)
+
+SECTIONS {
+	. = 0xFFFFFFFF80000000;
+
+	.text ALIGN(0x1000) : { *(.text .text.*) }
+	.rodata ALIGN(0x1000) : { *(.rodata .rodata.*) }
+	.eh_frame_hdr ALIGN(0x1000) : { *(.eh_frame_hdr) }
+	.eh_frame : { *(.eh_frame) }
+
+	.init_array ALIGN(0x1000) : {
+		PROVIDE_HIDDEN (__init_array_start = .);
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN (__init_array_end = .);
+	}
+
+	.data ALIGN(0x1000) : { *(.data) }
+	.bss : { *(.bss) }
+
+	.stab 0 : { *(.stab) }
+	.stabstr 0 : { *(.stabstr) }
+	.stab.excl 0 : { *(.stab.excl) }
+	.stab.exclstr 0 : { *(.stab.exclstr) }
+	.stab.index 0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+
+	.debug 0 : { *(.debug) }
+	.line 0 : { *(.line) }
+	.debug_srcinfo 0 : { *(.debug_srcinfo) }
+	.debug_sfnames 0 : { *(.debug_sfnames) }
+	.debug_aranges 0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	.debug_info 0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev 0 : { *(.debug_abbrev) }
+	.debug_line 0 : { *(.debug_line) }
+	.debug_frame 0 : { *(.debug_frame) }
+	.debug_str 0 : { *(.debug_str) }
+	.debug_loc 0 : { *(.debug_loc) }
+	.debug_macinfo 0 : { *(.debug_macinfo) }
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges 0 : { *(.debug_ranges) }
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames 0 : { *(.debug_varnames) }
+	.debug_gnu_pubnames 0 : { *(.debug_gnu_pubnames) }
+	.debug_gnu_pubtypes 0 : { *(.debug_gnu_pubtypes) }
+	.debug_types 0 : { *(.debug_types) }
+	.debug_addr 0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro 0 : { *(.debug_macro) }
+	.debug_names 0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+
+	.comment 0 : { *(.comment) }
+
+	.got.plt (INFO) : { *(.got.plt) }
+
+	.got : {
+		*(.got) *(.igot.*)
+	}
+	# TODO: RISC-V generates .got entries but no relocations. Do we need them?
+	#ASSERT(SIZEOF(.got) == 0, "Unexpected GOT entries detected!")
+
+	.plt : {
+		*(.plt) *(.plt.*) *(.iplt)
+	}
+	ASSERT(SIZEOF(.plt) == 0, "Unexpected run-time procedure linkages detected!")
+
+	.rel.dyn : {
+		*(.rel.*) *(.rel_*)
+	}
+	ASSERT(SIZEOF(.rel.dyn) == 0, "Unexpected run-time relocations (.rel) detected!")
+
+	.rela.dyn : {
+		*(.rela.*) *(.rela_*)
+	}
+	ASSERT(SIZEOF(.rela.dyn) == 0, "Unexpected run-time relocations (.rela) detected!")
+
+	/DISCARD/ : {
+		*(.note.GNU-stack)
+	}
+}

--- a/kernel/thor/arch/riscv/meson.build
+++ b/kernel/thor/arch/riscv/meson.build
@@ -1,0 +1,19 @@
+src += files(
+	'cpu.cpp',
+	'debug.cpp',
+	'entry.S',
+	'paging.cpp',
+	'stubs.S',
+	# TODO: Remove the stubs.cpp file after moving its functions elsewhere.
+	'stubs.cpp',
+	'system.cpp',
+	# TODO: Remove unimplemented.cpp after implementing most of the architecture.
+	'unimplemented.cpp',
+)
+
+# TODO: Remove this after implementing most of the architecture.
+cpp_args += ['-Wno-unused-parameter']
+
+inc += include_directories('.')
+link_args += [ '-z', 'max-page-size=0x1000', '-Wl,-T,' + meson.current_source_dir()/'link.x' ]
+link_depends += files('link.x')

--- a/kernel/thor/arch/riscv/paging.cpp
+++ b/kernel/thor/arch/riscv/paging.cpp
@@ -1,0 +1,54 @@
+#include <arch/variable.hpp>
+#include <thor-internal/arch/ints.hpp>
+#include <thor-internal/arch/paging.hpp>
+#include <thor-internal/arch/unimplemented.hpp>
+#include <thor-internal/cpu-data.hpp>
+#include <thor-internal/physical.hpp>
+
+namespace thor {
+
+// --------------------------------------------------------
+// Physical page access.
+// --------------------------------------------------------
+
+void switchToPageTable(PhysicalAddr root, int asid, bool invalidate) { unimplementedOnRiscv(); }
+
+void switchAwayFromPageTable(int asid) { unimplementedOnRiscv(); }
+
+void invalidateAsid(int asid) { unimplementedOnRiscv(); }
+
+void invalidatePage(int asid, const void *address) { unimplementedOnRiscv(); }
+
+// --------------------------------------------------------
+// Kernel page management.
+// --------------------------------------------------------
+
+frg::manual_box<KernelPageSpace> kernelSpaceSingleton;
+
+void KernelPageSpace::initialize() { unimplementedOnRiscv(); }
+KernelPageSpace &KernelPageSpace::global() { return *kernelSpaceSingleton; }
+
+KernelPageSpace::KernelPageSpace(PhysicalAddr satp) : PageSpace{satp} {}
+
+void KernelPageSpace::mapSingle4k(
+    VirtualAddr pointer, PhysicalAddr physical, uint32_t flags, CachingMode caching_mode
+) {
+	unimplementedOnRiscv();
+}
+
+PhysicalAddr KernelPageSpace::unmapSingle4k(VirtualAddr pointer) { unimplementedOnRiscv(); }
+
+// --------------------------------------------------------
+// User page management.
+// --------------------------------------------------------
+
+ClientPageSpace::ClientPageSpace()
+
+    : PageSpace{physicalAllocator->allocate(kPageSize)} {
+	unimplementedOnRiscv();
+}
+ClientPageSpace::~ClientPageSpace() { unimplementedOnRiscv(); }
+
+bool ClientPageSpace::updatePageAccess(VirtualAddr pointer) { unimplementedOnRiscv(); }
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/stubs.S
+++ b/kernel/thor/arch/riscv/stubs.S
@@ -1,0 +1,7 @@
+// TODO: Implement interrupt stubs etc. in this file.
+//       RISC-V Interrupt handling is slightly weird; in that there are two ways to handle interrupts:
+//       - Using a single exception vector
+//       - Using a table of jump instructions (similar to ARM)
+//       An OS needs to support both, as the spec makes it possible for a CPU to only support one of these modes.
+//       Technically, you can use the table of jump instructions to _slightly_ speed up interrupt handling (you instantly know
+//       which exception/interrupt was fired), however in practice there is little difference.

--- a/kernel/thor/arch/riscv/stubs.cpp
+++ b/kernel/thor/arch/riscv/stubs.cpp
@@ -1,0 +1,22 @@
+#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch/unimplemented.hpp>
+#include <thor-internal/timer.hpp>
+
+namespace thor {
+
+// TODO: The following functions should be moved to more appropriate places.
+
+void restoreExecutor(Executor *executor) { unimplementedOnRiscv(); }
+
+extern "C" int doCopyFromUser(void *dest, const void *src, size_t size) { unimplementedOnRiscv(); }
+extern "C" int doCopyToUser(void *dest, const void *src, size_t size) { unimplementedOnRiscv(); }
+
+uint64_t getRawTimestampCounter() { unimplementedOnRiscv(); }
+
+bool haveTimer() { unimplementedOnRiscv(); }
+
+bool preemptionIsArmed() { unimplementedOnRiscv(); }
+void armPreemption(uint64_t nanos) { unimplementedOnRiscv(); }
+void disarmPreemption() { unimplementedOnRiscv(); }
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/system.cpp
+++ b/kernel/thor/arch/riscv/system.cpp
@@ -1,0 +1,14 @@
+#include <thor-internal/arch/cpu.hpp>
+#include <thor-internal/arch/system.hpp>
+#include <thor-internal/arch/unimplemented.hpp>
+
+namespace thor {
+
+void initializeArchitecture() {
+	// setupBootCpuContext();
+	// initializeTimers();
+	// initializeIrqVectors();
+	unimplementedOnRiscv();
+}
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -1,0 +1,285 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <utility>
+
+#include <frg/tuple.hpp>
+#include <frg/vector.hpp>
+#include <initgraph.hpp>
+#include <thor-internal/arch/ints.hpp>
+#include <thor-internal/arch/unimplemented.hpp>
+#include <thor-internal/error.hpp>
+#include <thor-internal/kernel-stack.hpp>
+#include <thor-internal/types.hpp>
+
+#include <thor-internal/arch-generic/asid.hpp>
+
+namespace thor {
+
+enum class Domain : uint64_t { irq = 0, fault, fiber, user, idle };
+
+struct FpRegisters {
+	// F - single precision floating point - 32 bits / number
+	// D - double precision floating point - 64 bits / number
+	// Q - quadruple precision floating point - 128 bits / number
+	// Since there are always 32 registers, 64 uint64_t's are required
+	// in order to support all possible hardware floating point
+	// configurations.
+	uint64_t v[64];
+	uint64_t fpcr;
+	uint64_t fpsr;
+};
+
+struct Frame {
+	uint64_t x[30]; // X0 is constant zero, no need to save it.
+	uint64_t ip;
+	Domain domain;
+
+	FpRegisters fp;
+};
+// TODO: add static assert
+
+struct Executor;
+
+struct Continuation {
+	void *sp;
+};
+
+struct FaultImageAccessor;
+
+struct SyscallImageAccessor {
+	friend void saveExecutor(Executor *executor, SyscallImageAccessor accessor);
+
+	// The "- 1" is since we do not save x0
+	// this makes the first number the register ID
+	// We begin from A0
+	// in7 and in8 are actually S2 and S3, since (according to
+	// the calling convention) not enough argument registers
+	Word *number() { return &_frame()->x[10 - 1]; }
+	Word *in0() { return &_frame()->x[11 - 1]; }
+	Word *in1() { return &_frame()->x[12 - 1]; }
+	Word *in2() { return &_frame()->x[13 - 1]; }
+	Word *in3() { return &_frame()->x[14 - 1]; }
+	Word *in4() { return &_frame()->x[15 - 1]; }
+	Word *in5() { return &_frame()->x[16 - 1]; }
+	Word *in6() { return &_frame()->x[17 - 1]; }
+	Word *in7() { return &_frame()->x[18 - 1]; }
+	Word *in8() { return &_frame()->x[19 - 1]; }
+
+	Word *error() { return &_frame()->x[10 - 1]; }
+	Word *out0() { return &_frame()->x[11 - 1]; }
+	Word *out1() { return &_frame()->x[12 - 1]; }
+
+	void *frameBase() { return _pointer + sizeof(Frame); }
+
+private:
+	friend struct FaultImageAccessor;
+
+	SyscallImageAccessor(char *ptr) : _pointer{ptr} {}
+
+	Frame *_frame() { return reinterpret_cast<Frame *>(_pointer); }
+
+	char *_pointer;
+};
+
+struct FaultImageAccessor {
+	friend void saveExecutor(Executor *executor, FaultImageAccessor accessor);
+
+	Word *ip() { unimplementedOnRiscv(); }
+	Word *sp() { unimplementedOnRiscv(); }
+
+	// TODO: There are several flag registers on RISC-V.
+	Word *rflags() { unimplementedOnRiscv(); }
+	Word *code() { unimplementedOnRiscv(); }
+
+	bool inKernelDomain() { unimplementedOnRiscv(); }
+
+	bool allowUserPages() { unimplementedOnRiscv(); }
+
+	operator SyscallImageAccessor() { return SyscallImageAccessor{_pointer}; }
+
+	void *frameBase() { return _pointer + sizeof(Frame); }
+
+private:
+	Frame *_frame() { return reinterpret_cast<Frame *>(_pointer); }
+
+	char *_pointer;
+};
+
+struct IrqImageAccessor {
+	friend void saveExecutor(Executor *executor, IrqImageAccessor accessor);
+
+	Word *ip() { unimplementedOnRiscv(); }
+	Word *rflags() { unimplementedOnRiscv(); }
+
+	bool inPreemptibleDomain() { unimplementedOnRiscv(); }
+
+	bool inThreadDomain() { unimplementedOnRiscv(); }
+
+	bool inManipulableDomain() { unimplementedOnRiscv(); }
+
+	bool inFiberDomain() { unimplementedOnRiscv(); }
+
+	bool inIdleDomain() { unimplementedOnRiscv(); }
+
+	void *frameBase() { unimplementedOnRiscv(); }
+
+private:
+	Frame *_frame() { return reinterpret_cast<Frame *>(_pointer); }
+
+	char *_pointer;
+};
+
+// CpuData is some high-level struct that inherits from PlatformCpuData.
+struct CpuData;
+
+struct AbiParameters {
+	uintptr_t ip;
+	uintptr_t sp;
+	uintptr_t argument;
+};
+
+struct UserContext {
+	static void deactivate();
+
+	UserContext() { unimplementedOnRiscv(); }
+
+	UserContext(const UserContext &other) = delete;
+
+	UserContext &operator=(const UserContext &other) = delete;
+
+	// Migrates this UserContext to a different CPU.
+	void migrate(CpuData *cpu_data) { unimplementedOnRiscv(); }
+
+	// TODO: This should be private.
+	UniqueKernelStack kernelStack;
+};
+
+struct FiberContext {
+	FiberContext(UniqueKernelStack stack) { unimplementedOnRiscv(); }
+
+	FiberContext(const FiberContext &other) = delete;
+
+	FiberContext &operator=(const FiberContext &other) = delete;
+
+	// TODO: This should be private.
+	UniqueKernelStack stack;
+};
+
+struct Executor;
+
+// Restores the current executor from its saved image.
+// This is functions does the heavy lifting during task switch.
+// Note: due to the attribute, this must be declared before the friend declaration below.
+[[noreturn]] void restoreExecutor(Executor *executor);
+
+struct Executor {
+	friend void saveExecutor(Executor *executor, FaultImageAccessor accessor);
+	friend void saveExecutor(Executor *executor, IrqImageAccessor accessor);
+	friend void saveExecutor(Executor *executor, SyscallImageAccessor accessor);
+	friend void workOnExecutor(Executor *executor);
+	friend void restoreExecutor(Executor *executor);
+
+	static size_t determineSize();
+
+	Executor() { unimplementedOnRiscv(); }
+
+	explicit Executor(UserContext *context, AbiParameters abi) { unimplementedOnRiscv(); }
+	explicit Executor(FiberContext *context, AbiParameters abi) { unimplementedOnRiscv(); }
+
+	Executor(const Executor &other) = delete;
+
+	~Executor() { unimplementedOnRiscv(); }
+
+	Executor &operator=(const Executor &other) = delete;
+
+	// FIXME: remove or refactor the rdi / rflags accessors
+	// as they are platform specific and need to be abstracted here
+	Word *rflags() { unimplementedOnRiscv(); }
+
+	Word *ip() { unimplementedOnRiscv(); }
+	Word *sp() { unimplementedOnRiscv(); }
+	Word *cs() { unimplementedOnRiscv(); }
+	Word *ss() { unimplementedOnRiscv(); }
+
+	Word *arg0() { unimplementedOnRiscv(); }
+	Word *arg1() { unimplementedOnRiscv(); }
+	Word *result0() { unimplementedOnRiscv(); }
+	Word *result1() { unimplementedOnRiscv(); }
+
+	Frame *general() { return reinterpret_cast<Frame *>(_pointer); }
+
+	void *getExceptionStack() { return _exceptionStack; }
+
+private:
+	char *_pointer;
+	void *_exceptionStack;
+};
+
+size_t getStateSize();
+
+// Note: These constants we mirrored in assembly.
+// Do not change their values!
+inline constexpr unsigned int uarRead = 1;
+inline constexpr unsigned int uarWrite = 2;
+
+// Note: This struct is accessed from assembly.
+// Do not change the field offsets!
+struct UserAccessRegion {
+	void *startIp;
+	void *endIp;
+	void *faultIp;
+	unsigned int flags;
+};
+
+// Note: This struct is accessed from assembly.
+// Do not change the field offsets!
+struct AssemblyCpuData {
+	AssemblyCpuData *selfPointer;
+	uint64_t currentDomain;
+	void *exceptionStackPtr;
+	void *irqStackPtr;
+	UserAccessRegion *currentUar;
+};
+
+struct Thread;
+
+struct PlatformCpuData : public AssemblyCpuData {
+	PlatformCpuData() { unimplementedOnRiscv(); }
+
+	UniqueKernelStack irqStack;
+
+	frg::manual_box<AsidCpuData> asidData;
+
+	uint32_t profileFlags = 0;
+
+	bool preemptionIsArmed = false;
+
+	// TODO: This is not really arch-specific!
+	smarter::borrowed_ptr<Thread> activeExecutor;
+};
+
+// Get a pointer to this CPU's PlatformCpuData instance.
+inline PlatformCpuData *getPlatformCpuData() { unimplementedOnRiscv(); }
+
+// Determine whether this address belongs to the higher half.
+inline constexpr bool inHigherHalf(uintptr_t address) {
+	return address & (static_cast<uintptr_t>(1) << 63);
+}
+
+void initializeThisProcessor();
+
+void bootSecondary(unsigned int apic_id);
+
+inline size_t getCpuCount() { unimplementedOnRiscv(); }
+
+inline void saveCurrentSimdState(Executor *executor) { unimplementedOnRiscv(); }
+
+void setupBootCpuContext();
+
+void setupCpuContext(AssemblyCpuData *context);
+
+initgraph::Stage *getBootProcessorReadyStage();
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/thor-internal/arch/debug.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/debug.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <thor-internal/debug.hpp>
+
+typedef unsigned long SbiWord;
+
+namespace thor {
+
+struct FirmwareLogHandler : public LogHandler {
+	void emit(Severity severity, frg::string_view msg) override;
+
+	void printChar(char c);
+	void sbiCall1(int ext, int func, SbiWord arg0);
+};
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/thor-internal/arch/ints.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/ints.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <assert.h>
+#include <frg/spinlock.hpp>
+#include <thor-internal/arch/unimplemented.hpp>
+#include <thor-internal/debug.hpp>
+
+namespace thor {
+
+void initializeIrqVectors();
+
+inline bool intsAreEnabled() { unimplementedOnRiscv(); }
+
+inline void enableInts() { unimplementedOnRiscv(); }
+
+inline void disableInts() { unimplementedOnRiscv(); }
+
+inline void halt() { unimplementedOnRiscv(); }
+
+inline void suspendSelf() { unimplementedOnRiscv(); }
+
+inline void sendPingIpi(int id) { unimplementedOnRiscv(); }
+
+inline void sendShootdownIpi() { unimplementedOnRiscv(); }
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/thor-internal/arch/paging.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/paging.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <atomic>
+
+#include <assert.h>
+#include <thor-internal/physical.hpp>
+#include <thor-internal/types.hpp>
+#include <thor-internal/work-queue.hpp>
+
+#include <thor-internal/arch-generic/asid.hpp>
+#include <thor-internal/arch-generic/cursor.hpp>
+#include <thor-internal/arch-generic/paging-consts.hpp>
+
+namespace thor {
+
+constexpr uint64_t pteValid = UINT64_C(1) << 0;
+constexpr uint64_t pteRead = UINT64_C(1) << 1;
+constexpr uint64_t pteWrite = UINT64_C(1) << 2;
+constexpr uint64_t pteExecute = UINT64_C(1) << 3;
+constexpr uint64_t pteUser = UINT64_C(1) << 4;
+constexpr uint64_t pteGlobal = UINT64_C(1) << 5;
+constexpr uint64_t pteAccess = UINT64_C(1) << 6;
+constexpr uint64_t pteDirty = UINT64_C(1) << 7;
+// Sv48 has 44 PPN bits starting at bit 10.
+constexpr uint64_t ptePpnMask = (((UINT64_C(1) << 44) - 1) << 10);
+
+template <bool Kernel>
+struct RiscvCursorPolicy {
+	static inline constexpr size_t maxLevels = 4;
+	static inline constexpr size_t bitsPerLevel = 9;
+
+	static constexpr size_t numLevels() { return 4; }
+
+	static constexpr bool ptePagePresent(uint64_t pte) {
+		return (pte & pteValid) && (pte & pteRead);
+	}
+
+	static constexpr PhysicalAddr ptePageAddress(uint64_t pte) { return (pte & ptePpnMask) << 2; }
+
+	static constexpr PageStatus ptePageStatus(uint64_t pte) {
+		if (!(pte & pteValid) || !(pte & pteRead))
+			return 0;
+		PageStatus status = page_status::present;
+		if (pte & pteDirty)
+			status |= page_status::dirty;
+		return status;
+	}
+
+	static PageStatus pteClean(uint64_t *ptePtr) {
+		auto pte = __atomic_fetch_and(ptePtr, ~pteDirty, __ATOMIC_RELAXED);
+		return ptePageStatus(pte);
+	}
+
+	static constexpr uint64_t
+	pteBuild(PhysicalAddr physical, PageFlags flags, CachingMode cachingMode) {
+		auto pte = (physical >> 2) | pteValid | pteRead;
+
+		if constexpr (Kernel)
+			pte |= pteGlobal;
+		else
+			pte |= pteUser;
+		if (flags & page_access::write)
+			pte |= pteWrite;
+		if (flags & page_access::execute)
+			pte |= pteExecute;
+		// TODO: Support caching modes.
+		(void)cachingMode;
+
+		return pte;
+	}
+
+	static constexpr bool pteTablePresent(uint64_t pte) { return pte & pteValid; }
+
+	static constexpr PhysicalAddr pteTableAddress(uint64_t pte) { return (pte & ptePpnMask) << 2; }
+
+	static uint64_t pteNewTable() {
+		auto newPtAddr = physicalAllocator->allocate(kPageSize);
+		assert(newPtAddr != PhysicalAddr(-1) && "OOM");
+
+		PageAccessor accessor{newPtAddr};
+		memset(accessor.get(), 0, kPageSize);
+
+		return newPtAddr | pteValid;
+	}
+};
+
+using KernelCursorPolicy = RiscvCursorPolicy<true>;
+static_assert(CursorPolicy<KernelCursorPolicy>);
+
+using ClientCursorPolicy = RiscvCursorPolicy<false>;
+static_assert(CursorPolicy<ClientCursorPolicy>);
+
+struct KernelPageSpace : PageSpace {
+public:
+	using Cursor = thor::PageCursor<KernelCursorPolicy>;
+
+	static void initialize();
+
+	static KernelPageSpace &global();
+
+	// TODO: This should be private.
+	explicit KernelPageSpace(PhysicalAddr satp);
+
+	KernelPageSpace(const KernelPageSpace &) = delete;
+	KernelPageSpace &operator=(const KernelPageSpace &) = delete;
+
+	void mapSingle4k(
+	    VirtualAddr pointer, PhysicalAddr physical, uint32_t flags, CachingMode caching_mode
+	);
+	PhysicalAddr unmapSingle4k(VirtualAddr pointer);
+};
+
+struct ClientPageSpace : PageSpace {
+public:
+	using Cursor = thor::PageCursor<KernelCursorPolicy>;
+
+	ClientPageSpace();
+
+	ClientPageSpace(const ClientPageSpace &) = delete;
+
+	~ClientPageSpace();
+
+	ClientPageSpace &operator=(const ClientPageSpace &) = delete;
+
+	bool updatePageAccess(VirtualAddr pointer);
+};
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/thor-internal/arch/stack.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/stack.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace thor {
+
+template <typename F>
+inline void walkThisStack(F) {
+	// TODO
+}
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/thor-internal/arch/system.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/system.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace thor {
+
+static inline constexpr int numIrqSlots = 0;
+
+void initializeArchitecture();
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/thor-internal/arch/unimplemented.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/unimplemented.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <source_location>
+
+namespace thor {
+
+[[noreturn]] void unimplementedOnRiscv(std::source_location loc = std::source_location::current());
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/unimplemented.cpp
+++ b/kernel/thor/arch/riscv/unimplemented.cpp
@@ -1,0 +1,10 @@
+#include <thor-internal/arch/unimplemented.hpp>
+#include <thor-internal/debug.hpp>
+
+void thor::unimplementedOnRiscv(std::source_location loc) {
+	panicLogger() << "Function " << loc.function_name()
+	              << " is unimplemented on RISC-V"
+	                 ", at "
+	              << loc.file_name() << ":" << loc.line() << frg::endlog;
+	__builtin_trap(); // Stop Clang from complaining about [[noreturn]].
+}

--- a/kernel/thor/generic/gdbserver.cpp
+++ b/kernel/thor/generic/gdbserver.cpp
@@ -352,6 +352,8 @@ coroutine<frg::expected<ProtocolError>> GdbServer::handleRequest_() {
 		resp.appendLeHex32(thread_->_executor.general()->sp);
 		resp.appendLeHex32(thread_->_executor.general()->elr);
 		resp.appendLeHex32(thread_->_executor.general()->spsr);
+#elif defined(__riscv) && __riscv_xlen == 64
+		warningLogger() << "GDB server is unimplemented for RISC-V" << frg::endlog;
 #else
 #	error Unknown architecture
 #endif
@@ -399,6 +401,8 @@ coroutine<frg::expected<ProtocolError>> GdbServer::handleRequest_() {
 					"<architecture>i386:x86-64</architecture>"
 #elif defined(__aarch64__)
 					"<architecture>aarch64</architecture>"
+#elif defined(__riscv) && __riscv_xlen == 64
+					"<architecture>riscv64</architecture>"
 #else
 #	error Unknown architecture
 #endif

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3525,6 +3525,10 @@ HelError helQueryRegisterInfo(int set, HelRegisterInfo *info) {
 			outInfo.setSize = 15 * sizeof(uintptr_t);
 #elif defined (__aarch64__)
 			outInfo.setSize = 31 * sizeof(uintptr_t);
+#elif defined (__riscv) && __riscv_xlen == 64
+			// TODO: Double check and uncomment:
+			// outInfo.setSize = 31 * sizeof(uintptr_t);
+			return kHelErrUnsupportedOperation;
 #else
 #			error Unknown architecture
 #endif
@@ -3535,6 +3539,10 @@ HelError helQueryRegisterInfo(int set, HelRegisterInfo *info) {
 			outInfo.setSize = 2 * sizeof(uintptr_t);
 #elif defined (__aarch64__)
 			outInfo.setSize = 1 * sizeof(uintptr_t);
+#elif defined (__riscv) && __riscv_xlen == 64
+			// TODO: Double check and uncomment:
+			// outInfo.setSize = 1 * sizeof(uintptr_t);
+			return kHelErrUnsupportedOperation;
 #else
 #			error Unknown architecture
 #endif
@@ -3551,6 +3559,9 @@ HelError helQueryRegisterInfo(int set, HelRegisterInfo *info) {
 			outInfo.setSize = Executor::determineSimdSize();
 #elif defined (__aarch64__)
 			outInfo.setSize = sizeof(FpRegisters);
+#elif defined (__riscv) && __riscv_xlen == 64
+			// TODO: Implement this.
+			return kHelErrUnsupportedOperation;
 #else
 #			error Unknown architecture
 #endif
@@ -3561,6 +3572,9 @@ HelError helQueryRegisterInfo(int set, HelRegisterInfo *info) {
 			outInfo.setSize = 19 * sizeof(uintptr_t);
 #elif defined (__aarch64__)
 			outInfo.setSize = 35 * sizeof(uintptr_t);
+#elif defined (__riscv) && __riscv_xlen == 64
+			// TODO: Implement this.
+			return kHelErrUnsupportedOperation;
 #else
 #			error Unknown architecture
 #endif

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -126,6 +126,8 @@ endif
 
 if arch == 'aarch64'
 	subdir('arch/arm')
+elif arch == 'riscv64'
+	subdir('arch/riscv')
 elif arch == 'x86_64'
 	subdir('arch/x86')
 endif
@@ -162,15 +164,12 @@ link_with += static_library('cralgo', cralgo_sources,
 
 deps = [ libgcc, frigg, libsmarter, bragi_dep, libasync_dep, libarch, hel_dep ]
 
-# TODO: also build thor on RISC-V.
-if arch != 'riscv64'
-	executable('thor', src,
-		include_directories : inc,
-		dependencies : deps,
-		cpp_args : cpp_args + args,
-		link_with : link_with,
-		link_args : link_args,
-		link_depends : link_depends,
-		install : true
-	)
-endif
+executable('thor', src,
+	include_directories : inc,
+	dependencies : deps,
+	cpp_args : cpp_args + args,
+	link_with : link_with,
+	link_args : link_args,
+	link_depends : link_depends,
+	install : true
+)


### PR DESCRIPTION
This PR makes thor compile, even though it (obviously) does not work yet.

We also use clang-format for the newly added files in `kernel/thor/arch/riscv` and add the appropriate configuration files for that purpose.

Original code by @ElectrodeYT, rebased by @no92 and rebased again by me.

Supersedes #534.