### PR TITLE
kernel/eir: Reformat using clang-format

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,6 @@
+# This file is read by Meson to configure "ninja clang-format".
+
+# Data only.
+kernel/common/font-8x16.cpp
+# Vendored file.
+kernel/eir/protos/limine/limine.h

--- a/.clang-format-include
+++ b/.clang-format-include
@@ -1,4 +1,5 @@
 # This file is read by Meson to configure "ninja clang-format".
 
-kernel/common/riscv/**/*
+kernel/common/**/*
+kernel/eir/**/*
 kernel/thor/arch/riscv/**/*

--- a/kernel/common/dtb.hpp
+++ b/kernel/common/dtb.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
+#include <arch/variable.hpp>
+#include <assert.h>
+#include <cstddef>
+#include <frg/optional.hpp>
+#include <frg/span.hpp>
 #include <frg/string.hpp>
 #include <frg/utility.hpp>
-#include <arch/variable.hpp>
 #include <string.h>
-#include <assert.h>
-#include <frg/span.hpp>
-#include <frg/optional.hpp>
 #include <type_traits>
-#include <cstddef>
 
 struct DtbHeader {
 	arch::scalar_storage<uint32_t, arch::big_endian> magic;
@@ -30,25 +30,20 @@ struct DeviceTreeMemoryReservation {
 	bool operator==(const DeviceTreeMemoryReservation &other) const = default;
 };
 
-enum class Tag : uint32_t {
-	beginNode = 1,
-	endNode = 2,
-	prop = 3,
-	nop = 4,
-	end = 9
-};
+enum class Tag : uint32_t { beginNode = 1, endNode = 2, prop = 3, nop = 4, end = 9 };
 
 struct DeviceTreeNode;
 
 template <typename T>
-concept DeviceTreeWalker = requires (T t, DeviceTreeNode n) {
+concept DeviceTreeWalker = requires(T t, DeviceTreeNode n) {
 	t.push(n);
 	t.pop();
 };
 
 struct DeviceTree {
 	DeviceTree(void *data)
-	: data_{reinterpret_cast<std::byte *>(data)}, memoryReservations_{nullptr} {
+	: data_{reinterpret_cast<std::byte *>(data)},
+	  memoryReservations_{nullptr} {
 		DtbHeader header;
 		memcpy(&header, data, sizeof(header));
 		assert(header.magic.load() == 0xd00dfeed);
@@ -61,26 +56,19 @@ struct DeviceTree {
 		memoryReservations_ = {data_ + header.off_mem_rsvmap.load()};
 	}
 
-	size_t size() const {
-		return totalSize_;
-	}
+	size_t size() const { return totalSize_; }
 
-	void *data() const {
-		return data_;
-	}
+	void *data() const { return data_; }
 
 	DeviceTreeNode rootNode();
 
-	const std::byte *stringsBlock() const {
-		return stringsBlock_;
-	}
+	const std::byte *stringsBlock() const { return stringsBlock_; }
 
 	template <DeviceTreeWalker T>
 	void walkTree(T &&walker);
 
 	struct MemoryReservationRange {
-		MemoryReservationRange(std::byte *begin)
-		: begin_{begin}, end_{nullptr} {
+		MemoryReservationRange(std::byte *begin) : begin_{begin}, end_{nullptr} {
 			if (begin) {
 				Iterator it{begin};
 				while (*it != DeviceTreeMemoryReservation{0, 0})
@@ -93,8 +81,7 @@ struct DeviceTree {
 		struct Iterator {
 			friend MemoryReservationRange;
 
-			Iterator(std::byte *ptr)
-			: ptr_{ptr} { }
+			Iterator(std::byte *ptr) : ptr_{ptr} {}
 
 			bool operator==(const Iterator &other) const = default;
 
@@ -119,29 +106,21 @@ struct DeviceTree {
 			}
 
 		private:
-			void next() {
-				ptr_ += 16;
-			}
+			void next() { ptr_ += 16; }
 
 			std::byte *ptr_;
 		};
 
-		Iterator begin() const {
-			return begin_;
-		}
+		Iterator begin() const { return begin_; }
 
-		Iterator end() const {
-			return end_;
-		}
+		Iterator end() const { return end_; }
 
 	private:
 		Iterator begin_;
 		Iterator end_;
 	};
 
-	MemoryReservationRange memoryReservations() const {
-		return memoryReservations_;
-	}
+	MemoryReservationRange memoryReservations() const { return memoryReservations_; }
 
 private:
 	std::byte *data_;
@@ -155,26 +134,21 @@ private:
 };
 
 struct DeviceTreeProperty {
-	DeviceTreeProperty()
-	: name_{nullptr}, data_{nullptr, 0} { }
+	DeviceTreeProperty() : name_{nullptr}, data_{nullptr, 0} {}
 
 	DeviceTreeProperty(const char *name, frg::span<std::byte> data)
-	: name_{name}, data_{data.data(), data.size()} { }
+	: name_{name},
+	  data_{data.data(), data.size()} {}
 
 	DeviceTreeProperty(const char *name, frg::span<const std::byte> data)
-	: name_{name}, data_{data} { }
+	: name_{name},
+	  data_{data} {}
 
-	const char *name() const {
-		return name_;
-	}
+	const char *name() const { return name_; }
 
-	const void *data() const {
-		return data_.data();
-	}
+	const void *data() const { return data_.data(); }
 
-	size_t size() const {
-		return data_.size();
-	}
+	size_t size() const { return data_.size(); }
 
 	uint32_t asU32(size_t offset = 0) {
 		assert(offset + 4 <= data_.size());
@@ -223,65 +197,73 @@ private:
 };
 
 namespace detail {
-	inline Tag readTag(std::byte *&ptr) {
-		Tag t;
-		do {
-			arch::scalar_storage<uint32_t, arch::big_endian> tag;
-			memcpy(&tag, ptr, 4);
-			ptr += 4;
-			t = static_cast<Tag>(tag.load());
-		} while (t == Tag::nop);
-
-		assert(t != Tag::end);
-
-		return t;
-	}
-
-	inline const char *readStringInline(std::byte *&ptr) {
-		auto str = reinterpret_cast<char *>(ptr);
-		ptr += (strlen(str) + 4) & ~3;
-
-		return str;
-	}
-
-	inline const char *readString(DeviceTree *tree, std::byte *&ptr) {
-		arch::scalar_storage<uint32_t, arch::big_endian> strOff;
-		memcpy(&strOff, ptr, 4);
+inline Tag readTag(std::byte *&ptr) {
+	Tag t;
+	do {
+		arch::scalar_storage<uint32_t, arch::big_endian> tag;
+		memcpy(&tag, ptr, 4);
 		ptr += 4;
+		t = static_cast<Tag>(tag.load());
+	} while (t == Tag::nop);
 
-		return reinterpret_cast<const char *>(tree->stringsBlock()) + strOff.load();
-	}
+	assert(t != Tag::end);
 
-	inline uint32_t readLength(std::byte *&ptr) {
-		arch::scalar_storage<uint32_t, arch::big_endian> len;
-		memcpy(&len, ptr, 4);
-		ptr += 4;
+	return t;
+}
 
-		return len.load();
-	}
+inline const char *readStringInline(std::byte *&ptr) {
+	auto str = reinterpret_cast<char *>(ptr);
+	ptr += (strlen(str) + 4) & ~3;
 
-	inline frg::span<std::byte> readPropData(std::byte *&ptr, uint32_t len) {
-		auto dataPtr = ptr;
-		ptr += (len + 3) & ~3;
+	return str;
+}
 
-		return {dataPtr, len};
-	}
+inline const char *readString(DeviceTree *tree, std::byte *&ptr) {
+	arch::scalar_storage<uint32_t, arch::big_endian> strOff;
+	memcpy(&strOff, ptr, 4);
+	ptr += 4;
 
-	inline void skipProp(std::byte *&ptr) {
-		auto len = readLength(ptr);
-		ptr += 4; // skip name
-		ptr += (len + 3) & ~3; // skip data
-	}
+	return reinterpret_cast<const char *>(tree->stringsBlock()) + strOff.load();
+}
+
+inline uint32_t readLength(std::byte *&ptr) {
+	arch::scalar_storage<uint32_t, arch::big_endian> len;
+	memcpy(&len, ptr, 4);
+	ptr += 4;
+
+	return len.load();
+}
+
+inline frg::span<std::byte> readPropData(std::byte *&ptr, uint32_t len) {
+	auto dataPtr = ptr;
+	ptr += (len + 3) & ~3;
+
+	return {dataPtr, len};
+}
+
+inline void skipProp(std::byte *&ptr) {
+	auto len = readLength(ptr);
+	ptr += 4;              // skip name
+	ptr += (len + 3) & ~3; // skip data
+}
 } // namespace detail
 
 struct DeviceTreeNode {
 	DeviceTreeNode()
-	: tree_{}, base_{}, nodeOff_{}, propOff_{}, name_{},
-			properties_{nullptr, nullptr, nullptr} { }
+	: tree_{},
+	  base_{},
+	  nodeOff_{},
+	  propOff_{},
+	  name_{},
+	  properties_{nullptr, nullptr, nullptr} {}
 
 	DeviceTreeNode(DeviceTree *tree, std::byte *base)
-	: tree_{tree}, base_{base}, nodeOff_{}, propOff_{}, name_{},
-			properties_{nullptr, nullptr, nullptr} {
+	: tree_{tree},
+	  base_{base},
+	  nodeOff_{},
+	  propOff_{},
+	  name_{},
+	  properties_{nullptr, nullptr, nullptr} {
 		std::byte *tmp = base;
 
 		auto tag = detail::readTag(tmp);
@@ -354,9 +336,7 @@ struct DeviceTreeNode {
 					onDiscover(node);
 			}
 
-			void pop() {
-				depth--;
-			}
+			void pop() { depth--; }
 
 			int depth;
 			Pred pred;
@@ -366,21 +346,17 @@ struct DeviceTreeNode {
 		walkChildren(walker);
 	}
 
-	const char *name() const {
-		return name_;
-	}
+	const char *name() const { return name_; }
 
-	DeviceTree *tree() const {
-		return tree_;
-	}
+	DeviceTree *tree() const { return tree_; }
 
 	struct PropertyRange {
 		PropertyRange(DeviceTree *tree, std::byte *begin, std::byte *end)
-		: begin_{tree, begin}, end_{tree, end} { }
+		: begin_{tree, begin},
+		  end_{tree, end} {}
 
 		struct Iterator {
-			Iterator(DeviceTree *tree, std::byte *ptr)
-			: tree_{tree}, ptr_{ptr} { }
+			Iterator(DeviceTree *tree, std::byte *ptr) : tree_{tree}, ptr_{ptr} {}
 
 			bool operator==(const Iterator &other) const = default;
 
@@ -405,34 +381,29 @@ struct DeviceTreeNode {
 				next();
 				return *this;
 			}
+
 		private:
 			void next() {
 				ptr_ += 4; // skip tag
 				detail::skipProp(ptr_);
 				detail::readTag(ptr_); // skip potential nop tags
-				ptr_ -= 4; // rewind back to tag
+				ptr_ -= 4;             // rewind back to tag
 			}
 
 			DeviceTree *tree_;
 			std::byte *ptr_;
 		};
 
-		Iterator begin() const {
-			return begin_;
-		}
+		Iterator begin() const { return begin_; }
 
-		Iterator end() const {
-			return end_;
-		}
+		Iterator end() const { return end_; }
 
 	private:
 		Iterator begin_;
 		Iterator end_;
 	};
 
-	PropertyRange properties() const {
-		return properties_;
-	}
+	PropertyRange properties() const { return properties_; }
 
 private:
 	std::byte *findNodeOff_() {
@@ -461,9 +432,7 @@ private:
 	PropertyRange properties_;
 };
 
-inline DeviceTreeNode DeviceTree::rootNode() {
-	return {this, structureBlock_};
-}
+inline DeviceTreeNode DeviceTree::rootNode() { return {this, structureBlock_}; }
 
 template <DeviceTreeWalker T>
 inline void DeviceTree::walkTree(T &&walker) {

--- a/kernel/common/initgraph.hpp
+++ b/kernel/common/initgraph.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <assert.h>
 #include <frg/array.hpp>
 #include <frg/list.hpp>
-#include <assert.h>
 
 namespace initgraph {
 
@@ -12,25 +12,18 @@ struct Node;
 struct Edge;
 struct Engine;
 
-enum class NodeType {
-	none,
-	stage,
-	task
-};
+enum class NodeType { none, stage, task };
 
 struct Edge {
 	friend struct Node;
 	friend struct Engine;
 	friend void realizeEdge(Edge *edge);
 
-	Edge(Node *source, Node *target)
-	: source_{source}, target_{target} {
-		realizeEdge(this);
-	}
+	Edge(Node *source, Node *target) : source_{source}, target_{target} { realizeEdge(this); }
 
 	Edge(const Edge &) = delete;
 
-	Edge &operator= (const Edge &) = delete;
+	Edge &operator=(const Edge &) = delete;
 
 	Node *source() { return source_; }
 	Node *target() { return target_; }
@@ -49,13 +42,15 @@ struct Node {
 	friend void realizeEdge(Edge *edge);
 
 	Node(NodeType type, Engine *engine, const char *displayName = nullptr)
-	: type_{type}, engine_{engine}, displayName_{displayName} {
+	: type_{type},
+	  engine_{engine},
+	  displayName_{displayName} {
 		realizeNode(this);
 	}
 
 	Node(const Node &) = delete;
 
-	Node &operator= (const Node &) = delete;
+	Node &operator=(const Node &) = delete;
 
 	NodeType type() { return type_; }
 	Engine *engine() { return engine_; }
@@ -63,7 +58,7 @@ struct Node {
 	const char *displayName() { return displayName_; }
 
 protected:
-	virtual void activate() { };
+	virtual void activate() {};
 
 	~Node() = default;
 
@@ -74,22 +69,13 @@ private:
 	const char *displayName_;
 
 	frg::intrusive_list<
-		Edge,
-		frg::locate_member<
-			Edge,
-			frg::default_list_hook<Edge>,
-			&Edge::outHook_
-		>
-	> outList_;
+	    Edge,
+	    frg::locate_member<Edge, frg::default_list_hook<Edge>, &Edge::outHook_>>
+	    outList_;
 
-	frg::intrusive_list<
-		Edge,
-		frg::locate_member<
-			Edge,
-			frg::default_list_hook<Edge>,
-			&Edge::inHook_
-		>
-	> inList_;
+	frg::
+	    intrusive_list<Edge, frg::locate_member<Edge, frg::default_list_hook<Edge>, &Edge::inHook_>>
+	        inList_;
 
 	frg::default_list_hook<Node> nodesHook_;
 	frg::default_list_hook<Node> queueHook_;
@@ -119,51 +105,47 @@ protected:
 public:
 	void run(Node *goal = nullptr) {
 		frg::intrusive_list<
-			Node,
-			frg::locate_member<
-				Node,
-				frg::default_list_hook<Node>,
-				&Node::queueHook_
-			>
-		> q;
+		    Node,
+		    frg::locate_member<Node, frg::default_list_hook<Node>, &Node::queueHook_>>
+		    q;
 
 		// First, identify all nodes that we want to run.
-		if(goal) {
-			if(!goal->wanted_) {
+		if (goal) {
+			if (!goal->wanted_) {
 				q.push_back(goal);
 				goal->wanted_ = true;
 			}
 
-			while(!q.empty())  {
+			while (!q.empty()) {
 				auto node = q.pop_front();
 
 				// We also want the dependencies of the current node.
-				for(auto edge : node->inList_) {
-					if(!edge->source_->wanted_) {
+				for (auto edge : node->inList_) {
+					if (!edge->source_->wanted_) {
 						q.push_back(edge->source_);
 						edge->source_->wanted_ = true;
 					}
 				}
 			}
-		}else{
+		} else {
 			// If no goal is defined, we pick all nodes.
-			for(auto node : nodes_)
+			for (auto node : nodes_)
 				node->wanted_ = true;
 		}
 
-		for(auto node : nodes_) {
-			if(!node->wanted_)
+		for (auto node : nodes_) {
+			if (!node->wanted_)
 				continue;
 			// Skip nodes that ran in a previous call to run().
-			if(node->done_)
+			if (node->done_)
 				continue;
 
-			if(!node->nUnsatisfied)
+			if (!node->nUnsatisfied)
 				pending_.push_back(node);
 		}
 
 		// Now, run pending nodes until no such nodes remain.
-		while(!pending_.empty()) {
+		while (!pending_.empty()) {
 			auto current = pending_.pop_front();
 			assert(current->wanted_);
 			assert(!current->done_);
@@ -175,48 +157,40 @@ public:
 
 			postActivate(current);
 
-			for(auto edge : current->outList_) {
+			for (auto edge : current->outList_) {
 				auto successor = edge->target_;
 
 				assert(successor->nUnsatisfied);
 				--successor->nUnsatisfied;
-				if(successor->wanted_ && !successor->done_ && !successor->nUnsatisfied)
+				if (successor->wanted_ && !successor->done_ && !successor->nUnsatisfied)
 					pending_.push_back(successor);
 			}
 		}
 
 		unsigned int nUnreached = 0;
-		for(auto node : nodes_) {
-			if(!node->wanted_)
+		for (auto node : nodes_) {
+			if (!node->wanted_)
 				continue;
-			if(node->done_)
+			if (node->done_)
 				continue;
 			reportUnreached(node);
 			++nUnreached;
 		}
 
-		if(nUnreached)
+		if (nUnreached)
 			onUnreached();
 	}
 
 private:
 	frg::intrusive_list<
-		Node,
-		frg::locate_member<
-			Node,
-			frg::default_list_hook<Node>,
-			&Node::nodesHook_
-		>
-	> nodes_;
+	    Node,
+	    frg::locate_member<Node, frg::default_list_hook<Node>, &Node::nodesHook_>>
+	    nodes_;
 
 	frg::intrusive_list<
-		Node,
-		frg::locate_member<
-			Node,
-			frg::default_list_hook<Node>,
-			&Node::queueHook_
-		>
-	> pending_;
+	    Node,
+	    frg::locate_member<Node, frg::default_list_hook<Node>, &Node::queueHook_>>
+	    pending_;
 };
 
 inline void realizeNode(Node *node) {
@@ -234,41 +208,39 @@ inline void realizeEdge(Edge *edge) {
 }
 
 struct Stage final : Node {
-	Stage(Engine *engine, const char *displayName)
-	: Node{NodeType::stage, engine, displayName} { }
+	Stage(Engine *engine, const char *displayName) : Node{NodeType::stage, engine, displayName} {}
 };
 
-template<size_t N>
+template <size_t N>
 struct Requires {
-	template<typename... Args>
-	requires (std::is_convertible_v<Args, Node *> && ...)
-	Requires(Args &&... args)
-	: array{{args...}} { }
+	template <typename... Args>
+	    requires(std::is_convertible_v<Args, Node *> && ...)
+	Requires(Args &&...args) : array{{args...}} {}
 
 	Requires(const Requires &) = default;
 
 	frg::array<Node *, N> array;
 };
 
-template<typename... Args>
+template <typename... Args>
 Requires(Args &&...) -> Requires<sizeof...(Args)>;
 
-template<size_t N>
+template <size_t N>
 struct Entails {
-	template<typename... Args>
-	Entails(Args &&... args)
-	requires (std::is_convertible_v<Args, Node *> && ...)
-	: array{{args...}} { }
+	template <typename... Args>
+	Entails(Args &&...args)
+	    requires(std::is_convertible_v<Args, Node *> && ...)
+	: array{{args...}} {}
 
 	frg::array<Node *, N> array;
 };
 
-template<typename... Args>
+template <typename... Args>
 Entails(Args &&...) -> Entails<sizeof...(Args)>;
 
 struct IntoEdgesTo {
-	template<typename... Args>
-	frg::array<Edge, sizeof...(Args)> operator() (Args &&... args) const {
+	template <typename... Args>
+	frg::array<Edge, sizeof...(Args)> operator()(Args &&...args) const {
 		return {{{args, target}...}};
 	}
 
@@ -276,39 +248,38 @@ struct IntoEdgesTo {
 };
 
 struct IntoEdgesFrom {
-	template<typename... Args>
-	frg::array<Edge, sizeof...(Args)> operator() (Args &&... args) const {
+	template <typename... Args>
+	frg::array<Edge, sizeof...(Args)> operator()(Args &&...args) const {
 		return {{{source, args}...}};
 	}
 
 	Node *source;
 };
 
-template<size_t... S, typename T, size_t N, typename I>
+template <size_t... S, typename T, size_t N, typename I>
 auto apply(std::index_sequence<S...>, frg::array<T, N> array, I invocable) {
 	return invocable(array[S]...);
 }
 
-template< typename F, size_t NR = 0, size_t NE = 0>
+template <typename F, size_t NR = 0, size_t NE = 0>
 struct Task final : Node {
 	Task(Engine *engine, const char *displayName, Requires<NR> r, Entails<NE> e, F invocable)
-	: Node{NodeType::task, engine, displayName}, invocable_{std::move(invocable)},
-			rEdges_{apply(std::make_index_sequence<NR>{}, r.array, IntoEdgesTo{this})},
-			eEdges_{apply(std::make_index_sequence<NE>{}, e.array, IntoEdgesFrom{this})} { }
+	: Node{NodeType::task, engine, displayName},
+	  invocable_{std::move(invocable)},
+	  rEdges_{apply(std::make_index_sequence<NR>{}, r.array, IntoEdgesTo{this})},
+	  eEdges_{apply(std::make_index_sequence<NE>{}, e.array, IntoEdgesFrom{this})} {}
 
 	Task(Engine *engine, const char *displayName, F invocable)
-	: Task{engine, displayName, {}, {}, std::move(invocable)} { }
+	: Task{engine, displayName, {}, {}, std::move(invocable)} {}
 
 	Task(Engine *engine, const char *displayName, Requires<NR> r, F invocable)
-	: Task{engine, displayName, r, {}, std::move(invocable)} { }
+	: Task{engine, displayName, r, {}, std::move(invocable)} {}
 
 	Task(Engine *engine, const char *displayName, Entails<NE> e, F invocable)
-	: Task{engine, displayName, {}, e, std::move(invocable)} { }
+	: Task{engine, displayName, {}, e, std::move(invocable)} {}
 
 protected:
-	void activate() override {
-		invocable_();
-	}
+	void activate() override { invocable_(); }
 
 private:
 	F invocable_;

--- a/kernel/common/libc.cpp
+++ b/kernel/common/libc.cpp
@@ -15,10 +15,10 @@ extern "C" {
 int memcmp(const void *lhs, const void *rhs, size_t count) {
 	auto lhs_str = (const uint8_t *)lhs;
 	auto rhs_str = (const uint8_t *)rhs;
-	for(size_t i = 0; i < count; i++) {
-		if(lhs_str[i] < rhs_str[i])
+	for (size_t i = 0; i < count; i++) {
+		if (lhs_str[i] < rhs_str[i])
 			return -1;
-		if(lhs_str[i] > rhs_str[i])
+		if (lhs_str[i] > rhs_str[i])
 			return 1;
 	}
 	return 0;
@@ -26,14 +26,14 @@ int memcmp(const void *lhs, const void *rhs, size_t count) {
 
 size_t strlen(const char *str) {
 	size_t length = 0;
-	while(*str++ != 0)
+	while (*str++ != 0)
 		length++;
 	return length;
 }
 
 size_t strnlen(const char *str, size_t maxlen) {
 	size_t length = 0;
-	while(length < maxlen && str[length]) {
+	while (length < maxlen && str[length]) {
 		length++;
 	}
 	return length;
@@ -44,33 +44,33 @@ size_t strnlen(const char *str, size_t maxlen) {
 // --------------------------------------------------------------------------------------
 
 namespace {
-	extern "C++" {
+extern "C++" {
 
-	template<typename T>
-	struct word_helper {
-		enum class [[gnu::may_alias, gnu::aligned(1)]] word_enum : T { };
-	};
+template <typename T>
+struct word_helper {
+	enum class [[gnu::may_alias, gnu::aligned(1)]] word_enum : T {};
+};
 
-	template<typename T>
-	using word = typename word_helper<T>::word_enum;
+template <typename T>
+using word = typename word_helper<T>::word_enum;
 
-	template<typename T>
-	[[gnu::always_inline, gnu::artificial]]
-	inline word<T> alias_load(const unsigned char *&p) {
-		word<T> value = *reinterpret_cast<const word<T> *>(p);
-		p += sizeof(T);
-		return value;
-	}
-
-	template<typename T>
-	[[gnu::always_inline, gnu::artificial]]
-	inline void alias_store(unsigned char *&p, word<T> value) {
-		*reinterpret_cast<word<T> *>(p) = value;
-		p += sizeof(T);
-	}
-
-	} // extern "C++"
+template <typename T>
+[[gnu::always_inline, gnu::artificial]]
+inline word<T> alias_load(const unsigned char *&p) {
+	word<T> value = *reinterpret_cast<const word<T> *>(p);
+	p += sizeof(T);
+	return value;
 }
+
+template <typename T>
+[[gnu::always_inline, gnu::artificial]]
+inline void alias_store(unsigned char *&p, word<T> value) {
+	*reinterpret_cast<word<T> *>(p) = value;
+	p += sizeof(T);
+}
+
+} // extern "C++"
+} // namespace
 
 #ifdef __LP64__
 
@@ -78,7 +78,7 @@ void *memcpy(void *__restrict dest, const void *__restrict src, size_t n) {
 	auto curDest = reinterpret_cast<unsigned char *>(dest);
 	auto curSrc = reinterpret_cast<const unsigned char *>(src);
 
-	while(n >= 8 * 8) {
+	while (n >= 8 * 8) {
 		auto w1 = alias_load<uint64_t>(curSrc);
 		auto w2 = alias_load<uint64_t>(curSrc);
 		auto w3 = alias_load<uint64_t>(curSrc);
@@ -97,7 +97,7 @@ void *memcpy(void *__restrict dest, const void *__restrict src, size_t n) {
 		alias_store<uint64_t>(curDest, w8);
 		n -= 8 * 8;
 	}
-	if(n >= 4 * 8) {
+	if (n >= 4 * 8) {
 		auto w1 = alias_load<uint64_t>(curSrc);
 		auto w2 = alias_load<uint64_t>(curSrc);
 		auto w3 = alias_load<uint64_t>(curSrc);
@@ -108,29 +108,29 @@ void *memcpy(void *__restrict dest, const void *__restrict src, size_t n) {
 		alias_store<uint64_t>(curDest, w4);
 		n -= 4 * 8;
 	}
-	if(n >= 2 * 8) {
+	if (n >= 2 * 8) {
 		auto w1 = alias_load<uint64_t>(curSrc);
 		auto w2 = alias_load<uint64_t>(curSrc);
 		alias_store<uint64_t>(curDest, w1);
 		alias_store<uint64_t>(curDest, w2);
 		n -= 2 * 8;
 	}
-	if(n >= 8) {
+	if (n >= 8) {
 		auto w = alias_load<uint64_t>(curSrc);
 		alias_store<uint64_t>(curDest, w);
 		n -= 8;
 	}
-	if(n >= 4) {
+	if (n >= 4) {
 		auto w = alias_load<uint32_t>(curSrc);
 		alias_store<uint32_t>(curDest, w);
 		n -= 4;
 	}
-	if(n >= 2) {
+	if (n >= 2) {
 		auto w = alias_load<uint16_t>(curSrc);
 		alias_store<uint16_t>(curDest, w);
 		n -= 2;
 	}
-	if(n)
+	if (n)
 		*curDest = *curSrc;
 	return dest;
 }
@@ -138,7 +138,7 @@ void *memcpy(void *__restrict dest, const void *__restrict src, size_t n) {
 #else // !__LP64__
 
 void *memcpy(void *dest, const void *src, size_t n) {
-	for(size_t i = 0; i < n; i++)
+	for (size_t i = 0; i < n; i++)
 		((char *)dest)[i] = ((const char *)src)[i];
 	return dest;
 }
@@ -156,32 +156,28 @@ void *memset(void *dest, int val, size_t n) {
 	unsigned char byte = val;
 
 	// Get rid of misalignment.
-	while(n && (reinterpret_cast<uintptr_t>(curDest) & 7)) {
+	while (n && (reinterpret_cast<uintptr_t>(curDest) & 7)) {
 		*curDest++ = byte;
 		--n;
 	}
 
 	auto pattern64 = static_cast<word<uint64_t>>(
-			static_cast<uint64_t>(byte)
-			| (static_cast<uint64_t>(byte) << 8)
-			| (static_cast<uint64_t>(byte) << 16)
-			| (static_cast<uint64_t>(byte) << 24)
-			| (static_cast<uint64_t>(byte) << 32)
-			| (static_cast<uint64_t>(byte) << 40)
-			| (static_cast<uint64_t>(byte) << 48)
-			| (static_cast<uint64_t>(byte) << 56));
+	    static_cast<uint64_t>(byte) | (static_cast<uint64_t>(byte) << 8)
+	    | (static_cast<uint64_t>(byte) << 16) | (static_cast<uint64_t>(byte) << 24)
+	    | (static_cast<uint64_t>(byte) << 32) | (static_cast<uint64_t>(byte) << 40)
+	    | (static_cast<uint64_t>(byte) << 48) | (static_cast<uint64_t>(byte) << 56)
+	);
 
 	auto pattern32 = static_cast<word<uint32_t>>(
-			static_cast<uint32_t>(byte)
-			| (static_cast<uint32_t>(byte) << 8)
-			| (static_cast<uint32_t>(byte) << 16)
-			| (static_cast<uint32_t>(byte) << 24));
+	    static_cast<uint32_t>(byte) | (static_cast<uint32_t>(byte) << 8)
+	    | (static_cast<uint32_t>(byte) << 16) | (static_cast<uint32_t>(byte) << 24)
+	);
 
 	auto pattern16 = static_cast<word<uint16_t>>(
-			static_cast<uint16_t>(byte)
-			| (static_cast<uint16_t>(byte) << 8));
+	    static_cast<uint16_t>(byte) | (static_cast<uint16_t>(byte) << 8)
+	);
 
-	while(n >= 8 * 8) {
+	while (n >= 8 * 8) {
 		alias_store<uint64_t>(curDest, pattern64);
 		alias_store<uint64_t>(curDest, pattern64);
 		alias_store<uint64_t>(curDest, pattern64);
@@ -192,31 +188,31 @@ void *memset(void *dest, int val, size_t n) {
 		alias_store<uint64_t>(curDest, pattern64);
 		n -= 8 * 8;
 	}
-	if(n >= 4 * 8) {
+	if (n >= 4 * 8) {
 		alias_store<uint64_t>(curDest, pattern64);
 		alias_store<uint64_t>(curDest, pattern64);
 		alias_store<uint64_t>(curDest, pattern64);
 		alias_store<uint64_t>(curDest, pattern64);
 		n -= 4 * 8;
 	}
-	if(n >= 2 * 8) {
+	if (n >= 2 * 8) {
 		alias_store<uint64_t>(curDest, pattern64);
 		alias_store<uint64_t>(curDest, pattern64);
 		n -= 2 * 8;
 	}
-	if(n >= 8) {
+	if (n >= 8) {
 		alias_store<uint64_t>(curDest, pattern64);
 		n -= 8;
 	}
-	if(n >= 4) {
+	if (n >= 4) {
 		alias_store<uint32_t>(curDest, pattern32);
 		n -= 4;
 	}
-	if(n >= 2) {
+	if (n >= 2) {
 		alias_store<uint16_t>(curDest, pattern16);
 		n -= 2;
 	}
-	if(n)
+	if (n)
 		*curDest = byte;
 	return dest;
 }
@@ -224,7 +220,7 @@ void *memset(void *dest, int val, size_t n) {
 #else // !__LP64__
 
 void *memset(void *dest, int byte, size_t count) {
-	for(size_t i = 0; i < count; i++)
+	for (size_t i = 0; i < count; i++)
 		((char *)dest)[i] = (char)byte;
 	return dest;
 }
@@ -237,13 +233,13 @@ void *memmove(void *dest, const void *src, size_t size) {
 	uintptr_t udest = reinterpret_cast<uintptr_t>(dest);
 	uintptr_t usrc = reinterpret_cast<uintptr_t>(src);
 
-	if(udest < usrc || usrc + size <= udest) {
+	if (udest < usrc || usrc + size <= udest) {
 		return memcpy(dest, src, size);
-	} else if(udest > usrc) {
+	} else if (udest > usrc) {
 		char *dest_bytes = (char *)dest;
 		char *src_bytes = (char *)src;
 
-		for(size_t i = 0; i < size; i++)
+		for (size_t i = 0; i < size; i++)
 			dest_bytes[size - i - 1] = src_bytes[size - i - 1];
 	}
 

--- a/kernel/common/physical-buddy.hpp
+++ b/kernel/common/physical-buddy.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <assert.h>
 
 #include <frg/optional.hpp>
 
 namespace {
-	constexpr bool enableBuddySanityChecking = false;
+constexpr bool enableBuddySanityChecking = false;
 }
 
 struct BuddyAccessor {
@@ -16,10 +16,10 @@ struct BuddyAccessor {
 	static inline constexpr AddressType illegalAddress = static_cast<AddressType>(-1);
 
 private:
-	static AddressType findAllocatableChunk(int8_t *slice, AddressType base, AddressType limit,
-			int target) {
-		for(AddressType i = 0; i < limit; i++) {
-			if(slice[base + i] >= target)
+	static AddressType
+	findAllocatableChunk(int8_t *slice, AddressType base, AddressType limit, int target) {
+		for (AddressType i = 0; i < limit; i++) {
+			if (slice[base + i] >= target)
 				return base + i;
 		}
 		return illegalAddress;
@@ -30,14 +30,14 @@ private:
 		int freeOrder = -1;
 		bool allEqualOrder = true;
 
-		for(AddressType i = 0; i < limit; i++) {
-			if(slice[base + i] >= freeOrder)
+		for (AddressType i = 0; i < limit; i++) {
+			if (slice[base + i] >= freeOrder)
 				freeOrder = slice[base + i];
-			if(slice[base + i] != order)
+			if (slice[base + i] != order)
 				allEqualOrder = false;
 		}
 
-		if(allEqualOrder)
+		if (allEqualOrder)
 			return order + 1;
 		else
 			return freeOrder;
@@ -47,47 +47,49 @@ private:
 		assert(slice[base] >= -1);
 		assert(slice[base] <= order);
 
-		if(!order)
+		if (!order)
 			return slice[base];
 
-		if(slice[base] == -1) {
+		if (slice[base] == -1) {
 			// All descendents are either:
 			// - marked as free (if this entry is allocated and we never descend further),
 			// - or marked as used (if they are all allocated).
 			bool allFree = true;
 			bool allUsed = true;
-			for(size_t i = 0; i < 2; ++i) {
-				int k = traverseForSanityCheck(slice + (size_t(numRoots_) << (tableOrder_ - order)),
-						order - 1, 2 * base + i);
-				if(k != order - 1)
+			for (size_t i = 0; i < 2; ++i) {
+				int k = traverseForSanityCheck(
+				    slice + (size_t(numRoots_) << (tableOrder_ - order)), order - 1, 2 * base + i
+				);
+				if (k != order - 1)
 					allFree = false;
-				if(k != -1)
+				if (k != -1)
 					allUsed = false;
 			}
 
 			assert(allFree || allUsed);
 			return -1;
-		}else{
+		} else {
 			int freeOrder = -1;
 			bool allFree = true;
-			for(size_t i = 0; i < 2; ++i) {
-				int k = traverseForSanityCheck(slice + (size_t(numRoots_) << (tableOrder_ - order)),
-						order - 1, 2 * base + i);
-				if(k != order - 1)
+			for (size_t i = 0; i < 2; ++i) {
+				int k = traverseForSanityCheck(
+				    slice + (size_t(numRoots_) << (tableOrder_ - order)), order - 1, 2 * base + i
+				);
+				if (k != order - 1)
 					allFree = false;
 
 				assert(slice[base] >= k);
-				if(freeOrder < k)
+				if (freeOrder < k)
 					freeOrder = k;
 			}
 
 			// Either:
 			// - all descedants are completely free (and then this entry is also completely free),
 			// - or there is at least one partially free descendant.
-			if(allFree) {
+			if (allFree) {
 				assert(slice[base] == order);
 				return order;
-			}else{
+			} else {
 				assert(slice[base] == freeOrder);
 				return freeOrder;
 			}
@@ -98,7 +100,7 @@ public:
 	// This function determines a suitable order based on the number of items.
 	static int suitableOrder(AddressType num_items) {
 		int order = 0;
-		while(num_items / (AddressType(1) << order) > 64)
+		while (num_items / (AddressType(1) << order) > 64)
 			order++;
 		return order;
 	}
@@ -106,7 +108,7 @@ public:
 	// Determines the size required for the buddy allocator in bytes.
 	static size_t determineSize(AddressType numRoots, int tableOrder) {
 		size_t size = 0;
-		for(int order = 0; order <= tableOrder; order++)
+		for (int order = 0; order <= tableOrder; order++)
 			size += size_t(numRoots) << (tableOrder - order);
 		return size;
 	}
@@ -114,27 +116,34 @@ public:
 	// Inititalizes the buddy allocator array.
 	static void initialize(int8_t *pointer, AddressType numRoots, int tableOrder) {
 		int8_t *slice = pointer;
-		for(int order = tableOrder; order >= 0; order--) {
+		for (int order = tableOrder; order >= 0; order--) {
 			auto chunksInOrder = size_t(numRoots) << (tableOrder - order);
-			for(AddressType i = 0; i < chunksInOrder; i++)
+			for (AddressType i = 0; i < chunksInOrder; i++)
 				slice[i] = order;
 			slice += chunksInOrder;
 		}
 	}
 
-	BuddyAccessor()
-	: buddyPointer_{nullptr}, numRoots_{0}, tableOrder_{0} { }
+	BuddyAccessor() : buddyPointer_{nullptr}, numRoots_{0}, tableOrder_{0} {}
 
-	BuddyAccessor(AddressType baseAddress, int sizeShift,
-			int8_t *buddyPointer, AddressType numRoots, int tableOrder_)
-	: _baseAddress{baseAddress}, _sizeShift{sizeShift},
-			buddyPointer_{buddyPointer}, numRoots_{numRoots}, tableOrder_{tableOrder_} { }
+	BuddyAccessor(
+	    AddressType baseAddress,
+	    int sizeShift,
+	    int8_t *buddyPointer,
+	    AddressType numRoots,
+	    int tableOrder_
+	)
+	: _baseAddress{baseAddress},
+	  _sizeShift{sizeShift},
+	  buddyPointer_{buddyPointer},
+	  numRoots_{numRoots},
+	  tableOrder_{tableOrder_} {}
 
 	int tableOrder() { return tableOrder_; }
 
 	AddressType allocate(int order, int addressBits) {
 		assert(order >= 0);
-		if(order > tableOrder_)
+		if (order > tableOrder_)
 			return illegalAddress;
 
 		if constexpr (enableBuddySanityChecking)
@@ -146,38 +155,39 @@ public:
 		// Note: the calculations here need to carefully take overflows into account!
 		//       Hence, first exclude the case that the entire buddy tree is accessible.
 		AddressType eligibleRoots = numRoots_;
-		if(addressBits < static_cast<int>(sizeof(AddressType) * 8)) {
-			if(_baseAddress >= (AddressType{1} << addressBits))
+		if (addressBits < static_cast<int>(sizeof(AddressType) * 8)) {
+			if (_baseAddress >= (AddressType{1} << addressBits))
 				return illegalAddress;
 
 			// Range of memory that can be addressed;
 			// starts at _baseAddress but is not necessarily fully contained in the buddy.
 			AddressType addressableRange = (AddressType{1} << addressBits) - _baseAddress;
-			if(addressableRange < (AddressType{1} << (order + _sizeShift)))
+			if (addressableRange < (AddressType{1} << (order + _sizeShift)))
 				return illegalAddress;
 
 			// Descend until some constant number (i.e., 4) of roots are fully addressable,
 			// i.e., are addressable with addressBits-many bits.
-			while(currentOrder > order
-					&& (addressableRange >> (currentOrder + _sizeShift)) > 4) {
+			while (currentOrder > order && (addressableRange >> (currentOrder + _sizeShift)) > 4) {
 				slice += size_t(numRoots_) << (tableOrder_ - currentOrder);
 				currentOrder--;
 			}
-			eligibleRoots = std::min(addressableRange >> (currentOrder + _sizeShift),
-					AddressType(numRoots_) << (tableOrder_ - currentOrder));
+			eligibleRoots = std::min(
+			    addressableRange >> (currentOrder + _sizeShift),
+			    AddressType(numRoots_) << (tableOrder_ - currentOrder)
+			);
 			assert(eligibleRoots);
 		}
 
 		// First phase: Descent to the target order.
 		// In this phase find a free element.
 		AddressType allocIndex = findAllocatableChunk(slice, 0, eligibleRoots, order);
-		if(allocIndex == illegalAddress)
+		if (allocIndex == illegalAddress)
 			return illegalAddress;
-		while(currentOrder > order) {
+		while (currentOrder > order) {
 			slice += size_t(numRoots_) << (tableOrder_ - currentOrder);
 			currentOrder--;
 			allocIndex = findAllocatableChunk(slice, 2 * allocIndex, 2, order);
-			if(allocIndex == illegalAddress)
+			if (allocIndex == illegalAddress)
 				return illegalAddress;
 		}
 
@@ -190,7 +200,7 @@ public:
 		// Second phase: Ascent to the tableOrder.
 		// In this phase we fix all superior elements.
 		AddressType updateIndex = allocIndex;
-		while(currentOrder < tableOrder_) {
+		while (currentOrder < tableOrder_) {
 			updateIndex /= 2;
 			auto freeOrder = scanFreeChunks(slice, 2 * updateIndex, 2, currentOrder);
 			currentOrder++;
@@ -199,7 +209,7 @@ public:
 		}
 
 		AddressType physical = _baseAddress + (allocIndex << (order + _sizeShift));
-		if(addressBits < static_cast<int>(sizeof(AddressType) * 8))
+		if (addressBits < static_cast<int>(sizeof(AddressType) * 8))
 			assert(!(physical >> addressBits));
 
 		if constexpr (enableBuddySanityChecking)
@@ -222,7 +232,7 @@ public:
 
 		// Analogous to the allocate operation:
 		// First we decend to the target order.
-		while(currentOrder > order) {
+		while (currentOrder > order) {
 			slice += size_t(numRoots_) << (tableOrder_ - currentOrder);
 			currentOrder--;
 		}
@@ -233,7 +243,7 @@ public:
 		slice[updateIndex] = order;
 
 		// Update all superior elements.
-		while(currentOrder < tableOrder_) {
+		while (currentOrder < tableOrder_) {
 			updateIndex /= 2;
 			auto freeOrder = scanFreeChunks(slice, 2 * updateIndex, 2, currentOrder);
 			currentOrder++;
@@ -246,7 +256,7 @@ public:
 	}
 
 	void sanityCheck() {
-		for(size_t i = 0; i < size_t(numRoots_); ++i)
+		for (size_t i = 0; i < size_t(numRoots_); ++i)
 			traverseForSanityCheck(buddyPointer_, tableOrder_, i);
 	}
 

--- a/kernel/common/render-text.hpp
+++ b/kernel/common/render-text.hpp
@@ -1,53 +1,48 @@
 #pragma once
 
-#include <stdint.h>
 #include <cstddef>
+#include <stdint.h>
 #include <utility>
 
-constexpr uint32_t rgb(int r, int g, int b) {
-	return (r << 16) | (g << 8) | b;
-}
+constexpr uint32_t rgb(int r, int g, int b) { return (r << 16) | (g << 8) | b; }
 
 inline constexpr uint32_t rgbColor[16] = {
-	rgb(1, 1, 1),
-	rgb(222, 56, 43),
-	rgb(57, 181, 74),
-	rgb(255, 199, 6),
-	rgb(0, 111, 184),
-	rgb(118, 38, 113),
-	rgb(44, 181, 233),
-	rgb(204, 204, 204),
-	rgb(128, 128, 128),
-	rgb(255, 0, 0),
-	rgb(0, 255, 0),
-	rgb(255, 255, 0),
-	rgb(0, 0, 255),
-	rgb(255, 0, 255),
-	rgb(0, 255, 255),
-	rgb(255, 255, 255)
+    rgb(1, 1, 1),
+    rgb(222, 56, 43),
+    rgb(57, 181, 74),
+    rgb(255, 199, 6),
+    rgb(0, 111, 184),
+    rgb(118, 38, 113),
+    rgb(44, 181, 233),
+    rgb(204, 204, 204),
+    rgb(128, 128, 128),
+    rgb(255, 0, 0),
+    rgb(0, 255, 0),
+    rgb(255, 255, 0),
+    rgb(0, 0, 255),
+    rgb(255, 0, 255),
+    rgb(0, 255, 255),
+    rgb(255, 255, 255)
 };
 
 inline constexpr uint32_t defaultBg = rgb(16, 16, 16);
 
 extern uint8_t fontBitmap[];
 
-template<int FontWidth, int FontHeight>
-void renderChars(void *fb_ptr, unsigned int pitch,
-		unsigned int x, unsigned int y,
-		const char *c, int count, int fg, int bg,
-		std::integral_constant<int, FontWidth>,
-		std::integral_constant<int, FontHeight>) {
+template <int FontWidth, int FontHeight>
+void
+renderChars(void *fb_ptr, unsigned int pitch, unsigned int x, unsigned int y, const char *c, int count, int fg, int bg, std::integral_constant<int, FontWidth>, std::integral_constant<int, FontHeight>) {
 	auto fg_rgb = rgbColor[fg];
 	auto bg_rgb = (bg < 0) ? defaultBg : rgbColor[bg];
 
 	auto fb = reinterpret_cast<uint32_t *>(fb_ptr);
 	auto line = fb + y * FontHeight * pitch + x * FontWidth;
-	for(size_t i = 0; i < FontHeight; i++) {
+	for (size_t i = 0; i < FontHeight; i++) {
 		auto dest = line;
-		for(int k = 0; k < count; k++) {
+		for (int k = 0; k < count; k++) {
 			auto dc = (c[k] >= 32 && c[k] <= 127) ? c[k] : 127;
 			auto fontbits = fontBitmap[(dc - 32) * FontHeight + i];
-			for(size_t j = 0; j < FontWidth; j++) {
+			for (size_t j = 0; j < FontWidth; j++) {
 				int bit = (1 << ((FontWidth - 1) - j));
 				*dest++ = (fontbits & bit) ? fg_rgb : bg_rgb;
 			}
@@ -55,6 +50,5 @@ void renderChars(void *fb_ptr, unsigned int pitch,
 		line += pitch;
 	}
 
-	asm volatile ("" : : : "memory");
+	asm volatile("" : : : "memory");
 }
-

--- a/kernel/common/x86/gdt.hpp
+++ b/kernel/common/x86/gdt.hpp
@@ -18,15 +18,15 @@ enum GdtFlags : uint32_t {
 struct Gdtr {
 	uint16_t limit;
 	uint32_t *pointer;
-} __attribute__ (( packed ));
+} __attribute__((packed));
 
 namespace detail {
-	inline void makeGdtSegment(uint32_t *gdt, int entry, uint32_t offset,
-			uint32_t limit, uint32_t word1_flags) {
-		gdt[entry * 2 + 0] = (limit & 0xFFFF) | (offset << 16);
-		gdt[entry * 2 + 1] = ((offset >> 16) & 0xFF) | word1_flags
-				| (limit & 0x000F0000) | (offset & 0xFF000000);
-	}
+inline void
+makeGdtSegment(uint32_t *gdt, int entry, uint32_t offset, uint32_t limit, uint32_t word1_flags) {
+	gdt[entry * 2 + 0] = (limit & 0xFFFF) | (offset << 16);
+	gdt[entry * 2 + 1] =
+	    ((offset >> 16) & 0xFF) | word1_flags | (limit & 0x000F0000) | (offset & 0xFF000000);
+}
 } // namespace detail
 
 inline void makeGdtNullSegment(uint32_t *gdt, int entry) {
@@ -35,41 +35,54 @@ inline void makeGdtNullSegment(uint32_t *gdt, int entry) {
 }
 
 inline void makeGdtFlatCode32SystemSegment(uint32_t *gdt, int entry) {
-	detail::makeGdtSegment(gdt, entry, 0, 0x000FFFFF, kGdtWord1CodeSegment | kGdtWord1Present
-			| kGdtWord1Default | kGdtWord1Granularity);
+	detail::makeGdtSegment(
+	    gdt,
+	    entry,
+	    0,
+	    0x000FFFFF,
+	    kGdtWord1CodeSegment | kGdtWord1Present | kGdtWord1Default | kGdtWord1Granularity
+	);
 }
 
 inline void makeGdtFlatData32SystemSegment(uint32_t *gdt, int entry) {
-	detail::makeGdtSegment(gdt, entry, 0, 0x000FFFFF, kGdtWord1DataSegment | kGdtWord1Present
-			| kGdtWord1Default | kGdtWord1Granularity);
+	detail::makeGdtSegment(
+	    gdt,
+	    entry,
+	    0,
+	    0x000FFFFF,
+	    kGdtWord1DataSegment | kGdtWord1Present | kGdtWord1Default | kGdtWord1Granularity
+	);
 }
 inline void makeGdtFlatData32UserSegment(uint32_t *gdt, int entry) {
-	detail::makeGdtSegment(gdt, entry, 0, 0x000FFFFF, kGdtWord1DataSegment | kGdtWord1User | kGdtWord1Present
-			| kGdtWord1Default | kGdtWord1Granularity);
+	detail::makeGdtSegment(
+	    gdt,
+	    entry,
+	    0,
+	    0x000FFFFF,
+	    kGdtWord1DataSegment | kGdtWord1User | kGdtWord1Present | kGdtWord1Default
+	        | kGdtWord1Granularity
+	);
 }
 
 inline void makeGdtCode64SystemSegment(uint32_t *gdt, int entry) {
 	gdt[entry * 2 + 0] = 0;
-	gdt[entry * 2 + 1] = kGdtWord1CodeSegment | kGdtWord1Present
-			| kGdtWord1Long | kGdtWord1Granularity;
+	gdt[entry * 2 + 1] =
+	    kGdtWord1CodeSegment | kGdtWord1Present | kGdtWord1Long | kGdtWord1Granularity;
 }
 
 inline void makeGdtCode64UserSegment(uint32_t *gdt, int entry) {
 	gdt[entry * 2 + 0] = 0;
-	gdt[entry * 2 + 1] = kGdtWord1CodeSegment | kGdtWord1User | kGdtWord1Present
-			| kGdtWord1Long | kGdtWord1Granularity;
+	gdt[entry * 2 + 1] = kGdtWord1CodeSegment | kGdtWord1User | kGdtWord1Present | kGdtWord1Long
+	                     | kGdtWord1Granularity;
 }
 
-inline void makeGdtTss64Descriptor(uint32_t *gdt, int entry, void *tss,
-		size_t size) {
+inline void makeGdtTss64Descriptor(uint32_t *gdt, int entry, void *tss, size_t size) {
 	uint64_t address = (uint64_t)tss;
 	gdt[entry * 2 + 0] = ((uint32_t)size & 0xFFFF) | ((address & 0xFFFF) << 16);
-	gdt[entry * 2 + 1] = ((address >> 16) & 0xFF)
-			| kGdtWord1TssDescriptor | kGdtWord1Present
-			| ((uint32_t)size & 0x000F0000) | (address & 0xFF000000);
+	gdt[entry * 2 + 1] = ((address >> 16) & 0xFF) | kGdtWord1TssDescriptor | kGdtWord1Present
+	                     | ((uint32_t)size & 0x000F0000) | (address & 0xFF000000);
 	gdt[entry * 2 + 2] = address >> 32;
 	gdt[entry * 2 + 3] = 0;
 }
-
 
 } // namespace common::x86

--- a/kernel/common/x86/gdt.hpp
+++ b/kernel/common/x86/gdt.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 namespace common::x86 {

--- a/kernel/common/x86/idt.hpp
+++ b/kernel/common/x86/idt.hpp
@@ -13,7 +13,7 @@ enum IdtFlags : uint32_t {
 struct Idtr {
 	uint16_t limit;
 	uint32_t *pointer;
-} __attribute__ (( packed ));
+} __attribute__((packed));
 
 inline void makeIdt64NullGate(uint32_t *idt, int entry) {
 	idt[entry * 4 + 0] = 0;
@@ -22,22 +22,20 @@ inline void makeIdt64NullGate(uint32_t *idt, int entry) {
 	idt[entry * 4 + 3] = 0;
 }
 
-inline void makeIdt64IntSystemGate(uint32_t *idt, int entry,
-		int segment, void *handler, int ist) {
+inline void makeIdt64IntSystemGate(uint32_t *idt, int entry, int segment, void *handler, int ist) {
 	uintptr_t offset = (uintptr_t)handler;
 	idt[entry * 4 + 0] = ((uint32_t)offset & 0xFFFF) | ((uint32_t)segment << 16);
-	idt[entry * 4 + 1] = kIdtWord1InterruptGate | kIdtWord1Present
-			| ((uint32_t)offset & 0xFFFF0000) | (uint32_t)ist;
+	idt[entry * 4 + 1] =
+	    kIdtWord1InterruptGate | kIdtWord1Present | ((uint32_t)offset & 0xFFFF0000) | (uint32_t)ist;
 	idt[entry * 4 + 2] = (uint32_t)(offset >> 32);
 	idt[entry * 4 + 3] = 0;
 }
 
-inline void makeIdt64IntUserGate(uint32_t *idt, int entry,
-		int segment, void *handler, int ist) {
+inline void makeIdt64IntUserGate(uint32_t *idt, int entry, int segment, void *handler, int ist) {
 	uintptr_t offset = (uintptr_t)handler;
 	idt[entry * 4 + 0] = ((uint32_t)offset & 0xFFFF) | ((uint32_t)segment << 16);
 	idt[entry * 4 + 1] = kIdtWord1InterruptGate | kIdtWord1Present | kIdtWord1User
-			| ((uint32_t)offset & 0xFFFF0000) | (uint32_t)ist;
+	                     | ((uint32_t)offset & 0xFFFF0000) | (uint32_t)ist;
 	idt[entry * 4 + 2] = (uint32_t)(offset >> 32);
 	idt[entry * 4 + 3] = 0;
 }

--- a/kernel/common/x86/machine.hpp
+++ b/kernel/common/x86/machine.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <stdint.h>
-#include <stddef.h>
-#include <frg/array.hpp>
 #include <assert.h>
+#include <frg/array.hpp>
+#include <stddef.h>
+#include <stdint.h>
 
 namespace common::x86 {
 
@@ -28,9 +28,9 @@ enum {
 
 inline frg::array<uint32_t, 4> cpuid(uint32_t eax, uint32_t ecx = 0) {
 	frg::array<uint32_t, 4> out;
-	asm volatile ( "cpuid"
-			: "=a" (out[0]), "=b" (out[1]), "=c" (out[2]), "=d" (out[3])
-			: "a" (eax), "c" (ecx) );
+	asm volatile("cpuid"
+	             : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
+	             : "a"(eax), "c"(ecx));
 	return out;
 }
 
@@ -48,11 +48,9 @@ enum {
 	kMsrIndexVmCr = 0xC0010114,
 };
 
-enum {
-	kMsrSyscallEnable = 1
-};
+enum { kMsrSyscallEnable = 1 };
 
-inline void xsave(uint8_t* area, uint64_t rfbm){
+inline void xsave(uint8_t *area, uint64_t rfbm) {
 	assert(!((uintptr_t)area & 0x3F));
 
 	uintptr_t low = rfbm & 0xFFFFFFFF;
@@ -60,7 +58,7 @@ inline void xsave(uint8_t* area, uint64_t rfbm){
 	asm volatile("xsave %0" : : "m"(*area), "a"(low), "d"(high) : "memory");
 }
 
-inline void xrstor(uint8_t* area, uint64_t rfbm){
+inline void xrstor(uint8_t *area, uint64_t rfbm) {
 	assert(!((uintptr_t)area & 0x3F));
 
 	uintptr_t low = rfbm & 0xFFFFFFFF;
@@ -71,54 +69,52 @@ inline void xrstor(uint8_t* area, uint64_t rfbm){
 inline void wrmsr(uint32_t index, uint64_t value) {
 	uint32_t low = value;
 	uint32_t high = value >> 32;
-	asm volatile ( "wrmsr" : : "c" (index),
-			"a" (low), "d" (high) : "memory" );
+	asm volatile("wrmsr" : : "c"(index), "a"(low), "d"(high) : "memory");
 }
 
 inline uint64_t rdmsr(uint32_t index) {
 	uint32_t low, high;
-	asm volatile ( "rdmsr" : "=a" (low), "=d" (high)
-			: "c" (index) : "memory" );
+	asm volatile("rdmsr" : "=a"(low), "=d"(high) : "c"(index) : "memory");
 	return ((uint64_t)high << 32) | (uint64_t)low;
 }
 
-inline void wrxcr(uint32_t index, uint64_t value){
+inline void wrxcr(uint32_t index, uint64_t value) {
 	uint32_t low = value;
 	uint32_t high = value >> 32;
-	asm volatile ( "xsetbv" : : "c" (index),
-			"a" (low), "d" (high) : "memory" );
+	asm volatile("xsetbv" : : "c"(index), "a"(low), "d"(high) : "memory");
 }
 
 inline uint64_t rdxcr(uint32_t index) {
 	uint32_t low, high;
-	asm volatile ( "xgetbv" : "=a" (low), "=d" (high)
-			: "c" (index) : "memory" );
+	asm volatile("xgetbv" : "=a"(low), "=d"(high) : "c"(index) : "memory");
 	return ((uint64_t)high << 32) | (uint64_t)low;
 }
 
 inline uint8_t ioInByte(uint16_t port) {
 	register uint16_t in_port asm("dx") = port;
 	register uint8_t out_value asm("al");
-	asm volatile ( "inb %%dx, %%al" : "=r" (out_value) : "r" (in_port) );
+	asm volatile("inb %%dx, %%al" : "=r"(out_value) : "r"(in_port));
 	return out_value;
 }
 
 inline uint16_t ioInShort(uint16_t port) {
 	register uint16_t in_port asm("dx") = port;
 	register uint16_t out_value asm("ax");
-	asm volatile ( "inw %%dx, %%ax" : "=r" (out_value) : "r" (in_port) );
+	asm volatile("inw %%dx, %%ax" : "=r"(out_value) : "r"(in_port));
 	return out_value;
 }
 
 inline void ioPeekMultiple(uint16_t port, uint16_t *dest, size_t count) {
-	asm volatile ( "cld\n"
-			"\trep insw" : : "d" (port), "D" (dest), "c" (count) );
+	asm volatile("cld\n"
+	             "\trep insw"
+	             :
+	             : "d"(port), "D"(dest), "c"(count));
 }
 
 inline void ioOutByte(uint16_t port, uint8_t value) {
 	register uint16_t in_port asm("dx") = port;
 	register uint8_t in_value asm("al") = value;
-	asm volatile ( "outb %%al, %%dx" : : "r" (in_port), "r" (in_value) );
+	asm volatile("outb %%al, %%dx" : : "r"(in_port), "r"(in_value));
 }
 
 } // namespace common::x86

--- a/kernel/common/x86/tss.hpp
+++ b/kernel/common/x86/tss.hpp
@@ -21,12 +21,12 @@ struct Tss64 {
 	uint16_t ioMapOffset;
 	uint8_t ioBitmap[8192];
 	uint8_t ioAllOnes;
-} __attribute__ (( packed ));
+} __attribute__((packed));
 
 inline void initializeTss64(Tss64 *tss) {
 	tss->ioMapOffset = __builtin_offsetof(Tss64, ioBitmap);
 
-	for(int i = 0; i < 8192; i++)
+	for (int i = 0; i < 8192; i++)
 		tss->ioBitmap[i] = 0xFF;
 	tss->ioAllOnes = 0xFF;
 }

--- a/kernel/eir/arch/arm/arch.cpp
+++ b/kernel/eir/arch/arm/arch.cpp
@@ -1,7 +1,7 @@
-#include <eir-internal/arch.hpp>
-#include <eir-internal/generic.hpp>
-#include <eir-internal/debug.hpp>
 #include <assert.h>
+#include <eir-internal/arch.hpp>
+#include <eir-internal/debug.hpp>
+#include <eir-internal/generic.hpp>
 
 namespace eir {
 
@@ -31,8 +31,8 @@ static inline constexpr uint64_t kPageWb = (0 << 2);
 static inline constexpr uint64_t kPageGRE = (1 << 2);
 static inline constexpr uint64_t kPagenGnRnE = (2 << 2);
 
-void mapSingle4kPage(address_t address, address_t physical, uint32_t flags,
-		CachingMode caching_mode) {
+void
+mapSingle4kPage(address_t address, address_t physical, uint32_t flags, CachingMode caching_mode) {
 	auto ttbr = (address >> 63) & 1;
 	auto l0 = (address >> 39) & 0x1FF;
 	auto l1 = (address >> 30) & 0x1FF;
@@ -44,11 +44,10 @@ void mapSingle4kPage(address_t address, address_t physical, uint32_t flags,
 	if (!(l0_ent & kPageValid)) {
 		uint64_t addr = allocPage();
 
-		for(int i = 0; i < 512; i++)
+		for (int i = 0; i < 512; i++)
 			((uint64_t *)addr)[i] = 0;
 
-		((uint64_t *)eirTTBR[ttbr])[l0] =
-			addr | kPageValid | kPageTable;
+		((uint64_t *)eirTTBR[ttbr])[l0] = addr | kPageValid | kPageTable;
 
 		l1_ptr = addr;
 	}
@@ -58,11 +57,10 @@ void mapSingle4kPage(address_t address, address_t physical, uint32_t flags,
 	if (!(l1_ent & kPageValid)) {
 		uint64_t addr = allocPage();
 
-		for(int i = 0; i < 512; i++)
+		for (int i = 0; i < 512; i++)
 			((uint64_t *)addr)[i] = 0;
 
-		((uint64_t *)l1_ptr)[l1] =
-			addr | kPageValid | kPageTable;
+		((uint64_t *)l1_ptr)[l1] = addr | kPageValid | kPageTable;
 
 		l2_ptr = addr;
 	}
@@ -72,11 +70,10 @@ void mapSingle4kPage(address_t address, address_t physical, uint32_t flags,
 	if (!(l2_ent & kPageValid)) {
 		uint64_t addr = allocPage();
 
-		for(int i = 0; i < 512; i++)
+		for (int i = 0; i < 512; i++)
 			((uint64_t *)addr)[i] = 0;
 
-		((uint64_t *)l2_ptr)[l2] =
-			addr | kPageValid | kPageTable;
+		((uint64_t *)l2_ptr)[l2] = addr | kPageValid | kPageTable;
 
 		l3_ptr = addr;
 	}
@@ -84,8 +81,8 @@ void mapSingle4kPage(address_t address, address_t physical, uint32_t flags,
 	auto l3_ent = ((uint64_t *)l3_ptr)[l3];
 
 	if (l3_ent & kPageValid)
-		eir::panicLogger() << "eir: Trying to map 0x" << frg::hex_fmt{address}
-				<< " twice!" << frg::endlog;
+		eir::panicLogger() << "eir: Trying to map 0x" << frg::hex_fmt{address} << " twice!"
+		                   << frg::endlog;
 
 	uint64_t new_entry = physical | kPageValid | kPageL3Page | kPageAccess;
 
@@ -106,9 +103,8 @@ void mapSingle4kPage(address_t address, address_t physical, uint32_t flags,
 	}
 
 	if (new_entry & (0b111ULL << 48)) {
-		eir::infoLogger() << "Oops, reserved bits set when mapping 0x"
-			<< frg::hex_fmt{physical} << " to 0x" << frg::hex_fmt{address}
-			<< frg::endlog;
+		eir::infoLogger() << "Oops, reserved bits set when mapping 0x" << frg::hex_fmt{physical}
+		                  << " to 0x" << frg::hex_fmt{address} << frg::endlog;
 
 		eir::panicLogger() << "New entry value: 0x" << frg::hex_fmt{new_entry} << frg::endlog;
 	}
@@ -150,52 +146,54 @@ void initProcessorEarly() {
 	eir::infoLogger() << "Starting Eir" << frg::endlog;
 
 	uint64_t aa64mmfr0;
-	asm volatile ("mrs %0, id_aa64mmfr0_el1" : "=r" (aa64mmfr0));
+	asm volatile("mrs %0, id_aa64mmfr0_el1" : "=r"(aa64mmfr0));
 
 	if (aa64mmfr0 & (0xF << 28))
-		eir::panicLogger() << "PANIC! This CPU doesn't support 4K memory translation granules" << frg::endlog;
+		eir::panicLogger() << "PANIC! This CPU doesn't support 4K memory translation granules"
+		                   << frg::endlog;
 
 	if ((aa64mmfr0 & 0xF) < 1)
-		eir::panicLogger() << "PANIC! This CPU doesn't support at least 48 bit physical addresses (max "
-			<< (aa64mmfr0 & 0xF) << ")" << frg::endlog;
+		eir::panicLogger(
+		) << "PANIC! This CPU doesn't support at least 48 bit physical addresses (max "
+		  << (aa64mmfr0 & 0xF) << ")" << frg::endlog;
 
 	auto pa = frg::min(uint64_t(5), aa64mmfr0 & 0xF);
 
-	uint64_t mair =
-		0b11111111 | // Normal, Write-back RW-Allocate non-transient
-		(0b00001100 << 8) | // Device, GRE
-		(0b00000000 << 16)| // Device, nGnRnE
-		(0b00000100 << 24)| // Device, nGnRE
-		(0b01000100UL << 32); // Normal Non-cacheable
+	uint64_t mair = 0b11111111 |          // Normal, Write-back RW-Allocate non-transient
+	                (0b00001100 << 8) |   // Device, GRE
+	                (0b00000000 << 16) |  // Device, nGnRnE
+	                (0b00000100 << 24) |  // Device, nGnRE
+	                (0b01000100UL << 32); // Normal Non-cacheable
 
-	asm volatile ("msr mair_el1, %0" :: "r" (mair));
+	asm volatile("msr mair_el1, %0" ::"r"(mair));
 
-	uint64_t tcr =
-		(16 << 0) | // T0SZ=16
-		(16 << 16) | // T1SZ=16
-		(1 << 8) | // TTBR0 Inner WB RW-Allocate
-		(1 << 10) | // TTBR0 Outer WB RW-Allocate
-		(1 << 24) | // TTBR1 Inner WB RW-Allocate
-		(1 << 26) | // TTBR1 Outer WB RW-Allocate
-		(2 << 12) | // TTBR0 Inner shareable
-		(2 << 28) | // TTBR1 Inner shareable
-		(uint64_t(pa) << 32) | // 48-bit intermediate address
-		(uint64_t(2) << 30); // TTBR1 4K granule
+	uint64_t tcr = (16 << 0) |            // T0SZ=16
+	               (16 << 16) |           // T1SZ=16
+	               (1 << 8) |             // TTBR0 Inner WB RW-Allocate
+	               (1 << 10) |            // TTBR0 Outer WB RW-Allocate
+	               (1 << 24) |            // TTBR1 Inner WB RW-Allocate
+	               (1 << 26) |            // TTBR1 Outer WB RW-Allocate
+	               (2 << 12) |            // TTBR0 Inner shareable
+	               (2 << 28) |            // TTBR1 Inner shareable
+	               (uint64_t(pa) << 32) | // 48-bit intermediate address
+	               (uint64_t(2) << 30);   // TTBR1 4K granule
 
-	asm volatile ("msr tcr_el1, %0" :: "r" (tcr));
+	asm volatile("msr tcr_el1, %0" ::"r"(tcr));
 }
 
 // Returns Core region index
 void initProcessorPaging(void *kernel_start, uint64_t &kernel_entry) {
 	setupPaging();
-	eir::infoLogger() << "eir: Allocated " << (allocatedMemory >> 10) << " KiB"
-			" after setting up paging" << frg::endlog;
+	eir::infoLogger() << "eir: Allocated " << (allocatedMemory >> 10)
+	                  << " KiB"
+	                     " after setting up paging"
+	                  << frg::endlog;
 
 	// Identically map the first 128 MiB so that we can activate paging
 	// without causing a page fault.
 	auto floor = reinterpret_cast<address_t>(&eirImageFloor) & ~address_t{0xFFF};
 	auto ceiling = (reinterpret_cast<address_t>(&eirImageCeiling) + 0xFFF) & ~address_t{0xFFF};
-	for(address_t addr = floor; addr < ceiling; addr += 0x1000)
+	for (address_t addr = floor; addr < ceiling; addr += 0x1000)
 		mapSingle4kPage(addr, addr, PageFlags::write | PageFlags::execute);
 
 	mapRegionsAndStructs();
@@ -205,11 +203,13 @@ void initProcessorPaging(void *kernel_start, uint64_t &kernel_entry) {
 
 	// Setup the kernel image.
 	kernel_entry = loadKernelImage(kernel_start);
-	eir::infoLogger() << "eir: Allocated " << (allocatedMemory >> 10) << " KiB"
-			" after loading the kernel" << frg::endlog;
+	eir::infoLogger() << "eir: Allocated " << (allocatedMemory >> 10)
+	                  << " KiB"
+	                     " after loading the kernel"
+	                  << frg::endlog;
 
 	// Setup the kernel stack.
-	for(address_t page = 0; page < 0x10000; page += pageSize)
+	for (address_t page = 0; page < 0x10000; page += pageSize)
 		mapSingle4kPage(0xFFFF'FE80'0000'0000 + page, allocPage(), PageFlags::write);
 	mapKasanShadow(0xFFFF'FE80'0000'0000, 0x10000);
 	unpoisonKasanShadow(0xFFFF'FE80'0000'0000, 0x10000);

--- a/kernel/eir/arch/arm/eir-internal/arch/pl011.hpp
+++ b/kernel/eir/arch/arm/eir-internal/arch/pl011.hpp
@@ -1,43 +1,40 @@
 #pragma once
 
-#include <stdint.h>
 #include <arch/mem_space.hpp>
 #include <arch/register.hpp>
+#include <stdint.h>
 
 namespace eir {
 
 namespace pl011_reg {
-	static constexpr arch::scalar_register<uint32_t> data{0x00};
-	static constexpr arch::bit_register<uint32_t> status{0x18};
-	static constexpr arch::scalar_register<uint32_t> i_baud{0x24};
-	static constexpr arch::scalar_register<uint32_t> f_baud{0x28};
-	static constexpr arch::bit_register<uint32_t> control{0x30};
-	static constexpr arch::bit_register<uint32_t> line_control{0x2c};
-	static constexpr arch::scalar_register<uint32_t> int_clear{0x44};
-}
+static constexpr arch::scalar_register<uint32_t> data{0x00};
+static constexpr arch::bit_register<uint32_t> status{0x18};
+static constexpr arch::scalar_register<uint32_t> i_baud{0x24};
+static constexpr arch::scalar_register<uint32_t> f_baud{0x28};
+static constexpr arch::bit_register<uint32_t> control{0x30};
+static constexpr arch::bit_register<uint32_t> line_control{0x2c};
+static constexpr arch::scalar_register<uint32_t> int_clear{0x44};
+} // namespace pl011_reg
 
 namespace pl011_status {
-	static constexpr arch::field<uint32_t, bool> tx_full{5, 1};
+static constexpr arch::field<uint32_t, bool> tx_full{5, 1};
 };
 
 namespace pl011_control {
-	static constexpr arch::field<uint32_t, bool> rx_en{9, 1};
-	static constexpr arch::field<uint32_t, bool> tx_en{8, 1};
-	static constexpr arch::field<uint32_t, bool> uart_en{0, 1};
-};
+static constexpr arch::field<uint32_t, bool> rx_en{9, 1};
+static constexpr arch::field<uint32_t, bool> tx_en{8, 1};
+static constexpr arch::field<uint32_t, bool> uart_en{0, 1};
+}; // namespace pl011_control
 
 namespace pl011_line_control {
-	static constexpr arch::field<uint32_t, uint8_t> word_len{5, 2};
-	static constexpr arch::field<uint32_t, bool> fifo_en{4, 1};
-}
+static constexpr arch::field<uint32_t, uint8_t> word_len{5, 2};
+static constexpr arch::field<uint32_t, bool> fifo_en{4, 1};
+} // namespace pl011_line_control
 
 struct PL011 {
-	PL011(uintptr_t base, uint64_t clock)
-	: space_{base}, clock_{clock} { }
+	PL011(uintptr_t base, uint64_t clock) : space_{base}, clock_{clock} {}
 
-	void disable() {
-		space_.store(pl011_reg::control, pl011_control::uart_en(false));
-	}
+	void disable() { space_.store(pl011_reg::control, pl011_control::uart_en(false)); }
 
 	void init(uint64_t baud) {
 		disable();
@@ -45,20 +42,21 @@ struct PL011 {
 		uint64_t int_part = clock_ / (16 * baud);
 
 		// 3 decimal places of precision should be enough :^)
-		uint64_t frac_part = (((clock_ * 1000) / (16 * baud) - (int_part * 1000))
-			* 64 + 500) / 1000;
+		uint64_t frac_part =
+		    (((clock_ * 1000) / (16 * baud) - (int_part * 1000)) * 64 + 500) / 1000;
 
 		space_.store(pl011_reg::i_baud, int_part);
 		space_.store(pl011_reg::f_baud, frac_part);
 
 		// 8n1, fifo enabled
-		space_.store(pl011_reg::line_control,
-				pl011_line_control::word_len(3)
-				| pl011_line_control::fifo_en(true));
-		space_.store(pl011_reg::control,
-				pl011_control::rx_en(true)
-				| pl011_control::tx_en(true)
-				| pl011_control::uart_en(true));
+		space_.store(
+		    pl011_reg::line_control,
+		    pl011_line_control::word_len(3) | pl011_line_control::fifo_en(true)
+		);
+		space_.store(
+		    pl011_reg::control,
+		    pl011_control::rx_en(true) | pl011_control::tx_en(true) | pl011_control::uart_en(true)
+		);
 	}
 
 	void send(uint8_t val) {

--- a/kernel/eir/arch/arm/eir-internal/arch/types.hpp
+++ b/kernel/eir/arch/arm/eir-internal/arch/types.hpp
@@ -9,7 +9,7 @@ using physaddr_t = uint64_t;
 
 extern uintptr_t eirTTBR[2];
 
-extern "C" void eirEnterKernel(uintptr_t ttbr0, uintptr_t ttbr1, uint64_t entry, uint64_t stack, uintptr_t eirInfo);
+extern "C" void
+eirEnterKernel(uintptr_t ttbr0, uintptr_t ttbr1, uint64_t entry, uint64_t stack, uintptr_t eirInfo);
 
 } // namespace eir
-

--- a/kernel/eir/arch/arm/fault.cpp
+++ b/kernel/eir/arch/arm/fault.cpp
@@ -1,14 +1,10 @@
 #include <eir-internal/debug.hpp>
 
-enum class IntrType {
-	synchronous,
-	irq,
-	fiq,
-	serror
-};
+enum class IntrType { synchronous, irq, fiq, serror };
 
-extern "C" void eirExceptionHandler(IntrType i_type, uintptr_t syndrome, uintptr_t link,
-		uintptr_t state, uintptr_t fault_addr) {
+extern "C" void eirExceptionHandler(
+    IntrType i_type, uintptr_t syndrome, uintptr_t link, uintptr_t state, uintptr_t fault_addr
+) {
 	eir::infoLogger() << "An unexpected fault has occured:" << frg::endlog;
 
 	const char *i_type_str = "Unknown";
@@ -32,39 +28,68 @@ extern "C" void eirExceptionHandler(IntrType i_type, uintptr_t syndrome, uintptr
 	auto exc_type = syndrome >> 26;
 	const char *exc_type_str = "Unknown";
 	switch (exc_type) {
-		case 0x01: exc_type_str = "Trapped WFI/WFE"; break;
-		case 0x0e: exc_type_str = "Illegal execution"; break;
-		case 0x15: exc_type_str = "System call"; break;
-		case 0x20: exc_type_str = "Instruction abort, lower EL"; break;
-		case 0x21: exc_type_str = "Instruction abort, same EL"; break;
-		case 0x22: exc_type_str = "Instruction alignment fault"; break;
-		case 0x24: exc_type_str = "Data abort, lower EL"; break;
-		case 0x25: exc_type_str = "Data abort, same EL"; break;
-		case 0x26: exc_type_str = "Stack alignment fault"; break;
-		case 0x2c: exc_type_str = "Floating point"; break;
+		case 0x01:
+			exc_type_str = "Trapped WFI/WFE";
+			break;
+		case 0x0e:
+			exc_type_str = "Illegal execution";
+			break;
+		case 0x15:
+			exc_type_str = "System call";
+			break;
+		case 0x20:
+			exc_type_str = "Instruction abort, lower EL";
+			break;
+		case 0x21:
+			exc_type_str = "Instruction abort, same EL";
+			break;
+		case 0x22:
+			exc_type_str = "Instruction alignment fault";
+			break;
+		case 0x24:
+			exc_type_str = "Data abort, lower EL";
+			break;
+		case 0x25:
+			exc_type_str = "Data abort, same EL";
+			break;
+		case 0x26:
+			exc_type_str = "Stack alignment fault";
+			break;
+		case 0x2c:
+			exc_type_str = "Floating point";
+			break;
 	}
 
-	eir::infoLogger() << "Exception type: " << exc_type_str << " (" << (void *)exc_type << ")" << frg::endlog;
+	eir::infoLogger() << "Exception type: " << exc_type_str << " (" << (void *)exc_type << ")"
+	                  << frg::endlog;
 
 	auto iss = syndrome & ((1 << 25) - 1);
 
 	if (exc_type == 0x25 || exc_type == 0x24) {
 		constexpr const char *sas_values[4] = {"Byte", "Halfword", "Word", "Doubleword"};
-		constexpr const char *set_values[4] = {"Recoverable", "Uncontainable", "Reserved", "Restartable/Corrected"};
-		constexpr const char *dfsc_values[4] = {"Address size", "Translation", "Access flag", "Permission"};
+		constexpr const char *set_values[4] = {
+		    "Recoverable", "Uncontainable", "Reserved", "Restartable/Corrected"
+		};
+		constexpr const char *dfsc_values[4] = {
+		    "Address size", "Translation", "Access flag", "Permission"
+		};
 		eir::infoLogger() << "Access size: " << sas_values[(iss >> 22) & 3] << frg::endlog;
 		eir::infoLogger() << "Sign extended? " << (iss & (1 << 21) ? "Yes" : "No") << frg::endlog;
 		eir::infoLogger() << "Sixty-Four? " << (iss & (1 << 15) ? "Yes" : "No") << frg::endlog;
 		eir::infoLogger() << "Acquire/Release? " << (iss & (1 << 14) ? "Yes" : "No") << frg::endlog;
 		eir::infoLogger() << "Synch error type: " << set_values[(iss >> 11) & 3] << frg::endlog;
-		eir::infoLogger() << "Fault address valid? " << (iss & (1 << 10) ? "No" : "Yes") << frg::endlog;
-		eir::infoLogger() << "Cache maintenance? " << (iss & (1 << 8) ? "Yes" : "No") << frg::endlog;
+		eir::infoLogger() << "Fault address valid? " << (iss & (1 << 10) ? "No" : "Yes")
+		                  << frg::endlog;
+		eir::infoLogger() << "Cache maintenance? " << (iss & (1 << 8) ? "Yes" : "No")
+		                  << frg::endlog;
 		eir::infoLogger() << "S1PTW? " << (iss & (1 << 7) ? "Yes" : "No") << frg::endlog;
 		eir::infoLogger() << "Access type: " << (iss & (1 << 6) ? "Write" : "Read") << frg::endlog;
 		if ((iss & 0b111111) <= 0b001111)
-			eir::infoLogger() << "Data fault status code: " << dfsc_values[(iss >> 2) & 4] << " fault level " << (iss & 3) << frg::endlog;
+			eir::infoLogger() << "Data fault status code: " << dfsc_values[(iss >> 2) & 4]
+			                  << " fault level " << (iss & 3) << frg::endlog;
 		else if ((iss & 0b111111) == 0b10000)
-			eir::infoLogger() << "Data fault status code: Synchronous external fault" << frg::endlog;
+			eir::infoLogger() << "Data fault status code: Synchronous external fault"
+			                  << frg::endlog;
 		else if ((iss & 0b111111) == 0b100001)
 			eir::infoLogger() << "Data fault status code: Alignment fault" << frg::endlog;
 		else if ((iss & 0b111111) == 0b110000)
@@ -74,10 +99,10 @@ extern "C" void eirExceptionHandler(IntrType i_type, uintptr_t syndrome, uintptr
 	}
 
 	eir::infoLogger() << "IP: " << (void *)link << ", State: " << (void *)state << frg::endlog;
-	eir::infoLogger() << "Syndrome: " << (void *)syndrome << ", Fault address: " << (void *)fault_addr << frg::endlog;
+	eir::infoLogger() << "Syndrome: " << (void *)syndrome
+	                  << ", Fault address: " << (void *)fault_addr << frg::endlog;
 	eir::infoLogger() << "Halting..." << frg::endlog;
 
-	while(1)
-		asm volatile ("wfi");
+	while (1)
+		asm volatile("wfi");
 }
-

--- a/kernel/eir/arch/arm/generic.cpp
+++ b/kernel/eir/arch/arm/generic.cpp
@@ -1,8 +1,8 @@
 #include <dtb.hpp>
-#include <elf.h>
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
+#include <elf.h>
 
 namespace eir {
 
@@ -15,20 +15,20 @@ void eirRelocate() {
 	uintptr_t relaAddr = 0;
 	uintptr_t relaSize = 0;
 
-	for(auto *dyn = _DYNAMIC; dyn->d_tag != DT_NULL; ++dyn) {
-		switch(dyn->d_tag) {
-		case DT_RELA:
-			relaAddr = dyn->d_ptr + base;
-			break;
-		case DT_RELASZ:
-			relaSize = dyn->d_val;
-			break;
-		default:
-			break;
+	for (auto *dyn = _DYNAMIC; dyn->d_tag != DT_NULL; ++dyn) {
+		switch (dyn->d_tag) {
+			case DT_RELA:
+				relaAddr = dyn->d_ptr + base;
+				break;
+			case DT_RELASZ:
+				relaSize = dyn->d_val;
+				break;
+			default:
+				break;
 		}
 	}
 
-	for(uintptr_t i = 0; i < relaSize; i += sizeof(Elf64_Rela)) {
+	for (uintptr_t i = 0; i < relaSize; i += sizeof(Elf64_Rela)) {
 		auto *rela = reinterpret_cast<const Elf64_Rela *>(relaAddr + i);
 		assert(ELF64_R_TYPE(rela->r_info) == R_AARCH64_RELATIVE);
 		*reinterpret_cast<Elf64_Addr *>(rela->r_offset + base) = base + rela->r_addend;
@@ -55,36 +55,36 @@ void eirRelocate() {
 	size_t nMemoryNodes = 0;
 
 	dt.rootNode().discoverSubnodes(
-		[](DeviceTreeNode &node) {
-			return !memcmp("memory", node.name(), 6)
-				|| !memcmp("chosen", node.name(), 7)
-				|| !memcmp("reserved-memory", node.name(), 15);
-		},
-		[&](DeviceTreeNode node) {
-			if(!memcmp("chosen", node.name(), 7)) {
-				assert(!hasChosenNode);
+	    [](DeviceTreeNode &node) {
+		    return !memcmp("memory", node.name(), 6) || !memcmp("chosen", node.name(), 7)
+		           || !memcmp("reserved-memory", node.name(), 15);
+	    },
+	    [&](DeviceTreeNode node) {
+		    if (!memcmp("chosen", node.name(), 7)) {
+			    assert(!hasChosenNode);
 
-				chosenNode = node;
-				hasChosenNode = true;
-			} else if(!memcmp("reserved-memory", node.name(), 15)) {
-				assert(!hasReservedMemoryNode);
+			    chosenNode = node;
+			    hasChosenNode = true;
+		    } else if (!memcmp("reserved-memory", node.name(), 15)) {
+			    assert(!hasReservedMemoryNode);
 
-				reservedMemoryNode = node;
-				hasReservedMemoryNode = true;
-			} else {
-				assert(nMemoryNodes < 32);
+			    reservedMemoryNode = node;
+			    hasReservedMemoryNode = true;
+		    } else {
+			    assert(nMemoryNodes < 32);
 
-				memoryNodes[nMemoryNodes++] = node;
-			}
-			infoLogger() << "Node \"" << node.name() << "\" discovered" << frg::endlog;
-		});
+			    memoryNodes[nMemoryNodes++] = node;
+		    }
+		    infoLogger() << "Node \"" << node.name() << "\" discovered" << frg::endlog;
+	    }
+	);
 
 	uint32_t addressCells = 2, sizeCells = 1;
 
-	for(auto prop : dt.rootNode().properties()) {
-		if(!memcmp("#address-cells", prop.name(), 15)) {
+	for (auto prop : dt.rootNode().properties()) {
+		if (!memcmp("#address-cells", prop.name(), 15)) {
 			addressCells = prop.asU32();
-		} else if(!memcmp("#size-cells", prop.name(), 12)) {
+		} else if (!memcmp("#size-cells", prop.name(), 12)) {
 			sizeCells = prop.asU32();
 		}
 	}
@@ -101,47 +101,46 @@ void eirRelocate() {
 		reservedRegions[nReservedRegions++] = {base, size};
 	};
 
-	for(auto ent : dt.memoryReservations()) {
-		eir::infoLogger() << "At 0x" << frg::hex_fmt{ent.address}
-			<< ", ends at 0x" << frg::hex_fmt{ent.address + ent.size}
-			<< " (0x" << frg::hex_fmt{ent.size} << " bytes)" << frg::endlog;
+	for (auto ent : dt.memoryReservations()) {
+		eir::infoLogger() << "At 0x" << frg::hex_fmt{ent.address} << ", ends at 0x"
+		                  << frg::hex_fmt{ent.address + ent.size} << " (0x"
+		                  << frg::hex_fmt{ent.size} << " bytes)" << frg::endlog;
 		addReservedRegion(ent.address, ent.size);
 	}
 
-	if(hasReservedMemoryNode) {
+	if (hasReservedMemoryNode) {
 		// reserved-memory should have same address-cells and size-cells as the root node.
-		for(auto prop : reservedMemoryNode.properties()) {
-			if(!memcmp("#address-cells", prop.name(), 15)) {
+		for (auto prop : reservedMemoryNode.properties()) {
+			if (!memcmp("#address-cells", prop.name(), 15)) {
 				assert(prop.asU32() == addressCells);
-			} else if(!memcmp("#size-cells", prop.name(), 12)) {
+			} else if (!memcmp("#size-cells", prop.name(), 12)) {
 				assert(prop.asU32() == sizeCells);
 			}
 		}
 
 		reservedMemoryNode.discoverSubnodes(
-			[](DeviceTreeNode &) {
-				return true;
-			},
-			[&](DeviceTreeNode node) {
-			auto reg = node.findProperty("reg");
-			if(!reg) {
-				return;
-			}
+		    [](DeviceTreeNode &) { return true; },
+		    [&](DeviceTreeNode node) {
+			    auto reg = node.findProperty("reg");
+			    if (!reg) {
+				    return;
+			    }
 
-			size_t i = 0;
-			while(i < reg->size()) {
-				auto base = reg->asPropArrayEntry(addressCells, i);
-				i += addressCells * 4;
+			    size_t i = 0;
+			    while (i < reg->size()) {
+				    auto base = reg->asPropArrayEntry(addressCells, i);
+				    i += addressCells * 4;
 
-				auto size = reg->asPropArrayEntry(sizeCells, i);
-				i += sizeCells * 4;
+				    auto size = reg->asPropArrayEntry(sizeCells, i);
+				    i += sizeCells * 4;
 
-				eir::infoLogger() << "At 0x" << frg::hex_fmt{base}
-					<< ", ends at 0x" << frg::hex_fmt{base + size}
-					<< " (0x" << frg::hex_fmt{size} << " bytes)" << frg::endlog;
-				addReservedRegion(base, size);
-			}
-		});
+				    eir::infoLogger() << "At 0x" << frg::hex_fmt{base} << ", ends at 0x"
+				                      << frg::hex_fmt{base + size} << " (0x" << frg::hex_fmt{size}
+				                      << " bytes)" << frg::endlog;
+				    addReservedRegion(base, size);
+			    }
+		    }
+		);
 	}
 
 	eir::infoLogger() << "End of memory reservation entries" << frg::endlog;
@@ -151,7 +150,7 @@ void eirRelocate() {
 	addReservedRegion(eirStart, eirEnd - eirStart);
 
 	uintptr_t initrd = 0;
-	if(auto p = chosenNode.findProperty("linux,initrd-start"); p) {
+	if (auto p = chosenNode.findProperty("linux,initrd-start"); p) {
 		if (p->size() == 4)
 			initrd = p->asU32();
 		else if (p->size() == 8)
@@ -170,12 +169,12 @@ void eirRelocate() {
 	addReservedRegion(initrd, initrd_image.size());
 	addReservedRegion(genericInfo.deviceTreePtr, dt.size());
 
-	for(size_t i = 0; i < nMemoryNodes; i++) {
+	for (size_t i = 0; i < nMemoryNodes; i++) {
 		auto reg = memoryNodes[i].findProperty("reg");
 		assert(reg);
 
 		size_t j = 0;
-		while(j < reg->size()) {
+		while (j < reg->size()) {
 			auto base = reg->asPropArrayEntry(addressCells, j);
 			j += addressCells * 4;
 
@@ -189,25 +188,25 @@ void eirRelocate() {
 	setupRegionStructs();
 
 	eir::infoLogger() << "Kernel memory regions:" << frg::endlog;
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType == RegionType::null)
+	for (size_t i = 0; i < numRegions; ++i) {
+		if (regions[i].regionType == RegionType::null)
 			continue;
 		eir::infoLogger() << "    Memory region [" << i << "]."
-				<< " Base: 0x" << frg::hex_fmt{regions[i].address}
-				<< ", length: 0x" << frg::hex_fmt{regions[i].size} << frg::endlog;
-		if(regions[i].regionType == RegionType::allocatable)
+		                  << " Base: 0x" << frg::hex_fmt{regions[i].address} << ", length: 0x"
+		                  << frg::hex_fmt{regions[i].size} << frg::endlog;
+		if (regions[i].regionType == RegionType::allocatable)
 			eir::infoLogger() << "        Buddy tree at 0x" << frg::hex_fmt{regions[i].buddyTree}
-					<< ", overhead: 0x" << frg::hex_fmt{regions[i].buddyOverhead}
-					<< frg::endlog;
+			                  << ", overhead: 0x" << frg::hex_fmt{regions[i].buddyOverhead}
+			                  << frg::endlog;
 	}
 
 	uint64_t kernel_entry = 0;
 	initProcessorPaging(kernel_image.data(), kernel_entry);
 
 	const char *cmdline = "";
-	if(genericInfo.cmdline) {
+	if (genericInfo.cmdline) {
 		cmdline = genericInfo.cmdline;
-	} else if(auto p = chosenNode.findProperty("bootargs"); p) {
+	} else if (auto p = chosenNode.findProperty("bootargs"); p) {
 		cmdline = static_cast<const char *>(p->data());
 	}
 
@@ -227,14 +226,18 @@ void eirRelocate() {
 	info_ptr->dtbPtr = genericInfo.deviceTreePtr;
 	info_ptr->dtbSize = dt.size();
 
-	if(genericInfo.hasFb) {
+	if (genericInfo.hasFb) {
 		info_ptr->frameBuffer = genericInfo.fb;
 		assert(genericInfo.fb.fbAddress & ~(pageSize - 1));
 		size_t fbSize = genericInfo.fb.fbPitch * genericInfo.fb.fbHeight;
 
-		for(address_t pg = 0; pg < fbSize; pg += 0x1000)
-			mapSingle4kPage(0xFFFF'FE00'4000'0000 + pg, genericInfo.fb.fbAddress + pg,
-					PageFlags::write, CachingMode::writeCombine);
+		for (address_t pg = 0; pg < fbSize; pg += 0x1000)
+			mapSingle4kPage(
+			    0xFFFF'FE00'4000'0000 + pg,
+			    genericInfo.fb.fbAddress + pg,
+			    PageFlags::write,
+			    CachingMode::writeCombine
+			);
 
 		mapKasanShadow(0xFFFF'FE00'4000'0000, fbSize);
 		unpoisonKasanShadow(0xFFFF'FE00'4000'0000, fbSize);
@@ -243,17 +246,17 @@ void eirRelocate() {
 
 	info_ptr->debugFlags = genericInfo.debugFlags;
 
-	mapSingle4kPage(0xFFFF'0000'0000'0000, 0x9000000,
-			PageFlags::write, CachingMode::mmio);
+	mapSingle4kPage(0xFFFF'0000'0000'0000, 0x9000000, PageFlags::write, CachingMode::mmio);
 	mapKasanShadow(0xFFFF'0000'0000'0000, 0x1000);
 	unpoisonKasanShadow(0xFFFF'0000'0000'0000, 0x1000);
 
 	eir::infoLogger() << "Leaving Eir and entering the real kernel" << frg::endlog;
 
-	eirEnterKernel(eirTTBR[0] + 1, eirTTBR[1] + 1, kernel_entry,
-			0xFFFF'FE80'0001'0000, 0xFFFF'FE80'0001'0000);
+	eirEnterKernel(
+	    eirTTBR[0] + 1, eirTTBR[1] + 1, kernel_entry, 0xFFFF'FE80'0001'0000, 0xFFFF'FE80'0001'0000
+	);
 
-	while(true) {
+	while (true) {
 		asm volatile("" : : : "memory");
 	}
 }

--- a/kernel/eir/arch/arm/raspi4/raspi4.cpp
+++ b/kernel/eir/arch/arm/raspi4/raspi4.cpp
@@ -1,15 +1,15 @@
-#include <stdint.h>
 #include <assert.h>
-#include <eir-internal/debug.hpp>
-#include <eir/interface.hpp>
-#include <render-text.hpp>
 #include <dtb.hpp>
+#include <eir-internal/arch.hpp>
+#include <eir-internal/arch/pl011.hpp>
+#include <eir-internal/debug.hpp>
+#include <eir-internal/generic.hpp>
+#include <eir/interface.hpp>
 #include <frg/eternal.hpp> // for aligned_storage
 #include <frg/manual_box.hpp>
 #include <frg/tuple.hpp>
-#include <eir-internal/arch/pl011.hpp>
-#include <eir-internal/arch.hpp>
-#include <eir-internal/generic.hpp>
+#include <render-text.hpp>
+#include <stdint.h>
 
 #include <arch/aarch64/mem_space.hpp>
 #include <arch/register.hpp>
@@ -17,230 +17,222 @@
 #include <arch/bit.hpp>
 #include <arch/variable.hpp>
 
-//#define RASPI3
-//#define LOW_PERIPH
+// #define RASPI3
+// #define LOW_PERIPH
 
 namespace eir {
 
 #if defined(RASPI3)
 static constexpr inline uintptr_t mmioBase = 0x3f000000;
-#elif defined (LOW_PERIPH)
+#elif defined(LOW_PERIPH)
 static constexpr inline uintptr_t mmioBase = 0xfe000000;
 #else
 static constexpr inline uintptr_t mmioBase = 0x47e000000;
 #endif
 
 namespace Gpio {
-	namespace reg {
-		static constexpr arch::bit_register<uint32_t> sel1{0x04};
-		static constexpr arch::bit_register<uint32_t> pup_pdn0{0xE4};
-	}
+namespace reg {
+static constexpr arch::bit_register<uint32_t> sel1{0x04};
+static constexpr arch::bit_register<uint32_t> pup_pdn0{0xE4};
+} // namespace reg
 
-	static constexpr arch::mem_space space{mmioBase + 0x200000};
+static constexpr arch::mem_space space{mmioBase + 0x200000};
 
-	void configUart0Gpio() {
-		arch::field<uint32_t, uint8_t> sel1_p14{12, 3};
-		arch::field<uint32_t, uint8_t> sel1_p15{15, 3};
+void configUart0Gpio() {
+	arch::field<uint32_t, uint8_t> sel1_p14{12, 3};
+	arch::field<uint32_t, uint8_t> sel1_p15{15, 3};
 
-		arch::field<uint32_t, uint8_t> pup_pdn0_p14{28, 2};
-		arch::field<uint32_t, uint8_t> pup_pdn0_p15{30, 2};
+	arch::field<uint32_t, uint8_t> pup_pdn0_p14{28, 2};
+	arch::field<uint32_t, uint8_t> pup_pdn0_p15{30, 2};
 
-		// Alt 0
-		space.store(reg::sel1, space.load(reg::sel1) / sel1_p14(4) / sel1_p15(4));
-		// No pull up/down
-		space.store(reg::pup_pdn0, space.load(reg::pup_pdn0) / pup_pdn0_p14(0) / pup_pdn0_p15(0));
-	}
+	// Alt 0
+	space.store(reg::sel1, space.load(reg::sel1) / sel1_p14(4) / sel1_p15(4));
+	// No pull up/down
+	space.store(reg::pup_pdn0, space.load(reg::pup_pdn0) / pup_pdn0_p14(0) / pup_pdn0_p15(0));
 }
+} // namespace Gpio
 
 namespace Mbox {
-	static constexpr arch::mem_space space{mmioBase + 0xb880};
+static constexpr arch::mem_space space{mmioBase + 0xb880};
 
-	namespace reg {
-		static constexpr arch::bit_register<uint32_t> read{0x00};
-		static constexpr arch::bit_register<uint32_t> status{0x18};
-		static constexpr arch::bit_register<uint32_t> write{0x20};
-	}
+namespace reg {
+static constexpr arch::bit_register<uint32_t> read{0x00};
+static constexpr arch::bit_register<uint32_t> status{0x18};
+static constexpr arch::bit_register<uint32_t> write{0x20};
+} // namespace reg
 
-	enum class Channel {
-		pmi = 0,
-		fb,
-		vuart,
-		vchiq,
-		led,
-		button,
-		touch,
-		property = 8
-	};
+enum class Channel { pmi = 0, fb, vuart, vchiq, led, button, touch, property = 8 };
 
-	namespace io {
-		static constexpr arch::field<uint32_t, Channel> channel{0, 4};
-		static constexpr arch::field<uint32_t, uint32_t> value{4, 28};
-	}
+namespace io {
+static constexpr arch::field<uint32_t, Channel> channel{0, 4};
+static constexpr arch::field<uint32_t, uint32_t> value{4, 28};
+} // namespace io
 
-	namespace status {
-		static constexpr arch::field<uint32_t, bool> empty{30, 1};
-		static constexpr arch::field<uint32_t, bool> full{31, 1};
-	}
+namespace status {
+static constexpr arch::field<uint32_t, bool> empty{30, 1};
+static constexpr arch::field<uint32_t, bool> full{31, 1};
+} // namespace status
 
-	void write(Channel channel, uint32_t value) {
-		while(space.load(reg::status) & status::full)
-			;
+void write(Channel channel, uint32_t value) {
+	while (space.load(reg::status) & status::full)
+		;
 
-		space.store(reg::write, io::channel(channel) | io::value(value >> 4));
-	}
-
-	uint32_t read(Channel channel) {
-		while(space.load(reg::status) & status::empty)
-			;
-
-		auto f = space.load(reg::read);
-
-		return (f & io::value) << 4;
-	}
+	space.store(reg::write, io::channel(channel) | io::value(value >> 4));
 }
+
+uint32_t read(Channel channel) {
+	while (space.load(reg::status) & status::empty)
+		;
+
+	auto f = space.load(reg::read);
+
+	return (f & io::value) << 4;
+}
+} // namespace Mbox
 
 namespace PropertyMbox {
-	enum class Clock {
-		uart = 2
-	};
+enum class Clock { uart = 2 };
 
-	void setClockFreq(Clock clock, uint32_t freq, bool turbo = false) {
-		constexpr uint32_t req_size = 9 * 4;
-		frg::aligned_storage<req_size, 16> stor;
-		auto ptr = reinterpret_cast<volatile uint32_t *>(stor.buffer);
+void setClockFreq(Clock clock, uint32_t freq, bool turbo = false) {
+	constexpr uint32_t req_size = 9 * 4;
+	frg::aligned_storage<req_size, 16> stor;
+	auto ptr = reinterpret_cast<volatile uint32_t *>(stor.buffer);
 
-		*ptr++ = req_size;
-		*ptr++ = 0x00000000; // Process request
-		*ptr++ = 0x00038002; // Set clock rate
-		*ptr++ = 12;
-		*ptr++ = 8;
-		*ptr++ = static_cast<uint32_t>(clock);
-		*ptr++ = freq;
-		*ptr++ = turbo;
-		*ptr++ = 0x00000000;
+	*ptr++ = req_size;
+	*ptr++ = 0x00000000; // Process request
+	*ptr++ = 0x00038002; // Set clock rate
+	*ptr++ = 12;
+	*ptr++ = 8;
+	*ptr++ = static_cast<uint32_t>(clock);
+	*ptr++ = freq;
+	*ptr++ = turbo;
+	*ptr++ = 0x00000000;
 
-		auto val = reinterpret_cast<uint64_t>(stor.buffer);
-		assert(!(val & ~(uint64_t(0xFFFFFFF0))));
-		Mbox::write(Mbox::Channel::property, val);
+	auto val = reinterpret_cast<uint64_t>(stor.buffer);
+	assert(!(val & ~(uint64_t(0xFFFFFFF0))));
+	Mbox::write(Mbox::Channel::property, val);
 
-		auto ret = Mbox::read(Mbox::Channel::property);
-		assert(val == ret);
-	}
-
-	frg::tuple<int, int, void *, size_t> setupFb(unsigned int width, unsigned int height, unsigned int bpp) {
-		constexpr uint32_t req_size = 36 * 4;
-		frg::aligned_storage<req_size, 16> stor;
-		auto ptr = reinterpret_cast<volatile uint32_t *>(stor.buffer);
-
-		*ptr++ = req_size;
-		*ptr++ = 0x00000000; // Process request
-
-		*ptr++ = 0x00048003; // Set physical width/height
-		*ptr++ = 8;
-		*ptr++ = 0;
-		*ptr++ = width;
-		*ptr++ = height;
-
-		*ptr++ = 0x00048004; // Set virtual width/height
-		*ptr++ = 8;
-		*ptr++ = 0;
-		*ptr++ = width;
-		*ptr++ = height;
-
-		*ptr++ = 0x00048009; // Set virtual offset
-		*ptr++ = 8;
-		*ptr++ = 0;
-		*ptr++ = 0;
-		*ptr++ = 0;
-
-		*ptr++ = 0x00048005; // Set depth
-		*ptr++ = 4;
-		*ptr++ = 0;
-		*ptr++ = bpp;
-
-		*ptr++ = 0x00048006; // Set pixel order
-		*ptr++ = 4;
-		*ptr++ = 0;
-		*ptr++ = 0; // RGB
-
-		*ptr++ = 0x00040001; // Allocate buffer
-		*ptr++ = 8;
-		*ptr++ = 0;
-		*ptr++ = 0x1000;
-		*ptr++ = 0;
-
-		*ptr++ = 0x00040008; // Get pitch
-		*ptr++ = 4;
-		*ptr++ = 0;
-		*ptr++ = 0;
-
-		*ptr++ = 0;
-
-		*ptr++ = 0x00000000;
-
-		auto val = reinterpret_cast<uint64_t>(stor.buffer);
-		assert(!(val & ~(uint64_t(0xFFFFFFF0))));
-		Mbox::write(Mbox::Channel::property, val);
-
-		auto ret = Mbox::read(Mbox::Channel::property);
-		assert(val == ret);
-
-		ptr = reinterpret_cast<volatile uint32_t *>(ret);
-
-		auto fbPtr = 0;
-
-		// if depth is not the expected depth, pretend we failed
-		if(ptr[20] == bpp) { // depth == expected depth
-#ifndef RASPI3
-			// Translate legacy master view address into our address space
-			fbPtr = ptr[28] - 0xC0000000;
-#else
-			fbPtr = ptr[28];
-#endif
-		}
-
-		return frg::make_tuple(int(ptr[5]), int(ptr[6]), reinterpret_cast<void *>(fbPtr), size_t(ptr[33]));
-	}
-
-	template <size_t MaxSize>
-	size_t getCmdline(void *dest) requires (!(MaxSize & 3)) {
-		constexpr uint32_t req_size = 5 * 4 + MaxSize;
-		frg::aligned_storage<req_size, 16> stor;
-		memset(stor.buffer, 0, req_size);
-
-		auto ptr = reinterpret_cast<volatile uint32_t *>(stor.buffer);
-
-		*ptr++ = req_size;
-		*ptr++ = 0x00000000; // Process request
-
-		*ptr++ = 0x00050001; // Get commandline
-		*ptr++ = MaxSize;
-
-		auto val = reinterpret_cast<uint64_t>(stor.buffer);
-		assert(!(val & ~(uint64_t(0xFFFFFFF0))));
-		Mbox::write(Mbox::Channel::property, val);
-
-		auto ret = Mbox::read(Mbox::Channel::property);
-		assert(val == ret);
-
-		ptr = reinterpret_cast<volatile uint32_t *>(ret);
-
-		auto data = reinterpret_cast<char *>(ret + 20);
-		auto totalLen = ptr[3];
-		auto cmdlineLen = strlen(data);
-
-		assert(totalLen <= MaxSize);
-		memcpy(dest, data, cmdlineLen + 1);
-
-		return cmdlineLen;
-	}
+	auto ret = Mbox::read(Mbox::Channel::property);
+	assert(val == ret);
 }
+
+frg::tuple<int, int, void *, size_t>
+setupFb(unsigned int width, unsigned int height, unsigned int bpp) {
+	constexpr uint32_t req_size = 36 * 4;
+	frg::aligned_storage<req_size, 16> stor;
+	auto ptr = reinterpret_cast<volatile uint32_t *>(stor.buffer);
+
+	*ptr++ = req_size;
+	*ptr++ = 0x00000000; // Process request
+
+	*ptr++ = 0x00048003; // Set physical width/height
+	*ptr++ = 8;
+	*ptr++ = 0;
+	*ptr++ = width;
+	*ptr++ = height;
+
+	*ptr++ = 0x00048004; // Set virtual width/height
+	*ptr++ = 8;
+	*ptr++ = 0;
+	*ptr++ = width;
+	*ptr++ = height;
+
+	*ptr++ = 0x00048009; // Set virtual offset
+	*ptr++ = 8;
+	*ptr++ = 0;
+	*ptr++ = 0;
+	*ptr++ = 0;
+
+	*ptr++ = 0x00048005; // Set depth
+	*ptr++ = 4;
+	*ptr++ = 0;
+	*ptr++ = bpp;
+
+	*ptr++ = 0x00048006; // Set pixel order
+	*ptr++ = 4;
+	*ptr++ = 0;
+	*ptr++ = 0; // RGB
+
+	*ptr++ = 0x00040001; // Allocate buffer
+	*ptr++ = 8;
+	*ptr++ = 0;
+	*ptr++ = 0x1000;
+	*ptr++ = 0;
+
+	*ptr++ = 0x00040008; // Get pitch
+	*ptr++ = 4;
+	*ptr++ = 0;
+	*ptr++ = 0;
+
+	*ptr++ = 0;
+
+	*ptr++ = 0x00000000;
+
+	auto val = reinterpret_cast<uint64_t>(stor.buffer);
+	assert(!(val & ~(uint64_t(0xFFFFFFF0))));
+	Mbox::write(Mbox::Channel::property, val);
+
+	auto ret = Mbox::read(Mbox::Channel::property);
+	assert(val == ret);
+
+	ptr = reinterpret_cast<volatile uint32_t *>(ret);
+
+	auto fbPtr = 0;
+
+	// if depth is not the expected depth, pretend we failed
+	if (ptr[20] == bpp) { // depth == expected depth
+#ifndef RASPI3
+		// Translate legacy master view address into our address space
+		fbPtr = ptr[28] - 0xC0000000;
+#else
+		fbPtr = ptr[28];
+#endif
+	}
+
+	return frg::make_tuple(
+	    int(ptr[5]), int(ptr[6]), reinterpret_cast<void *>(fbPtr), size_t(ptr[33])
+	);
+}
+
+template <size_t MaxSize>
+size_t getCmdline(void *dest)
+    requires(!(MaxSize & 3))
+{
+	constexpr uint32_t req_size = 5 * 4 + MaxSize;
+	frg::aligned_storage<req_size, 16> stor;
+	memset(stor.buffer, 0, req_size);
+
+	auto ptr = reinterpret_cast<volatile uint32_t *>(stor.buffer);
+
+	*ptr++ = req_size;
+	*ptr++ = 0x00000000; // Process request
+
+	*ptr++ = 0x00050001; // Get commandline
+	*ptr++ = MaxSize;
+
+	auto val = reinterpret_cast<uint64_t>(stor.buffer);
+	assert(!(val & ~(uint64_t(0xFFFFFFF0))));
+	Mbox::write(Mbox::Channel::property, val);
+
+	auto ret = Mbox::read(Mbox::Channel::property);
+	assert(val == ret);
+
+	ptr = reinterpret_cast<volatile uint32_t *>(ret);
+
+	auto data = reinterpret_cast<char *>(ret + 20);
+	auto totalLen = ptr[3];
+	auto cmdlineLen = strlen(data);
+
+	assert(totalLen <= MaxSize);
+	memcpy(dest, data, cmdlineLen + 1);
+
+	return cmdlineLen;
+}
+} // namespace PropertyMbox
 
 frg::manual_box<PL011> debugUart;
 
-void debugPrintChar(char c) {
-	debugUart->send(c);
-}
+void debugPrintChar(char c) { debugUart->send(c); }
 
 extern "C" [[noreturn]] void eirRaspi4Main(uintptr_t deviceTreePtr) {
 	// the device tree pointer is 32-bit and the upper bits are undefined
@@ -264,27 +256,27 @@ extern "C" [[noreturn]] void eirRaspi4Main(uintptr_t deviceTreePtr) {
 	// Parse the command line.
 	{
 		const char *l = cmd_buf;
-		while(true) {
-			while(*l && *l == ' ')
+		while (true) {
+			while (*l && *l == ' ')
 				l++;
-			if(!(*l))
+			if (!(*l))
 				break;
 
 			const char *s = l;
-			while(*s && *s != ' ')
+			while (*s && *s != ' ')
 				s++;
 
 			frg::string_view token{l, static_cast<size_t>(s - l)};
 
-			if(auto equals = token.find_first('='); equals != size_t(-1)) {
+			if (auto equals = token.find_first('='); equals != size_t(-1)) {
 				auto key = token.sub_string(0, equals);
 				auto value = token.sub_string(equals + 1, token.size() - equals - 1);
 
-				if(key == "bcm2708_fb.fbwidth") {
-					if(auto width = value.to_number<unsigned int>(); width)
+				if (key == "bcm2708_fb.fbwidth") {
+					if (auto width = value.to_number<unsigned int>(); width)
 						fb_width = *width;
-				} else if(key == "bcm2708_fb.fbheight") {
-					if(auto height = value.to_number<unsigned int>(); height)
+				} else if (key == "bcm2708_fb.fbheight") {
+					if (auto height = value.to_number<unsigned int>(); height)
 						fb_height = *height;
 				}
 			}
@@ -296,12 +288,12 @@ extern "C" [[noreturn]] void eirRaspi4Main(uintptr_t deviceTreePtr) {
 	uintptr_t fb_ptr = 0;
 	size_t fb_pitch = 0;
 	bool have_fb = false;
-	if(!fb_width || !fb_height) {
+	if (!fb_width || !fb_height) {
 		eir::infoLogger() << "No display attached" << frg::endlog;
 	} else {
 		auto [actualW, actualH, ptr, pitch] = PropertyMbox::setupFb(fb_width, fb_height, 32);
 
-		if(!ptr || !pitch) {
+		if (!ptr || !pitch) {
 			eir::infoLogger() << "Mode setting failed..." << frg::endlog;
 		} else {
 			eir::infoLogger() << "Success!" << frg::endlog;
@@ -319,21 +311,21 @@ extern "C" [[noreturn]] void eirRaspi4Main(uintptr_t deviceTreePtr) {
 	}
 
 	GenericInfo info{
-		.deviceTreePtr = deviceTreePtr,
-		.cmdline = cmd_buf,
-		.fb {},
-		.debugFlags = eirDebugSerial,
-		.hasFb = have_fb
+	    .deviceTreePtr = deviceTreePtr,
+	    .cmdline = cmd_buf,
+	    .fb{},
+	    .debugFlags = eirDebugSerial,
+	    .hasFb = have_fb
 	};
 
-	if(have_fb) {
+	if (have_fb) {
 		info.fb = {
-			.fbAddress = fb_ptr,
-			.fbPitch = fb_pitch,
-			.fbWidth = static_cast<EirSize>(fb_width),
-			.fbHeight = static_cast<EirSize>(fb_height),
-			.fbBpp = 32,
-			.fbType = 0
+		    .fbAddress = fb_ptr,
+		    .fbPitch = fb_pitch,
+		    .fbWidth = static_cast<EirSize>(fb_width),
+		    .fbHeight = static_cast<EirSize>(fb_height),
+		    .fbBpp = 32,
+		    .fbType = 0
 		};
 	}
 

--- a/kernel/eir/arch/arm/virt/virt.cpp
+++ b/kernel/eir/arch/arm/virt/virt.cpp
@@ -1,25 +1,23 @@
-#include <frg/manual_box.hpp>
-#include <eir-internal/generic.hpp>
 #include <eir-internal/arch/pl011.hpp>
+#include <eir-internal/generic.hpp>
+#include <frg/manual_box.hpp>
 
 namespace eir {
 
 frg::manual_box<PL011> debugUart;
 
-void debugPrintChar(char c) {
-	debugUart->send(c);
-}
+void debugPrintChar(char c) { debugUart->send(c); }
 
 extern "C" [[noreturn]] void eirVirtMain(uintptr_t deviceTreePtr) {
 	eirRelocate();
 	debugUart.initialize(0x9000000, 24000000);
 	debugUart->init(115200);
 	GenericInfo info{
-		.deviceTreePtr = deviceTreePtr,
-		.cmdline = nullptr,
-		.fb {},
-		.debugFlags = eirDebugSerial,
-		.hasFb = false
+	    .deviceTreePtr = deviceTreePtr,
+	    .cmdline = nullptr,
+	    .fb{},
+	    .debugFlags = eirDebugSerial,
+	    .hasFb = false
 	};
 	eirGenericMain(info);
 }

--- a/kernel/eir/arch/riscv/cpu.cpp
+++ b/kernel/eir/arch/riscv/cpu.cpp
@@ -1,9 +1,9 @@
+#include <algorithm>
 #include <dtb.hpp>
 #include <eir-internal/arch.hpp>
-#include <eir-internal/main.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/main.hpp>
 #include <riscv/csr.hpp>
-#include <algorithm>
 
 namespace eir {
 
@@ -13,10 +13,9 @@ void handleException() {
 	auto cause = riscv::readCsr<riscv::Csr::scause>();
 	auto ip = riscv::readCsr<riscv::Csr::sepc>();
 	auto trapValue = riscv::readCsr<riscv::Csr::stval>();
-	eir::infoLogger() << "Exception with cause 0x" << frg::hex_fmt{cause}
-			<< ", trap value 0x" << frg::hex_fmt{trapValue}
-			<< " at IP 0x" << frg::hex_fmt{ip} << frg::endlog;
-	while(true)
+	eir::infoLogger() << "Exception with cause 0x" << frg::hex_fmt{cause} << ", trap value 0x"
+	                  << frg::hex_fmt{trapValue} << " at IP 0x" << frg::hex_fmt{ip} << frg::endlog;
+	while (true)
 		;
 }
 
@@ -49,20 +48,21 @@ void initProcessorEarly() {
 	riscv::writeCsr<riscv::Csr::stvec>(reinterpret_cast<uint64_t>(&handleException));
 
 	// Check whether or not our environment is capable of all RVA22 extensions.
-	// TODO: If ACPI is enabled, we might not have a device tree. In that case, use the RHCT to get the ISA string.
+	// TODO: If ACPI is enabled, we might not have a device tree. In that case, use the RHCT to get
+	// the ISA string.
 	if (eirDtbPtr) {
 		DeviceTree dt(eirDtbPtr);
 
 		// Get the first "/cpus/cpu@..."
 		frg::optional<DeviceTreeNode> cpuNode;
 		dt.rootNode().discoverSubnodes(
-			[](auto node) { return frg::string_view(node.name()) == "cpus"; },
-			[&](auto cpus) {
-				cpus.discoverSubnodes(
-					[](auto node) { return frg::string_view(node.name()).starts_with("cpu@"); },
-					[&](auto a) { cpuNode = a; }
-				);
-			}
+		    [](auto node) { return frg::string_view(node.name()) == "cpus"; },
+		    [&](auto cpus) {
+			    cpus.discoverSubnodes(
+			        [](auto node) { return frg::string_view(node.name()).starts_with("cpu@"); },
+			        [&](auto a) { cpuNode = a; }
+			    );
+		    }
 		);
 		assert(cpuNode.has_value());
 
@@ -71,7 +71,7 @@ void initProcessorEarly() {
 		assert(isaBase.has_value());
 		if (isaBase.value().asString() != "rv64i") {
 			infoLogger() << "eir: This device does not have rv64i base! riscv,isa-base = "
-				<< "\"" << isaBase.value().asString().value() << "\"" << frg::endlog;
+			             << "\"" << isaBase.value().asString().value() << "\"" << frg::endlog;
 		}
 
 		// Check isa-extensions
@@ -122,8 +122,9 @@ void initProcessorEarly() {
 		}
 
 		// If not all bits are set, we can't boot.
-		if (!std::ranges::all_of(bits, [](auto a){return a;})) {
-			panicLogger() << "Processor doesn't support all required RVA22 extensions!" << frg::endlog;
+		if (!std::ranges::all_of(bits, [](auto a) { return a; })) {
+			panicLogger() << "Processor doesn't support all required RVA22 extensions!"
+			              << frg::endlog;
 		}
 
 		// Make sure Sv48 is available.

--- a/kernel/eir/arch/riscv/dtb.cpp
+++ b/kernel/eir/arch/riscv/dtb.cpp
@@ -1,12 +1,10 @@
-#include <eir-internal/main.hpp>
 #include <eir-internal/dtb/discovery.hpp>
+#include <eir-internal/main.hpp>
 
 namespace eir {
 
-static initgraph::Task discoverMemory{&globalInitEngine, "riscv.discover-memory",
-	[] {
-		discoverMemoryFromDtb(eirDtbPtr);
-	}
-};
+static initgraph::Task discoverMemory{&globalInitEngine, "riscv.discover-memory", [] {
+	                                      discoverMemoryFromDtb(eirDtbPtr);
+                                      }};
 
 } // namespace eir

--- a/kernel/eir/arch/riscv/platform/allwinner-d1/early-log.cpp
+++ b/kernel/eir/arch/riscv/platform/allwinner-d1/early-log.cpp
@@ -10,13 +10,10 @@ void sbiCall1(int ext, int func, SbiWord arg0) {
 	register SbiWord rArg0 asm("a0") = arg0;
 	register SbiWord rArg1 asm("a1");
 	asm volatile("ecall" : "+r"(rArg0), "=r"(rArg1) : "r"(rExt), "r"(rFunc));
-	if(rArg0)
+	if (rArg0)
 		__builtin_trap();
 }
 
+void debugPrintChar(char c) { sbiCall1(1, 0, c); }
 
-void debugPrintChar(char c) {
-	sbiCall1(1, 0, c);
-}
-
-}
+} // namespace eir

--- a/kernel/eir/arch/riscv/platform/virt/early-log.cpp
+++ b/kernel/eir/arch/riscv/platform/virt/early-log.cpp
@@ -10,13 +10,10 @@ void sbiCall1(int ext, int func, SbiWord arg0) {
 	register SbiWord rArg0 asm("a0") = arg0;
 	register SbiWord rArg1 asm("a1");
 	asm volatile("ecall" : "+r"(rArg0), "=r"(rArg1) : "r"(rExt), "r"(rFunc));
-	if(rArg0)
+	if (rArg0)
 		__builtin_trap();
 }
 
+void debugPrintChar(char c) { sbiCall1(1, 0, c); }
 
-void debugPrintChar(char c) {
-	sbiCall1(1, 0, c);
-}
-
-}
+} // namespace eir

--- a/kernel/eir/arch/x86/i386.cpp
+++ b/kernel/eir/arch/x86/i386.cpp
@@ -1,6 +1,6 @@
 #include <stdint.h>
-#include <x86/machine.hpp>
 #include <x86/gdt.hpp>
+#include <x86/machine.hpp>
 
 namespace arch = common::x86;
 
@@ -20,4 +20,4 @@ void initArchCpu() {
 	eirLoadGdt(gdtEntries, 4 * 8 - 1);
 }
 
-}
+} // namespace eir

--- a/kernel/eir/arch/x86/x86_64.cpp
+++ b/kernel/eir/arch/x86/x86_64.cpp
@@ -1,8 +1,8 @@
 
 namespace eir {
 
-void initArchCpu(){
-    // We don't need to do anything for x86_64
+void initArchCpu() {
+	// We don't need to do anything for x86_64
 }
 
-}
+} // namespace eir

--- a/kernel/eir/generic/debug.cpp
+++ b/kernel/eir/generic/debug.cpp
@@ -1,6 +1,6 @@
+#include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
-#include <eir-internal/arch.hpp>
 #include <frg/logging.hpp>
 #include <render-text.hpp>
 
@@ -35,61 +35,64 @@ extern "C" void frg_panic(const char *cstring) {
 }
 
 void OutputSink::print(char c) {
-	if(log_e9)
+	if (log_e9)
 		debugPrintChar(c);
 
-	if(logHandler)
+	if (logHandler)
 		logHandler(c);
 
-	if(displayFb) {
-		if(c == '\n') {
+	if (displayFb) {
+		if (c == '\n') {
 			outputX = 0;
 			outputY++;
-		}else if(outputX >= displayWidth / fontWidth) {
+		} else if (outputX >= displayWidth / fontWidth) {
 			outputX = 0;
 			outputY++;
-		}else if(outputY >= displayHeight / fontHeight) {
+		} else if (outputY >= displayHeight / fontHeight) {
 			// TODO: Scroll.
-		}else{
-			renderChars(displayFb, displayPitch / sizeof(uint32_t),
-					outputX, outputY, &c, 1, 15, -1,
-					std::integral_constant<int, fontWidth>{},
-					std::integral_constant<int, fontHeight>{});
+		} else {
+			renderChars(
+			    displayFb,
+			    displayPitch / sizeof(uint32_t),
+			    outputX,
+			    outputY,
+			    &c,
+			    1,
+			    15,
+			    -1,
+			    std::integral_constant<int, fontWidth>{},
+			    std::integral_constant<int, fontHeight>{}
+			);
 			outputX++;
 		}
 	}
 }
 
 void OutputSink::print(const char *str) {
-	while(*str)
+	while (*str)
 		print(*(str++));
 }
-
 
 void LogSink::operator()(const char *c) {
 	infoSink.print(c);
 	infoSink.print('\n');
 }
 
-void PanicSink::operator()(const char *c) {
-	infoSink.print(c);
-}
+void PanicSink::operator()(const char *c) { infoSink.print(c); }
 
 void PanicSink::finalize(bool) {
 	infoSink.print('\n');
-	while(true)
+	while (true)
 		asm volatile("" : : : "memory");
 }
 
 } // namespace eir
 
-extern "C" void __assert_fail(const char *assertion, const char *file,
-		unsigned int line, const char *function) {
+extern "C" void
+__assert_fail(const char *assertion, const char *file, unsigned int line, const char *function) {
 	eir::panicLogger() << "Assertion failed: " << assertion << "\n"
-			<< "In function " << function
-			<< " at " << file << ":" << line << frg::endlog;
+	                   << "In function " << function << " at " << file << ":" << line
+	                   << frg::endlog;
 }
 
-extern "C" void __cxa_pure_virtual() {
-	eir::panicLogger() << "Pure virtual call" << frg::endlog;
-}
+extern "C" void __cxa_pure_virtual() { eir::panicLogger() << "Pure virtual call" << frg::endlog; }

--- a/kernel/eir/generic/eir-internal/arch.hpp
+++ b/kernel/eir/generic/eir-internal/arch.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <stdint.h>
-#include <stddef.h>
 #include <eir-internal/arch/types.hpp>
+#include <stddef.h>
+#include <stdint.h>
 
 namespace eir {
 
@@ -10,16 +10,12 @@ void debugPrintChar(char c);
 
 // read and privileged/supervisor is implied
 namespace PageFlags {
-	static inline constexpr uint32_t write = 1;
-	static inline constexpr uint32_t execute = 2;
-	static inline constexpr uint32_t global = 4;
-} // namespace PageFlag
+static inline constexpr uint32_t write = 1;
+static inline constexpr uint32_t execute = 2;
+static inline constexpr uint32_t global = 4;
+} // namespace PageFlags
 
-enum class CachingMode {
-	null,
-	writeCombine,
-	mmio
-}; // enum class CachingMode
+enum class CachingMode { null, writeCombine, mmio }; // enum class CachingMode
 
 static constexpr int pageShift = 12;
 static constexpr size_t pageSize = size_t(1) << pageShift;
@@ -27,8 +23,12 @@ static constexpr size_t pageSize = size_t(1) << pageShift;
 extern uint64_t kernelEntry;
 
 void setupPaging();
-void mapSingle4kPage(address_t address, address_t physical, uint32_t flags,
-		CachingMode caching_mode = CachingMode::null);
+void mapSingle4kPage(
+    address_t address,
+    address_t physical,
+    uint32_t flags,
+    CachingMode caching_mode = CachingMode::null
+);
 address_t getSingle4kPage(address_t address);
 
 void initProcessorEarly();

--- a/kernel/eir/generic/eir-internal/cpio.hpp
+++ b/kernel/eir/generic/eir-internal/cpio.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <assert.h>
-#include <frg/string.hpp>
 #include <frg/span.hpp>
+#include <frg/string.hpp>
 
 struct CpioHeader {
 	char magic[6];
@@ -28,25 +28,19 @@ struct CpioFile {
 
 struct CpioRange {
 	struct Iterator {
-		Iterator(void *ptr)
-		: ptr_{static_cast<uint8_t *>(ptr)} {}
+		Iterator(void *ptr) : ptr_{static_cast<uint8_t *>(ptr)} {}
 
 		Iterator &operator++() {
 			next();
 			return *this;
 		}
 
-		CpioFile operator*() {
-			return parse();
-		}
+		CpioFile operator*() { return parse(); }
 
-		uint8_t *get() {
-			return ptr_;
-		}
+		uint8_t *get() { return ptr_; }
 
-		bool operator==(const Iterator &other) const {
-			return other.ptr_ == ptr_;
-		}
+		bool operator==(const Iterator &other) const { return other.ptr_ == ptr_; }
+
 	private:
 		uint32_t parseHex(const char *c, int n) {
 			uint32_t v = 0;
@@ -75,10 +69,11 @@ struct CpioRange {
 			auto nameSize = parseHex(hdr.nameSize, 8);
 			auto fileSize = parseHex(hdr.fileSize, 8);
 
-			frg::string_view path{reinterpret_cast<char *>(ptr_) + sizeof(CpioHeader), nameSize - 1};
+			frg::string_view path{
+			    reinterpret_cast<char *>(ptr_) + sizeof(CpioHeader), nameSize - 1
+			};
 			frg::span<uint8_t> data{
-				ptr_ + ((sizeof(CpioHeader) + nameSize + 3) & ~uint32_t{3}),
-				fileSize
+			    ptr_ + ((sizeof(CpioHeader) + nameSize + 3) & ~uint32_t{3}), fileSize
 			};
 
 			return {path, data};
@@ -95,18 +90,15 @@ struct CpioRange {
 			auto fileSize = parseHex(hdr.fileSize, 8);
 
 			ptr_ += ((sizeof(CpioHeader) + nameSize + 3) & ~uint32_t{3})
-				+ ((fileSize + 3) & ~uint32_t{3});
+			        + ((fileSize + 3) & ~uint32_t{3});
 		}
 
 		uint8_t *ptr_;
 	};
 
-	CpioRange(void *data)
-	: data_{data} { }
+	CpioRange(void *data) : data_{data} {}
 
-	Iterator begin() {
-		return Iterator{data_};
-	}
+	Iterator begin() { return Iterator{data_}; }
 
 	Iterator end() {
 		Iterator it{data_};

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <stdint.h>
-#include <stddef.h>
 #include <eir-internal/arch/types.hpp>
-#include <frg/string.hpp>
-#include <frg/span.hpp>
 #include <eir/interface.hpp>
+#include <frg/span.hpp>
+#include <frg/string.hpp>
+#include <stddef.h>
+#include <stdint.h>
 
 namespace eir {
 
@@ -14,11 +14,7 @@ extern frg::span<uint8_t> kernel_image;
 extern address_t kernel_physical;
 extern frg::span<uint8_t> initrd_image;
 
-enum class RegionType {
-	null,
-	unconstructed,
-	allocatable
-};
+enum class RegionType { null, unconstructed, allocatable };
 
 struct Region {
 	RegionType regionType;
@@ -87,10 +83,10 @@ EirInfo *generateInfo(frg::string_view cmdline);
 
 void setFbInfo(void *ptr, int width, int height, size_t pitch);
 
-template<typename T>
+template <typename T>
 T *bootAlloc(size_t n = 1) {
 	auto pointer = physToVirt<T>(bootReserve(sizeof(T) * n, alignof(T)));
-	for(size_t i = 0; i < n; i++)
+	for (size_t i = 0; i < n; i++)
 		new (&pointer[i]) T();
 	return pointer;
 }

--- a/kernel/eir/generic/eir-internal/paging.hpp
+++ b/kernel/eir/generic/eir-internal/paging.hpp
@@ -8,7 +8,11 @@ using address_t = uint64_t;
 void debugPrintChar(char c);
 
 void setupPaging();
-void mapSingle4kPage(uint64_t address, uint64_t physical, uint32_t flags,
-		CachingMode caching_mode = CachingMode::null);
+void mapSingle4kPage(
+    uint64_t address,
+    uint64_t physical,
+    uint32_t flags,
+    CachingMode caching_mode = CachingMode::null
+);
 
 } // namespace eir

--- a/kernel/eir/generic/global-constructors.cpp
+++ b/kernel/eir/generic/global-constructors.cpp
@@ -7,15 +7,16 @@ extern "C" InitializerPtr __init_array_start[];
 extern "C" InitializerPtr __init_array_end[];
 
 extern "C" void eirRunConstructors() {
-	eir::infoLogger() << "There are "
-			<< (__init_array_end - __init_array_start) << " constructors" << frg::endlog;
-	for(InitializerPtr *p = __init_array_start; p != __init_array_end; ++p)
-			(*p)();
+	eir::infoLogger() << "There are " << (__init_array_end - __init_array_start) << " constructors"
+	                  << frg::endlog;
+	for (InitializerPtr *p = __init_array_start; p != __init_array_end; ++p)
+		(*p)();
 }
 
 #else
 
-// MSVC puts global constructors in a section .CRT$XCU that is ordered between .CRT$XCA and .CRT$XCZ.
+// MSVC puts global constructors in a section .CRT$XCU that is ordered between .CRT$XCA and
+// .CRT$XCZ.
 __declspec(allocate(".CRT$XCA")) const void *crt_xct = nullptr;
 __declspec(allocate(".CRT$XCZ")) const void *crt_xcz = nullptr;
 

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -1,12 +1,12 @@
+#include <eir-internal/arch.hpp>
 #include <eir-internal/cpio.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
-#include <eir-internal/arch.hpp>
 
-#include <frg/utility.hpp>
-#include <frg/manual_box.hpp>
-#include <frg/array.hpp>
 #include <elf.h>
+#include <frg/array.hpp>
+#include <frg/manual_box.hpp>
+#include <frg/utility.hpp>
 #include <physical-buddy.hpp>
 
 // Pointer to the DTB.
@@ -31,8 +31,8 @@ address_t physOffset = 0;
 Region regions[numRegions];
 
 Region *obtainRegion() {
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType != RegionType::null)
+	for (size_t i = 0; i < numRegions; ++i) {
+		if (regions[i].regionType != RegionType::null)
 			continue;
 		regions[i].regionType = RegionType::unconstructed;
 		return &regions[i];
@@ -50,9 +50,9 @@ void createInitialRegion(address_t base, address_t size) {
 	// This ensures thor can allocate contiguous chunks of up to 2 MiB.
 	address = (address + 0x1FFFFF) & ~address_t(0x1FFFFF);
 
-	if(address >= limit) {
-		eir::infoLogger() << "eir: Discarding memory region at 0x"
-				<< frg::hex_fmt{base} << " (smaller than alignment)" << frg::endlog;
+	if (address >= limit) {
+		eir::infoLogger() << "eir: Discarding memory region at 0x" << frg::hex_fmt{base}
+		                  << " (smaller than alignment)" << frg::endlog;
 		return;
 	}
 
@@ -62,17 +62,17 @@ void createInitialRegion(address_t base, address_t size) {
 	auto accessor = reinterpret_cast<uint8_t *>(address);
 	uint64_t pattern = 0xB306'94E7'F8D2'78AB;
 	for(ptrdiff_t i = 0; i < limit - address; ++i) {
-		accessor[i] = pattern;
-		pattern = (pattern << 8) | (pattern >> 56);
+	    accessor[i] = pattern;
+	    pattern = (pattern << 8) | (pattern >> 56);
 	}
 	asm volatile ("" : : : "memory");
 	*/
 
 	// For now we ensure that the kernel has some memory to work with.
 	// TODO: Handle small memory regions.
-	if(limit - address < 32 * address_t(0x100000)) {
-		eir::infoLogger() << "eir: Discarding memory region at 0x"
-				<< frg::hex_fmt{base} << " (smaller than minimum size)" << frg::endlog;
+	if (limit - address < 32 * address_t(0x100000)) {
+		eir::infoLogger() << "eir: Discarding memory region at 0x" << frg::hex_fmt{base}
+		                  << " (smaller than minimum size)" << frg::endlog;
 		return;
 	}
 
@@ -91,34 +91,38 @@ void createInitialRegions(InitialRegion region, frg::span<InitialRegion> reserve
 	} else {
 		auto rsv = reserved.data()[0];
 
-		if (rsv.base > (region.base + region.size)
-				|| (rsv.base + rsv.size) < region.base) {
+		if (rsv.base > (region.base + region.size) || (rsv.base + rsv.size) < region.base) {
 			createInitialRegions(region, {reserved.data() + 1, reserved.size() - 1});
 			return;
 		}
 
 		if (rsv.base > region.base) {
-			createInitialRegions({region.base, rsv.base - region.base}, {reserved.data() + 1, reserved.size() - 1});
+			createInitialRegions(
+			    {region.base, rsv.base - region.base}, {reserved.data() + 1, reserved.size() - 1}
+			);
 		}
 
 		if (rsv.base + rsv.size < region.base + region.size) {
-			createInitialRegions({rsv.base + rsv.size, region.base + region.size - (rsv.base + rsv.size)}, {reserved.data() + 1, reserved.size() - 1});
+			createInitialRegions(
+			    {rsv.base + rsv.size, region.base + region.size - (rsv.base + rsv.size)},
+			    {reserved.data() + 1, reserved.size() - 1}
+			);
 		}
 	}
 }
 
 address_t cutFromRegion(size_t size) {
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType != RegionType::allocatable)
+	for (size_t i = 0; i < numRegions; ++i) {
+		if (regions[i].regionType != RegionType::allocatable)
 			continue;
 
-		if(regions[i].size < size)
+		if (regions[i].size < size)
 			continue;
 
 		regions[i].size -= size;
 
 		// Discard this region if it's smaller than alignment
-		if(regions[i].size < 0x200000)
+		if (regions[i].size < 0x200000)
 			regions[i].regionType = RegionType::null;
 
 		return regions[i].address + regions[i].size;
@@ -129,10 +133,10 @@ address_t cutFromRegion(size_t size) {
 }
 
 void setupRegionStructs() {
-	for(size_t j = numRegions; j > 0; j--) {
+	for (size_t j = numRegions; j > 0; j--) {
 		size_t i = j - 1;
 
-		if(regions[i].regionType != RegionType::allocatable)
+		if (regions[i].regionType != RegionType::allocatable)
 			continue;
 
 		// Setup a buddy allocator.
@@ -147,8 +151,8 @@ void setupRegionStructs() {
 		regions[i].buddyOverhead = overhead;
 	}
 
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType != RegionType::allocatable)
+	for (size_t i = 0; i < numRegions; ++i) {
+		if (regions[i].regionType != RegionType::allocatable)
 			continue;
 
 		// Setup a buddy allocator.
@@ -173,15 +177,16 @@ physaddr_t bootReserve(size_t length, size_t alignment) {
 	assert(length <= pageSize);
 	assert(alignment <= pageSize);
 
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType != RegionType::allocatable)
+	for (size_t i = 0; i < numRegions; ++i) {
+		if (regions[i].regionType != RegionType::allocatable)
 			continue;
 
 		auto table = physToVirt<int8_t>(regions[i].buddyTree);
-		BuddyAccessor accessor{regions[i].address, pageShift,
-				table, regions[i].numRoots, regions[i].order};
+		BuddyAccessor accessor{
+		    regions[i].address, pageShift, table, regions[i].numRoots, regions[i].order
+		};
 		auto physical = accessor.allocate(0, 32);
-		if(physical == BuddyAccessor::illegalAddress)
+		if (physical == BuddyAccessor::illegalAddress)
 			continue;
 		return physical;
 	}
@@ -191,15 +196,16 @@ physaddr_t bootReserve(size_t length, size_t alignment) {
 }
 
 physaddr_t allocPage() {
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType != RegionType::allocatable)
+	for (size_t i = 0; i < numRegions; ++i) {
+		if (regions[i].regionType != RegionType::allocatable)
 			continue;
 
 		auto table = physToVirt<int8_t>(regions[i].buddyTree);
-		BuddyAccessor accessor{regions[i].address, pageShift,
-				table, regions[i].numRoots, regions[i].order};
+		BuddyAccessor accessor{
+		    regions[i].address, pageShift, table, regions[i].numRoots, regions[i].order
+		};
 		auto physical = accessor.allocate(0, 32);
-		if(physical == BuddyAccessor::illegalAddress)
+		if (physical == BuddyAccessor::illegalAddress)
 			continue;
 		allocatedMemory += pageSize;
 		return physical;
@@ -213,67 +219,65 @@ physaddr_t allocPage() {
 
 #ifdef EIR_KASAN
 namespace {
-	constexpr int kasanShift = 3;
-	constexpr address_t kasanShadowDelta = 0xdfffe00000000000;
+constexpr int kasanShift = 3;
+constexpr address_t kasanShadowDelta = 0xdfffe00000000000;
 
-	constexpr size_t kasanScale = size_t{1} << kasanShift;
+constexpr size_t kasanScale = size_t{1} << kasanShift;
 
-	address_t kasanToShadow(address_t address) {
-		return kasanShadowDelta + (address >> kasanShift);
-	}
+address_t kasanToShadow(address_t address) { return kasanShadowDelta + (address >> kasanShift); }
 
-	void setShadowRange(address_t base, size_t size, int8_t value) {
-		assert(!(base & (kasanScale - 1)));
-		assert(!(size & (kasanScale - 1)));
+void setShadowRange(address_t base, size_t size, int8_t value) {
+	assert(!(base & (kasanScale - 1)));
+	assert(!(size & (kasanScale - 1)));
 
-		size_t progress = 0;
-		while(progress < size) {
-			auto shadow = kasanToShadow(base + progress);
-			auto page = shadow & ~address_t{pageSize - 1};
-			auto physical = getSingle4kPage(page);
-			assert(physical != static_cast<address_t>(-1));
-
-			auto p = reinterpret_cast<int8_t *>(physical);
-			auto n = shadow & (pageSize - 1);
-			while(n < pageSize && progress < size) {
-				assert(p[n] == static_cast<int8_t>(0xFF));
-				p[n] = value;
-				++n;
-				progress += kasanScale;
-			}
-		}
-	};
-
-	void setShadowByte(address_t address, int8_t value) {
-		assert(!(address & (kasanScale - 1)));
-
-		auto shadow = kasanToShadow(address);
+	size_t progress = 0;
+	while (progress < size) {
+		auto shadow = kasanToShadow(base + progress);
 		auto page = shadow & ~address_t{pageSize - 1};
 		auto physical = getSingle4kPage(page);
 		assert(physical != static_cast<address_t>(-1));
 
 		auto p = reinterpret_cast<int8_t *>(physical);
 		auto n = shadow & (pageSize - 1);
-		assert(p[n] == static_cast<int8_t>(0xFF));
-		p[n] = value;
-	};
-}
+		while (n < pageSize && progress < size) {
+			assert(p[n] == static_cast<int8_t>(0xFF));
+			p[n] = value;
+			++n;
+			progress += kasanScale;
+		}
+	}
+};
+
+void setShadowByte(address_t address, int8_t value) {
+	assert(!(address & (kasanScale - 1)));
+
+	auto shadow = kasanToShadow(address);
+	auto page = shadow & ~address_t{pageSize - 1};
+	auto physical = getSingle4kPage(page);
+	assert(physical != static_cast<address_t>(-1));
+
+	auto p = reinterpret_cast<int8_t *>(physical);
+	auto n = shadow & (pageSize - 1);
+	assert(p[n] == static_cast<int8_t>(0xFF));
+	p[n] = value;
+};
+} // namespace
 #endif // EIR_KASAN
 
 void mapKasanShadow(address_t base, size_t size) {
 #ifdef EIR_KASAN
 	assert(!(base & (kasanScale - 1)));
 
-	eir::infoLogger() << "eir: Mapping KASAN shadow for 0x" << frg::hex_fmt{base}
-			<< ", size: 0x" << frg::hex_fmt{size} << frg::endlog;
+	eir::infoLogger() << "eir: Mapping KASAN shadow for 0x" << frg::hex_fmt{base} << ", size: 0x"
+	                  << frg::hex_fmt{size} << frg::endlog;
 
 	size = (size + kasanScale - 1) & ~(kasanScale - 1);
 
-	for(address_t page = (kasanToShadow(base) & ~address_t{pageSize - 1});
-			page < ((kasanToShadow(base + size) + pageSize - 1) & ~address_t{pageSize - 1});
-			page += pageSize) {
+	for (address_t page = (kasanToShadow(base) & ~address_t{pageSize - 1});
+	     page < ((kasanToShadow(base + size) + pageSize - 1) & ~address_t{pageSize - 1});
+	     page += pageSize) {
 		auto physical = getSingle4kPage(page);
-		if(physical != static_cast<address_t>(-1))
+		if (physical != static_cast<address_t>(-1))
 			continue;
 		physical = allocPage();
 		memset(reinterpret_cast<void *>(physical), 0xFF, pageSize);
@@ -290,10 +294,10 @@ void unpoisonKasanShadow(address_t base, size_t size) {
 	assert(!(base & (kasanScale - 1)));
 
 	eir::infoLogger() << "eir: Unpoisoning KASAN shadow for 0x" << frg::hex_fmt{base}
-			<< ", size: 0x" << frg::hex_fmt{size} << frg::endlog;
+	                  << ", size: 0x" << frg::hex_fmt{size} << frg::endlog;
 
 	setShadowRange(base, size & ~(kasanScale - 1), 0);
-	if(size & (kasanScale - 1))
+	if (size & (kasanScale - 1))
 		setShadowByte(base + (size & ~(kasanScale - 1)), size & (kasanScale - 1));
 #else
 	(void)base;
@@ -305,25 +309,26 @@ void unpoisonKasanShadow(address_t base, size_t size) {
 
 void mapRegionsAndStructs() {
 	// This region should be available RAM on every PC.
-	for(size_t page = 0x8000; page < 0x80000; page += pageSize) {
-		mapSingle4kPage(0xFFFF'8000'0000'0000 + page,
-			page, PageFlags::write | PageFlags::global);
-		mapSingle4kPage(page, page,
-			PageFlags::write | PageFlags::global | PageFlags::execute);
+	for (size_t page = 0x8000; page < 0x80000; page += pageSize) {
+		mapSingle4kPage(0xFFFF'8000'0000'0000 + page, page, PageFlags::write | PageFlags::global);
+		mapSingle4kPage(page, page, PageFlags::write | PageFlags::global | PageFlags::execute);
 	}
 
 	mapKasanShadow(0xFFFF'8000'0000'8000, 0x80000);
 	unpoisonKasanShadow(0xFFFF'8000'0000'8000, 0x80000);
 
 	address_t treeMapping = 0xFFFF'C080'0000'0000;
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType != RegionType::allocatable)
+	for (size_t i = 0; i < numRegions; ++i) {
+		if (regions[i].regionType != RegionType::allocatable)
 			continue;
 
 		// Map the region itself.
-		for(address_t page = 0; page < regions[i].size; page += pageSize)
-			mapSingle4kPage(0xFFFF'8000'0000'0000 + regions[i].address + page,
-					regions[i].address + page, PageFlags::write | PageFlags::global);
+		for (address_t page = 0; page < regions[i].size; page += pageSize)
+			mapSingle4kPage(
+			    0xFFFF'8000'0000'0000 + regions[i].address + page,
+			    regions[i].address + page,
+			    PageFlags::write | PageFlags::global
+			);
 		mapKasanShadow(0xFFFF'8000'0000'0000 + regions[i].address, regions[i].size);
 		unpoisonKasanShadow(0xFFFF'8000'0000'0000 + regions[i].address, regions[i].size);
 
@@ -331,9 +336,12 @@ void mapRegionsAndStructs() {
 		address_t buddyMapping = treeMapping;
 		treeMapping += regions[i].buddyOverhead;
 
-		for(address_t page = 0; page < regions[i].buddyOverhead; page += pageSize) {
-			mapSingle4kPage(buddyMapping + page,
-					regions[i].buddyTree + page, PageFlags::write | PageFlags::global);
+		for (address_t page = 0; page < regions[i].buddyOverhead; page += pageSize) {
+			mapSingle4kPage(
+			    buddyMapping + page,
+			    regions[i].buddyTree + page,
+			    PageFlags::write | PageFlags::global
+			);
 		}
 		mapKasanShadow(buddyMapping, regions[i].buddyOverhead);
 		unpoisonKasanShadow(buddyMapping, regions[i].buddyOverhead);
@@ -344,8 +352,9 @@ void mapRegionsAndStructs() {
 void allocLogRingBuffer() {
 	// 256 MiB
 	for (size_t i = 0; i < 0x1000'0000; i += pageSize)
-		mapSingle4kPage(0xFFFF'F000'0000'0000 + i,
-				allocPage(), PageFlags::write | PageFlags::global);
+		mapSingle4kPage(
+		    0xFFFF'F000'0000'0000 + i, allocPage(), PageFlags::write | PageFlags::global
+		);
 	mapKasanShadow(0xFFFF'F000'0000'0000, 0x1000'0000);
 	unpoisonKasanShadow(0xFFFF'F000'0000'0000, 0x1000'0000);
 }
@@ -374,65 +383,65 @@ void parseInitrd(void *initrd) {
 	auto initrd_end = reinterpret_cast<uintptr_t>(cpio_range.eof());
 	eir::infoLogger() << "Initrd ends at " << (void *)initrd_end << frg::endlog;
 	initrd_image = frg::span<uint8_t>{
-		reinterpret_cast<uint8_t *>(initrd),
-		initrd_end - reinterpret_cast<uintptr_t>(initrd)};
+	    reinterpret_cast<uint8_t *>(initrd), initrd_end - reinterpret_cast<uintptr_t>(initrd)
+	};
 
-	for(auto entry : cpio_range) {
-		if(entry.name == "thor") {
+	for (auto entry : cpio_range) {
+		if (entry.name == "thor") {
 			kernel_image = entry.data;
 		}
 	}
 
-	if(!kernel_image.data() || !kernel_image.size())
+	if (!kernel_image.data() || !kernel_image.size())
 		eir::panicLogger() << "eir: could not find thor in the initrd.cpio" << frg::endlog;
 }
 
 address_t loadKernelImage(void *image) {
 	Elf64_Ehdr ehdr;
 	memcpy(&ehdr, image, sizeof(Elf64_Ehdr));
-	if(ehdr.e_ident[0] != '\x7F'
-			|| ehdr.e_ident[1] != 'E'
-			|| ehdr.e_ident[2] != 'L'
-			|| ehdr.e_ident[3] != 'F') {
+	if (ehdr.e_ident[0] != '\x7F' || ehdr.e_ident[1] != 'E' || ehdr.e_ident[2] != 'L'
+	    || ehdr.e_ident[3] != 'F') {
 		eir::panicLogger() << "Illegal magic fields" << frg::endlog;
 	}
 	assert(ehdr.e_type == ET_EXEC);
 
-	for(int i = 0; i < ehdr.e_phnum; i++) {
+	for (int i = 0; i < ehdr.e_phnum; i++) {
 		Elf64_Phdr phdr;
-		memcpy(&phdr, (void *)((uintptr_t)image
-				+ (uintptr_t)ehdr.e_phoff
-				+ i * ehdr.e_phentsize),
-				sizeof(Elf64_Phdr));
-		if(phdr.p_type != PT_LOAD)
+		memcpy(
+		    &phdr,
+		    (void *)((uintptr_t)image + (uintptr_t)ehdr.e_phoff + i * ehdr.e_phentsize),
+		    sizeof(Elf64_Phdr)
+		);
+		if (phdr.p_type != PT_LOAD)
 			continue;
 		assert(!(phdr.p_offset & (pageSize - 1)));
 		assert(!(phdr.p_vaddr & (pageSize - 1)));
 
 		uint32_t map_flags = PageFlags::global;
-		if((phdr.p_flags & (PF_R | PF_W | PF_X)) == PF_R) {
+		if ((phdr.p_flags & (PF_R | PF_W | PF_X)) == PF_R) {
 			// no additional flags
-		}else if((phdr.p_flags & (PF_R | PF_W | PF_X)) == (PF_R | PF_W)) {
+		} else if ((phdr.p_flags & (PF_R | PF_W | PF_X)) == (PF_R | PF_W)) {
 			map_flags |= PageFlags::write;
-		}else if((phdr.p_flags & (PF_R | PF_W | PF_X)) == (PF_R | PF_X)) {
+		} else if ((phdr.p_flags & (PF_R | PF_W | PF_X)) == (PF_R | PF_X)) {
 			map_flags |= PageFlags::execute;
-		}else if((phdr.p_flags & (PF_R | PF_W | PF_X)) == (PF_R | PF_W | PF_X)) {
+		} else if ((phdr.p_flags & (PF_R | PF_W | PF_X)) == (PF_R | PF_W | PF_X)) {
 			eir::infoLogger() << "eir: warning: Mapping PHDR with RWX permissions" << frg::endlog;
 			map_flags |= PageFlags::write | PageFlags::execute;
-		}else{
-			eir::panicLogger() << "Illegal combination of segment permissions"
-					<< frg::endlog;
+		} else {
+			eir::panicLogger() << "Illegal combination of segment permissions" << frg::endlog;
 		}
 
 		uintptr_t pg = 0;
-		while(pg < (uintptr_t)phdr.p_memsz) {
+		while (pg < (uintptr_t)phdr.p_memsz) {
 			auto backing = allocPage();
 			auto backingVirt = physToVirt<uint8_t>(backing);
 			memset(backingVirt, 0, pageSize);
-			if(pg < (uintptr_t)phdr.p_filesz)
-				memcpy(backingVirt,
-						reinterpret_cast<void *>((uintptr_t)image + (uintptr_t)phdr.p_offset + pg),
-						frg::min(pageSize, (uintptr_t)phdr.p_filesz - pg));
+			if (pg < (uintptr_t)phdr.p_filesz)
+				memcpy(
+				    backingVirt,
+				    reinterpret_cast<void *>((uintptr_t)image + (uintptr_t)phdr.p_offset + pg),
+				    frg::min(pageSize, (uintptr_t)phdr.p_filesz - pg)
+				);
 			mapSingle4kPage(phdr.p_vaddr + pg, backing, map_flags);
 			pg += pageSize;
 		}
@@ -444,7 +453,7 @@ address_t loadKernelImage(void *image) {
 	return ehdr.e_entry;
 }
 
-EirInfo *generateInfo(frg::string_view cmdline){
+EirInfo *generateInfo(frg::string_view cmdline) {
 	// Setup the eir interface struct.
 	auto info_ptr = bootAlloc<EirInfo>();
 	memset(info_ptr, 0, sizeof(EirInfo));
@@ -454,8 +463,8 @@ EirInfo *generateInfo(frg::string_view cmdline){
 
 	// Pass all memory regions to thor.
 	int n = 0;
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType == RegionType::allocatable)
+	for (size_t i = 0; i < numRegions; ++i) {
+		if (regions[i].regionType == RegionType::allocatable)
 			n++;
 	}
 
@@ -463,8 +472,8 @@ EirInfo *generateInfo(frg::string_view cmdline){
 	info_ptr->numRegions = n;
 	info_ptr->regionInfo = mapBootstrapData(regionInfos);
 	int j = 0;
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType != RegionType::allocatable)
+	for (size_t i = 0; i < numRegions; ++i) {
+		if (regions[i].regionType != RegionType::allocatable)
 			continue;
 
 		regionInfos[j].address = regions[i].address;
@@ -477,22 +486,22 @@ EirInfo *generateInfo(frg::string_view cmdline){
 
 	// Parse the kernel command line.
 	const char *l = cmdline.data();
-	while(true) {
-		while(*l && *l == ' ')
+	while (true) {
+		while (*l && *l == ' ')
 			l++;
-		if(!(*l))
+		if (!(*l))
 			break;
 
 		const char *s = l;
-		while(*s && *s != ' ')
+		while (*s && *s != ' ')
 			s++;
 
 		frg::string_view token{l, static_cast<size_t>(s - l)};
-		if(token == "serial") {
+		if (token == "serial") {
 			info_ptr->debugFlags |= eirDebugSerial;
-		}else if(token == "bochs") {
+		} else if (token == "bochs") {
 			info_ptr->debugFlags |= eirDebugBochs;
-		}else if(token == "kernel-profile") {
+		} else if (token == "kernel-profile") {
 			info_ptr->debugFlags |= eirDebugKernelProfile;
 		}
 		l = s;

--- a/kernel/eir/protos/limine/entry.cpp
+++ b/kernel/eir/protos/limine/entry.cpp
@@ -1,12 +1,12 @@
-#include <stdint.h>
 #include <assert.h>
-#include <eir/interface.hpp>
-#include <eir-internal/arch.hpp>
-#include <eir-internal/generic.hpp>
-#include <eir-internal/debug.hpp>
-#include <eir-internal/main.hpp>
 #include <dtb.hpp>
+#include <eir-internal/arch.hpp>
+#include <eir-internal/debug.hpp>
+#include <eir-internal/generic.hpp>
+#include <eir-internal/main.hpp>
+#include <eir/interface.hpp>
 #include <frg/cmdline.hpp>
+#include <stdint.h>
 #include <uacpi/acpi.h>
 
 #include "limine.h"
@@ -15,12 +15,12 @@ namespace eir {
 
 namespace {
 
-#define LIMINE_REQUEST(request, tag, rev) \
-	[[gnu::used, gnu::section(".requests")]] \
-	volatile struct limine_##request request = { \
-		.id = tag, \
-		.revision = rev, \
-		.response = nullptr, \
+#define LIMINE_REQUEST(request, tag, rev)                                                          \
+	[[gnu::used, gnu::section(".requests")]]                                                       \
+	volatile struct limine_##request request = {                                                   \
+	    .id = tag,                                                                                 \
+	    .revision = rev,                                                                           \
+	    .response = nullptr,                                                                       \
 	}
 
 [[gnu::used, gnu::section(".requestsStartMarker")]] volatile LIMINE_REQUESTS_START_MARKER;
@@ -36,94 +36,100 @@ LIMINE_REQUEST(rsdp_request, LIMINE_RSDP_REQUEST, 0);
 LIMINE_REQUEST(dtb_request, LIMINE_DTB_REQUEST, 0);
 [[gnu::used, gnu::section(".requestsEndMarker")]] volatile LIMINE_REQUESTS_END_MARKER;
 
-initgraph::Task setupMiscInfo{&globalInitEngine,
-	"limine.setup-misc-info",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
+initgraph::Task setupMiscInfo{
+    &globalInitEngine,
+    "limine.setup-misc-info",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] {
 #ifdef __riscv
-		info_ptr->hartId = smp_request.response->bsp_hartid;
+	    info_ptr->hartId = smp_request.response->bsp_hartid;
 #endif
 
-		if(dtb_request.response) {
-			DeviceTree dt{dtb_request.response->dtb_ptr};
-			info_ptr->dtbPtr = virtToPhys(dtb_request.response->dtb_ptr);
-			info_ptr->dtbSize = dt.size();
-		}
+	    if (dtb_request.response) {
+		    DeviceTree dt{dtb_request.response->dtb_ptr};
+		    info_ptr->dtbPtr = virtToPhys(dtb_request.response->dtb_ptr);
+		    info_ptr->dtbSize = dt.size();
+	    }
 
-		if(rsdp_request.response) {
-			info_ptr->acpiRsdp = virtToPhys(rsdp_request.response->address);
-		}
-	}
+	    if (rsdp_request.response) {
+		    info_ptr->acpiRsdp = virtToPhys(rsdp_request.response->address);
+	    }
+    }
 };
 
-initgraph::Task setupFramebufferInfo{&globalInitEngine,
-	"limine.setup-framebuffer-info",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
-		if(framebuffer_request.response &&
-		   framebuffer_request.response->framebuffer_count > 0 &&
-		   framebuffer_request.response->framebuffers) {
-			auto *limine_fb = framebuffer_request.response->framebuffers[0];
-			fb = &info_ptr->frameBuffer;
-			fb->fbAddress = virtToPhys(limine_fb->address);
-			fb->fbPitch = limine_fb->pitch;
-			fb->fbWidth = limine_fb->width;
-			fb->fbHeight = limine_fb->height;
-			fb->fbBpp = limine_fb->bpp;
-			fb->fbType = limine_fb->memory_model; // TODO: Maybe inaccurate
-		} else {
-			infoLogger() << "eir: Got no framebuffer!" << frg::endlog;
-		}
-	}
+initgraph::Task setupFramebufferInfo{
+    &globalInitEngine,
+    "limine.setup-framebuffer-info",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] {
+	    if (framebuffer_request.response && framebuffer_request.response->framebuffer_count > 0
+	        && framebuffer_request.response->framebuffers) {
+		    auto *limine_fb = framebuffer_request.response->framebuffers[0];
+		    fb = &info_ptr->frameBuffer;
+		    fb->fbAddress = virtToPhys(limine_fb->address);
+		    fb->fbPitch = limine_fb->pitch;
+		    fb->fbWidth = limine_fb->width;
+		    fb->fbHeight = limine_fb->height;
+		    fb->fbBpp = limine_fb->bpp;
+		    fb->fbType = limine_fb->memory_model; // TODO: Maybe inaccurate
+	    } else {
+		    infoLogger() << "eir: Got no framebuffer!" << frg::endlog;
+	    }
+    }
 };
 
-initgraph::Task setupMemoryRegions{&globalInitEngine,
-	"limine.setup-memory-regions",
-	initgraph::Requires{getReservedRegionsKnownStage()},
-	initgraph::Entails{getMemoryRegionsKnownStage()},
-	[] {
-		assert(memmap_request.response);
+initgraph::Task setupMemoryRegions{
+    &globalInitEngine,
+    "limine.setup-memory-regions",
+    initgraph::Requires{getReservedRegionsKnownStage()},
+    initgraph::Entails{getMemoryRegionsKnownStage()},
+    [] {
+	    assert(memmap_request.response);
 
-		eir::infoLogger() << "Memory map:" << frg::endlog;
-		for(size_t entry = 0; entry < memmap_request.response->entry_count; entry++) {
-			auto *map = memmap_request.response->entries[entry];
-			eir::infoLogger() << "    Type " << map->type << " mapping."
-					<< " Base: 0x" << frg::hex_fmt{map->base}
-					<< ", length: 0x" << frg::hex_fmt{map->length} << frg::endlog;
-			if(map->type == LIMINE_MEMMAP_USABLE || map->type == LIMINE_MEMMAP_BOOTLOADER_RECLAIMABLE)
-				createInitialRegions({map->base, map->length}, {reservedRegions.data(), nReservedRegions});
-		}
-	}
+	    eir::infoLogger() << "Memory map:" << frg::endlog;
+	    for (size_t entry = 0; entry < memmap_request.response->entry_count; entry++) {
+		    auto *map = memmap_request.response->entries[entry];
+		    eir::infoLogger() << "    Type " << map->type << " mapping."
+		                      << " Base: 0x" << frg::hex_fmt{map->base} << ", length: 0x"
+		                      << frg::hex_fmt{map->length} << frg::endlog;
+		    if (map->type == LIMINE_MEMMAP_USABLE
+		        || map->type == LIMINE_MEMMAP_BOOTLOADER_RECLAIMABLE)
+			    createInitialRegions(
+			        {map->base, map->length}, {reservedRegions.data(), nReservedRegions}
+			    );
+	    }
+    }
 };
 
-initgraph::Task setupInitrdInfo{&globalInitEngine,
-	"limine.setup-initrd-info",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
-		auto initrd_module = bootAlloc<EirModule>(1);
-		initrd_module->physicalBase = virtToPhys(initrd);
-		initrd_module->length = module_request.response->modules[0]->size;
-		const char *initrd_mod_name = "initrd.cpio";
-		size_t name_length = strlen(initrd_mod_name);
-		char *name_ptr = bootAlloc<char>(name_length);
-		memcpy(name_ptr, initrd_mod_name, name_length);
-		initrd_module->namePtr = mapBootstrapData(name_ptr);
-		initrd_module->nameLength = name_length;
+initgraph::Task setupInitrdInfo{
+    &globalInitEngine,
+    "limine.setup-initrd-info",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] {
+	    auto initrd_module = bootAlloc<EirModule>(1);
+	    initrd_module->physicalBase = virtToPhys(initrd);
+	    initrd_module->length = module_request.response->modules[0]->size;
+	    const char *initrd_mod_name = "initrd.cpio";
+	    size_t name_length = strlen(initrd_mod_name);
+	    char *name_ptr = bootAlloc<char>(name_length);
+	    memcpy(name_ptr, initrd_mod_name, name_length);
+	    initrd_module->namePtr = mapBootstrapData(name_ptr);
+	    initrd_module->nameLength = name_length;
 
-		info_ptr->moduleInfo = mapBootstrapData(initrd_module);
-	}
+	    info_ptr->moduleInfo = mapBootstrapData(initrd_module);
+    }
 };
 
 } // namespace
 
-extern "C" void eirLimineMain(void){
+extern "C" void eirLimineMain(void) {
 	eir::infoLogger() << "Booting Eir from Limine" << frg::endlog;
 	eirRunConstructors();
 
-	if(dtb_request.response) {
+	if (dtb_request.response) {
 		eirDtbPtr = dtb_request.response->dtb_ptr;
 		eir::infoLogger() << "DTB accessible at " << eirDtbPtr << frg::endlog;
 	} else {
@@ -131,11 +137,11 @@ extern "C" void eirLimineMain(void){
 	}
 
 	assert(kernel_file_request.response);
-	cmdline = frg::string_view {kernel_file_request.response->kernel_file->cmdline};
+	cmdline = frg::string_view{kernel_file_request.response->kernel_file->cmdline};
 	eir::infoLogger() << "Command line: " << cmdline << frg::endlog;
 
 	frg::array args = {
-		frg::option{"bochs", frg::store_true(log_e9)},
+	    frg::option{"bochs", frg::store_true(log_e9)},
 	};
 	frg::parse_arguments(cmdline, args);
 

--- a/kernel/eir/protos/multiboot2/eir-internal/spec.hpp
+++ b/kernel/eir/protos/multiboot2/eir-internal/spec.hpp
@@ -55,8 +55,7 @@ struct Mb2TagFramebuffer {
 			uint16_t palette_num_colors;
 			Mb2Colour palette[];
 		};
-		struct
-		{
+		struct {
 			uint8_t red_field_position;
 			uint8_t red_mask_size;
 			uint8_t green_field_position;

--- a/kernel/eir/protos/multiboot2/multiboot2.cpp
+++ b/kernel/eir/protos/multiboot2/multiboot2.cpp
@@ -1,152 +1,162 @@
-#include <stdint.h>
 #include <assert.h>
-#include <eir/interface.hpp>
 #include <eir-internal/arch.hpp>
-#include <eir-internal/generic.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
 #include <eir-internal/spec.hpp>
+#include <eir/interface.hpp>
+#include <stdint.h>
 #include <uacpi/acpi.h>
 
 namespace eir {
 
 namespace {
 
-eir::Mb2Info* mbInfo = nullptr;
+eir::Mb2Info *mbInfo = nullptr;
 
 uintptr_t mmapStart = 0;
 uintptr_t mmapEnd = 0;
 
-eir::Mb2TagFramebuffer* framebuffer = nullptr;
+eir::Mb2TagFramebuffer *framebuffer = nullptr;
 eir::Mb2Tag *acpiTag = nullptr;
 
-initgraph::Task setupAcpiInfo{&globalInitEngine,
-	"mb2.setup-acpi-info",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
-		if(acpiTag) {
-			auto *rsdpPtr = bootAlloc<uint8_t>(acpiTag->size - sizeof(Mb2TagRSDP));
-			memcpy(rsdpPtr, acpiTag->data, acpiTag->size - sizeof(Mb2TagRSDP));
-			info_ptr->acpiRsdp = reinterpret_cast<uint64_t>(rsdpPtr);
-		}
-	}
+initgraph::Task setupAcpiInfo{
+    &globalInitEngine,
+    "mb2.setup-acpi-info",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] {
+	    if (acpiTag) {
+		    auto *rsdpPtr = bootAlloc<uint8_t>(acpiTag->size - sizeof(Mb2TagRSDP));
+		    memcpy(rsdpPtr, acpiTag->data, acpiTag->size - sizeof(Mb2TagRSDP));
+		    info_ptr->acpiRsdp = reinterpret_cast<uint64_t>(rsdpPtr);
+	    }
+    }
 };
 
-initgraph::Task setupFramebufferInfo{&globalInitEngine,
-	"mb2.setup-framebuffer-info",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
-		if(framebuffer) {
-			fb = &info_ptr->frameBuffer;
-			fb->fbAddress = framebuffer->address;
-			fb->fbPitch = framebuffer->pitch;
-			fb->fbWidth = framebuffer->width;
-			fb->fbHeight = framebuffer->height;
-			fb->fbBpp = framebuffer->bpp;
-			fb->fbType = framebuffer->type;
-		}
-	}
+initgraph::Task setupFramebufferInfo{
+    &globalInitEngine,
+    "mb2.setup-framebuffer-info",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] {
+	    if (framebuffer) {
+		    fb = &info_ptr->frameBuffer;
+		    fb->fbAddress = framebuffer->address;
+		    fb->fbPitch = framebuffer->pitch;
+		    fb->fbWidth = framebuffer->width;
+		    fb->fbHeight = framebuffer->height;
+		    fb->fbBpp = framebuffer->bpp;
+		    fb->fbType = framebuffer->type;
+	    }
+    }
 };
 
-initgraph::Task setupMemoryRegions{&globalInitEngine,
-	"mb2.setup-memory-regions",
-	initgraph::Requires{getReservedRegionsKnownStage()},
-	initgraph::Entails{getMemoryRegionsKnownStage()},
-	[] {
-		assert(mmapStart);
-		assert(mmapEnd > mmapStart);
-		assert(cmdline.data()); // Make sure it at least exists
+initgraph::Task setupMemoryRegions{
+    &globalInitEngine,
+    "mb2.setup-memory-regions",
+    initgraph::Requires{getReservedRegionsKnownStage()},
+    initgraph::Entails{getMemoryRegionsKnownStage()},
+    [] {
+	    assert(mmapStart);
+	    assert(mmapEnd > mmapStart);
+	    assert(cmdline.data()); // Make sure it at least exists
 
-		eir::infoLogger() << "Command line: " << cmdline << frg::endlog;
+	    eir::infoLogger() << "Command line: " << cmdline << frg::endlog;
 
-		eir::infoLogger() << "Memory map:" << frg::endlog;
-		for(Mb2MmapEntry* map = (Mb2MmapEntry*)mmapStart; map < (Mb2MmapEntry*)mmapEnd; map++) {
-			eir::infoLogger() << "    Type " << map->type << " mapping."
-					<< " Base: 0x" << frg::hex_fmt{map->base}
-					<< ", length: 0x" << frg::hex_fmt{map->length} << frg::endlog;
-			if(map->type == 1)
-				createInitialRegions({map->base, map->length}, {reservedRegions.data(), nReservedRegions});
-		}
-	}
+	    eir::infoLogger() << "Memory map:" << frg::endlog;
+	    for (Mb2MmapEntry *map = (Mb2MmapEntry *)mmapStart; map < (Mb2MmapEntry *)mmapEnd; map++) {
+		    eir::infoLogger() << "    Type " << map->type << " mapping."
+		                      << " Base: 0x" << frg::hex_fmt{map->base} << ", length: 0x"
+		                      << frg::hex_fmt{map->length} << frg::endlog;
+		    if (map->type == 1)
+			    createInitialRegions(
+			        {map->base, map->length}, {reservedRegions.data(), nReservedRegions}
+			    );
+	    }
+    }
 };
 
-initgraph::Task setupInitrdInfo{&globalInitEngine,
-	"mb2.setup-initrd-info",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
-		auto initrd_module = bootAlloc<EirModule>(1);
-		size_t add_size = 0;
+initgraph::Task setupInitrdInfo{
+    &globalInitEngine,
+    "mb2.setup-initrd-info",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] {
+	    auto initrd_module = bootAlloc<EirModule>(1);
+	    size_t add_size = 0;
 
-		for(size_t i = 8 /* Skip size and reserved fields*/; i < mbInfo->size; i += add_size){
-			Mb2Tag *tag = (Mb2Tag *) ((uint8_t *) mbInfo + i);
+	    for (size_t i = 8 /* Skip size and reserved fields*/; i < mbInfo->size; i += add_size) {
+		    Mb2Tag *tag = (Mb2Tag *)((uint8_t *)mbInfo + i);
 
-			if(tag->type == kMb2TagEnd)
-				break;
+		    if (tag->type == kMb2TagEnd)
+			    break;
 
-			add_size = tag->size;
-			if((add_size % 8)!= 0)
-				add_size += (8 - add_size % 8); // Align 8byte
+		    add_size = tag->size;
+		    if ((add_size % 8) != 0)
+			    add_size += (8 - add_size % 8); // Align 8byte
 
-			switch (tag->type) {
-				case kMb2TagModule: {
-					auto *module = reinterpret_cast<Mb2TagModule *>(tag);
+		    switch (tag->type) {
+			    case kMb2TagModule: {
+				    auto *module = reinterpret_cast<Mb2TagModule *>(tag);
 
-					initrd_module->physicalBase = (EirPtr)module->start;
-					initrd_module->length = (EirPtr)module->end - (EirPtr)module->start;
+				    initrd_module->physicalBase = (EirPtr)module->start;
+				    initrd_module->length = (EirPtr)module->end - (EirPtr)module->start;
 
-					size_t name_length = strlen(module->string);
-					char *name_ptr = bootAlloc<char>(name_length);
-					memcpy(name_ptr, module->string, name_length);
-					initrd_module->namePtr = mapBootstrapData(name_ptr);
-					initrd_module->nameLength = name_length;
-					break;
-				}
-			}
-		}
+				    size_t name_length = strlen(module->string);
+				    char *name_ptr = bootAlloc<char>(name_length);
+				    memcpy(name_ptr, module->string, name_length);
+				    initrd_module->namePtr = mapBootstrapData(name_ptr);
+				    initrd_module->nameLength = name_length;
+				    break;
+			    }
+		    }
+	    }
 
-		info_ptr->moduleInfo = mapBootstrapData(initrd_module);
-	}
+	    info_ptr->moduleInfo = mapBootstrapData(initrd_module);
+    }
 };
 
 } // namespace
 
-extern "C" void eirMultiboot2Main(uint32_t info, uint32_t magic){
-	if(magic != MB2_MAGIC)
+extern "C" void eirMultiboot2Main(uint32_t info, uint32_t magic) {
+	if (magic != MB2_MAGIC)
 		eir::panicLogger() << "eir: Invalid multiboot2 signature, halting..." << frg::endlog;
 
 	uintptr_t eirEnd = reinterpret_cast<uintptr_t>(&eirImageCeiling);
 	reservedRegions[nReservedRegions++] = {0, eirEnd};
 
-	mbInfo = reinterpret_cast<Mb2Info*>(info);
+	mbInfo = reinterpret_cast<Mb2Info *>(info);
 	size_t add_size = 0;
 	size_t n_modules = 0;
 
-	for(size_t i = 8 /* Skip size and reserved fields*/; i < mbInfo->size; i += add_size){
-		Mb2Tag* tag = (Mb2Tag*)((uint8_t*)info + i);
+	for (size_t i = 8 /* Skip size and reserved fields*/; i < mbInfo->size; i += add_size) {
+		Mb2Tag *tag = (Mb2Tag *)((uint8_t *)info + i);
 
-		if(tag->type == kMb2TagEnd)
+		if (tag->type == kMb2TagEnd)
 			break;
 
 		add_size = tag->size;
-		if((add_size % 8)!= 0)
+		if ((add_size % 8) != 0)
 			add_size += (8 - add_size % 8); // Align 8byte
 
 		switch (tag->type) {
 			case kMb2TagFramebuffer: {
-				auto *framebuffer_tag = reinterpret_cast<Mb2TagFramebuffer*>(tag);
-				if(framebuffer_tag->address + framebuffer_tag->width * framebuffer_tag->pitch >= UINTPTR_MAX) {
-					eir::infoLogger() << "eir: Framebuffer outside of addressable memory!"
-						<< frg::endlog;
+				auto *framebuffer_tag = reinterpret_cast<Mb2TagFramebuffer *>(tag);
+				if (framebuffer_tag->address + framebuffer_tag->width * framebuffer_tag->pitch
+				    >= UINTPTR_MAX) {
+					eir::infoLogger()
+					    << "eir: Framebuffer outside of addressable memory!" << frg::endlog;
 					framebuffer = framebuffer_tag;
-				}else if(framebuffer_tag->bpp != 32) {
-					eir::infoLogger() << "eir: Framebuffer does not use 32 bpp!"
-						<< frg::endlog;
-				}else{
-					setFbInfo(reinterpret_cast<void *>(framebuffer_tag->address),
-							framebuffer_tag->width, framebuffer_tag->height, framebuffer_tag->pitch);
+				} else if (framebuffer_tag->bpp != 32) {
+					eir::infoLogger() << "eir: Framebuffer does not use 32 bpp!" << frg::endlog;
+				} else {
+					setFbInfo(
+					    reinterpret_cast<void *>(framebuffer_tag->address),
+					    framebuffer_tag->width,
+					    framebuffer_tag->height,
+					    framebuffer_tag->pitch
+					);
 
 					framebuffer = framebuffer_tag;
 				}
@@ -154,9 +164,9 @@ extern "C" void eirMultiboot2Main(uint32_t info, uint32_t magic){
 			}
 
 			case kMb2TagModule: {
-				auto *module = reinterpret_cast<Mb2TagModule*>(tag);
+				auto *module = reinterpret_cast<Mb2TagModule *>(tag);
 
-				if(n_modules)
+				if (n_modules)
 					eir::panicLogger() << "eir: only one module is supported!" << frg::endlog;
 
 				initrd = reinterpret_cast<void *>(module->start);
@@ -167,7 +177,7 @@ extern "C" void eirMultiboot2Main(uint32_t info, uint32_t magic){
 			}
 
 			case kMb2TagMmap: {
-				auto *mmap = reinterpret_cast<Mb2TagMmap*>(tag);
+				auto *mmap = reinterpret_cast<Mb2TagMmap *>(tag);
 
 				mmapStart = (uintptr_t)mmap->entries;
 				mmapEnd = (uintptr_t)mmap + mmap->length;
@@ -176,7 +186,7 @@ extern "C" void eirMultiboot2Main(uint32_t info, uint32_t magic){
 			}
 
 			case kMb2TagCmdline: {
-				auto *cmdline_tag = reinterpret_cast<Mb2TagCmdline*>(tag);
+				auto *cmdline_tag = reinterpret_cast<Mb2TagCmdline *>(tag);
 
 				cmdline = {cmdline_tag->string};
 

--- a/kernel/eir/protos/uefi/efi.hpp
+++ b/kernel/eir/protos/uefi/efi.hpp
@@ -55,16 +55,15 @@ struct efi_configuration_table {
 	void *vendor_table;
 };
 
-constexpr efi_guid ACPI_20_TABLE_GUID = { 0x8868e871, 0xe4f1, 0x11d3, { 0xbc, 0x22, 0x00, 0x80, 0xc7, 0x3c, 0x88, 0x81 } };
-constexpr efi_guid EFI_DTB_TABLE_GUID = { 0xb1b621d5, 0xf19c, 0x41a5, { 0x83, 0x0b, 0xd9, 0x15, 0x2c, 0x69, 0xaa, 0xe0 } };
+constexpr efi_guid ACPI_20_TABLE_GUID = {
+    0x8868e871, 0xe4f1, 0x11d3, {0xbc, 0x22, 0x00, 0x80, 0xc7, 0x3c, 0x88, 0x81}
+};
+constexpr efi_guid EFI_DTB_TABLE_GUID = {
+    0xb1b621d5, 0xf19c, 0x41a5, {0x83, 0x0b, 0xd9, 0x15, 0x2c, 0x69, 0xaa, 0xe0}
+};
 
 // 7.2.1 EFI_BOOT_SERVICES.AllocatePages()
-enum efi_allocate_type {
-	AllocateAnyPages,
-	AllocateMaxAddress,
-	AllocateAddress,
-	MaxAllocateType
-};
+enum efi_allocate_type { AllocateAnyPages, AllocateMaxAddress, AllocateAddress, MaxAllocateType };
 
 enum efi_memory_type {
 	EfiReservedMemoryType,
@@ -118,7 +117,9 @@ struct efi_time {
 
 // 9.1.1 EFI_LOADED_IMAGE_PROTOCOL
 
-constexpr efi_guid EFI_LOADED_IMAGE_PROTOCOL_GUID = {0x5B1B31A1, 0x9562, 0x11d2, {0x8E, 0x3F, 0x00, 0xA0, 0xC9, 0x69, 0x72, 0x3B}};
+constexpr efi_guid EFI_LOADED_IMAGE_PROTOCOL_GUID = {
+    0x5B1B31A1, 0x9562, 0x11d2, {0x8E, 0x3F, 0x00, 0xA0, 0xC9, 0x69, 0x72, 0x3B}
+};
 
 struct efi_loaded_image_protocol {
 	uint32_t revision;
@@ -153,7 +154,9 @@ struct efi_simple_text_output_protocol {
 
 // 12.9.2 EFI_GRAPHICS_OUTPUT_PROTOCOL
 
-constexpr efi_guid EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID = { 0x9042a9de, 0x23dc, 0x4a38, { 0x96, 0xfb, 0x7a, 0xde, 0xd0, 0x80, 0x51, 0x6a } };
+constexpr efi_guid EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID = {
+    0x9042a9de, 0x23dc, 0x4a38, {0x96, 0xfb, 0x7a, 0xde, 0xd0, 0x80, 0x51, 0x6a}
+};
 
 struct efi_graphics_output_protocol_mode;
 
@@ -199,27 +202,42 @@ struct efi_graphics_output_protocol_mode {
 
 // 13.4.1 EFI_SIMPLE_FILE_SYSTEM_PROTOCOL
 
-constexpr efi_guid EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_GUID = { 0x0964e5b22, 0x6459, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+constexpr efi_guid EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_GUID = {
+    0x0964e5b22, 0x6459, 0x11d2, {0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b}
+};
 
 struct efi_file_protocol;
 
 struct efi_simple_file_system_protocol {
 	uint64_t revision;
-	efi_status (*open_volume)(struct efi_simple_file_system_protocol *self, struct efi_file_protocol **root);
+	efi_status (*open_volume)(
+	    struct efi_simple_file_system_protocol *self, struct efi_file_protocol **root
+	);
 };
 
 // 13.5.1 EFI_FILE_PROTOCOL
 
 struct efi_file_protocol {
 	uint64_t revision;
-	efi_status (*open)(struct efi_file_protocol *self, struct efi_file_protocol **new_handle, char16_t *file_name, uint64_t open_mode, uint64_t attributes);
+	efi_status (*open)(
+	    struct efi_file_protocol *self,
+	    struct efi_file_protocol **new_handle,
+	    char16_t *file_name,
+	    uint64_t open_mode,
+	    uint64_t attributes
+	);
 	void *close;
 	void *del;
 	efi_status (*read)(struct efi_file_protocol *self, size_t *buffer_size, void *buffer);
 	void *write;
 	efi_status (*get_position)(struct efi_file_protocol *self, uint64_t *position);
 	efi_status (*set_position)(struct efi_file_protocol *self, uint64_t position);
-	efi_status (*get_info)(struct efi_file_protocol *self, efi_guid *information_type, size_t *buffer_size, void *buffer);
+	efi_status (*get_info)(
+	    struct efi_file_protocol *self,
+	    efi_guid *information_type,
+	    size_t *buffer_size,
+	    void *buffer
+	);
 	void *set_info;
 	void *flush;
 	void *open_ex;
@@ -244,7 +262,9 @@ constexpr uint64_t EFI_FILE_VALID_ATTR = 0x0000000000000037;
 
 // 13.5.16 EFI_FILE_INFO
 
-constexpr efi_guid EFI_FILE_INFO_GUID = { 0x09576e92, 0x6d3f, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+constexpr efi_guid EFI_FILE_INFO_GUID = {
+    0x09576e92, 0x6d3f, 0x11d2, {0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b}
+};
 
 struct efi_file_info {
 	uint64_t size;
@@ -305,7 +325,9 @@ constexpr efi_status EFI_HTTP_ERROR = (INTPTR_MAX + 1ULL) + 35;
 
 // Related Documents: RISC-V EFI Boot Protocol
 
-constexpr efi_guid RISCV_EFI_BOOT_PROTOCOL_GUID = { 0xccd15fec, 0x6f73, 0x4eec, { 0x83, 0x95, 0x3e, 0x69, 0xe4, 0xb9, 0x40, 0xbf } };
+constexpr efi_guid RISCV_EFI_BOOT_PROTOCOL_GUID = {
+    0xccd15fec, 0x6f73, 0x4eec, {0x83, 0x95, 0x3e, 0x69, 0xe4, 0xb9, 0x40, 0xbf}
+};
 
 struct riscv_efi_boot_protocol {
 	uint64_t revision;
@@ -322,9 +344,17 @@ struct efi_boot_services {
 	efi_table_header hdr;
 	void *raise_tpl;
 	void *restore_tpl;
-	efi_status (*allocate_pages)(efi_allocate_type type, efi_memory_type memory_type, size_t pages, efi_physical_addr *memory);
+	efi_status (*allocate_pages)(
+	    efi_allocate_type type, efi_memory_type memory_type, size_t pages, efi_physical_addr *memory
+	);
 	void *free_pages;
-	efi_status (*get_memory_map)(size_t *memory_map_size, efi_memory_descriptor *memory_map, size_t *map_key, size_t *descriptor_size, uint32_t *descriptor_version);
+	efi_status (*get_memory_map)(
+	    size_t *memory_map_size,
+	    efi_memory_descriptor *memory_map,
+	    size_t *map_key,
+	    size_t *descriptor_size,
+	    uint32_t *descriptor_version
+	);
 	efi_status (*allocate_pool)(efi_memory_type pool_type, size_t size, void **buffer);
 	void *free_pool;
 	void *create_event;
@@ -349,7 +379,9 @@ struct efi_boot_services {
 	efi_status (*exit_boot_services)(efi_handle image_handle, size_t map_key);
 	void *get_next_monotonic_count;
 	void *stall;
-	efi_status (*set_watchdog_timer)(size_t timeout, uint64_t watchdog_code, size_t data_size, char16_t *watchdog_data);
+	efi_status (*set_watchdog_timer)(
+	    size_t timeout, uint64_t watchdog_code, size_t data_size, char16_t *watchdog_data
+	);
 	void *connect_controller;
 	void *disconnect_controller;
 	void *open_protocol;

--- a/kernel/eir/protos/uefi/entry.cpp
+++ b/kernel/eir/protos/uefi/entry.cpp
@@ -13,7 +13,10 @@
 #include "efi.hpp"
 #include "helpers.hpp"
 
-static_assert(sizeof(char16_t) == sizeof(wchar_t), "Strings are not UTF-16-ish, are you missing -fshort-wchar?");
+static_assert(
+    sizeof(char16_t) == sizeof(wchar_t),
+    "Strings are not UTF-16-ish, are you missing -fshort-wchar?"
+);
 
 namespace eir {
 
@@ -44,8 +47,8 @@ initgraph::Stage *getBootservicesDoneStage() {
 }
 
 void uefiBootServicesLogHandler(const char c) {
-	if(bs) {
-		if(c == '\n') {
+	if (bs) {
+		if (c == '\n') {
 			frg::array<char16_t, 3> newline = {u"\r\n"};
 			st->con_out->output_string(st->con_out, newline.data());
 			return;
@@ -56,329 +59,342 @@ void uefiBootServicesLogHandler(const char c) {
 	}
 }
 
-initgraph::Task findAcpi{&globalInitEngine,
-	"uefi.find-acpi",
-	initgraph::Entails{getBootservicesDoneStage()},
-	[] {
-		// acquire ACPI table info
-		efi_guid acpi_guid = ACPI_20_TABLE_GUID;
-		const efi_configuration_table *t = st->configuration_table;
-		for(size_t i = 0; i < st->number_of_table_entries && t; i++, t++)
-			if(!memcmp(&acpi_guid, &t->vendor_guid, sizeof(acpi_guid))) {
-				rsdp = reinterpret_cast<physaddr_t>(t->vendor_table);
-				infoLogger() << "eir: Got RSDP" << frg::endlog;
-			}
-	}
+initgraph::Task findAcpi{
+    &globalInitEngine, "uefi.find-acpi", initgraph::Entails{getBootservicesDoneStage()}, [] {
+	    // acquire ACPI table info
+	    efi_guid acpi_guid = ACPI_20_TABLE_GUID;
+	    const efi_configuration_table *t = st->configuration_table;
+	    for (size_t i = 0; i < st->number_of_table_entries && t; i++, t++)
+		    if (!memcmp(&acpi_guid, &t->vendor_guid, sizeof(acpi_guid))) {
+			    rsdp = reinterpret_cast<physaddr_t>(t->vendor_table);
+			    infoLogger() << "eir: Got RSDP" << frg::endlog;
+		    }
+    }
 };
 
-initgraph::Task findDtb{&globalInitEngine,
-	"uefi.find-dtb",
-	initgraph::Entails{getBootservicesDoneStage()},
-	[] {
-		// acquire ACPI table info
-		efi_guid dtb_guid = EFI_DTB_TABLE_GUID;
-		const efi_configuration_table *t = st->configuration_table;
-		for(size_t i = 0; i < st->number_of_table_entries && t; i++, t++)
-			if(!memcmp(&dtb_guid, &t->vendor_guid, sizeof(dtb_guid))) {
-				eirDtbPtr = physToVirt<void>(reinterpret_cast<physaddr_t>(t->vendor_table));
-				infoLogger() << "eir: Got DTB" << frg::endlog;
-			}
-	}
+initgraph::Task findDtb{
+    &globalInitEngine, "uefi.find-dtb", initgraph::Entails{getBootservicesDoneStage()}, [] {
+	    // acquire ACPI table info
+	    efi_guid dtb_guid = EFI_DTB_TABLE_GUID;
+	    const efi_configuration_table *t = st->configuration_table;
+	    for (size_t i = 0; i < st->number_of_table_entries && t; i++, t++)
+		    if (!memcmp(&dtb_guid, &t->vendor_guid, sizeof(dtb_guid))) {
+			    eirDtbPtr = physToVirt<void>(reinterpret_cast<physaddr_t>(t->vendor_table));
+			    infoLogger() << "eir: Got DTB" << frg::endlog;
+		    }
+    }
 };
 
 #if defined(__riscv)
 size_t boot_hart = 0;
 
-initgraph::Task findRiscVBootHart{&globalInitEngine,
-	"uefi.find-riscv-boot-hart",
-	initgraph::Entails{getBootservicesDoneStage()},
-	[] {
-		riscv_efi_boot_protocol *boot_table = nullptr;
-		efi_guid riscv_boot_guid = RISCV_EFI_BOOT_PROTOCOL_GUID;
-		auto status = bs->locate_protocol(&riscv_boot_guid, nullptr, (void **) &boot_table);
-		assert(status == EFI_SUCCESS);
-		assert(boot_table);
+initgraph::Task findRiscVBootHart{
+    &globalInitEngine,
+    "uefi.find-riscv-boot-hart",
+    initgraph::Entails{getBootservicesDoneStage()},
+    [] {
+	    riscv_efi_boot_protocol *boot_table = nullptr;
+	    efi_guid riscv_boot_guid = RISCV_EFI_BOOT_PROTOCOL_GUID;
+	    auto status = bs->locate_protocol(&riscv_boot_guid, nullptr, (void **)&boot_table);
+	    assert(status == EFI_SUCCESS);
+	    assert(boot_table);
 
-		status = boot_table->get_boot_hartid(boot_table, &boot_hart);
-		assert(status == EFI_SUCCESS);
+	    status = boot_table->get_boot_hartid(boot_table, &boot_hart);
+	    assert(status == EFI_SUCCESS);
 
-		eir::infoLogger() << "eir: boot HART ID " << boot_hart << frg::endlog;
-	}
+	    eir::infoLogger() << "eir: boot HART ID " << boot_hart << frg::endlog;
+    }
 };
 
-initgraph::Task setupBootHartId{&globalInitEngine,
-	"uefi.setup-riscv-boot-hard-info",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
-		info_ptr->hartId = boot_hart;
-	}
+initgraph::Task setupBootHartId{
+    &globalInitEngine,
+    "uefi.setup-riscv-boot-hard-info",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] { info_ptr->hartId = boot_hart; }
 };
 #endif
 
-initgraph::Task readInitrd{&globalInitEngine,
-	"uefi.read-initrd",
-	initgraph::Entails{getBootservicesDoneStage()},
-	[] {
-		efi_file_protocol *initrdFile = nullptr;
-		EFI_CHECK(fsOpen(&initrdFile, asciiToUcs2(initrd_path)));
-		initrdInfo = fsGetInfo(initrdFile);
+initgraph::Task readInitrd{
+    &globalInitEngine, "uefi.read-initrd", initgraph::Entails{getBootservicesDoneStage()}, [] {
+	    efi_file_protocol *initrdFile = nullptr;
+	    EFI_CHECK(fsOpen(&initrdFile, asciiToUcs2(initrd_path)));
+	    initrdInfo = fsGetInfo(initrdFile);
 
-		// Read initrd.
-		efi_physical_addr initrd_addr = 0;
-		EFI_CHECK(bs->allocate_pages(AllocateAnyPages, EfiLoaderData, (initrdInfo->file_size >> 12) + 1, &initrd_addr));
-		EFI_CHECK(fsRead(initrdFile, initrdInfo->file_size, 0, initrd_addr));
+	    // Read initrd.
+	    efi_physical_addr initrd_addr = 0;
+	    EFI_CHECK(bs->allocate_pages(
+	        AllocateAnyPages, EfiLoaderData, (initrdInfo->file_size >> 12) + 1, &initrd_addr
+	    ));
+	    EFI_CHECK(fsRead(initrdFile, initrdInfo->file_size, 0, initrd_addr));
 
-		initrd = reinterpret_cast<void *>(initrd_addr);
-	}
+	    initrd = reinterpret_cast<void *>(initrd_addr);
+    }
 };
 
-initgraph::Task setupGop{&globalInitEngine,
-	"uefi.setup-gop",
-	initgraph::Entails{getBootservicesDoneStage()},
-	[] {
-		// Get the frame buffer.
-		efi_guid gop_protocol = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
-		efi_status status = bs->locate_protocol(&gop_protocol, nullptr, reinterpret_cast<void **>(&gop));
+initgraph::Task setupGop{
+    &globalInitEngine, "uefi.setup-gop", initgraph::Entails{getBootservicesDoneStage()}, [] {
+	    // Get the frame buffer.
+	    efi_guid gop_protocol = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
+	    efi_status status =
+	        bs->locate_protocol(&gop_protocol, nullptr, reinterpret_cast<void **>(&gop));
 
-		if(gop->mode->info->version != 0)
-			eir::panicLogger() << "error: unsupported EFI_GRAPHICS_OUTPUT_MODE_INFORMATION version!" << frg::endlog;
+	    if (gop->mode->info->version != 0)
+		    eir::panicLogger() << "error: unsupported EFI_GRAPHICS_OUTPUT_MODE_INFORMATION version!"
+		                       << frg::endlog;
 
-		if(status == EFI_SUCCESS) {
-			eir::infoLogger() << "eir: framebuffer "
-				<< gop->mode->info->horizontal_resolution << "x"
-				<< gop->mode->info->vertical_resolution << " address=0x"
-				<< frg::hex_fmt{gop->mode->framebuffer_base}
-				<< frg::endlog;
-		} else {
-			// the spec claims that the `void **interface` argument will be a nullptr on
-			// spec-listed error returns, but only lists two error codes; there are more
-			// error codes in the wild, so best to not rely on them to return a nullptr
-			gop = nullptr;
-		}
-	}
+	    if (status == EFI_SUCCESS) {
+		    eir::infoLogger() << "eir: framebuffer " << gop->mode->info->horizontal_resolution
+		                      << "x" << gop->mode->info->vertical_resolution << " address=0x"
+		                      << frg::hex_fmt{gop->mode->framebuffer_base} << frg::endlog;
+	    } else {
+		    // the spec claims that the `void **interface` argument will be a nullptr on
+		    // spec-listed error returns, but only lists two error codes; there are more
+		    // error codes in the wild, so best to not rely on them to return a nullptr
+		    gop = nullptr;
+	    }
+    }
 };
 
-initgraph::Task exitBootServices{&globalInitEngine,
-	"uefi.exit-boot-services",
-	initgraph::Requires{getBootservicesDoneStage()},
-	initgraph::Entails{getReservedRegionsKnownStage()},
-	[] {
-		memMapSize = sizeof(efi_memory_descriptor);
-		efi_memory_descriptor dummy;
+initgraph::Task exitBootServices{
+    &globalInitEngine,
+    "uefi.exit-boot-services",
+    initgraph::Requires{getBootservicesDoneStage()},
+    initgraph::Entails{getReservedRegionsKnownStage()},
+    [] {
+	    memMapSize = sizeof(efi_memory_descriptor);
+	    efi_memory_descriptor dummy;
 
-		// First get the size of the memory map buffer to allocate.
-		efi_status status = bs->get_memory_map(&memMapSize, &dummy, &mapKey, &descriptorSize, &descriptorVersion);
-		assert(status == EFI_BUFFER_TOO_SMALL);
+	    // First get the size of the memory map buffer to allocate.
+	    efi_status status =
+	        bs->get_memory_map(&memMapSize, &dummy, &mapKey, &descriptorSize, &descriptorVersion);
+	    assert(status == EFI_BUFFER_TOO_SMALL);
 
-		// the number of descriptors we overallocate the buffer by; get doubled every iteration
-		size_t overallocation = 8;
+	    // the number of descriptors we overallocate the buffer by; get doubled every iteration
+	    size_t overallocation = 8;
 
-		while(status != EFI_SUCCESS) {
-			// needing more than that would be quite unreasonable
-			assert(overallocation <= 0x800);
+	    while (status != EFI_SUCCESS) {
+		    // needing more than that would be quite unreasonable
+		    assert(overallocation <= 0x800);
 
-			// over-allocate a bit to accomodate the allocation we have to make here
-			// we only get one shot(tm) to allocate an appropriately-sized buffer, as the spec does not
-			// allow for calling any boot services other than GetMemoryMap and ExitBootServices after
-			// a call to ExitBootServices fails
-			memMapSize += overallocation * descriptorSize;
-			EFI_CHECK(bs->allocate_pool(EfiLoaderData, memMapSize, &memMap));
-			overallocation *= 2;
+		    // over-allocate a bit to accomodate the allocation we have to make here
+		    // we only get one shot(tm) to allocate an appropriately-sized buffer, as the spec does
+		    // not allow for calling any boot services other than GetMemoryMap and ExitBootServices
+		    // after a call to ExitBootServices fails
+		    memMapSize += overallocation * descriptorSize;
+		    EFI_CHECK(bs->allocate_pool(EfiLoaderData, memMapSize, &memMap));
+		    overallocation *= 2;
 
-			// Now, get the actual memory map.
-			EFI_CHECK(bs->get_memory_map(&memMapSize,
-				reinterpret_cast<efi_memory_descriptor*>(memMap),
-				&mapKey, &descriptorSize, &descriptorVersion));
+		    // Now, get the actual memory map.
+		    EFI_CHECK(bs->get_memory_map(
+		        &memMapSize,
+		        reinterpret_cast<efi_memory_descriptor *>(memMap),
+		        &mapKey,
+		        &descriptorSize,
+		        &descriptorVersion
+		    ));
 
-			// Exit boot services.
-			status = bs->exit_boot_services(handle, mapKey);
-		}
+		    // Exit boot services.
+		    status = bs->exit_boot_services(handle, mapKey);
+	    }
 
-		bs = nullptr;
+	    bs = nullptr;
 
 #if defined(__x86_64__)
-		asm volatile ("cli");
+	    asm volatile("cli");
 #elif defined(__riscv)
-		asm volatile("csrci sstatus, 0x2" ::: "memory");
+	    asm volatile("csrci sstatus, 0x2" ::: "memory");
 #else
 #error "Unsupported architecture!"
 #endif
-	}
+    }
 };
 
-initgraph::Task setupMemoryMap{&globalInitEngine,
-	"uefi.setup-memory-map",
-	initgraph::Requires{&exitBootServices},
-	initgraph::Entails{getReservedRegionsKnownStage()},
-	[] {
-		reservedRegions[nReservedRegions++] = {reinterpret_cast<uintptr_t>(loadedImage->image_base), loadedImage->image_size};
-		reservedRegions[nReservedRegions++] = {reinterpret_cast<uintptr_t>(initrd), initrdInfo->file_size};
+initgraph::Task setupMemoryMap{
+    &globalInitEngine,
+    "uefi.setup-memory-map",
+    initgraph::Requires{&exitBootServices},
+    initgraph::Entails{getReservedRegionsKnownStage()},
+    [] {
+	    reservedRegions[nReservedRegions++] = {
+	        reinterpret_cast<uintptr_t>(loadedImage->image_base), loadedImage->image_size
+	    };
+	    reservedRegions[nReservedRegions++] = {
+	        reinterpret_cast<uintptr_t>(initrd), initrdInfo->file_size
+	    };
 
-		auto entries = memMapSize / descriptorSize;
+	    auto entries = memMapSize / descriptorSize;
 
-		auto endAddr = [](const efi_memory_descriptor *e) -> efi_physical_addr {
-			return e->physical_start + (e->number_of_pages * eir::pageSize);
-		};
+	    auto endAddr = [](const efi_memory_descriptor *e) -> efi_physical_addr {
+		    return e->physical_start + (e->number_of_pages * eir::pageSize);
+	    };
 
-		auto nextEntry = [&](efi_physical_addr addr) {
-			const efi_memory_descriptor *lowest = nullptr;
+	    auto nextEntry = [&](efi_physical_addr addr) {
+		    const efi_memory_descriptor *lowest = nullptr;
 
-			for(size_t i = 0; i < entries; i++) {
-				auto e = reinterpret_cast<const efi_memory_descriptor *>(uintptr_t(memMap) + (i * descriptorSize));
-				if(e->physical_start >= addr) {
-					if(!lowest || e->physical_start < lowest->physical_start) {
-						lowest = e;
-					}
-				}
-			}
+		    for (size_t i = 0; i < entries; i++) {
+			    auto e = reinterpret_cast<const efi_memory_descriptor *>(
+			        uintptr_t(memMap) + (i * descriptorSize)
+			    );
+			    if (e->physical_start >= addr) {
+				    if (!lowest || e->physical_start < lowest->physical_start) {
+					    lowest = e;
+				    }
+			    }
+		    }
 
-			return lowest;
-		};
+		    return lowest;
+	    };
 
-		auto isContiguous = [](const efi_memory_descriptor *a, const efi_memory_descriptor *b) {
-			if(a->physical_start + (a->number_of_pages * eir::pageSize) == b->physical_start)
-				return true;
-			return false;
-		};
+	    auto isContiguous = [](const efi_memory_descriptor *a, const efi_memory_descriptor *b) {
+		    if (a->physical_start + (a->number_of_pages * eir::pageSize) == b->physical_start)
+			    return true;
+		    return false;
+	    };
 
-		auto isUsable = [](const efi_memory_descriptor *e) {
-			switch(e->type) {
-				case EfiConventionalMemory:
-				case EfiBootServicesCode:
-				case EfiBootServicesData:
-					return true;
-				default:
-					return false;
-			}
-		};
+	    auto isUsable = [](const efi_memory_descriptor *e) {
+		    switch (e->type) {
+			    case EfiConventionalMemory:
+			    case EfiBootServicesCode:
+			    case EfiBootServicesData:
+				    return true;
+			    default:
+				    return false;
+		    }
+	    };
 
-		eir::infoLogger() << "Memory map:" << frg::endlog;
-		auto entry = nextEntry(0);
+	    eir::infoLogger() << "Memory map:" << frg::endlog;
+	    auto entry = nextEntry(0);
 
-		while(entry) {
-			auto lastContiguousEntry = entry;
+	    while (entry) {
+		    auto lastContiguousEntry = entry;
 
-			while(true) {
-				auto next = nextEntry(endAddr(lastContiguousEntry));
+		    while (true) {
+			    auto next = nextEntry(endAddr(lastContiguousEntry));
 
-				if(!next || !isContiguous(lastContiguousEntry, next))
-					break;
+			    if (!next || !isContiguous(lastContiguousEntry, next))
+				    break;
 
-				if(isUsable(lastContiguousEntry) != isUsable(next))
-					break;
+			    if (isUsable(lastContiguousEntry) != isUsable(next))
+				    break;
 
-				lastContiguousEntry = next;
-			}
+			    lastContiguousEntry = next;
+		    }
 
-			eir::infoLogger()
-				<< "\tbase=0x" << frg::hex_fmt{entry->physical_start}
-				<< " length=0x" << frg::hex_fmt{endAddr(lastContiguousEntry) - entry->physical_start}
-				<< " usable=" << (isUsable(entry) ? "true" : "false")
-				<< frg::endlog;
+		    eir::infoLogger() << "\tbase=0x" << frg::hex_fmt{entry->physical_start} << " length=0x"
+		                      << frg::hex_fmt{endAddr(lastContiguousEntry) - entry->physical_start}
+		                      << " usable=" << (isUsable(entry) ? "true" : "false") << frg::endlog;
 
-			if(isUsable(entry)) {
-				createInitialRegions(
-					{entry->physical_start, endAddr(lastContiguousEntry) - entry->physical_start},
-					{reservedRegions.data(), nReservedRegions}
-				);
-			}
+		    if (isUsable(entry)) {
+			    createInitialRegions(
+			        {entry->physical_start, endAddr(lastContiguousEntry) - entry->physical_start},
+			        {reservedRegions.data(), nReservedRegions}
+			    );
+		    }
 
-			entry = nextEntry(endAddr(lastContiguousEntry));
-		}
-	}
+		    entry = nextEntry(endAddr(lastContiguousEntry));
+	    }
+    }
 };
 
-initgraph::Task setupAcpiInfo{&globalInitEngine,
-	"uefi.setup-acpi-info",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
-		info_ptr->acpiRsdp = rsdp;
-	}
+initgraph::Task setupAcpiInfo{
+    &globalInitEngine,
+    "uefi.setup-acpi-info",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] { info_ptr->acpiRsdp = rsdp; }
 };
 
-initgraph::Task setupInitrdInfo{&globalInitEngine,
-	"uefi.setup-initrd-info",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
-		auto initrd_module = bootAlloc<EirModule>(1);
-		initrd_module->physicalBase = reinterpret_cast<EirPtr>(initrd);
-		initrd_module->length = initrdInfo->file_size;
-		const char *initrd_mod_name = "initrd.cpio";
-		size_t name_length = strlen(initrd_mod_name);
-		char *name_ptr = bootAlloc<char>(name_length);
-		memcpy(name_ptr, initrd_mod_name, name_length);
-		initrd_module->namePtr = mapBootstrapData(name_ptr);
-		initrd_module->nameLength = name_length;
+initgraph::Task setupInitrdInfo{
+    &globalInitEngine,
+    "uefi.setup-initrd-info",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] {
+	    auto initrd_module = bootAlloc<EirModule>(1);
+	    initrd_module->physicalBase = reinterpret_cast<EirPtr>(initrd);
+	    initrd_module->length = initrdInfo->file_size;
+	    const char *initrd_mod_name = "initrd.cpio";
+	    size_t name_length = strlen(initrd_mod_name);
+	    char *name_ptr = bootAlloc<char>(name_length);
+	    memcpy(name_ptr, initrd_mod_name, name_length);
+	    initrd_module->namePtr = mapBootstrapData(name_ptr);
+	    initrd_module->nameLength = name_length;
 
-		info_ptr->moduleInfo = mapBootstrapData(initrd_module);
-	}
+	    info_ptr->moduleInfo = mapBootstrapData(initrd_module);
+    }
 };
 
-initgraph::Task mapEirImage{&globalInitEngine,
-	"uefi.map-eir-image",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
-		auto base = reinterpret_cast<uintptr_t>(loadedImage->image_base);
-		auto pages = (loadedImage->image_size >> 12) + 1;
+initgraph::Task mapEirImage{
+    &globalInitEngine,
+    "uefi.map-eir-image",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] {
+	    auto base = reinterpret_cast<uintptr_t>(loadedImage->image_base);
+	    auto pages = (loadedImage->image_size >> 12) + 1;
 
-		for(size_t i = 0; i < pages; i++) {
-			mapSingle4kPage(base + (i << 12), base + (i << 12), PageFlags::write | PageFlags::execute);
-		}
-	}
+	    for (size_t i = 0; i < pages; i++) {
+		    mapSingle4kPage(
+		        base + (i << 12), base + (i << 12), PageFlags::write | PageFlags::execute
+		    );
+	    }
+    }
 };
 
-initgraph::Task setupFramebufferInfo{&globalInitEngine,
-	"uefi.setup-framebuffer-info",
-	initgraph::Requires{getInfoStructAvailableStage()},
-	initgraph::Entails{getEirDoneStage()},
-	[] {
-		if(gop && gop->mode->info->pixel_format != PixelBltOnly) {
-			fb = &info_ptr->frameBuffer;
+initgraph::Task setupFramebufferInfo{
+    &globalInitEngine,
+    "uefi.setup-framebuffer-info",
+    initgraph::Requires{getInfoStructAvailableStage()},
+    initgraph::Entails{getEirDoneStage()},
+    [] {
+	    if (gop && gop->mode->info->pixel_format != PixelBltOnly) {
+		    fb = &info_ptr->frameBuffer;
 
-			switch(gop->mode->info->pixel_format) {
-				case PixelBlueGreenRedReserved8BitPerColor:
-					fb->fbBpp = 32;
-					break;
-				case PixelRedGreenBlueReserved8BitPerColor:
-					fb->fbBpp = 32;
-					break;
-				case PixelBitMask: {
-					assert(gop->mode->info->pixel_information.red_mask);
-					assert(gop->mode->info->pixel_information.green_mask);
-					assert(gop->mode->info->pixel_information.blue_mask);
+		    switch (gop->mode->info->pixel_format) {
+			    case PixelBlueGreenRedReserved8BitPerColor:
+				    fb->fbBpp = 32;
+				    break;
+			    case PixelRedGreenBlueReserved8BitPerColor:
+				    fb->fbBpp = 32;
+				    break;
+			    case PixelBitMask: {
+				    assert(gop->mode->info->pixel_information.red_mask);
+				    assert(gop->mode->info->pixel_information.green_mask);
+				    assert(gop->mode->info->pixel_information.blue_mask);
 
-					size_t hbred = (sizeof(uint32_t) * 8) - __builtin_clz(gop->mode->info->pixel_information.red_mask);
-					size_t hbgreen = (sizeof(uint32_t) * 8) - __builtin_clz(gop->mode->info->pixel_information.green_mask);
-					size_t hbblue = (sizeof(uint32_t) * 8) - __builtin_clz(gop->mode->info->pixel_information.blue_mask);
+				    size_t hbred = (sizeof(uint32_t) * 8)
+				                   - __builtin_clz(gop->mode->info->pixel_information.red_mask);
+				    size_t hbgreen = (sizeof(uint32_t) * 8)
+				                     - __builtin_clz(gop->mode->info->pixel_information.green_mask);
+				    size_t hbblue = (sizeof(uint32_t) * 8)
+				                    - __builtin_clz(gop->mode->info->pixel_information.blue_mask);
 
-					frg::optional<size_t> hbres = {};
-					if(gop->mode->info->pixel_information.reserved_mask)
-						hbres = (sizeof(uint32_t) * 8) - __builtin_clz(gop->mode->info->pixel_information.reserved_mask);
+				    frg::optional<size_t> hbres = {};
+				    if (gop->mode->info->pixel_information.reserved_mask)
+					    hbres = (sizeof(uint32_t) * 8)
+					            - __builtin_clz(gop->mode->info->pixel_information.reserved_mask);
 
-					size_t highest_bit = frg::max(hbred, hbgreen);
-					highest_bit = frg::max(highest_bit, hbblue);
-					if(hbres)
-						highest_bit = frg::max(highest_bit, hbres.value());
+				    size_t highest_bit = frg::max(hbred, hbgreen);
+				    highest_bit = frg::max(highest_bit, hbblue);
+				    if (hbres)
+					    highest_bit = frg::max(highest_bit, hbres.value());
 
-					assert(highest_bit % 8 == 0);
-					fb->fbBpp = highest_bit;
-					break;
-				}
-				default:
-					eir::panicLogger() << "eir: unhandled GOP pixel format" << frg::endlog;
-			}
+				    assert(highest_bit % 8 == 0);
+				    fb->fbBpp = highest_bit;
+				    break;
+			    }
+			    default:
+				    eir::panicLogger() << "eir: unhandled GOP pixel format" << frg::endlog;
+		    }
 
-			fb->fbAddress = gop->mode->framebuffer_base;
-			fb->fbPitch = gop->mode->info->pixels_per_scan_line * (fb->fbBpp / 8);
-			fb->fbWidth = gop->mode->info->horizontal_resolution;
-			fb->fbHeight = gop->mode->info->vertical_resolution;
-			fb->fbType = 1; // linear framebuffer
-		}
-	}
+		    fb->fbAddress = gop->mode->framebuffer_base;
+		    fb->fbPitch = gop->mode->info->pixels_per_scan_line * (fb->fbBpp / 8);
+		    fb->fbWidth = gop->mode->info->horizontal_resolution;
+		    fb->fbHeight = gop->mode->info->vertical_resolution;
+		    fb->fbType = 1; // linear framebuffer
+	    }
+    }
 };
 
 } // namespace
@@ -404,14 +420,16 @@ extern "C" efi_status eirUefiMain(const efi_handle h, const efi_system_table *sy
 	// Convert the command line to ASCII.
 	char *ascii_cmdline = nullptr;
 	{
-		EFI_CHECK(bs->allocate_pool(EfiLoaderData,
-			(loadedImage->load_options_size / sizeof(uint16_t)) + 1,
-			reinterpret_cast<void **>(&ascii_cmdline)));
+		EFI_CHECK(bs->allocate_pool(
+		    EfiLoaderData,
+		    (loadedImage->load_options_size / sizeof(uint16_t)) + 1,
+		    reinterpret_cast<void **>(&ascii_cmdline)
+		));
 		size_t i = 0;
-		for(; i < loadedImage->load_options_size / sizeof(char16_t); i++) {
+		for (; i < loadedImage->load_options_size / sizeof(char16_t); i++) {
 			auto c = reinterpret_cast<char16_t *>(loadedImage->load_options)[i];
 			// we only use printable ASCII characters, everything else gets discarded
-			if(c >= 0x20 && c <= 0x7E) {
+			if (c >= 0x20 && c <= 0x7E) {
 				ascii_cmdline[i] = c;
 			} else {
 				ascii_cmdline[i] = '\0';
@@ -426,10 +444,10 @@ extern "C" efi_status eirUefiMain(const efi_handle h, const efi_system_table *sy
 	bool eir_gdb_ready_val = true;
 
 	frg::array args = {
-		// allow for attaching GDB to eir
-		frg::option{"eir.efidebug", frg::store_false(eir_gdb_ready_val)},
-		frg::option{"bochs", frg::store_true(log_e9)},
-		frg::option{"eir.initrd", frg::as_string_view(initrd_path)},
+	    // allow for attaching GDB to eir
+	    frg::option{"eir.efidebug", frg::store_false(eir_gdb_ready_val)},
+	    frg::option{"bochs", frg::store_true(log_e9)},
+	    frg::option{"eir.initrd", frg::as_string_view(initrd_path)},
 	};
 	frg::parse_arguments(ascii_cmdline, args);
 
@@ -438,23 +456,25 @@ extern "C" efi_status eirUefiMain(const efi_handle h, const efi_system_table *sy
 	// this needs to be volatile as GDB sets this to true on attach
 	volatile bool eir_gdb_ready = eir_gdb_ready_val;
 
-	if(!eir_gdb_ready_val) {
+	if (!eir_gdb_ready_val) {
 #ifdef __x86_64__
 		// exfiltrate our base address for use with gdb
 		constexpr arch::scalar_register<uint8_t> offset{0};
 		auto port = arch::global_io.subspace(0xCB7);
 
-		for(size_t i = 0; i < sizeof(uintptr_t); i++) {
+		for (size_t i = 0; i < sizeof(uintptr_t); i++) {
 			uint8_t b = reinterpret_cast<uintptr_t>(loadedImage->image_base) >> (i * 8);
 			port.store(offset, b);
 		}
 #endif
 
-		eir::infoLogger() << "eir: image base address " << frg::hex_fmt{loadedImage->image_base} << frg::endlog;
+		eir::infoLogger() << "eir: image base address " << frg::hex_fmt{loadedImage->image_base}
+		                  << frg::endlog;
 		eir::infoLogger() << "eir: Waiting for GDB to attach" << frg::endlog;
 	}
 
-	while(!eir_gdb_ready);
+	while (!eir_gdb_ready)
+		;
 
 	eirMain();
 

--- a/kernel/eir/protos/uefi/helpers.cpp
+++ b/kernel/eir/protos/uefi/helpers.cpp
@@ -1,15 +1,13 @@
-#include "efi.hpp"
 #include "helpers.hpp"
+#include "efi.hpp"
 
 void EFI_CHECK(efi_status s, std::source_location loc) {
-	if(s == EFI_SUCCESS)
+	if (s == EFI_SUCCESS)
 		return;
 
-	eir::panicLogger() << "eir: unexpected EFI error 0x"
-	<< frg::hex_fmt {s}
-	<< " in " << loc.function_name()
-	<< " at " << loc.file_name() << ":" << loc.line()
-	<< frg::endlog;
+	eir::panicLogger() << "eir: unexpected EFI error 0x" << frg::hex_fmt{s} << " in "
+	                   << loc.function_name() << " at " << loc.file_name() << ":" << loc.line()
+	                   << frg::endlog;
 }
 
 namespace eir {
@@ -19,10 +17,13 @@ efi_status fsOpen(efi_file_protocol **file, char16_t *path) {
 	efi_guid simpleFsGuid = EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_GUID;
 
 	efi_loaded_image_protocol *loadedImage = nullptr;
-	EFI_CHECK(bs->handle_protocol(handle, &loadedImageGuid, reinterpret_cast<void **>(&loadedImage)));
+	EFI_CHECK(bs->handle_protocol(handle, &loadedImageGuid, reinterpret_cast<void **>(&loadedImage))
+	);
 
 	efi_simple_file_system_protocol *fileSystem = nullptr;
-	EFI_CHECK(bs->handle_protocol(loadedImage->device_handle, &simpleFsGuid, reinterpret_cast<void **>(&fileSystem)));
+	EFI_CHECK(bs->handle_protocol(
+	    loadedImage->device_handle, &simpleFsGuid, reinterpret_cast<void **>(&fileSystem)
+	));
 
 	efi_file_protocol *root = nullptr;
 	EFI_CHECK(fileSystem->open_volume(fileSystem, &root));
@@ -58,9 +59,10 @@ char16_t *asciiToUcs2(frg::string_view &s) {
 	assert(bs);
 
 	char16_t *ucs2 = nullptr;
-	EFI_CHECK(bs->allocate_pool(EfiLoaderData, (s.size() + 1) * 2, reinterpret_cast<void **>(&ucs2)));
+	EFI_CHECK(bs->allocate_pool(EfiLoaderData, (s.size() + 1) * 2, reinterpret_cast<void **>(&ucs2))
+	);
 
-	for(size_t i = 0; i < s.size(); i++) {
+	for (size_t i = 0; i < s.size(); i++) {
 		ucs2[i] = static_cast<char16_t>(s[i]);
 	}
 

--- a/kernel/eir/system/dtb/discovery.cpp
+++ b/kernel/eir/system/dtb/discovery.cpp
@@ -10,14 +10,14 @@ namespace eir {
 
 size_t findSizeCells(DeviceTreeNode parent) {
 	auto maybeProperty = parent.findProperty("#address-cells");
-	if(maybeProperty)
+	if (maybeProperty)
 		return maybeProperty->asU32();
 	return 2;
 }
 
 size_t findAddressCells(DeviceTreeNode parent) {
 	auto maybeProperty = parent.findProperty("#size-cells");
-	if(maybeProperty)
+	if (maybeProperty)
 		return maybeProperty->asU32();
 	return 1;
 }
@@ -32,24 +32,22 @@ void discoverMemoryFromDtb(void *dtbPtr) {
 	struct Walker {
 		void push(DeviceTreeNode node) {
 			auto log = eir::infoLogger();
-			for(unsigned int i = 0; i < nesting_; ++i)
+			for (unsigned int i = 0; i < nesting_; ++i)
 				log << "  ";
 			log << node.name() << frg::endlog;
 
 			++nesting_;
 
-			for(auto prop : node.properties()) {
+			for (auto prop : node.properties()) {
 				auto plog = eir::infoLogger();
-				for(unsigned int i = 0; i < nesting_; ++i)
+				for (unsigned int i = 0; i < nesting_; ++i)
 					plog << "  ";
-				plog << "Property " << prop.name()
-					<< ", " << prop.size() << " bytes" << frg::endlog;
+				plog << "Property " << prop.name() << ", " << prop.size() << " bytes"
+				     << frg::endlog;
 			}
 		}
 
-		void pop() {
-			--nesting_;
-		}
+		void pop() { --nesting_; }
 
 	private:
 		unsigned int nesting_ = 0;
@@ -63,17 +61,17 @@ void discoverMemoryFromDtb(void *dtbPtr) {
 	bool foundChosen = false;
 
 	dt.rootNode().discoverSubnodes(
-		[](DeviceTreeNode &node) {
-			auto name = frg::string_view(node.name());
-			return name == "chosen";
-		},
-		[&](DeviceTreeNode node) {
-			chosenNode = node;
-			foundChosen = true;
-		}
+	    [](DeviceTreeNode &node) {
+		    auto name = frg::string_view(node.name());
+		    return name == "chosen";
+	    },
+	    [&](DeviceTreeNode node) {
+		    chosenNode = node;
+		    foundChosen = true;
+	    }
 	);
 
-	if(!foundChosen)
+	if (!foundChosen)
 		eir::panicLogger() << "DTB does not contain \"chosen\" node" << frg::endlog;
 
 	uint64_t initrdStart = 0;
@@ -95,8 +93,8 @@ void discoverMemoryFromDtb(void *dtbPtr) {
 			eir::panicLogger() << "Invalid linux,initrd-end size" << frg::endlog;
 	}
 
-	eir::infoLogger() << "initrd is between 0x" << frg::hex_fmt(initrdStart)
-			<< " and 0x" << frg::hex_fmt(initrdEnd) << frg::endlog;
+	eir::infoLogger() << "initrd is between 0x" << frg::hex_fmt(initrdStart) << " and 0x"
+	                  << frg::hex_fmt(initrdEnd) << frg::endlog;
 
 	// Determine all reserved memory areas.
 	InitialRegion reservedRegions[32];
@@ -112,96 +110,93 @@ void discoverMemoryFromDtb(void *dtbPtr) {
 
 	// Handle entries from the top-level table within the DTB.
 	for (auto ent : dt.memoryReservations()) {
-		eir::infoLogger() << "    At 0x" << frg::hex_fmt{ent.address}
-			<< ", ends at 0x" << frg::hex_fmt{ent.address + ent.size}
-			<< " (0x" << frg::hex_fmt{ent.size} << " bytes)" << frg::endlog;
+		eir::infoLogger() << "    At 0x" << frg::hex_fmt{ent.address} << ", ends at 0x"
+		                  << frg::hex_fmt{ent.address + ent.size} << " (0x"
+		                  << frg::hex_fmt{ent.size} << " bytes)" << frg::endlog;
 
-		if(nReservedRegions >= 32)
+		if (nReservedRegions >= 32)
 			eir::panicLogger() << "Cannot deal with > 32 DTB memory reservations" << frg::endlog;
 		reservedRegions[nReservedRegions++] = {ent.address, ent.size};
 	}
 
 	// Handle entries from /reserved-memory.
 	dt.rootNode().discoverSubnodes(
-		[](DeviceTreeNode &node) {
-			auto name = frg::string_view(node.name());
-			return name == "reserved-memory";
-		},
-		[&](DeviceTreeNode reservedNode) {
-			auto addressCells = findAddressCells(reservedNode);
-			auto sizeCells = findSizeCells(reservedNode);
+	    [](DeviceTreeNode &node) {
+		    auto name = frg::string_view(node.name());
+		    return name == "reserved-memory";
+	    },
+	    [&](DeviceTreeNode reservedNode) {
+		    auto addressCells = findAddressCells(reservedNode);
+		    auto sizeCells = findSizeCells(reservedNode);
 
-			reservedNode.discoverSubnodes(
-				[](DeviceTreeNode &) { return true; },
-				[&](DeviceTreeNode childNode) {
-					// Children without "reg" correspond to OS-allocated reserved memory.
-					auto reg = childNode.findProperty("reg");
-					if(!reg) {
-						eir::infoLogger() << "DTB reserved-memory child "
-								<< childNode.name() << " has no \"reg\" property"
-								<< frg::endlog;
-						return;
-					}
+		    reservedNode.discoverSubnodes(
+		        [](DeviceTreeNode &) { return true; },
+		        [&](DeviceTreeNode childNode) {
+			        // Children without "reg" correspond to OS-allocated reserved memory.
+			        auto reg = childNode.findProperty("reg");
+			        if (!reg) {
+				        eir::infoLogger() << "DTB reserved-memory child " << childNode.name()
+				                          << " has no \"reg\" property" << frg::endlog;
+				        return;
+			        }
 
-					size_t j = 0;
-					while (j < reg->size()) {
-						auto base = reg->asPropArrayEntry(addressCells, j);
-						j += addressCells * 4;
+			        size_t j = 0;
+			        while (j < reg->size()) {
+				        auto base = reg->asPropArrayEntry(addressCells, j);
+				        j += addressCells * 4;
 
-						auto size = reg->asPropArrayEntry(sizeCells, j);
-						j += sizeCells * 4;
+				        auto size = reg->asPropArrayEntry(sizeCells, j);
+				        j += sizeCells * 4;
 
-						eir::infoLogger() << "    " << childNode.name()
-							<< ", at 0x" << frg::hex_fmt{base}
-							<< ", ends at 0x" << frg::hex_fmt{base + size}
-							<< " (0x" << frg::hex_fmt{size} << " bytes)" << frg::endlog;
-						reservedRegions[nReservedRegions++] = {base, size};
-					}
-				}
-			);
-		}
+				        eir::infoLogger()
+				            << "    " << childNode.name() << ", at 0x" << frg::hex_fmt{base}
+				            << ", ends at 0x" << frg::hex_fmt{base + size} << " (0x"
+				            << frg::hex_fmt{size} << " bytes)" << frg::endlog;
+				        reservedRegions[nReservedRegions++] = {base, size};
+			        }
+		        }
+		    );
+	    }
 	);
 
 	// Find all memory nodes.
 	dt.rootNode().discoverSubnodes(
-		[](DeviceTreeNode &node) {
-			return !memcmp("memory@", node.name(), 7);
-		},
-		[&](DeviceTreeNode node) {
-			auto addressCells = findAddressCells(rootNode);
-			auto sizeCells = findSizeCells(rootNode);
+	    [](DeviceTreeNode &node) { return !memcmp("memory@", node.name(), 7); },
+	    [&](DeviceTreeNode node) {
+		    auto addressCells = findAddressCells(rootNode);
+		    auto sizeCells = findSizeCells(rootNode);
 
-			auto reg = node.findProperty("reg");
-			if(!reg)
-				eir::panicLogger() << "DTB memory node has no \"reg\" property" << frg::endlog;
+		    auto reg = node.findProperty("reg");
+		    if (!reg)
+			    eir::panicLogger() << "DTB memory node has no \"reg\" property" << frg::endlog;
 
-			size_t j = 0;
-			while (j < reg->size()) {
-				auto base = reg->asPropArrayEntry(addressCells, j);
-				j += addressCells * 4;
+		    size_t j = 0;
+		    while (j < reg->size()) {
+			    auto base = reg->asPropArrayEntry(addressCells, j);
+			    j += addressCells * 4;
 
-				auto size = reg->asPropArrayEntry(sizeCells, j);
-				j += sizeCells * 4;
+			    auto size = reg->asPropArrayEntry(sizeCells, j);
+			    j += sizeCells * 4;
 
-				createInitialRegions({base, size}, {reservedRegions, nReservedRegions});
-			}
-		}
+			    createInitialRegions({base, size}, {reservedRegions, nReservedRegions});
+		    }
+	    }
 	);
 
 	// Create and dump the resulting memory regions.
 	setupRegionStructs();
 
 	eir::infoLogger() << "Kernel memory regions:" << frg::endlog;
-	for(size_t i = 0; i < numRegions; ++i) {
-		if(regions[i].regionType == RegionType::null)
+	for (size_t i = 0; i < numRegions; ++i) {
+		if (regions[i].regionType == RegionType::null)
 			continue;
 		eir::infoLogger() << "    Memory region [" << i << "]."
-				<< " Base: 0x" << frg::hex_fmt{regions[i].address}
-				<< ", length: 0x" << frg::hex_fmt{regions[i].size} << frg::endlog;
-		if(regions[i].regionType == RegionType::allocatable)
+		                  << " Base: 0x" << frg::hex_fmt{regions[i].address} << ", length: 0x"
+		                  << frg::hex_fmt{regions[i].size} << frg::endlog;
+		if (regions[i].regionType == RegionType::allocatable)
 			eir::infoLogger() << "        Buddy tree at 0x" << frg::hex_fmt{regions[i].buddyTree}
-					<< ", overhead: 0x" << frg::hex_fmt{regions[i].buddyOverhead}
-					<< frg::endlog;
+			                  << ", overhead: 0x" << frg::hex_fmt{regions[i].buddyOverhead}
+			                  << frg::endlog;
 	}
 }
 


### PR DESCRIPTION
Apply clang-format to all of `kernel/eir` and `kernel/common`.