### PR TITLE
thor: Implement workOnExecutor on RISC-V, rework FP handling

### DIFF
--- a/kernel/thor/arch/arm/cpu.cpp
+++ b/kernel/thor/arch/arm/cpu.cpp
@@ -154,15 +154,6 @@ size_t getStateSize() {
 	return Executor::determineSize();
 }
 
-void switchExecutor(smarter::borrowed_ptr<Thread> thread) {
-	assert(!intsAreEnabled());
-	getCpuData()->activeExecutor = thread;
-}
-
-smarter::borrowed_ptr<Thread> activeExecutor() {
-	return getCpuData()->activeExecutor;
-}
-
 PlatformCpuData::PlatformCpuData() {
 }
 

--- a/kernel/thor/arch/arm/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/cpu.hpp
@@ -310,9 +310,6 @@ struct PlatformCpuData : public AssemblyCpuData {
 
 	GicCpuInterfaceV2 *gicCpuInterfaceV2 = nullptr;
 	uint32_t affinity;
-
-	// TODO: This is not really arch-specific!
-	smarter::borrowed_ptr<Thread> activeExecutor;
 };
 
 // Get a pointer to this CPU's PlatformCpuData instance.

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -111,13 +111,6 @@ void scrubStack(Executor *executor, Continuation cont) {
 	scrubStackFrom(reinterpret_cast<uintptr_t>(*executor->sp()), cont);
 }
 
-void switchExecutor(smarter::borrowed_ptr<Thread> thread) {
-	assert(!intsAreEnabled());
-	getCpuData()->activeExecutor = thread;
-}
-
-smarter::borrowed_ptr<Thread> activeExecutor() { return getCpuData()->activeExecutor; }
-
 Error getEntropyFromCpu(void *buffer, size_t size) { return Error::noHardwareSupport; }
 
 void doRunOnStack(void (*function)(void *, void *), void *sp, void *argument) {

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -210,6 +210,8 @@ struct Executor {
 
 	void *getExceptionStack() { return _exceptionStack; }
 
+	void *fpRegisters() { return _pointer + fsOffset(); }
+
 private:
 	char *_pointer{nullptr};
 	void *_exceptionStack{nullptr};

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -274,9 +274,6 @@ struct PlatformCpuData : public AssemblyCpuData {
 	uint32_t profileFlags = 0;
 
 	bool preemptionIsArmed = false;
-
-	// TODO: This is not really arch-specific!
-	smarter::borrowed_ptr<Thread> activeExecutor;
 };
 
 // Get a pointer to this CPU's PlatformCpuData instance.

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -258,6 +258,14 @@ struct PlatformCpuData : public AssemblyCpuData {
 
 	uint64_t hartId{~UINT64_C(0)};
 
+	// Executor image that we use to save/restore state.
+	Executor *activeExecutor{nullptr};
+
+	// Actual value of the FS field in sstatus before it was cleared in the kernel.
+	// Zero (= extOff) indicates that the current register state cannot be relied upon
+	// (i.e., it has been saved to the executor or it is in control of U-mode).
+	uint8_t stashedFs{0};
+
 	std::atomic<uint64_t> pendingIpis;
 
 	// Deadlines for global timers and preemption.
@@ -272,8 +280,6 @@ struct PlatformCpuData : public AssemblyCpuData {
 	frg::manual_box<AsidCpuData> asidData;
 
 	uint32_t profileFlags = 0;
-
-	bool preemptionIsArmed = false;
 };
 
 // Get a pointer to this CPU's PlatformCpuData instance.

--- a/kernel/thor/arch/riscv/thor-internal/arch/trap.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/trap.hpp
@@ -1,3 +1,11 @@
 #pragma once
 
+#include <thor-internal/arch-generic/cpu.hpp>
+
+namespace thor {
+
 extern "C" void thorExceptionEntry();
+
+void handleRiscvWorkOnExecutor(Executor *executor, Frame *frame);
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/trap.cpp
+++ b/kernel/thor/arch/riscv/trap.cpp
@@ -71,22 +71,31 @@ Word codeToPageFaultFlags(uint64_t code) {
 	return 0;
 }
 
-// Modified frame->sstatus. Must be called *before* sstatus is restored.
-void restoreExtendedState(Executor *executor, Frame *frame) {
+// Modifies frame->sstatus. Must be called *before* sstatus is restored.
+void restoreStaleExtendedState(Executor *executor, Frame *frame) {
+	auto cpuData = getCpuData();
+
 	// Load floating point state.
 	auto fs = (frame->sstatus >> riscv::sstatus::fsShift) & riscv::sstatus::extMask;
-	if (fs != riscv::sstatus::extOff) {
-		// Note that we have to enable the FP extension first since we disable it in the kernel.
-		// extDirty is all-ones hence the setCsrBits() is enough.
-		riscv::setCsrBits<riscv::Csr::sstatus>(riscv::sstatus::extDirty << riscv::sstatus::fsShift);
+	if (fs) {
+		if (!cpuData->stashedFs) {
+			// Note that we have to enable the FP extension first since we disable it in the kernel.
+			// extDirty is all-ones hence the setCsrBits() is enough.
+			riscv::setCsrBits<riscv::Csr::sstatus>(
+			    riscv::sstatus::extDirty << riscv::sstatus::fsShift
+			);
 
-		auto fs = reinterpret_cast<uint64_t *>(executor->fpRegisters());
-		riscv::writeCsr<riscv::Csr::fcsr>(fs[32]);
-		restoreFpRegisters(fs);
+			auto fs = reinterpret_cast<uint64_t *>(executor->fpRegisters());
+			riscv::writeCsr<riscv::Csr::fcsr>(fs[32]);
+			restoreFpRegisters(fs);
 
-		// sstatus is later reloaded from the frame. Mark FS as clean.
-		frame->sstatus &= ~(riscv::sstatus::extMask << riscv::sstatus::fsShift);
-		frame->sstatus |= riscv::sstatus::extClean << riscv::sstatus::fsShift;
+			// sstatus is later reloaded from the frame. Mark FS as clean.
+			frame->sstatus &= ~(riscv::sstatus::extMask << riscv::sstatus::fsShift);
+			frame->sstatus |= riscv::sstatus::extClean << riscv::sstatus::fsShift;
+		} else {
+			assert(fs == cpuData->stashedFs);
+		}
+		cpuData->stashedFs = 0;
 	}
 }
 
@@ -218,9 +227,20 @@ void writeSretCsrs(Frame *frame) {
 } // namespace
 
 extern "C" void thorHandleException(Frame *frame) {
+	auto cpuData = getCpuData();
+
 	// Perform the trap entry.
 	frame->sstatus = riscv::readCsr<riscv::Csr::sstatus>();
+	// TODO: This could be combined with the CSR read above.
+	riscv::clearCsrBits<riscv::Csr::sstatus>((riscv::sstatus::extMask << riscv::sstatus::fsShift));
 	auto cause = riscv::readCsr<riscv::Csr::scause>();
+
+	// Disable FP.
+	auto fs = (frame->sstatus >> riscv::sstatus::fsShift) & riscv::sstatus::extMask;
+	if (fs) {
+		assert(!cpuData->stashedFs);
+		cpuData->stashedFs = fs;
+	}
 
 	// Call the actual IRQ or exception handler.
 	auto code = cause & causeCodeMask;
@@ -230,34 +250,43 @@ extern "C" void thorHandleException(Frame *frame) {
 		handleRiscvException(frame, code);
 	}
 	assert(!intsAreEnabled());
+	assert(cpuData == getCpuData());
 
 	// Now perform the trap exit.
+	restoreStaleExtendedState(cpuData->activeExecutor, frame);
 	writeSretCsrs(frame);
 }
 
 void restoreExecutor(Executor *executor) {
+	auto *cpuData = getCpuData();
 	auto *frame = executor->general();
 
-	getCpuData()->exceptionStackPtr = executor->_exceptionStack;
+	// TODO: This should probably be done in some activateExectutor() function.
+	cpuData->activeExecutor = executor;
+	cpuData->exceptionStackPtr = executor->_exceptionStack;
 
-	restoreExtendedState(executor, frame);
+	assert(!cpuData->stashedFs);
+	restoreStaleExtendedState(executor, frame);
 	writeSretCsrs(frame);
 	// TODO: In principle, this is only necessary on CPU migration.
 	if (!frame->umode())
-		frame->tp() = reinterpret_cast<uintptr_t>(getCpuData());
+		frame->tp() = reinterpret_cast<uintptr_t>(cpuData);
 	thorRestoreExecutorRegs(frame);
 }
 
 void handleRiscvWorkOnExecutor(Executor *executor, Frame *frame) {
+	auto *cpuData = getCpuData();
+
 	enableInts();
 	getCurrentThread()->mainWorkQueue()->run();
 	disableInts();
 
-	restoreExtendedState(executor, frame);
+	assert(!cpuData->stashedFs);
+	restoreStaleExtendedState(executor, frame);
 	writeSretCsrs(frame);
 	// TODO: In principle, this is only necessary on CPU migration.
 	if (!frame->umode())
-		frame->tp() = reinterpret_cast<uintptr_t>(getCpuData());
+		frame->tp() = reinterpret_cast<uintptr_t>(cpuData);
 	thorRestoreExecutorRegs(frame);
 }
 

--- a/kernel/thor/arch/x86/cpu.cpp
+++ b/kernel/thor/arch/x86/cpu.cpp
@@ -211,11 +211,6 @@ void saveExecutor(Executor *executor, SyscallImageAccessor accessor) {
 	}
 }
 
-void switchExecutor(smarter::borrowed_ptr<Thread> thread) {
-	assert(!intsAreEnabled());
-	getCpuData()->activeExecutor = thread;
-}
-
 extern "C" void workStub();
 
 void workOnExecutor(Executor *executor) {
@@ -315,10 +310,6 @@ void UserContext::migrate(CpuData *cpu_data) {
 	tss.ist1 = (Word)cpu_data->irqStack.basePtr();
 	tss.ist2 = (Word)cpu_data->dfStack.basePtr();
 	tss.ist3 = (Word)cpu_data->nmiStack.basePtr();
-}
-
-smarter::borrowed_ptr<Thread> activeExecutor() {
-	return getCpuData()->activeExecutor;
 }
 
 // --------------------------------------------------------

--- a/kernel/thor/arch/x86/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/cpu.hpp
@@ -577,9 +577,6 @@ struct PlatformCpuData : public AssemblyCpuData {
 	bool haveVirtualization = false;
 
 	LocalApicContext apicContext;
-
-	// TODO: This is not really arch-specific!
-	smarter::borrowed_ptr<Thread> activeExecutor;
 };
 
 // Get a pointer to this CPU's PlatformCpuData instance.

--- a/kernel/thor/generic/schedule.cpp
+++ b/kernel/thor/generic/schedule.cpp
@@ -422,7 +422,7 @@ Scheduler *localScheduler() {
 }
 
 smarter::borrowed_ptr<Thread> getCurrentThread() {
-	return activeExecutor();
+	return getCpuData()->activeThread;
 }
 
 } // namespace thor

--- a/kernel/thor/generic/thor-internal/arch-generic/cpu.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/cpu.hpp
@@ -118,18 +118,6 @@ void saveExecutor(Executor *executor, SyscallImageAccessor accessor);
 void workOnExecutor(Executor *executor);
 
 
-// TODO(qookie): These two functions should probably be renamed
-// and moved out of here.
-struct Thread;
-
-// Set the current thread on this CPU.
-// Note: This does not invoke restoreExecutor!
-void switchExecutor(smarter::borrowed_ptr<Thread> executor);
-
-// Get the current thread on this CPU.
-smarter::borrowed_ptr<Thread> activeExecutor();
-
-
 // Validate AssemblyCpuData and PlatformCpuData definitions.
 static_assert(offsetof(AssemblyCpuData, selfPointer) == 0);
 static_assert(std::derived_from<PlatformCpuData, AssemblyCpuData>);

--- a/kernel/thor/generic/thor-internal/cpu-data.hpp
+++ b/kernel/thor/generic/thor-internal/cpu-data.hpp
@@ -8,6 +8,7 @@
 namespace thor {
 
 // Forward defined for pointers that are part of CpuData.
+struct Thread;
 struct KernelFiber;
 struct SingleContextRecordRing;
 struct ReentrantRecordRing;
@@ -38,9 +39,10 @@ struct CpuData : public PlatformCpuData {
 
 	int cpuIndex;
 
-	ExecutorContext *executorContext = nullptr;
-	KernelFiber *activeFiber;
-	KernelFiber *wqFiber = nullptr;
+	ExecutorContext *executorContext{nullptr};
+	smarter::borrowed_ptr<Thread> activeThread;
+	KernelFiber *activeFiber{nullptr};
+	KernelFiber *wqFiber{nullptr};
 	std::atomic<SelfIntCallBase *> selfIntCallPtr{nullptr};
 	smarter::shared_ptr<WorkQueue> generalWorkQueue;
 	std::atomic<uint64_t> heartbeat;

--- a/kernel/thor/generic/thread.cpp
+++ b/kernel/thor/generic/thread.cpp
@@ -443,6 +443,7 @@ smarter::borrowed_ptr<AddressSpace, BindableHandle> Thread::getAddressSpace() {
 
 void Thread::invoke() {
 	assert(!intsAreEnabled());
+	auto *cpuData = getCpuData();
 	auto lock = frg::guard(&_mutex);
 	
 	if(logRunStates)
@@ -466,10 +467,10 @@ void Thread::invoke() {
 
 	lock.unlock();
 
-	_userContext.migrate(getCpuData());
+	_userContext.migrate(cpuData);
 	AddressSpace::activate(_addressSpace);
-	getCpuData()->executorContext = &_executorContext;
-	switchExecutor(self);
+	cpuData->executorContext = &_executorContext;
+	cpuData->activeThread = self;
 	restoreExecutor(&_executor);
 }
 


### PR DESCRIPTION
This PR brings some minor improvements to the RISC-V code. The next missing piece in userspace is to implement `helLoadRegisters`/`helStoreRegisters` to enable POSIX to `exec()`.