### PR TITLE
thor: Add a generic mechanism for declaring CPU-local variables

### DIFF
--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -147,6 +147,7 @@ namespace elf_note_type {
 // Values for Elf64_Nhdr::n_type of ELF notes embedded into Thor.
 // 0x10xx'xxxx range reserved for generic notes in Thor.
 constexpr unsigned int memoryLayout = 0x1000'0000;
+constexpr unsigned int perCpuRegion = 0x1000'0001;
 // 0x11xx'xxxx range reserved for arch-specific notes in Thor.
 // 0x1100'0xxx range reserved for x86.
 // 0x1100'1xxx range reserved for aarch64.
@@ -196,4 +197,9 @@ struct RiscvHartCaps {
 		auto n = static_cast<unsigned int>(ext);
 		return extensions[n >> 6] & (UINT64_C(1) << (n & 63));
 	}
+};
+
+struct PerCpuRegion {
+	uint64_t start;
+	uint64_t end;
 };

--- a/kernel/thor/arch/arm/link.x
+++ b/kernel/thor/arch/arm/link.x
@@ -6,6 +6,13 @@ SECTIONS {
 
 	.text ALIGN(0x1000) : { *(.text .text.*) }
 	.rodata ALIGN(0x1000) : { *(.rodata .rodata.*) }
+
+	.percpu_init : {
+		percpuInitStart = .;
+		*(.percpu_init)
+		percpuInitEnd = .;
+	}
+
 	.eh_frame_hdr ALIGN(0x1000) : { *(.eh_frame_hdr) }
 	.eh_frame : { *(.eh_frame) }
 
@@ -20,5 +27,17 @@ SECTIONS {
 	.note.managarm : { *(.note.managarm) }
 
 	.bss : { *(.bss .bss.*) }
+
+	/* Extra space to make a separate PHDR (so that .bss does not
+	get turned into PROGBITS) */
+	. += 0x1000;
+	. = ALIGN(0x1000);
+	.percpu : {
+		percpuStart = .;
+		*(.percpu_head) /* Static data we want at a fixed offset (AssemblyCpuData etc) */
+		*(.percpu)
+		. = ALIGN(0x1000);
+		percpuEnd = .;
+	}
 }
 

--- a/kernel/thor/arch/arm/smp.cpp
+++ b/kernel/thor/arch/arm/smp.cpp
@@ -103,7 +103,9 @@ bool bootSecondary(DeviceTreeNode *node) {
 	constexpr size_t stackSize = 0x10000;
 	void *stackPtr = kernelAlloc->allocate(stackSize);
 
-	auto context = frg::construct<CpuData>(*kernelAlloc);
+	auto [context, cpuNr] = extendPerCpuData();
+	prepareCpuDataFor(context, cpuNr);
+
 	context->localLogRing = frg::construct<ReentrantRecordRing>(*kernelAlloc);
 
 	// Participate in global TLB invalidation *before* paging is used by the target CPU.

--- a/kernel/thor/arch/arm/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/cpu.hpp
@@ -341,4 +341,7 @@ void setupCpuContext(AssemblyCpuData *context);
 
 initgraph::Stage *getBootProcessorReadyStage();
 
+struct CpuData;
+void prepareCpuDataFor(CpuData *context, int cpu);
+
 } // namespace thor

--- a/kernel/thor/arch/riscv/link.x
+++ b/kernel/thor/arch/riscv/link.x
@@ -10,6 +10,13 @@ SECTIONS {
 	. = ALIGN(CONSTANT(COMMONPAGESIZE)); /* Eir wants page-aligned segments. */
 
 	.rodata : { *(.rodata .rodata.*) }
+
+	.percpu_init : {
+		percpuInitStart = .;
+		*(.percpu_init)
+		percpuInitEnd = .;
+	}
+
 	.eh_frame_hdr : { *(.eh_frame_hdr) }
 	.eh_frame : { *(.eh_frame) }
 
@@ -30,6 +37,18 @@ SECTIONS {
 
 	/* BSS segment. */
 	.bss : { *(.bss) *(.bss.*) }
+
+	/* Extra space to make a separate PHDR (so that .bss does not
+	get turned into PROGBITS) */
+	. += CONSTANT(COMMONPAGESIZE);
+	. = ALIGN(CONSTANT(COMMONPAGESIZE));
+	.percpu : {
+		percpuStart = .;
+		*(.percpu_head) /* Static data we want at a fixed offset (AssemblyCpuData etc) */
+		*(.percpu)
+		. = ALIGN(CONSTANT(COMMONPAGESIZE));
+		percpuEnd = .;
+	}
 
 	/* Unallocated sections. */
 	.stab 0 : { *(.stab) }

--- a/kernel/thor/arch/x86/link.x
+++ b/kernel/thor/arch/x86/link.x
@@ -13,6 +13,13 @@ SECTIONS {
 
 	.text : { *(.text .text.*) }
 	.rodata : { *(.rodata .rodata.*) }
+
+	.percpu_init : {
+		percpuInitStart = .;
+		*(.percpu_init)
+		percpuInitEnd = .;
+	}
+
 	.eh_frame_hdr : { *(.eh_frame_hdr) }
 	.eh_frame : { *(.eh_frame) }
 
@@ -28,6 +35,18 @@ SECTIONS {
 	.note.managarm : { *(.note.managarm) }
 
 	.bss : { *(.bss .bss.*) }
+
+	/* Extra space to make a separate PHDR (so that .bss does not
+	get turned into PROGBITS) */
+	. += 0x1000;
+	. = ALIGN(0x1000);
+	.percpu : {
+		percpuStart = .;
+		*(.percpu_head) /* Static data we want at a fixed offset (AssemblyCpuData etc) */
+		*(.percpu)
+		. = ALIGN(0x1000);
+		percpuEnd = .;
+	}
 
 	.stab 0 : { *(.stab) }
 	.stabstr 0 : { *(.stabstr) }

--- a/kernel/thor/generic/cpu-data.cpp
+++ b/kernel/thor/generic/cpu-data.cpp
@@ -1,0 +1,84 @@
+#include <thor-internal/cpu-data.hpp>
+#include <thor-internal/physical.hpp>
+#include <thor-internal/arch-generic/paging.hpp>
+#include <thor-internal/kasan.hpp>
+#include <thor-internal/elf-notes.hpp>
+
+namespace thor {
+
+// Define a ELF note so that eir can find the per-CPU region and map
+// the KASAN shadow for it.
+
+// HACK: We define a different struct than eir's PerCpuRegion because
+// `reinterpret_cast<uint64_t>(&symbol)` is not constinit. We can't
+// just use `void *` in the eir struct because eir might be a 32-bit
+// binary. The two structs should have the same layout though, since
+// thor is always 64-bit.
+
+// Keep in sync with <eir/interface.hpp>!
+struct OurPerCpuRegion {
+	void *perCpuStart;
+	void *perCpuEnd;
+};
+
+extern ManagarmElfNote<OurPerCpuRegion> perCpuRegionNote;
+THOR_DEFINE_ELF_NOTE(perCpuRegionNote){elf_note_type::perCpuRegion, {&percpuStart, &percpuEnd}};
+
+
+// An instance of CpuData is the first thing in every CPU's per-CPU
+// region, hence it goes into a special section.
+THOR_DEFINE_PERCPU_UNINITIALIZED_PRIV(cpuData, "_head");
+
+
+extern "C" PerCpuInitializer percpuInitStart[], percpuInitEnd[];
+
+namespace {
+
+constinit void *curPos = percpuEnd;
+constinit size_t numExtraCpus = 0;
+
+
+void initializePerCpuDataFor(CpuData *context) {
+	for(PerCpuInitializer *p = percpuInitStart; p != percpuInitEnd; ++p) {
+		(*p)(context);
+	}
+}
+
+} // namespace anonymous
+
+void runBootCpuDataInitializers() {
+	initializePerCpuDataFor(reinterpret_cast<CpuData *>(percpuStart));
+}
+
+std::tuple<CpuData *, size_t> extendPerCpuData() {
+	size_t size = percpuEnd - percpuStart;
+	assert(!(size & 0xFFF));
+
+	auto base = reinterpret_cast<uintptr_t>(curPos);
+
+	// Make sure we don't wrap around.
+	assert((base + size) > reinterpret_cast<uintptr_t>(percpuStart));
+	// TODO(qookie): These two lines need to be protected with a
+	// lock if we want to start CPUs in parallel.
+	curPos = reinterpret_cast<void *>(base + size);
+	int cpuNr = ++numExtraCpus;
+
+	for(size_t pg = 0; pg < size; pg += kPageSize) {
+		auto page = physicalAllocator->allocate(kPageSize);
+		assert(page != PhysicalAddr(-1) && "OOM");
+
+		KernelPageSpace::global().mapSingle4k(base + pg, page, page_access::write, CachingMode::null);
+	}
+	unpoisonKasanShadow(reinterpret_cast<void *>(base), size);
+
+	auto context = reinterpret_cast<CpuData *>(base);
+	initializePerCpuDataFor(context);
+
+	return {context, cpuNr};
+}
+
+size_t getCpuCount() {
+	return numExtraCpus + 1;
+}
+
+} // namespace thor

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -97,6 +97,7 @@ extern "C" void thorInitialize() {
 
 	infoLogger() << "thor: Basic memory management is ready" << frg::endlog;
 
+	runBootCpuDataInitializers();
 	initializeAsidContext(getCpuData());
 }
 

--- a/kernel/thor/generic/thor-internal/cpu-data.hpp
+++ b/kernel/thor/generic/thor-internal/cpu-data.hpp
@@ -5,6 +5,9 @@
 #include <thor-internal/kernel-locks.hpp>
 #include <thor-internal/schedule.hpp>
 
+#include <new>
+#include <tuple>
+
 namespace thor {
 
 // Forward defined for pointers that are part of CpuData.
@@ -66,12 +69,100 @@ struct CpuData : public PlatformCpuData {
 	SingleContextRecordRing *localProfileRing = nullptr;
 };
 
-CpuData *getCpuData(size_t k);
-size_t getCpuCount();
-
 inline CpuData *getCpuData() {
 	return static_cast<CpuData *>(getPlatformCpuData());
 }
+
+
+extern "C" char percpuStart[], percpuEnd[];
+
+
+// To add a new per-CPU variable, add a forward declaration like
+// "extern PerCpu<Foo> foo;" in a header or source file, and then use
+// THOR_DEFINE_PERCPU{,_UNINITIALIZED}(foo) in a source file to define it.
+template <typename T>
+struct PerCpu {
+	T &get(CpuData *context) {
+		auto offset =
+			reinterpret_cast<uintptr_t>(&reservation)
+			- reinterpret_cast<uintptr_t>(percpuStart);
+
+		return *std::launder(reinterpret_cast<T *>(
+					reinterpret_cast<uintptr_t>(context) + offset));
+	}
+
+	T &get() {
+		return get(getCpuData());
+	}
+
+	T &getFor(size_t cpu) {
+		auto size = percpuEnd - percpuStart;
+
+		return *std::launder(reinterpret_cast<T *>(
+					reinterpret_cast<uintptr_t>(&reservation) + size * cpu));
+	}
+
+	void initialize(CpuData *context) {
+		auto offset =
+			reinterpret_cast<uintptr_t>(&reservation)
+			- reinterpret_cast<uintptr_t>(percpuStart);
+
+		auto ptr = reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(context) + offset);
+
+		new(ptr) T;
+	}
+
+private:
+	frg::aligned_storage<sizeof(T), alignof(T)> reservation;
+};
+
+
+using PerCpuInitializer = void(*)(CpuData *context);
+
+#define THOR_DEFINE_PERCPU_INITIALIZER_PRIV(Name)			\
+	[[gnu::section(".percpu_init"), gnu::used]]			\
+	const constinit PerCpuInitializer Name ## _initializer_ =	\
+		[] (CpuData *context) { Name.initialize(context); }	\
+
+#define THOR_DEFINE_PERCPU_UNINITIALIZED_PRIV(Name, Suffix)	\
+	[[gnu::section(".percpu" Suffix), gnu::used]]		\
+	constinit decltype(Name) Name				\
+
+
+// Define a per-CPU variable without an initializer. Care has to be
+// taken to call Name.initialize(context) prior to accessing it from
+// the given context. This is mainly intended for
+// architecture-specific fields that have to be initialized prior to
+// the allocator being available.
+#define THOR_DEFINE_PERCPU_UNINITIALIZED(Name)		\
+	THOR_DEFINE_PERCPU_UNINITIALIZED_PRIV(Name, "")	\
+
+// Define a per-CPU variable that's initialized automatically. The
+// initialization for the boot CPU happens after the kernel heap is
+// available.
+#define THOR_DEFINE_PERCPU(Name)			\
+	THOR_DEFINE_PERCPU_UNINITIALIZED(Name);		\
+	THOR_DEFINE_PERCPU_INITIALIZER_PRIV(Name)	\
+
+
+
+extern PerCpu<CpuData> cpuData;
+
+// Extend the per-CPU data area to make space for a new CPU, and run
+// initializers for it.
+// Returns a tuple of the pointer to the start of the new data, and
+// it's index (e.g. for PerCpu<T>::getFor).
+std::tuple<CpuData *, size_t> extendPerCpuData();
+
+// Run initializers for the per-CPU variables of the boot CPU.
+void runBootCpuDataInitializers();
+
+
+inline CpuData *getCpuData(size_t cpu) {
+	return &cpuData.getFor(cpu);
+}
+
+size_t getCpuCount();
 
 inline IrqMutex &irqMutex() {
 	return getCpuData()->irqMutex;

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -60,6 +60,7 @@ src = files(
 	'generic/universe.cpp',
 	'generic/work-queue.cpp',
 	'generic/asid.cpp',
+	'generic/cpu-data.cpp',
 	'system/framebuffer/boot-screen.cpp',
 	'system/framebuffer/fb.cpp',
 	'system/pci/dmalog.cpp',


### PR DESCRIPTION
With this mechanism new code (both generic and architecture-specific) can add new CPU-local variables by just doing:

extern PerCpu\<MyType\> myLocal;
THOR_DEFINE_PERCPU(myLocal);

instead of having to add the variable as a member to either PlatformCpuData or CpuData.

This should hopefully help untangle the header dependencies for cpu-data.hpp a bit, and help move some large stuff away from the head of CpuData (e.g. GDT and IDT on x86_64).

CpuData (and {Assembly,Platform}CpuData) is still kept around for stuff we want at/near the start of the CPU-local data (e.g. the self pointer, stuff accessed from assembly code, hot members). But for most things, the new mechanism should be used.