### PR TITLE
thor: Enable IRQs on RISC-V

### DIFF
--- a/kernel/common/riscv/csr.hpp
+++ b/kernel/common/riscv/csr.hpp
@@ -24,6 +24,7 @@ namespace sstatus {
 constexpr uint64_t sieBit = UINT64_C(1) << 1;  // Interrupt enable.
 constexpr uint64_t spieBit = UINT64_C(1) << 5; // Previous interrupt enable.
 constexpr uint64_t sppBit = UINT64_C(1) << 8;  // Previous privilege level (s-mode or not).
+constexpr uint64_t sumBit = UINT64_C(1) << 18; // User memory access permitted in S-mode.
 
 } // namespace sstatus
 

--- a/kernel/common/riscv/csr.hpp
+++ b/kernel/common/riscv/csr.hpp
@@ -27,6 +27,14 @@ constexpr uint64_t sppBit = UINT64_C(1) << 8;  // Previous privilege level (s-mo
 
 } // namespace sstatus
 
+namespace interrupts {
+
+constexpr uint64_t ssi = 1; // Supervisor software interrupt.
+constexpr uint64_t sti = 5; // Supervisor timer interrupt.
+constexpr uint64_t sei = 9; // Supervisor external interrupt.
+
+} // namespace interrupts
+
 // The CSR manipulation instructions on RISC-V take the CSR as an immediate operand.
 // Since we do not want to add separate read/write functions for each CSR,
 // using a template is out best option to ensure that the CSR is statically known.

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -53,7 +53,6 @@ Executor::Executor(UserContext *context, AbiParameters abi) {
 
 	general()->ip = abi.ip;
 	general()->sp() = abi.sp;
-	general()->umode = 1;
 
 	_exceptionStack = context->kernelStack.basePtr();
 }
@@ -66,6 +65,7 @@ Executor::Executor(FiberContext *context, AbiParameters abi) {
 	general()->ip = abi.ip;
 	general()->sp() = (uintptr_t)context->stack.basePtr();
 	general()->a(0) = abi.argument;
+	general()->sstatus = riscv::sstatus::sppBit;
 }
 
 void scrubStack(FaultImageAccessor accessor, Continuation cont) {

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -15,8 +15,8 @@ bool handleUserAccessFault(uintptr_t address, bool write, FaultImageAccessor acc
 	return false;
 }
 
-void enableUserAccess() { unimplementedOnRiscv(); }
-void disableUserAccess() { unimplementedOnRiscv(); }
+void enableUserAccess() { riscv::setCsrBits<riscv::Csr::sstatus>(riscv::sstatus::sumBit); }
+void disableUserAccess() { riscv::clearCsrBits<riscv::Csr::sstatus>(riscv::sstatus::sumBit); }
 
 bool iseqStore64(uint64_t *p, uint64_t v) {
 	// TODO: This is a shim. A proper implementation is needed for NMIs on ARM.

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -146,6 +146,9 @@ void initializeThisProcessor() {
 	assert(!(stvec & 3));
 	riscv::writeCsr<riscv::Csr::stvec>(stvec);
 
+	// Enable the interrupts that we care about.
+	riscv::writeCsr<riscv::Csr::sie>(UINT64_C(1) << riscv::interrupts::ssi);
+
 	// Setup the per-CPU work queue.
 	cpuData->wqFiber = KernelFiber::post([] {
 		// Do nothing. Our only purpose is to run the associated work queue.

--- a/kernel/thor/arch/riscv/ints.cpp
+++ b/kernel/thor/arch/riscv/ints.cpp
@@ -27,4 +27,10 @@ void sendSelfCallIpi() {
 	doSendIpi(getCpuData());
 }
 
+void suspendSelf() {
+	enableInts();
+	while (true)
+		asm volatile("wfi");
+}
+
 } // namespace thor

--- a/kernel/thor/arch/riscv/meson.build
+++ b/kernel/thor/arch/riscv/meson.build
@@ -12,6 +12,7 @@ src += files(
 	'trap.cpp',
 	# TODO: Remove unimplemented.cpp after implementing most of the architecture.
 	'unimplemented.cpp',
+	'user-access.S',
 )
 
 # TODO: Remove this after implementing most of the architecture.

--- a/kernel/thor/arch/riscv/meson.build
+++ b/kernel/thor/arch/riscv/meson.build
@@ -15,6 +15,11 @@ src += files(
 	'user-access.S',
 )
 
+src += files(
+	'../../system/dtb/dtb.cpp',
+	'../../system/pci/pci_dtb.cpp'
+)
+
 # TODO: Remove this after implementing most of the architecture.
 cpp_args += ['-Wno-unused-parameter']
 

--- a/kernel/thor/arch/riscv/paging.cpp
+++ b/kernel/thor/arch/riscv/paging.cpp
@@ -28,9 +28,13 @@ void switchToPageTable(PhysicalAddr root, int asid, bool invalidate) {
 
 void switchAwayFromPageTable(int asid) { unimplementedOnRiscv(); }
 
-void invalidateAsid(int asid) { unimplementedOnRiscv(); }
+void invalidateAsid(int asid) {
+	asm volatile("sfence.vma" : : : "memory"); // This is too coarse (also invalidates global).
+}
 
-void invalidatePage(int asid, const void *address) { unimplementedOnRiscv(); }
+void invalidatePage(int asid, const void *address) {
+	asm volatile("sfence.vma" : : : "memory"); // This is too coarse (also invalidates global).
+}
 
 void initializeAsidContext(CpuData *cpuData) {
 	auto irqLock = frg::guard(&irqMutex());

--- a/kernel/thor/arch/riscv/stubs.S
+++ b/kernel/thor/arch/riscv/stubs.S
@@ -143,9 +143,9 @@ thorExceptionEntry:
 
 	# Load GPRs.
 	ld           x1,  0x0(sp) # ra
-	# x2 = sp is restored separately.
+	# Restore x2 (aka sp) last.
 	ld           x3, 0x10(sp) # gp
-	# x4 = tp is restored separately.
+	ld           x4, 0x18(sp) # tp
 	ld           x5, 0x20(sp) # t0
 	ld           x6, 0x28(sp) # t1
 	ld           x7, 0x30(sp) # t2
@@ -173,12 +173,9 @@ thorExceptionEntry:
 	ld          x29, 0xE0(sp) # t4
 	ld          x30, 0xE8(sp) # t5
 	ld          x31, 0xF0(sp) # t6
-
-	ld tp, 0x18(sp)
-	ld sp, 0x8(sp)
-
+	# Finally, restore sp.
+	ld           sp,  0x8(sp)
 	sret
-
 	.cfi_endproc
 
 .global thorRestoreExecutorRegs
@@ -190,7 +187,7 @@ thorRestoreExecutorRegs:
 	ld  x1,  0x0(a0)
 	ld  x2,  0x8(a0)
 	ld  x3, 0x10(a0)
-	# Do not restore x4 (aka tp).
+	ld  x4, 0x18(a0)
 	ld  x5, 0x20(a0)
 	ld  x6, 0x28(a0)
 	ld  x7, 0x30(a0)
@@ -233,6 +230,11 @@ doForkExecutor:
 	# Load pointer to frame.
 	# TODO: Move this into C++ code.
 	ld a0, (a0)
+
+	# Store sstatus (see comments in Frame struct).
+	# TODO: This may need to be revised for FPU / SIMD state.
+	li t0, 0x100 # SPP = 1, SPIE = 0.
+	sd t0, 0x100(a0)
 
 	sd  x2,  0x8(a0) # Store sp.
 	sd  x8, 0x38(a0) # Store s0.

--- a/kernel/thor/arch/riscv/stubs.cpp
+++ b/kernel/thor/arch/riscv/stubs.cpp
@@ -4,36 +4,9 @@
 #include <thor-internal/cpu-data.hpp>
 #include <thor-internal/timer.hpp>
 
-extern "C" [[noreturn]] void thorRestoreExecutorRegs(void *frame);
-
 namespace thor {
 
 // TODO: The following functions should be moved to more appropriate places.
-
-void restoreExecutor(Executor *executor) {
-	// Check whether we return to user-mode or kernel mode.
-	if (executor->general()->umode) {
-		riscv::clearCsrBits<riscv::Csr::sstatus>(riscv::sstatus::sppBit);
-
-		auto kernelTp = reinterpret_cast<uintptr_t>(getCpuData());
-		riscv::writeCsr<riscv::Csr::sscratch>(kernelTp);
-	} else {
-		riscv::setCsrBits<riscv::Csr::sstatus>(riscv::sstatus::sppBit);
-
-		riscv::writeCsr<riscv::Csr::sscratch>(0);
-	}
-
-	// Disable interrupts on return.
-	riscv::clearCsrBits<riscv::Csr::sstatus>(riscv::sstatus::spieBit);
-
-	// Store return PC in sepc (since sret restores it from there).
-	auto sepc = executor->general()->ip;
-	riscv::writeCsr<riscv::Csr::sepc>(sepc);
-
-	// TODO: If we restore to user mode, we also need to restore tp.
-
-	thorRestoreExecutorRegs(executor->general());
-}
 
 extern "C" int doCopyFromUser(void *dest, const void *src, size_t size) { unimplementedOnRiscv(); }
 extern "C" int doCopyToUser(void *dest, const void *src, size_t size) { unimplementedOnRiscv(); }

--- a/kernel/thor/arch/riscv/stubs.cpp
+++ b/kernel/thor/arch/riscv/stubs.cpp
@@ -8,9 +8,6 @@ namespace thor {
 
 // TODO: The following functions should be moved to more appropriate places.
 
-extern "C" int doCopyFromUser(void *dest, const void *src, size_t size) { unimplementedOnRiscv(); }
-extern "C" int doCopyToUser(void *dest, const void *src, size_t size) { unimplementedOnRiscv(); }
-
 uint64_t getRawTimestampCounter() {
 	uint64_t v;
 	asm volatile("rdtime %0" : "=r"(v));

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -214,8 +214,9 @@ struct Executor {
 	Word *ip() { unimplementedOnRiscv(); }
 	Word *sp() { return &general()->sp(); }
 
-	Word *arg0() { unimplementedOnRiscv(); }
-	Word *arg1() { unimplementedOnRiscv(); }
+	// Note: a0 is used for the supercall code.
+	Word *arg0() { return &general()->a(1); }
+	Word *arg1() { return &general()->a(2); }
 	Word *result0() { return &general()->a(0); }
 	Word *result1() { return &general()->a(1); }
 

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -254,7 +254,7 @@ struct AssemblyCpuData {
 	void *exceptionStackPtr;      // 0x10
 	void *irqStackPtr;            // 0x18
 	uint64_t scratchSp;           // 0x20
-	UserAccessRegion *currentUar;
+	UserAccessRegion *currentUar; // 0x28
 	IseqContext *iseqPtr;
 };
 

--- a/kernel/thor/arch/riscv/thor-internal/arch/ints.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/ints.hpp
@@ -22,6 +22,6 @@ inline void disableInts() {
 
 inline void halt() { asm volatile("wfi"); }
 
-inline void suspendSelf() { unimplementedOnRiscv(); }
+void suspendSelf();
 
 } // namespace thor

--- a/kernel/thor/arch/riscv/trap.cpp
+++ b/kernel/thor/arch/riscv/trap.cpp
@@ -3,11 +3,15 @@
 
 namespace thor {
 
+extern "C" [[noreturn]] void thorRestoreExecutorRegs(void *frame);
+
 // TODO: Move declaration to header.
 void handlePageFault(FaultImageAccessor image, uintptr_t address, Word errorCode);
 void handleSyscall(SyscallImageAccessor image);
 
 namespace {
+
+constexpr bool logTrapStubs = false;
 
 constexpr uint64_t causeInt = UINT64_C(1) << 63;
 constexpr uint64_t causeCodeMask = ((UINT64_C(1) << 63) - 1);
@@ -16,6 +20,8 @@ constexpr uint64_t codeEcallUmode = 8;
 constexpr uint64_t codeInstructionPageFault = 12;
 constexpr uint64_t codeLoadPageFault = 13;
 constexpr uint64_t codeStorePageFault = 15;
+
+constexpr uint64_t sstatusMask = riscv::sstatus::spieBit | riscv::sstatus::sppBit;
 
 constexpr const char *exceptionStrings[] = {
     "instruction misaligned",
@@ -53,40 +59,40 @@ void handleRiscvSyscall(Frame *frame) { handleSyscall(SyscallImageAccessor{frame
 
 void handleRiscvPageFault(Frame *frame, uint64_t code, uint64_t address) {
 	if (!inHigherHalf(address)) {
-		// Note: We never set kPfAccess, but the generic code also does not rely on it.
-		//       Likewise, we never set kPfBadTable.
-		Word pfFlags = codeToPageFaultFlags(code);
-		if (frame->umode)
-			pfFlags |= kPfUser;
-
-		handlePageFault(FaultImageAccessor{frame}, address, pfFlags);
-		asm volatile("sfence.vma" : : : "memory"); // TODO: This is way too coarse.
-	} else {
-		// TODO: Implement page faults in higher half pages.
-		unimplementedOnRiscv();
+		// TODO: We need to distinguish higher half and lower half when we implement Svade.
 	}
+
+	// Note: We never set kPfAccess, but the generic code also does not rely on it.
+	//       Likewise, we never set kPfBadTable.
+	Word pfFlags = codeToPageFaultFlags(code);
+	if (frame->umode())
+		pfFlags |= kPfUser;
+
+	handlePageFault(FaultImageAccessor{frame}, address, pfFlags);
+	asm volatile("sfence.vma" : : : "memory"); // TODO: This is way too coarse.
 }
 
 void handleRiscvIrq(Frame *frame, uint64_t code) { infoLogger() << "thor: IRQ" << frg::endlog; }
 
-void handleRiscvException(Frame *frame, uint64_t code, uint64_t status) {
-	infoLogger() << "a0 is 0x" << frg::hex_fmt{frame->a(0)} << frg::endlog;
+void handleRiscvException(Frame *frame, uint64_t code) {
 	auto trapValue = riscv::readCsr<riscv::Csr::stval>();
 
 	const char *string = "unknown";
 	if (code <= 19)
 		string = exceptionStrings[code];
 
-	infoLogger() << "thor: Exception with code " << code << " (" << string << ")"
-	             << ", trap value 0x" << frg::hex_fmt{trapValue} << " at IP 0x"
-	             << frg::hex_fmt{frame->ip} << frg::endlog;
+	if (logTrapStubs) {
+		infoLogger() << "thor: Exception with code " << code << " (" << string << ")"
+		             << ", trap value 0x" << frg::hex_fmt{trapValue} << " at IP 0x"
+		             << frg::hex_fmt{frame->ip} << frg::endlog;
 
-	infoLogger() << "SPP was: " << static_cast<bool>(status & riscv::sstatus::sppBit)
-	             << ", SPIE was: " << static_cast<bool>(status & riscv::sstatus::spieBit)
-	             << frg::endlog;
+		infoLogger() << "SPP was: " << static_cast<bool>(frame->sstatus & riscv::sstatus::sppBit)
+		             << ", SPIE was: "
+		             << static_cast<bool>(frame->sstatus & riscv::sstatus::spieBit) << frg::endlog;
 
-	infoLogger() << "ra: 0x" << frg::hex_fmt{frame->ra()} << ", sp: 0x" << frg::hex_fmt{frame->sp()}
-	             << frg::endlog;
+		infoLogger() << "ra: 0x" << frg::hex_fmt{frame->ra()} << ", sp: 0x"
+		             << frg::hex_fmt{frame->sp()} << frg::endlog;
+	}
 
 	if (code == codeEcallUmode) {
 		// We need to skip over the ecall instruction (since sepc points to ecall on entry).
@@ -97,41 +103,48 @@ void handleRiscvException(Frame *frame, uint64_t code, uint64_t status) {
 	           code == codeStorePageFault) {
 		handleRiscvPageFault(frame, code, trapValue);
 	} else {
-		panicLogger() << "Unexpected exception" << frg::endlog;
+		panicLogger() << "Unexpected exception with code " << code << ", trap value 0x"
+		              << frg::hex_fmt{trapValue} << " at IP 0x" << frg::hex_fmt{frame->ip}
+		              << frg::endlog;
 	}
+}
+
+void writeSretCsrs(Frame *frame) {
+	auto sstatusForExit =
+	    (riscv::readCsr<riscv::Csr::sstatus>() & ~sstatusMask) | (frame->sstatus & sstatusMask);
+	if (frame->umode()) {
+		auto kernelTp = reinterpret_cast<uintptr_t>(getCpuData());
+		riscv::writeCsr<riscv::Csr::sscratch>(kernelTp);
+	}
+	riscv::writeCsr<riscv::Csr::sstatus>(sstatusForExit);
+	riscv::writeCsr<riscv::Csr::sepc>(frame->ip);
 }
 
 } // namespace
 
 extern "C" void thorHandleException(Frame *frame) {
-	auto status = riscv::readCsr<riscv::Csr::sstatus>();
-	frame->umode = !(status & riscv::sstatus::sppBit);
+	// Perform the trap entry.
+	frame->sstatus = riscv::readCsr<riscv::Csr::sstatus>();
+	auto cause = riscv::readCsr<riscv::Csr::scause>();
 
 	// Call the actual IRQ or exception handler.
-	auto cause = riscv::readCsr<riscv::Csr::scause>();
 	auto code = cause & causeCodeMask;
 	if (cause & causeInt) {
-		handleRiscvIrq(frame, code);
+		handleRiscvInterrupt(frame, code);
 	} else {
-		handleRiscvException(frame, code, status);
+		handleRiscvException(frame, code);
 	}
 
-	if (frame->umode) {
-		riscv::clearCsrBits<riscv::Csr::sstatus>(riscv::sstatus::sppBit);
+	// Now perform the trap exit.
+	writeSretCsrs(frame);
+}
 
-		auto kernelTp = reinterpret_cast<uintptr_t>(getCpuData());
-		riscv::writeCsr<riscv::Csr::sscratch>(kernelTp);
-	} else {
-		riscv::setCsrBits<riscv::Csr::sstatus>(riscv::sstatus::sppBit);
-
-		riscv::writeCsr<riscv::Csr::sscratch>(0);
-	}
-
-	// Disable interrupts on return.
-	riscv::clearCsrBits<riscv::Csr::sstatus>(riscv::sstatus::spieBit);
-
-	// Store return PC in sepc (since sret restores it from there).
-	riscv::writeCsr<riscv::Csr::sepc>(frame->ip);
+void restoreExecutor(Executor *executor) {
+	writeSretCsrs(executor->general());
+	// TODO: In principle, this is only necessary on CPU migration.
+	if (!executor->general()->umode())
+		executor->general()->tp() = reinterpret_cast<uintptr_t>(getCpuData());
+	thorRestoreExecutorRegs(executor->general());
 }
 
 } // namespace thor

--- a/kernel/thor/arch/riscv/user-access.S
+++ b/kernel/thor/arch/riscv/user-access.S
@@ -1,0 +1,92 @@
+.set .L_tpCurrentUar, 0x28
+
+.set .L_uarRead, 1
+.set .L_uarWrite, 2
+
+.option norelax
+
+#------------------------------------------------------------------------------
+# doCopyFromUser.
+#------------------------------------------------------------------------------
+
+.data
+1:
+	.quad 2f
+	.quad 3f
+	.quad 4f
+	.int .L_uarRead
+
+.text
+.global doCopyFromUser
+# a0: dst
+# a1: src
+# a2: size
+.p2align 2
+doCopyFromUser:
+	la t0, 1b
+	sd t0, .L_tpCurrentUar(tp) # Setup the UAR.
+
+2:
+	# TODO: It would be easy to improve this to not do a byte-wise copy.
+	beqz a2, 3f
+	lbu t0, (a1)
+	sb t0, (a0)
+	addi a0, a0, 1
+	addi a1, a1, 1
+	addi a2, a2, -1
+	j 2b
+
+3:
+	sd zero, .L_tpCurrentUar(tp) # Clean up the UAR.
+	li a0, 0
+	ret
+
+4:
+	sd zero, .L_tpCurrentUar(tp) # Clean up the UAR.
+	li a0, 1
+	ret
+
+#------------------------------------------------------------------------------
+# doCopyToUser.
+#------------------------------------------------------------------------------
+
+.data
+1:
+	.quad 2f
+	.quad 3f
+	.quad 4f
+	.int .L_uarWrite
+
+.text
+.global doCopyToUser
+# a0: dst
+# a1: src
+# a2: size
+.p2align 2
+doCopyToUser:
+	la t0, 1b
+	sd t0, .L_tpCurrentUar(tp) # Setup the UAR.
+
+2:
+	# TODO: It would be easy to improve this to not do a byte-wise copy.
+	beqz a2, 3f
+	lbu t0, (a1)
+	sb t0, (a0)
+	addi a0, a0, 1
+	addi a1, a1, 1
+	addi a2, a2, -1
+	j 2b
+
+3:
+	sd zero, .L_tpCurrentUar(tp) # Clean up the UAR.
+	li a0, 0
+	ret
+
+4:
+	sd zero, .L_tpCurrentUar(tp) # Clean up the UAR.
+	li a0, 1
+	ret
+
+#------------------------------------------------------------------------------
+
+.section .note.GNU-stack,"",%progbits

--- a/kernel/thor/system/dtb/dtb.cpp
+++ b/kernel/thor/system/dtb/dtb.cpp
@@ -195,6 +195,8 @@ void DeviceTreeNode::initializeWith(::DeviceTreeNode dtNode) {
 		// inherit interrupt parent from parent if we don't have one
 		auto parent = parent_;
 		while (!interruptParentId_) {
+			if (!parent)
+				break;
 			if (parent->isInterruptController()) {
 				assert(parent->phandle_);
 				interruptParentId_ = parent->phandle_;
@@ -204,22 +206,22 @@ void DeviceTreeNode::initializeWith(::DeviceTreeNode dtNode) {
 			interruptParentId_ = parent->interruptParentId_;
 			parent = parent->parent_;
 		}
-
-		assert(interruptParentId_);
 	}
 }
 
 void DeviceTreeNode::finalizeInit() {
-	auto ipIt = phandles->find(interruptParentId_);
-	if (ipIt == phandles->end()) {
-		panicLogger() << "thor: node \"" << name() << "\" has an interrupt parent id "
-			<< interruptParentId_ << " but no such node exists" << frg::endlog;
-	} else {
-		interruptParent_ = ipIt->get<1>();
-	}
+	if (interruptParentId_ != 0) {
+		auto ipIt = phandles->find(interruptParentId_);
+		if (ipIt == phandles->end()) {
+			panicLogger() << "thor: node \"" << name() << "\" has an interrupt parent id "
+				<< interruptParentId_ << " but no such node exists" << frg::endlog;
+		} else {
+			interruptParent_ = ipIt->get<1>();
+		}
 
-	if (irqData_.size()) {
-		irqs_ = interruptParent_->parseIrqs_(irqData_);
+		if (irqData_.size()) {
+			irqs_ = interruptParent_->parseIrqs_(irqData_);
+		}
 	}
 
 	// perform address translation

--- a/kernel/thor/system/dtb/dtb.cpp
+++ b/kernel/thor/system/dtb/dtb.cpp
@@ -363,7 +363,9 @@ void DeviceTreeNode::finalizeInit() {
 
 auto DeviceTreeNode::parseIrq_(::DeviceTreeProperty *prop, size_t i) -> DeviceIrq {
 	DeviceIrq irq{};
-
+	// TODO: This code assumes the GIC.
+	//       Revise it to simply store a reference to the property in DeviceIrq.
+#ifndef __riscv
 	bool isPPI = prop->asU32(i);
 	uint32_t rawId = prop->asU32(i + 4);
 	uint32_t flags = prop->asU32(i + 8);
@@ -399,7 +401,7 @@ auto DeviceTreeNode::parseIrq_(::DeviceTreeProperty *prop, size_t i) -> DeviceIr
 	}
 
 	irq.ppiCpuMask = isPPI ? ((flags >> 8) & 0xFF) : 0;
-
+#endif
 	return irq;
 }
 

--- a/kernel/thor/system/pci/pci_acpi.cpp
+++ b/kernel/thor/system/pci/pci_acpi.cpp
@@ -238,7 +238,7 @@ static initgraph::Task discoverConfigIoSpaces{&globalInitEngine, "pci.discover-a
 
 static initgraph::Task discoverAcpiRootBuses{&globalInitEngine, "pci.discover-acpi-root-buses",
 	initgraph::Requires{getTaskingAvailableStage(), acpi::getNsAvailableStage()},
-	initgraph::Entails{getDevicesEnumeratedStage()},
+	initgraph::Entails{getRootsDiscoveredStage()},
 	[] {
 		static const char *pciRootIds[] = {
 			acpi::ACPI_HID_PCI,
@@ -274,9 +274,6 @@ static initgraph::Task discoverAcpiRootBuses{&globalInitEngine, "pci.discover-ac
 				addRootBus(rootBus);
 				return UACPI_NS_ITERATION_DECISION_CONTINUE;
 		}, nullptr);
-
-		infoLogger() << "thor: Discovering PCI devices" << frg::endlog;
-		enumerateAll();
 	}
 };
 

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -49,6 +49,11 @@ initgraph::Stage *getBus0AvailableStage() {
 	return &s;
 }
 
+initgraph::Stage *getRootsDiscoveredStage() {
+	static initgraph::Stage s{&globalInitEngine, "pci.roots-discovered"};
+	return &s;
+}
+
 initgraph::Stage *getDevicesEnumeratedStage() {
 	static initgraph::Stage s{&globalInitEngine, "pci.devices-enumerated"};
 	return &s;
@@ -1967,5 +1972,14 @@ void writeConfigByte(uint32_t seg, uint32_t bus, uint32_t slot,
 
 	io->writeConfigByte(seg, bus, slot, function, offset, value);
 }
+
+static initgraph::Task enumerateRootBuses{&globalInitEngine, "pci.enumerate-buses",
+	initgraph::Requires{getTaskingAvailableStage(), getRootsDiscoveredStage()},
+	initgraph::Entails{getDevicesEnumeratedStage()},
+	[] {
+		infoLogger() << "thor: Discovering PCI devices" << frg::endlog;
+		enumerateAll();
+	}
+};
 
 } } // namespace thor::pci

--- a/kernel/thor/system/pci/pci_dtb.cpp
+++ b/kernel/thor/system/pci/pci_dtb.cpp
@@ -4,11 +4,14 @@
 #include <thor-internal/pci/pci.hpp>
 #include <thor-internal/main.hpp>
 #include <thor-internal/dtb/dtb.hpp>
-#include <thor-internal/arch/gic.hpp>
 #include <thor-internal/arch/system.hpp>
 
 #include <thor-internal/pci/pcie_ecam.hpp>
 #include <thor-internal/pci/pcie_brcmstb.hpp>
+
+#ifndef __riscv
+#include <thor-internal/arch/gic.hpp>
+#endif
 
 namespace thor {
 
@@ -77,13 +80,18 @@ DtbPciIrqRouter::DtbPciIrqRouter(PciIrqRouter *parent_, PciBus *associatedBus_,
 
 			// TODO: care about polarity
 			auto irq = ent.parentIrq.id;
+#ifndef __riscv
 			if (globalIrqSlots[irq]->isAvailable()) {
+				// TODO: Do not assume the GIC here.
 				auto pin = gic->setupIrq(irq, ent.parentIrq.trigger);
 				routingTable.push({slot, index, pin});
 			} else {
 				auto pin = globalIrqSlots[irq]->pin();
 				routingTable.push({slot, index, pin});
 			}
+#else
+			warningLogger() << "PCI IRQ routing is not implemented yet on RISC-V" << frg::endlog;
+#endif
 		}
 	}
 

--- a/kernel/thor/system/pci/pci_dtb.cpp
+++ b/kernel/thor/system/pci/pci_dtb.cpp
@@ -169,10 +169,9 @@ void initPciNode(DeviceTreeNode *node) {
 	addRootBus(rootBus);
 }
 
-} // namespace anonymous
-
-static initgraph::Task discoverDtbNodes{&globalInitEngine, "pci.discover-dtb-nodes",
+initgraph::Task discoverDtbNodes{&globalInitEngine, "pci.discover-dtb-nodes",
 	initgraph::Requires{getDeviceTreeParsedStage()},
+	initgraph::Entails{getRootsDiscoveredStage()},
 	[] {
 		size_t i = 0;
 
@@ -189,13 +188,6 @@ static initgraph::Task discoverDtbNodes{&globalInitEngine, "pci.discover-dtb-nod
 	}
 };
 
-static initgraph::Task enumerateRootBuses{&globalInitEngine, "pci.enumerate-buses",
-	initgraph::Requires{getTaskingAvailableStage()},
-	initgraph::Entails{getDevicesEnumeratedStage()},
-	[] {
-		infoLogger() << "thor: Discovering PCI devices" << frg::endlog;
-		enumerateAll();
-	}
-};
+} // namespace anonymous
 
 } // namespace thor::pci

--- a/kernel/thor/system/pci/thor-internal/pci/pci.hpp
+++ b/kernel/thor/system/pci/thor-internal/pci/pci.hpp
@@ -23,6 +23,7 @@ struct BootScreen;
 namespace pci {
 
 initgraph::Stage *getBus0AvailableStage();
+initgraph::Stage *getRootsDiscoveredStage();
 initgraph::Stage *getDevicesEnumeratedStage();
 
 inline constexpr arch::scalar_register<uint64_t> msixMessageAddress{0};


### PR DESCRIPTION
This allows userspace to advance further (in particular, ping IPIs are required to ensure that userspace does not get stuck in the idle task).