### PR TITLE
kernel/thor: Implement u-mode entry and page fault handler on RISC-V

### DIFF
--- a/kernel/eir/protos/limine/entry.cpp
+++ b/kernel/eir/protos/limine/entry.cpp
@@ -5,6 +5,7 @@
 #include <eir-internal/generic.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/main.hpp>
+#include <dtb.hpp>
 #include <uacpi/acpi.h>
 
 #include "limine.h"
@@ -44,8 +45,9 @@ initgraph::Task setupMiscInfo{&globalInitEngine,
 #endif
 
 		if(dtb_request.response) {
+			DeviceTree dt{dtb_request.response->dtb_ptr};
 			info_ptr->dtbPtr = virtToPhys(dtb_request.response->dtb_ptr);
-			info_ptr->dtbSize = 0;
+			info_ptr->dtbSize = dt.size();
 		}
 
 		if(rsdp_request.response) {

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -2,6 +2,7 @@
 #include <generic/thor-internal/cpu-data.hpp>
 #include <riscv/sbi.hpp>
 #include <thor-internal/arch-generic/cpu.hpp>
+#include <thor-internal/arch-generic/paging.hpp>
 #include <thor-internal/arch/unimplemented.hpp>
 #include <thor-internal/fiber.hpp>
 #include <thor-internal/kasan.hpp>
@@ -11,6 +12,9 @@
 extern "C" void thorExceptionEntry();
 
 namespace thor {
+
+// TODO: Move declaration to header.
+void handlePageFault(FaultImageAccessor image, uintptr_t address, Word errorCode);
 
 bool handleUserAccessFault(uintptr_t address, bool write, FaultImageAccessor accessor) {
 	return false;
@@ -150,6 +154,35 @@ constexpr const char *exceptionStrings[] = {
     "hardware error",
 };
 
+static constexpr uint64_t codeInstructionPageFault = 12;
+static constexpr uint64_t codeLoadPageFault = 13;
+static constexpr uint64_t codeStorePageFault = 15;
+
+Word codeToPageFaultFlags(uint64_t code) {
+	if (code == codeInstructionPageFault)
+		return kPfInstruction;
+	if (code == codeStorePageFault)
+		return kPfWrite;
+	assert(code == codeLoadPageFault);
+	return 0;
+}
+
+void handleRiscvPageFault(Frame *frame, uint64_t code, uint64_t address) {
+	if (!inHigherHalf(address)) {
+		// Note: We never set kPfAccess, but the generic code also does not rely on it.
+		//       Likewise, we never set kPfBadTable.
+		Word pfFlags = codeToPageFaultFlags(code);
+		if (frame->umode)
+			pfFlags |= kPfUser;
+
+		handlePageFault(FaultImageAccessor{frame}, address, pfFlags);
+		asm volatile("sfence.vma" : : : "memory"); // TODO: This is way too coarse.
+	} else {
+		// TODO: Implement page faults in higher half pages.
+		unimplementedOnRiscv();
+	}
+}
+
 extern "C" void thorHandleException(Frame *frame) {
 	auto cause = riscv::readCsr<riscv::Csr::scause>();
 	auto code = cause & ((UINT64_C(1) << 63) - 1);
@@ -173,6 +206,14 @@ extern "C" void thorHandleException(Frame *frame) {
 		infoLogger() << "SPP was: " << static_cast<bool>(status & riscv::sstatus::sppBit)
 		             << ", SPIE was: " << static_cast<bool>(status & riscv::sstatus::spieBit)
 		             << frg::endlog;
+
+		infoLogger() << "ra: 0x" << frg::hex_fmt{frame->ra()} << ", sp: 0x"
+		             << frg::hex_fmt{frame->sp()} << frg::endlog;
+
+		if (code == codeInstructionPageFault || code == codeLoadPageFault ||
+		    code == codeStorePageFault) {
+			return handleRiscvPageFault(frame, code, trapValue);
+		}
 	}
 	while (true)
 		;

--- a/kernel/thor/arch/riscv/paging.cpp
+++ b/kernel/thor/arch/riscv/paging.cpp
@@ -21,7 +21,10 @@ constinit frg::manual_box<smarter::shared_ptr<KernelPageSpace>> kernelSpacePtr;
 // Physical page access.
 // --------------------------------------------------------
 
-void switchToPageTable(PhysicalAddr root, int asid, bool invalidate) { unimplementedOnRiscv(); }
+void switchToPageTable(PhysicalAddr root, int asid, bool invalidate) {
+	riscv::writeCsr<riscv::Csr::satp>((root >> 12) | (UINT64_C(9) << 60));
+	asm volatile("sfence.vma" : : : "memory"); // This is too coarse (also invalidates global).
+}
 
 void switchAwayFromPageTable(int asid) { unimplementedOnRiscv(); }
 

--- a/kernel/thor/arch/riscv/stubs.S
+++ b/kernel/thor/arch/riscv/stubs.S
@@ -183,11 +183,9 @@ doForkExecutor:
 	sd x26, 0xC8(a0)
 	sd x27, 0xD0(a0)
 
-	la t0, 1f
-	sd t0, 0xF8(a0)
+	# We continue at the return address.
+	sd ra, 0xF8(a0)
 
+	# Jump to the lambda.
 	mv a0, a2
 	jr a1
-
-1:
-	ret

--- a/kernel/thor/arch/riscv/stubs.S
+++ b/kernel/thor/arch/riscv/stubs.S
@@ -32,7 +32,7 @@ thorExceptionEntry:
 	# Set SP to the IRQ stack.
 	ld sp, 0x18(tp)
 
-	addi sp, sp, -0x100 # Size of frame.
+	addi sp, sp, -0x108 # Size of frame.
 	.cfi_def_cfa sp, 0
 
 	sd           x1,  0x0(sp) # ra

--- a/kernel/thor/arch/riscv/stubs.cpp
+++ b/kernel/thor/arch/riscv/stubs.cpp
@@ -11,7 +11,11 @@ namespace thor {
 
 void restoreExecutor(Executor *executor) {
 	// Return to supervisor.
-	riscv::setCsrBits<riscv::Csr::sstatus>(riscv::sstatus::sppBit);
+	if (executor->general()->umode) {
+		riscv::clearCsrBits<riscv::Csr::sstatus>(riscv::sstatus::sppBit);
+	} else {
+		riscv::setCsrBits<riscv::Csr::sstatus>(riscv::sstatus::sppBit);
+	}
 
 	// Disable interrupts on return.
 	riscv::clearCsrBits<riscv::Csr::sstatus>(riscv::sstatus::spieBit);

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -152,14 +152,14 @@ struct AbiParameters {
 struct UserContext {
 	static void deactivate();
 
-	UserContext() { unimplementedOnRiscv(); }
+	UserContext();
 
 	UserContext(const UserContext &other) = delete;
 
 	UserContext &operator=(const UserContext &other) = delete;
 
 	// Migrates this UserContext to a different CPU.
-	void migrate(CpuData *cpu_data) { unimplementedOnRiscv(); }
+	void migrate(CpuData *cpuData);
 
 	// TODO: This should be private.
 	UniqueKernelStack kernelStack;
@@ -195,7 +195,7 @@ struct Executor {
 
 	Executor() { unimplementedOnRiscv(); }
 
-	explicit Executor(UserContext *context, AbiParameters abi) { unimplementedOnRiscv(); }
+	explicit Executor(UserContext *context, AbiParameters abi);
 	explicit Executor(FiberContext *context, AbiParameters abi);
 
 	Executor(const Executor &other) = delete;

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -97,25 +97,26 @@ private:
 struct FaultImageAccessor {
 	friend void saveExecutor(Executor *executor, FaultImageAccessor accessor);
 
-	Word *ip() { unimplementedOnRiscv(); }
+	FaultImageAccessor(Frame *frame) : _pointer{frame} {}
+
+	Word *ip() { return &_frame()->ip; }
 	Word *sp() { unimplementedOnRiscv(); }
 
 	// TODO: There are several flag registers on RISC-V.
 	Word *rflags() { unimplementedOnRiscv(); }
 	Word *code() { unimplementedOnRiscv(); }
 
-	bool inKernelDomain() { unimplementedOnRiscv(); }
+	bool inKernelDomain() { return !_frame()->umode; }
 
-	bool allowUserPages() { unimplementedOnRiscv(); }
+	// TODO: Implement the SUM bit in sstatus.
+	bool allowUserPages() { return false; }
 
-	operator SyscallImageAccessor() { return SyscallImageAccessor{_pointer}; }
-
-	void *frameBase() { return _pointer + sizeof(Frame); }
+	void *frameBase() { return reinterpret_cast<char *>(_pointer) + sizeof(Frame); }
 
 private:
 	Frame *_frame() { return reinterpret_cast<Frame *>(_pointer); }
 
-	char *_pointer;
+	void *_pointer;
 };
 
 struct IrqImageAccessor {

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -34,6 +34,7 @@ struct FpRegisters {
 struct Frame {
 	uint64_t xs[31]; // X0 is constant zero, no need to save it.
 	uint64_t ip;
+	uint64_t umode;
 
 	constexpr uint64_t &x(unsigned int n) {
 		assert(n > 0 && n <= 31);
@@ -44,10 +45,11 @@ struct Frame {
 		assert(n <= 7);
 		return x(10 + n);
 	}
+	constexpr uint64_t &ra() { return x(1); }
 	constexpr uint64_t &sp() { return x(2); }
 };
 static_assert(offsetof(Frame, ip) == 0xF8);
-static_assert(sizeof(Frame) == 0x100);
+static_assert(sizeof(Frame) == 0x108);
 
 struct Executor;
 

--- a/kernel/thor/arch/riscv/thor-internal/arch/paging.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/paging.hpp
@@ -112,7 +112,7 @@ public:
 
 struct ClientPageSpace : PageSpace {
 public:
-	using Cursor = thor::PageCursor<KernelCursorPolicy>;
+	using Cursor = thor::PageCursor<ClientCursorPolicy>;
 
 	ClientPageSpace();
 

--- a/kernel/thor/generic/servers.cpp
+++ b/kernel/thor/generic/servers.cpp
@@ -240,7 +240,7 @@ coroutine<ImageInfo> loadModuleImage(smarter::shared_ptr<AddressSpace, BindableH
 				|| phdr.p_type == PT_GNU_RELRO) {
 			// ignore the phdr
 		}else{
-			assert(!"Unexpected PHDR");
+			warningLogger() << "Unexpected PHDR of type 0x" << frg::hex_fmt{phdr.p_type} << frg::endlog;
 		}
 	}
 

--- a/kernel/thor/generic/thor-internal/address-space.hpp
+++ b/kernel/thor/generic/thor-internal/address-space.hpp
@@ -728,7 +728,7 @@ public:
 	static smarter::shared_ptr<AddressSpace, BindableHandle> create() {
 		auto ptr = smarter::allocate_shared<AddressSpace>(Allocator{});
 		ptr->selfPtr = ptr;
-		ptr->setupInitialHole(0x100000, 0x7ffffff00000);
+		ptr->setupInitialHole(0x1000, 0x7ffffff00000);
 		return constructHandle(std::move(ptr));
 	}
 


### PR DESCRIPTION
Note that while these patches can successfully run the RISC-V port until it performs the first syscall, the kernel currently still crashes due to missing DTB patches that I did not upstream yet.