### PR TITLE
kernel/thor: Add SelfIntCall infrastructure

### DIFF
--- a/kernel/thor/arch/arm/ints.cpp
+++ b/kernel/thor/arch/arm/ints.cpp
@@ -22,8 +22,8 @@ void suspendSelf() {
 	enableIntsAndHaltForever();
 }
 
-void sendPingIpi(int id) {
-	gic->sendIpi(id, 0);
+void sendPingIpi(CpuData *dstData) {
+	gic->sendIpi(dstData->cpuIndex, 0);
 }
 
 void sendShootdownIpi() {

--- a/kernel/thor/arch/arm/thor-internal/arch/ints.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/ints.hpp
@@ -27,7 +27,4 @@ inline void halt() {
 
 void suspendSelf();
 
-void sendPingIpi(int id);
-void sendShootdownIpi();
-
 } // namespace thor

--- a/kernel/thor/arch/riscv/ints.cpp
+++ b/kernel/thor/arch/riscv/ints.cpp
@@ -1,14 +1,28 @@
 #include <riscv/sbi.hpp>
-#include <thor-internal/arch/ints.hpp>
+#include <thor-internal/arch-generic/ints.hpp>
 #include <thor-internal/cpu-data.hpp>
 
 namespace thor {
 
-void sendPingIpi(int cpuIndex) {
-	auto hartId = getCpuData(cpuIndex)->hartId;
+namespace {
+
+void doSendIpi(CpuData *dstData) {
+	auto hartId = dstData->hartId;
 	if (sbi::Error e = sbi::ipi::sendIpi(1, hartId); e)
 		panicLogger() << "Failed to send ping IPI to HART " << hartId << " (error: " << e << ")"
 		              << frg::endlog;
+}
+
+} // namespace
+
+void sendPingIpi(int cpuIndex) {
+	// TODO: Set an atomic flag to indicate which IPI was raised.
+	doSendIpi(getCpuData(cpuIndex));
+}
+
+void sendSelfCallIpi() {
+	// TODO: Set an atomic flag to indicate which IPI was raised.
+	doSendIpi(getCpuData());
 }
 
 } // namespace thor

--- a/kernel/thor/arch/riscv/ints.cpp
+++ b/kernel/thor/arch/riscv/ints.cpp
@@ -15,10 +15,12 @@ void doSendIpi(CpuData *dstData) {
 
 } // namespace
 
-void sendPingIpi(int cpuIndex) {
+void sendPingIpi(CpuData *dstData) {
 	// TODO: Set an atomic flag to indicate which IPI was raised.
-	doSendIpi(getCpuData(cpuIndex));
+	doSendIpi(dstData);
 }
+
+void sendShootdownIpi() { unimplementedOnRiscv(); }
 
 void sendSelfCallIpi() {
 	// TODO: Set an atomic flag to indicate which IPI was raised.

--- a/kernel/thor/arch/riscv/thor-internal/arch/ints.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/ints.hpp
@@ -24,8 +24,4 @@ inline void halt() { asm volatile("wfi"); }
 
 inline void suspendSelf() { unimplementedOnRiscv(); }
 
-void sendPingIpi(int id);
-
-inline void sendShootdownIpi() { unimplementedOnRiscv(); }
-
 } // namespace thor

--- a/kernel/thor/arch/x86/pic.cpp
+++ b/kernel/thor/arch/x86/pic.cpp
@@ -470,8 +470,8 @@ void sendShootdownIpi() {
 	}
 }
 
-void sendPingIpi(int id) {
-	auto apic = getCpuData(id)->localApicId;
+void sendPingIpi(CpuData *dstData) {
+	auto apic = dstData->localApicId;
 //	infoLogger() << "thor [CPU" << getLocalApicId() << "]: Sending ping" << frg::endlog;
 	if(picBase.isUsingX2apic()) {
 		picBase.store(lX2ApicIcr, x2apicIcrLowVector(0xF1) | x2apicIcrLowDelivMode(0)

--- a/kernel/thor/arch/x86/stubs.S
+++ b/kernel/thor/arch/x86/stubs.S
@@ -444,6 +444,7 @@ MAKE_LEGACY_IRQ_STUB thorRtIsrLegacyIrq15, 15
 
 MAKE_IPI_STUB thorRtIpiShootdown, onPlatformShootdown
 MAKE_IPI_STUB thorRtIpiPing, onPlatformPing
+MAKE_IPI_STUB thorRtIpiCall, onPlatformCall
 MAKE_IPI_STUB thorRtPreemption, onPlatformPreemption
 
 # ---------------------------------------------------------

--- a/kernel/thor/arch/x86/thor-internal/arch/ints.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/ints.hpp
@@ -34,6 +34,4 @@ inline void halt() {
 
 void suspendSelf();
 
-void sendPingIpi(int id);
-
 } // namespace thor

--- a/kernel/thor/arch/x86/thor-internal/arch/pic.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/pic.hpp
@@ -119,7 +119,6 @@ void raiseInitDeassertIpi(uint32_t dest_apic_id);
 
 void raiseStartupIpi(uint32_t dest_apic_id, uint32_t page);
 
-void sendShootdownIpi();
 void sendGlobalNmi();
 
 // --------------------------------------------------------

--- a/kernel/thor/generic/asid.cpp
+++ b/kernel/thor/generic/asid.cpp
@@ -1,9 +1,9 @@
 #include <thor-internal/arch-generic/asid.hpp>
+#include <thor-internal/arch-generic/ints.hpp>
 #include <thor-internal/arch-generic/paging-consts.hpp>
 #include <thor-internal/arch-generic/paging.hpp>
 
 #include <thor-internal/cpu-data.hpp>
-#include <thor-internal/arch/ints.hpp>
 
 namespace thor {
 

--- a/kernel/thor/generic/int-call.cpp
+++ b/kernel/thor/generic/int-call.cpp
@@ -1,0 +1,40 @@
+#include <thor-internal/int-call.hpp>
+
+namespace thor {
+
+void SelfIntCallBase::runScheduledCalls() {
+	// Atomically take all objects from the linked list.
+	auto head = getCpuData()->selfIntCallPtr.exchange(
+		nullptr, std::memory_order_relaxed
+	);
+	while (head) {
+		auto current = head;
+		head = std::exchange(current->next_, nullptr);
+
+		// The call can be re-scheduled immediate after we clear the scheduled flag.
+		// However, re-scheduling it immediate cannot cause reentrancy due to !intsAreEnabled.
+		assert(current->scheduled_.test(std::memory_order_relaxed));
+		std::atomic_signal_fence(std::memory_order_release);
+		current->scheduled_.clear(std::memory_order_relaxed);
+		current->invoke_();
+	}
+}
+
+void SelfIntCallBase::schedule() {
+	auto cpuData = getCpuData();
+	if (scheduled_.test_and_set(std::memory_order_relaxed))
+		return;
+	std::atomic_signal_fence(std::memory_order_acquire);
+	// Push this object onto a lock-free singly linked list.
+	next_ = cpuData->selfIntCallPtr.load(std::memory_order_relaxed);
+	while (true) {
+		bool success = cpuData->selfIntCallPtr.compare_exchange_strong(
+			next_, this, std::memory_order_relaxed
+		);
+		if (success)
+			break;
+	}
+	sendSelfCallIpi();
+}
+
+} // namespace thor

--- a/kernel/thor/generic/schedule.cpp
+++ b/kernel/thor/generic/schedule.cpp
@@ -1,7 +1,7 @@
 #include <assert.h>
 
-#include <thor-internal/arch/ints.hpp>
 #include <thor-internal/arch-generic/cpu.hpp>
+#include <thor-internal/arch-generic/ints.hpp>
 #include <thor-internal/cpu-data.hpp>
 #include <thor-internal/debug.hpp>
 #include <thor-internal/schedule.hpp>
@@ -131,9 +131,9 @@ void Scheduler::resume(ScheduleEntity *entity) {
 
 	if(wasEmpty) {
 		if(self == &getCpuData()->scheduler) {
-			sendPingIpi(self->_cpuContext->cpuIndex);
+			sendPingIpi(self->_cpuContext);
 		}else{
-			sendPingIpi(self->_cpuContext->cpuIndex);
+			sendPingIpi(self->_cpuContext);
 		}
 	}
 }

--- a/kernel/thor/generic/thor-internal/arch-generic/ints.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/ints.hpp
@@ -4,6 +4,10 @@
 
 namespace thor {
 
+struct CpuData;
+
+void sendPingIpi(CpuData *dstData);
+void sendShootdownIpi();
 void sendSelfCallIpi();
 
 } // namespace thor

--- a/kernel/thor/generic/thor-internal/arch-generic/ints.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/ints.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <thor-internal/arch/ints.hpp>
+
+namespace thor {
+
+void sendSelfCallIpi();
+
+} // namespace thor

--- a/kernel/thor/generic/thor-internal/cpu-data.hpp
+++ b/kernel/thor/generic/thor-internal/cpu-data.hpp
@@ -11,6 +11,7 @@ namespace thor {
 struct KernelFiber;
 struct SingleContextRecordRing;
 struct ReentrantRecordRing;
+struct SelfIntCallBase;
 struct WorkQueue;
 
 enum class ProfileMechanism {
@@ -40,6 +41,7 @@ struct CpuData : public PlatformCpuData {
 	ExecutorContext *executorContext = nullptr;
 	KernelFiber *activeFiber;
 	KernelFiber *wqFiber = nullptr;
+	std::atomic<SelfIntCallBase *> selfIntCallPtr{nullptr};
 	smarter::shared_ptr<WorkQueue> generalWorkQueue;
 	std::atomic<uint64_t> heartbeat;
 

--- a/kernel/thor/generic/thor-internal/int-call.hpp
+++ b/kernel/thor/generic/thor-internal/int-call.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <thor-internal/arch-generic/ints.hpp>
+#include <thor-internal/cpu-data.hpp>
+
+namespace thor {
+
+struct SelfIntCallBase {
+	// Called by the interrupt handler.
+	// Pre-condition: !intsAreEnabled().
+	static void runScheduledCalls();
+
+	// Schedule this call to be invoked in interrupt context.
+	// Pre-condition: !intsAreEnabled().
+	void schedule();
+
+protected:
+	virtual void invoke_() = 0;
+
+private:
+	std::atomic_flag scheduled_{false};
+	SelfIntCallBase *next_{nullptr};
+};
+
+// Helper class to schedule a function in interrupt context.
+// For example, this can be used to "escape" NMI or exception contexts.
+//
+// Note: Do not deallocate this object while it is scheduled.
+// However, it is safe to re-schedule it while it is already scheduled.
+// If this is done, multiple calls to schedule() are coalesced.
+template<typename F>
+struct SelfIntCall : SelfIntCallBase {
+	SelfIntCall(F f)
+	: f_{std::move(f)} {}
+
+protected:
+	void invoke_() override {
+		f_();
+	}
+
+private:
+	F f_;
+};
+
+} // namespace thor

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -32,6 +32,7 @@ src = files(
 	'generic/fiber.cpp',
 	'generic/gdbserver.cpp',
 	'generic/hel.cpp',
+	'generic/int-call.cpp',
 	'generic/irq.cpp',
 	'generic/io.cpp',
 	'generic/ipc-queue.cpp',


### PR DESCRIPTION
This adds a helper call to invoke a function via an IPI. For example, this can be used to "escape" NMI and exception contexts.

Usage:
```c++
SelfIntCall foo {[] {
	infoLogger() << "Hello from foo in IPI context" << frg::endlog;
}};

foo.schedule();
```