### PR TITLE
kernel/eir: Determine memory layout at runtime

### DIFF
--- a/kernel/eir/arch/arm/generic.cpp
+++ b/kernel/eir/arch/arm/generic.cpp
@@ -2,6 +2,7 @@
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
+#include <eir-internal/memory-layout.hpp>
 #include <elf.h>
 
 namespace eir {
@@ -233,15 +234,15 @@ void eirRelocate() {
 
 		for (address_t pg = 0; pg < fbSize; pg += 0x1000)
 			mapSingle4kPage(
-			    0xFFFF'FE00'4000'0000 + pg,
+			    getKernelFrameBuffer() + pg,
 			    genericInfo.fb.fbAddress + pg,
 			    PageFlags::write,
 			    CachingMode::writeCombine
 			);
 
-		mapKasanShadow(0xFFFF'FE00'4000'0000, fbSize);
-		unpoisonKasanShadow(0xFFFF'FE00'4000'0000, fbSize);
-		info_ptr->frameBuffer.fbEarlyWindow = 0xFFFF'FE00'4000'0000;
+		mapKasanShadow(getKernelFrameBuffer(), fbSize);
+		unpoisonKasanShadow(getKernelFrameBuffer(), fbSize);
+		info_ptr->frameBuffer.fbEarlyWindow = getKernelFrameBuffer();
 	}
 
 	info_ptr->debugFlags = genericInfo.debugFlags;
@@ -252,7 +253,7 @@ void eirRelocate() {
 
 	eir::infoLogger() << "Leaving Eir and entering the real kernel" << frg::endlog;
 
-	eirEnterKernel(eirTTBR[0] + 1, eirTTBR[1] + 1, kernel_entry, 0xFFFF'FE80'0001'0000);
+	eirEnterKernel(eirTTBR[0] + 1, eirTTBR[1] + 1, kernel_entry, getKernelStackPtr());
 
 	while (true) {
 		asm volatile("" : : : "memory");

--- a/kernel/eir/arch/riscv/arch.cpp
+++ b/kernel/eir/arch/riscv/arch.cpp
@@ -1,5 +1,6 @@
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/memory-layout.hpp>
 
 extern "C" [[noreturn]] void eirEnterKernel(uintptr_t satp, uint64_t entryPtr, uint64_t stackPtr);
 
@@ -10,7 +11,7 @@ extern uint64_t pml4;
 void enterKernel() {
 	constexpr uint64_t modeSv48 = 9;
 	uint64_t satp = (pml4 >> 12) | (modeSv48 << 60);
-	eirEnterKernel(satp, kernelEntry, 0xFFFF'FE80'0001'0000);
+	eirEnterKernel(satp, kernelEntry, getKernelStackPtr());
 }
 
 } // namespace eir

--- a/kernel/eir/arch/riscv/paging.cpp
+++ b/kernel/eir/arch/riscv/paging.cpp
@@ -102,14 +102,6 @@ void initProcessorPaging(void *kernel_start, uint64_t &kernel_entry) {
 	                  << " KiB"
 	                     " after loading the kernel"
 	                  << frg::endlog;
-
-	// Setup the kernel stack.
-	for (address_t page = 0; page < 0x10000; page += pageSize)
-		mapSingle4kPage(0xFFFF'FE80'0000'0000 + page, allocPage(), PageFlags::write);
-	mapKasanShadow(0xFFFF'FE80'0000'0000, 0x10000);
-	unpoisonKasanShadow(0xFFFF'FE80'0000'0000, 0x10000);
-
-	mapKasanShadow(0xFFFF'E000'0000'0000, 0x8000'0000);
 }
 
 } // namespace eir

--- a/kernel/eir/arch/x86/arch.cpp
+++ b/kernel/eir/arch/x86/arch.cpp
@@ -2,6 +2,7 @@
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
+#include <eir-internal/memory-layout.hpp>
 #include <x86/gdt.hpp>
 #include <x86/machine.hpp>
 
@@ -220,18 +221,10 @@ void initProcessorPaging(void *kernel_start, uint64_t &kernel_entry) {
 	                  << " KiB"
 	                     " after loading the kernel"
 	                  << frg::endlog;
-
-	// Setup the kernel stack.
-	for (address_t page = 0; page < 0x10000; page += pageSize)
-		mapSingle4kPage(0xFFFF'FE80'0000'0000 + page, allocPage(), PageFlags::write);
-	mapKasanShadow(0xFFFF'FE80'0000'0000, 0x10000);
-	unpoisonKasanShadow(0xFFFF'FE80'0000'0000, 0x10000);
-
-	mapKasanShadow(0xFFFF'E000'0000'0000, 0x8000'0000);
 }
 
 [[noreturn]] void enterKernel() {
-	eirEnterKernel(eirPml4Pointer, kernelEntry, 0xFFFF'FE80'0001'0000);
+	eirEnterKernel(eirPml4Pointer, kernelEntry, getKernelStackPtr());
 }
 
 } // namespace eir

--- a/kernel/eir/generic/eir-internal/memory-layout.hpp
+++ b/kernel/eir/generic/eir-internal/memory-layout.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <eir/interface.hpp>
+
+namespace eir {
+
+// Size of the kernel's virtual address space in bits.
+// Must be set by the architecture before determineMemoryLayout().
+extern int kernelVirtualBits;
+
+// Kernel stack and kernel stack size.
+// TODO: This does not need to be global if we move stack allocation into memory-layout.cpp.
+extern uint64_t kernelStack;
+extern uint64_t kernelStackSize;
+
+// Compute the members of memoryLayout.
+// Also determine the kernel stack pointer.
+void determineMemoryLayout();
+
+const MemoryLayout &getMemoryLayout();
+
+uint64_t getKernelFrameBuffer();
+uint64_t getKernelStackPtr();
+
+} // namespace eir

--- a/kernel/eir/generic/main-function.cpp
+++ b/kernel/eir/generic/main-function.cpp
@@ -2,6 +2,7 @@
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
+#include <eir-internal/memory-layout.hpp>
 #include <initgraph.hpp>
 
 namespace eir {
@@ -123,14 +124,14 @@ static initgraph::Task prepareFramebufferForThor{
 		    assert(fb->fbAddress & ~static_cast<EirPtr>(pageSize - 1));
 		    for (address_t pg = 0; pg < fb->fbPitch * fb->fbHeight; pg += pageSize)
 			    mapSingle4kPage(
-			        0xFFFF'FE00'4000'0000 + pg,
+			        getKernelFrameBuffer() + pg,
 			        fb->fbAddress + pg,
 			        PageFlags::write,
 			        CachingMode::writeCombine
 			    );
-		    mapKasanShadow(0xFFFF'FE00'4000'0000, fb->fbPitch * fb->fbHeight);
-		    unpoisonKasanShadow(0xFFFF'FE00'4000'0000, fb->fbPitch * fb->fbHeight);
-		    fb->fbEarlyWindow = 0xFFFF'FE00'4000'0000;
+		    mapKasanShadow(getKernelFrameBuffer(), fb->fbPitch * fb->fbHeight);
+		    unpoisonKasanShadow(getKernelFrameBuffer(), fb->fbPitch * fb->fbHeight);
+		    fb->fbEarlyWindow = getKernelFrameBuffer();
 	    }
     }
 };

--- a/kernel/eir/generic/memory-layout.cpp
+++ b/kernel/eir/generic/memory-layout.cpp
@@ -1,0 +1,81 @@
+#include <eir-internal/arch.hpp>
+#include <eir-internal/debug.hpp>
+#include <eir-internal/main.hpp>
+#include <eir-internal/memory-layout.hpp>
+
+namespace eir {
+
+namespace {
+
+MemoryLayout memoryLayout;
+// Virtual address of the kernel's boot frame buffer.
+uint64_t kernelFrameBuffer;
+
+} // namespace
+
+int kernelVirtualBits{48};
+uint64_t kernelStack;
+uint64_t kernelStackSize;
+
+void determineMemoryLayout() {
+	auto s = kernelVirtualBits;
+	auto &ml = memoryLayout;
+
+	// First determine the sizes of various regions.
+	ml.kernelVirtualSize = 0x8000'0000;
+	ml.allocLogSize = 0x1000'0000;
+	kernelStackSize = 0x1'0000;
+
+	// Start allocation at the start of the higher half.
+	uint64_t nextAddress = -(UINT64_C(1) << (s - 1));
+
+	auto assignLayout = [&](uint64_t size) {
+		auto address = nextAddress;
+		nextAddress += size;
+		return address;
+	};
+
+	// The direct physical map takes 1/4 of the entire address space (= 1/2 of the higher half).
+	ml.directPhysical = assignLayout(UINT64_C(1) << (s - 2));
+	ml.kernelVirtual = assignLayout(ml.kernelVirtualSize);
+	ml.allocLog = assignLayout(ml.allocLogSize);
+	ml.eirInfo = assignLayout(0x200000);           // 2 MiB should be enough.
+	kernelFrameBuffer = assignLayout(0x4000'0000); // 1 GiB.
+	kernelStack = assignLayout(kernelStackSize);
+
+	infoLogger() << "eir: Kernel virtual memory layout:" << frg::endlog;
+	infoLogger() << "    Direct physical : 0x" << frg::hex_fmt{ml.directPhysical} << frg::endlog;
+	infoLogger() << "    Kernel virtual  : 0x" << frg::hex_fmt{ml.kernelVirtual} << frg::endlog;
+	infoLogger() << "    Allocation ring : 0x" << frg::hex_fmt{ml.allocLog} << frg::endlog;
+	infoLogger() << "    EirInfo         : 0x" << frg::hex_fmt{ml.eirInfo} << frg::endlog;
+	infoLogger() << "    Kernel FB       : 0x" << frg::hex_fmt{kernelFrameBuffer} << frg::endlog;
+	infoLogger() << "    Kernel stack    : 0x" << frg::hex_fmt{kernelStack} << frg::endlog;
+}
+
+const MemoryLayout &getMemoryLayout() { return memoryLayout; }
+
+uint64_t getKernelFrameBuffer() { return kernelFrameBuffer; }
+uint64_t getKernelStackPtr() { return kernelStack + kernelStackSize; }
+
+namespace {
+
+#ifndef __aarch64__
+initgraph::Task setupKernelStackHeap{
+    &globalInitEngine,
+    "generic.setup-kernel-stack-heap",
+    initgraph::Requires{getAllocationAvailableStage()},
+    [] {
+	    // Setup the kernel stack.
+	    for (address_t page = 0; page < kernelStackSize; page += pageSize)
+		    mapSingle4kPage(kernelStack + page, allocPage(), PageFlags::write);
+	    mapKasanShadow(kernelStack, kernelStackSize);
+	    unpoisonKasanShadow(kernelStack, kernelStackSize);
+
+	    mapKasanShadow(memoryLayout.kernelVirtual, memoryLayout.kernelVirtualSize);
+    }
+};
+#endif
+
+} // namespace
+
+} // namespace eir

--- a/kernel/eir/meson.build
+++ b/kernel/eir/meson.build
@@ -2,6 +2,7 @@ eir_generic_sources = files(
 	'../common/libc.cpp',
 	'../common/font-8x16.cpp',
 	'generic/main.cpp',
+	'generic/memory-layout.cpp',
 	'generic/debug.cpp')
 
 eir_generic_sources += files('generic/global-constructors.cpp')

--- a/kernel/memory.txt
+++ b/kernel/memory.txt
@@ -11,40 +11,12 @@ Thor uses the following PHYSICAL memory regions:
 
 Thor uses the following VIRTUAL memory regions:
 
-FFFF'8000'0000'0000
-	Length: (unlimited)
-	Physical memory window
-	Referenced in eir/src/main.cpp, thor/src/paging.cpp
-
 FFFF'D000'0000'0000
 	Length: 1000'0000'0000 bytes (1/8 of the higher half)
 	KASAN shadow memory
 	Referenced in Eir, Thor and kernel/thor/meson.build
 
-FFFF'E000'0000'0000
-	Length: 2 GiB
-	Kernel heap
-	Referenced in thor/generic/core.cpp
-
-FFFF'F000'0000'0000
-	Length: 256MiB
-	Log ring buffer memory
-	Referenced in eir/main.cpp, thor/generic/core.cpp
-
-FFFF'FE00'0000'0000
-	Length: 0x1'0000 bytes
-	Initial stack for thor
-
-FFFF'FE00'0001'0000
-	Eir information struct
-	Referenced in eir/arch/x86/load_{32,64}.S and eir/arch/x86/main.cpp
-
-FFFF'FE00'4000'0000
-	Initial framebuffer mapping
-	Referenced in multiple Eir files
-
 FFFF'FFFF'8000'0000
 	Length: (unlimited)
 	Kernel code and data
 	Referenced in thor/src/link.ld
-


### PR DESCRIPTION
This determines the virtual memory layout of Thor from the platform's number of virtual address bits.