### PR TITLE
thor: Add GlobalLogRing for raw log records

### DIFF
--- a/kernel/thor/arch/arm/debug.cpp
+++ b/kernel/thor/arch/arm/debug.cpp
@@ -27,15 +27,15 @@ namespace {
 
 } // namespace anonymous
 
-void UartLogHandler::emit(Severity severity, frg::string_view msg) {
-	(void)severity;
+void UartLogHandler::emit(frg::string_view record) {
+	auto [md, msg] = destructureLogRecord(record);
 	for (size_t i = 0; i < msg.size(); ++i)
 		printChar(msg[i]);
 	printChar('\n');
 }
 
-void UartLogHandler::emitUrgent(Severity severity, frg::string_view msg) {
-	(void)severity;
+void UartLogHandler::emitUrgent(frg::string_view record) {
+	auto [md, msg] = destructureLogRecord(record);
 	const char *prefix = "URGENT: ";
 	while(*prefix)
 		printChar(*(prefix++));

--- a/kernel/thor/arch/arm/thor-internal/arch/debug.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/debug.hpp
@@ -9,8 +9,8 @@ struct UartLogHandler : public LogHandler {
 		takesUrgentLogs = true;
 	}
 
-	void emit(Severity severity, frg::string_view msg) override;
-	void emitUrgent(Severity severity, frg::string_view msg) override;
+	void emit(frg::string_view record) override;
+	void emitUrgent(frg::string_view record) override;
 
 	void printChar(char c);
 };

--- a/kernel/thor/arch/riscv/debug.cpp
+++ b/kernel/thor/arch/riscv/debug.cpp
@@ -8,8 +8,8 @@ constinit FirmwareLogHandler firmwareLogHandler;
 
 void setupDebugging() { enableLogHandler(&firmwareLogHandler); }
 
-void FirmwareLogHandler::emit(Severity severity, frg::string_view msg) {
-	(void)severity;
+void FirmwareLogHandler::emit(frg::string_view record) {
+	auto [md, msg] = destructureLogRecord(record);
 	for (size_t i = 0; i < msg.size(); ++i)
 		printChar(msg[i]);
 	printChar('\n');

--- a/kernel/thor/arch/riscv/thor-internal/arch/debug.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/debug.hpp
@@ -7,7 +7,7 @@ typedef unsigned long SbiWord;
 namespace thor {
 
 struct FirmwareLogHandler : public LogHandler {
-	void emit(Severity severity, frg::string_view msg) override;
+	void emit(frg::string_view record) override;
 
 	void printChar(char c);
 	void sbiCall1(int ext, int func, SbiWord arg0);

--- a/kernel/thor/arch/x86/debug.cpp
+++ b/kernel/thor/arch/x86/debug.cpp
@@ -58,16 +58,18 @@ void setupDebugging() {
 	enableLogHandler(&pioLogHandler);
 }
 
-void PIOLogHandler::emit(Severity severity, frg::string_view msg) {
-	setPriority(severity);
+void PIOLogHandler::emit(frg::string_view record) {
+	auto [md, msg] = destructureLogRecord(record);
+	setPriority(md.severity);
 	for (size_t i = 0; i < msg.size(); ++i)
 		printChar(msg[i]);
 	resetPriority();
 	printChar('\n');
 }
 
-void PIOLogHandler::emitUrgent(Severity severity, frg::string_view msg) {
-	setPriority(severity);
+void PIOLogHandler::emitUrgent(frg::string_view record) {
+	auto [md, msg] = destructureLogRecord(record);
+	setPriority(md.severity);
 	const char *prefix = "URGENT: ";
 	while(*prefix)
 		printChar(*(prefix++));

--- a/kernel/thor/arch/x86/thor-internal/arch/debug.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/debug.hpp
@@ -57,8 +57,8 @@ struct PIOLogHandler final : public LogHandler {
 		takesUrgentLogs = true;
 	}
 
-	void emit(Severity severity, frg::string_view msg) override;
-	void emitUrgent(Severity severity, frg::string_view msg) override;
+	void emit(frg::string_view record) override;
+	void emitUrgent(frg::string_view record) override;
 
 	void printChar(char c);
 	void setPriority(Severity severity);

--- a/kernel/thor/generic/kerncfg.cpp
+++ b/kernel/thor/generic/kerncfg.cpp
@@ -252,7 +252,7 @@ void initializeKerncfg() {
 		async::detach_with_allocator(*kernelAlloc, kerncfg->run());
 
 		{
-			auto ring = frg::construct<ByteRingBusObject>(*kernelAlloc, getGlobalLogRing(), "kernel-log");
+			auto ring = frg::construct<ByteRingBusObject>(*kernelAlloc, getGlobalKmsgRing(), "kernel-log");
 			async::detach_with_allocator(*kernelAlloc, ring->run());
 		}
 

--- a/kernel/thor/generic/kernel-log.cpp
+++ b/kernel/thor/generic/kernel-log.cpp
@@ -27,7 +27,7 @@ namespace {
 
 				if(c == '\n') {
 					ctx()->buffer_.push_back(0);
-					getGlobalLogRing()->enqueue(ctx()->buffer_.data(), ctx()->buffer_.size());
+					getGlobalKmsgRing()->enqueue(ctx()->buffer_.data(), ctx()->buffer_.size());
 					ctx()->buffer_.resize(0);
 				}
 			};
@@ -94,7 +94,7 @@ namespace {
 		KmsgLogHandlerContext *context_;
 	};
 
-	frg::manual_box<LogRingBuffer> globalLogRing;
+	frg::manual_box<LogRingBuffer> globalKmsgRing;
 
 	initgraph::Task initLogSinks{&globalInitEngine, "generic.init-kernel-log",
 		initgraph::Requires{getFibersAvailableStage(),
@@ -106,7 +106,7 @@ namespace {
 			if(channel) {
 				infoLogger() << "thor: Connecting logging to I/O channel" << frg::endlog;
 				async::detach_with_allocator(*kernelAlloc,
-						dumpRingToChannel(globalLogRing.get(), std::move(channel), 2048));
+						dumpRingToChannel(globalKmsgRing.get(), std::move(channel), 2048));
 			}
 		}
 	};
@@ -117,14 +117,14 @@ frg::manual_box<KmsgLogHandler> kmsgLogHandler;
 
 void initializeLog() {
 	void *logMemory = kernelAlloc->allocate(1 << 20);
-	globalLogRing.initialize(reinterpret_cast<uintptr_t>(logMemory), 1 << 20);
+	globalKmsgRing.initialize(reinterpret_cast<uintptr_t>(logMemory), 1 << 20);
 	kmsgLogHandlerContext.initialize();
 	kmsgLogHandler.initialize(kmsgLogHandlerContext.get());
 	enableLogHandler(kmsgLogHandler.get());
 }
 
-LogRingBuffer *getGlobalLogRing() {
-	return globalLogRing.get();
+LogRingBuffer *getGlobalKmsgRing() {
+	return globalKmsgRing.get();
 }
 
 } // namespace thor

--- a/kernel/thor/generic/kernel-log.cpp
+++ b/kernel/thor/generic/kernel-log.cpp
@@ -78,8 +78,9 @@ namespace {
 			frg::output_to(ctx()->buffer_) << frg::fmt("{},{},{};", uint8_t(prio), ctx()->kmsgSeq_++, now);
 		}
 
-		void emit(Severity severity, frg::string_view msg) override {
-			setPriority(severity);
+		void emit(frg::string_view record) override {
+			auto [md, msg] = destructureLogRecord(record);
+			setPriority(md.severity);
 			for (size_t i = 0; i < msg.size(); ++i)
 				printChar(msg[i]);
 			printChar('\n');

--- a/kernel/thor/generic/thor-internal/kernel-log.hpp
+++ b/kernel/thor/generic/thor-internal/kernel-log.hpp
@@ -1,10 +1,53 @@
 #pragma once
 
+#include <thor-internal/debug.hpp>
+#include <thor-internal/int-call.hpp>
 #include <thor-internal/ring-buffer.hpp>
 
 namespace thor {
 
+struct GlobalLogRing {
+	void enable();
+
+	auto wait(uint64_t deqPtr) {
+		return event_.async_wait_if([=, this] () -> bool {
+			return ring_.peekHeadPtr() == deqPtr;
+		});
+	}
+
+	frg::tuple<bool, uint64_t, uint64_t, size_t>
+	dequeueAt(uint64_t deqPtr, void *data, size_t maxSize) {
+		return ring_.dequeueAt(deqPtr, data, maxSize);
+	}
+
+private:
+	struct Wakeup {
+		Wakeup(GlobalLogRing *ptr);
+
+		void operator() ();
+
+	private:
+		GlobalLogRing *ptr_;
+	};
+
+	struct Handler : LogHandler {
+		Handler(GlobalLogRing *ptr);
+
+		void emit(frg::string_view record) override;
+
+	private:
+		GlobalLogRing *ptr_;
+	};
+
+	async::recurring_event event_;
+	SingleContextRecordRing ring_;
+	SelfIntCall<Wakeup> wakeup_{this};
+	Handler handler_{this};
+};
+
 void initializeLog();
+
+GlobalLogRing *getGlobalLogRing();
 
 LogRingBuffer *getGlobalKmsgRing();
 

--- a/kernel/thor/generic/thor-internal/kernel-log.hpp
+++ b/kernel/thor/generic/thor-internal/kernel-log.hpp
@@ -6,6 +6,6 @@ namespace thor {
 
 void initializeLog();
 
-LogRingBuffer *getGlobalLogRing();
+LogRingBuffer *getGlobalKmsgRing();
 
 } // namespace thor

--- a/kernel/thor/generic/thor-internal/ring-buffer.hpp
+++ b/kernel/thor/generic/thor-internal/ring-buffer.hpp
@@ -215,6 +215,10 @@ struct SingleContextRecordRing {
 		return {true, deqPtr, newPtr, chunkSize};
 	}
 
+	uint64_t peekHeadPtr() {
+		return headPtr_.load(std::memory_order_relaxed);
+	}
+
 private:
 	static constexpr size_t headerSize = sizeof(size_t);
 	static constexpr size_t recordAlign = sizeof(size_t);

--- a/kernel/thor/system/framebuffer/boot-screen.cpp
+++ b/kernel/thor/system/framebuffer/boot-screen.cpp
@@ -96,11 +96,12 @@ BootScreen::BootScreen(TextDisplay *display)
 	_height = _display->getHeight();
 }
 
-void BootScreen::emit(Severity severity, frg::string_view msg) {
+void BootScreen::emit(frg::string_view record) {
+	auto [md, msg] = destructureLogRecord(record);
 	size_t idx = _displaySeq & (NUM_LINES - 1);
 	auto *line = &_displayLines[idx];
 
-	line->severity = severity;
+	line->severity = md.severity;
 	line->length = msg.size();
 	memcpy(line->msg, msg.data(), msg.size());
 	++_displaySeq;

--- a/kernel/thor/system/framebuffer/thor-internal/framebuffer/boot-screen.hpp
+++ b/kernel/thor/system/framebuffer/thor-internal/framebuffer/boot-screen.hpp
@@ -39,7 +39,7 @@ struct BootScreen final : public LogHandler {
 
 	BootScreen(TextDisplay *display);
 
-	void emit(Severity severity, frg::string_view msg) override;
+	void emit(frg::string_view record) override;
 
 	void redraw();
 


### PR DESCRIPTION
This enables in-kernel log consumers that cannot run in NMI or exception contexts. We also update the kmsg code to read records from the new global log ring (instead of using a `LogHandler`). This is necessary because memory allocations / async waiting etc. done by the kmsg code are not NMI safe.