### PR TITLE
kernel/thor: Remove magic memory layout constants

### DIFF
--- a/kernel/eir/arch/arm/eir-internal/arch/types.hpp
+++ b/kernel/eir/arch/arm/eir-internal/arch/types.hpp
@@ -9,7 +9,6 @@ using physaddr_t = uint64_t;
 
 extern uintptr_t eirTTBR[2];
 
-extern "C" void
-eirEnterKernel(uintptr_t ttbr0, uintptr_t ttbr1, uint64_t entry, uint64_t stack, uintptr_t eirInfo);
+extern "C" void eirEnterKernel(uintptr_t ttbr0, uintptr_t ttbr1, uint64_t entry, uint64_t stack);
 
 } // namespace eir

--- a/kernel/eir/arch/arm/generic.cpp
+++ b/kernel/eir/arch/arm/generic.cpp
@@ -252,9 +252,7 @@ void eirRelocate() {
 
 	eir::infoLogger() << "Leaving Eir and entering the real kernel" << frg::endlog;
 
-	eirEnterKernel(
-	    eirTTBR[0] + 1, eirTTBR[1] + 1, kernel_entry, 0xFFFF'FE80'0001'0000, 0xFFFF'FE80'0001'0000
-	);
+	eirEnterKernel(eirTTBR[0] + 1, eirTTBR[1] + 1, kernel_entry, 0xFFFF'FE80'0001'0000);
 
 	while (true) {
 		asm volatile("" : : : "memory");

--- a/kernel/eir/arch/arm/load64.S
+++ b/kernel/eir/arch/arm/load64.S
@@ -12,7 +12,6 @@ eirEnterKernel:
 	// x1 -> TTBR1 ptr
 	// x2 -> thor entry point
 	// x3 -> thor stack pointer
-	// x4 -> thor info ptr
 
 	// Set page table pointers
 	msr TTBR0_EL1, x0
@@ -27,7 +26,6 @@ eirEnterKernel:
 	isb
 
 	mov sp, x3
-	mov x0, x4
 	br x2
 
 #ifndef __clang__

--- a/kernel/eir/arch/riscv/stubs.S
+++ b/kernel/eir/arch/riscv/stubs.S
@@ -7,7 +7,6 @@ eirEnterKernel:
 
 	csrw satp, a0
 	mv sp, a2
-	li a0, 0xFFFFFE8000010000
 	jr a1
 
 .section .note.GNU-stack,"",%progbits

--- a/kernel/eir/arch/x86/load32.S
+++ b/kernel/eir/arch/x86/load32.S
@@ -92,7 +92,6 @@ eirEnterKernel:
 	mov %rcx, %rsp
 
 	xor %rbp, %rbp
-	movabs $0xFFFFFE8000010000, %rdi
 	jmp *%rdx
 
 	.section .note.GNU-stack,"",%progbits

--- a/kernel/eir/arch/x86/load64.S
+++ b/kernel/eir/arch/x86/load64.S
@@ -23,7 +23,6 @@ eirEnterKernel:
 	mov %rax, %cr0
 
 	xor %ebp, %ebp
-	movabs $0xFFFFFE8000010000, %rdi
 	jmp *%rsi
 
 #ifndef __clang__

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -406,6 +406,7 @@ void patchManagarmElfNote(unsigned int type, frg::span<char> desc) {
 		    .kernelVirtualSize = 0x8000'0000,
 		    .allocLog = 0xFFFF'F000'0000'0000,
 		    .allocLogSize = 0x1000'0000,
+		    .eirInfo = 0xFFFF'FE80'0001'0000,
 		};
 		if (desc.size() != sizeof(MemoryLayout))
 			panicLogger() << "MemoryLayout size does not match ELF note" << frg::endlog;

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -396,7 +396,31 @@ void parseInitrd(void *initrd) {
 		eir::panicLogger() << "eir: could not find thor in the initrd.cpio" << frg::endlog;
 }
 
-address_t loadKernelImage(void *image) {
+namespace {
+
+void patchManagarmElfNote(unsigned int type, frg::span<char> desc) {
+	if (type == elf_note_type::memoryLayout) {
+		MemoryLayout layout{
+		    .directPhysical = 0xFFFF'8000'0000'0000,
+		    .kernelVirtual = 0xFFFF'E000'0000'0000,
+		    .kernelVirtualSize = 0x8000'0000,
+		    .allocLog = 0xFFFF'F000'0000'0000,
+		    .allocLogSize = 0x1000'0000,
+		};
+		if (desc.size() != sizeof(MemoryLayout))
+			panicLogger() << "MemoryLayout size does not match ELF note" << frg::endlog;
+		memcpy(desc.data(), &layout, sizeof(MemoryLayout));
+	} else {
+		panicLogger() << "Thor has unknown Managarm ELF note with type 0x" << frg::hex_fmt{type}
+		              << frg::endlog;
+	}
+}
+
+} // namespace
+
+address_t loadKernelImage(void *imagePtr) {
+	auto image = reinterpret_cast<char *>(imagePtr);
+
 	Elf64_Ehdr ehdr;
 	memcpy(&ehdr, image, sizeof(Elf64_Ehdr));
 	if (ehdr.e_ident[0] != '\x7F' || ehdr.e_ident[1] != 'E' || ehdr.e_ident[2] != 'L'
@@ -404,6 +428,36 @@ address_t loadKernelImage(void *image) {
 		eir::panicLogger() << "Illegal magic fields" << frg::endlog;
 	}
 	assert(ehdr.e_type == ET_EXEC);
+
+	// Read and patch Thor's ELF notes.
+	for (int i = 0; i < ehdr.e_phnum; i++) {
+		Elf64_Phdr phdr;
+		memcpy(&phdr, image + ehdr.e_phoff + i * ehdr.e_phentsize, sizeof(Elf64_Phdr));
+		if (phdr.p_type != PT_NOTE)
+			continue;
+		if (phdr.p_memsz != phdr.p_filesz)
+			panicLogger() << "Eir does not support p_filesz != p_memsz for PT_NOTE" << frg::endlog;
+		size_t offset = 0;
+		while (offset < phdr.p_memsz) {
+			Elf64_Nhdr nhdr;
+			memcpy(&nhdr, image + phdr.p_offset + offset, sizeof(Elf64_Nhdr));
+			offset += sizeof(Elf64_Nhdr);
+
+			auto *namePtr = image + phdr.p_offset + offset;
+			offset += nhdr.n_namesz + 1;
+			offset = (offset + 7) & ~size_t{7};
+			auto *dataPtr = image + phdr.p_offset + offset;
+			offset += nhdr.n_descsz + 7;
+			offset = (offset + 7) & ~size_t{7};
+
+			frg::string_view name{namePtr, nhdr.n_namesz};
+			infoLogger() << "ELF note: " << name << ", type 0x" << frg::hex_fmt{nhdr.n_type}
+			             << frg::endlog;
+			if (name != "Managarm")
+				continue;
+			patchManagarmElfNote(nhdr.n_type, frg::span<char>{dataPtr, nhdr.n_descsz});
+		}
+	}
 
 	for (int i = 0; i < ehdr.e_phnum; i++) {
 		Elf64_Phdr phdr;

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -55,3 +55,21 @@ struct EirInfo {
 
 	uint64_t acpiRsdp;
 };
+
+namespace elf_note_type {
+
+// Values for Elf64_Nhdr::n_type of ELF notes embedded into Thor.
+constexpr unsigned int memoryLayout = 0x1000'0000;
+
+} // namespace elf_note_type
+
+struct MemoryLayout {
+	// Address of the direct physical mapping.
+	uint64_t directPhysical;
+	// Address and size of the kernel virtual mapping area.
+	uint64_t kernelVirtual;
+	uint64_t kernelVirtualSize;
+	// Address and size of the allocation log ring buffer.
+	uint64_t allocLog;
+	uint64_t allocLogSize;
+};

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -72,4 +72,6 @@ struct MemoryLayout {
 	// Address and size of the allocation log ring buffer.
 	uint64_t allocLog;
 	uint64_t allocLogSize;
+	// Address of the EirInfo struct.
+	uint64_t eirInfo;
 };

--- a/kernel/klibc/elf.h
+++ b/kernel/klibc/elf.h
@@ -176,3 +176,9 @@ struct Elf64_Dyn {
 		Elf64_Addr d_ptr;
 	};
 };
+
+struct Elf64_Nhdr {
+	Elf64_Word n_namesz;
+	Elf64_Word n_descsz;
+	Elf64_Word n_type;
+};

--- a/kernel/thor/arch/arm/entry.S
+++ b/kernel/thor/arch/arm/entry.S
@@ -1,15 +1,6 @@
-.data
-.align 3
-.global thorBootInfoPtr
-thorBootInfoPtr:
-	.quad 0
-
 .text
 .global thorRtEntry
 thorRtEntry:
-	ldr x1, =thorBootInfoPtr
-	str x0, [x1]
-
 	.extern thorInitialize
 	.extern thorRunConstructors
 	.extern thorMain

--- a/kernel/thor/arch/arm/link.x
+++ b/kernel/thor/arch/arm/link.x
@@ -17,6 +17,8 @@ SECTIONS {
 	}
 
 	.data ALIGN(0x1000) : { *(.data .data.*) }
+	.note.managarm : { *(.note.managarm) }
+
 	.bss : { *(.bss .bss.*) }
 }
 

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -212,7 +212,7 @@ void initializeThisProcessor() {
 void setupBootCpuContext() {
 	bootCpuContext.initialize();
 
-	bootCpuContext->hartId = thorBootInfoPtr->hartId;
+	bootCpuContext->hartId = getEirInfo()->hartId;
 	bootCpuContext->localLogRing = &bootLogRing;
 
 	writeToTp(bootCpuContext.get());

--- a/kernel/thor/arch/riscv/entry.S
+++ b/kernel/thor/arch/riscv/entry.S
@@ -1,14 +1,6 @@
-.data
-.global thorBootInfoPtr
-thorBootInfoPtr:
-	.quad 0
-
 .text
 .global thorRtEntry
 thorRtEntry:
-	la t0, thorBootInfoPtr
-	sd a0, (t0)
-
 	.extern thorInitialize
 	.extern thorRunConstructors
 	.extern thorMain

--- a/kernel/thor/arch/riscv/link.x
+++ b/kernel/thor/arch/riscv/link.x
@@ -26,6 +26,7 @@ SECTIONS {
 
 	.data : { *(.data) }
 	.got : { *(.got.plt) *(.got) }
+	.note.managarm : { *(.note.managarm) }
 
 	/* BSS segment. */
 	.bss : { *(.bss) *(.bss.*) }

--- a/kernel/thor/arch/x86/entry.S
+++ b/kernel/thor/arch/x86/entry.S
@@ -1,13 +1,6 @@
-.data
-.global thorBootInfoPtr
-thorBootInfoPtr:
-	.quad 0
-
 .text
 .global thorRtEntry
 thorRtEntry:
-	mov %rdi, (thorBootInfoPtr)
-
 	# enable SSE support
 	mov %cr0, %rax
 	and $0xFFFFFFFFFFFFFFFB, %rax # disable EM

--- a/kernel/thor/arch/x86/link.x
+++ b/kernel/thor/arch/x86/link.x
@@ -25,6 +25,8 @@ SECTIONS {
 		PROVIDE_HIDDEN (__init_array_end = .);
 	}
 	.data : { *(.data .data.*) }
+	.note.managarm : { *(.note.managarm) }
+
 	.bss : { *(.bss .bss.*) }
 
 	.stab 0 : { *(.stab) }

--- a/kernel/thor/generic/core.cpp
+++ b/kernel/thor/generic/core.cpp
@@ -117,8 +117,8 @@ frg::manual_box<KernelVirtualTree> virtualTree;
 
 KernelVirtualMemory::KernelVirtualMemory() {
 	// The size is chosen arbitrarily here; 2 GiB of kernel heap is sufficient for now.
-	uintptr_t vmBase = 0xFFFF'E000'0000'0000;
-	size_t desiredSize = 0x8000'0000;
+	uintptr_t vmBase = memoryLayoutNote->kernelVirtual;
+	size_t desiredSize = memoryLayoutNote->kernelVirtualSize;
 
 	corePool.initialize(coreSlabPolicy);
 	virtualTree.initialize();
@@ -303,7 +303,7 @@ void KernelVirtualAlloc::poison(void *pointer, size_t size) {
 
 void KernelVirtualAlloc::output_trace(void *buffer, size_t size) {
 	if (!allocLog)
-		allocLog.initialize(0xFFFF'F000'0000'0000, 268435456);
+		allocLog.initialize(memoryLayoutNote->allocLog, memoryLayoutNote->allocLogSize);
 
 	allocLog->enqueue(buffer, size);
 }

--- a/kernel/thor/generic/physical.cpp
+++ b/kernel/thor/generic/physical.cpp
@@ -8,14 +8,16 @@ namespace thor {
 
 static bool logPhysicalAllocs = false;
 
+THOR_DEFINE_ELF_NOTE(memoryLayoutNote){elf_note_type::memoryLayout, {}};
+
 void poisonPhysicalAccess(PhysicalAddr physical) {
-	auto address = 0xFFFF'8000'0000'0000 + physical;
+	auto address = directPhysicalOffset() + physical;
 	KernelPageSpace::global().unmapSingle4k(address);
 	invalidatePage(globalBindingId, reinterpret_cast<void *>(address));
 }
 
 void poisonPhysicalWriteAccess(PhysicalAddr physical) {
-	auto address = 0xFFFF'8000'0000'0000 + physical;
+	auto address = directPhysicalOffset() + physical;
 	KernelPageSpace::global().unmapSingle4k(address);
 	KernelPageSpace::global().mapSingle4k(address, physical, 0, CachingMode::null);
 	invalidatePage(globalBindingId, reinterpret_cast<void *>(address));

--- a/kernel/thor/generic/thor-internal/elf-notes.hpp
+++ b/kernel/thor/generic/thor-internal/elf-notes.hpp
@@ -11,7 +11,6 @@ namespace thor {
 // Name must be an std::array holding a null-terminated string.
 template<auto Name, typename T>
 struct ElfNote {
-	//static_assert(alignof(Elf64_Nhdr) == 8);
 	static_assert(alignof(T) <= 8);
 
 	constexpr ElfNote(unsigned int type, T data)

--- a/kernel/thor/generic/thor-internal/elf-notes.hpp
+++ b/kernel/thor/generic/thor-internal/elf-notes.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <array>
+#include <elf.h>
+
+#define THOR_DEFINE_ELF_NOTE(name) \
+	[[gnu::section(".note.managarm"), gnu::used]] constinit decltype(name) name
+
+namespace thor {
+
+// Name must be an std::array holding a null-terminated string.
+template<auto Name, typename T>
+struct ElfNote {
+	//static_assert(alignof(Elf64_Nhdr) == 8);
+	static_assert(alignof(T) <= 8);
+
+	constexpr ElfNote(unsigned int type, T data)
+	: hdr_{Name.size() - 1, sizeof(T), type}, name_{}, data_{data} {
+		for (size_t i = 0; i < Name.size() - 1; ++i)
+			name_[i] = Name[i];
+	}
+
+	T *operator-> () {
+		return &data_;
+	}
+
+private:
+	Elf64_Nhdr hdr_;
+	char name_[Name.size()];
+	alignas(8) T data_;
+};
+
+template<typename T>
+using ManagarmElfNote = ElfNote<std::to_array("Managarm"), T>;
+
+} // namespace thor

--- a/kernel/thor/generic/thor-internal/main.hpp
+++ b/kernel/thor/generic/thor-internal/main.hpp
@@ -3,9 +3,9 @@
 #include <eir/interface.hpp>
 #include <initgraph.hpp>
 
-extern "C" EirInfo *thorBootInfoPtr;
-
 namespace thor {
+
+EirInfo *getEirInfo();
 
 struct GlobalInitEngine : public initgraph::Engine {
 	virtual ~GlobalInitEngine() = default;

--- a/kernel/thor/system/acpi/madt.cpp
+++ b/kernel/thor/system/acpi/madt.cpp
@@ -217,8 +217,6 @@ void dumpMadt() {
 	}
 }
 
-extern "C" EirInfo *thorBootInfoPtr;
-
 initgraph::Stage *getTablesDiscoveredStage() {
 	static initgraph::Stage s{&globalInitEngine, "acpi.tables-discovered"};
 	return &s;
@@ -235,7 +233,7 @@ static initgraph::Task initTablesTask{&globalInitEngine, "acpi.initialize",
 	initgraph::Entails{getTablesDiscoveredStage()},
 	[] {
 		uacpi_init_params params = {
-			.rsdp = thorBootInfoPtr->acpiRsdp,
+			.rsdp = getEirInfo()->acpiRsdp,
 			.log_level = UACPI_LOG_INFO,
 			.flags = 0,
 		};

--- a/kernel/thor/system/dtb/dtb.cpp
+++ b/kernel/thor/system/dtb/dtb.cpp
@@ -16,8 +16,6 @@ initgraph::Stage *getDeviceTreeParsedStage() {
 	return &s;
 }
 
-extern "C" EirInfo *thorBootInfoPtr;
-
 namespace {
 	frg::manual_box<DeviceTree> dt;
 
@@ -499,12 +497,12 @@ DeviceTreeNode *getDeviceTreeRoot() {
 static initgraph::Task initTablesTask{&globalInitEngine, "dtb.parse-dtb",
 	initgraph::Entails{getDeviceTreeParsedStage()},
 	[] {
-		size_t dtbPageOff = thorBootInfoPtr->dtbPtr & (kPageSize - 1);
-		size_t dtbSize = (thorBootInfoPtr->dtbSize + dtbPageOff + kPageSize - 1) & ~(kPageSize - 1);
+		size_t dtbPageOff = getEirInfo()->dtbPtr & (kPageSize - 1);
+		size_t dtbSize = (getEirInfo()->dtbSize + dtbPageOff + kPageSize - 1) & ~(kPageSize - 1);
 
 		auto ptr = KernelVirtualMemory::global().allocate(dtbSize);
 		uintptr_t va = reinterpret_cast<uintptr_t>(ptr);
-		uintptr_t pa = thorBootInfoPtr->dtbPtr & ~(kPageSize - 1);
+		uintptr_t pa = getEirInfo()->dtbPtr & ~(kPageSize - 1);
 
 		for (size_t i = 0; i < dtbSize; i += kPageSize) {
 			KernelPageSpace::global().mapSingle4k(va, pa,


### PR DESCRIPTION
Instead of magic constants, we now take the memory layout dynamically from Eir (however, as of this PR, Eir itself still determines it statically).

This is achieved by adding an ELF note into `thor` that is patched at load time by Eir.