### PR TITLE
eir: Make the virt target work on RISC-V

### DIFF
--- a/kernel/eir/arch/arm/virt/meson.build
+++ b/kernel/eir/arch/arm/virt/meson.build
@@ -2,8 +2,9 @@ raspi4_sources = files('virt.S', 'virt.cpp')
 objcopy = find_program('aarch64-managarm-objcopy')
 
 exe = executable('eir-virt', eir_sources, raspi4_sources,
+	'../../../generic/elf-relocate.cpp',
 	include_directories : eir_includes,
-	cpp_args : [eir_cpp_args, '-DPIE'],
+	cpp_args : [eir_cpp_args, '-DEIR_PIE'],
 	link_args : [eir_link_args, '-Wl,-T,' + meson.current_source_dir() + '/link.x', '-static-pie'],
 	dependencies : eir_dependencies,
 	link_depends : files('link.x'),

--- a/kernel/eir/arch/arm/virt/virt.S
+++ b/kernel/eir/arch/arm/virt/virt.S
@@ -38,7 +38,9 @@ eirEntry:
 	b .loop
 
 .enter:
+	.extern eirRelocate
 	.extern eirVirtMain
+	bl eirRelocate
 	bl eirVirtMain
 
 .halt:

--- a/kernel/eir/arch/arm/virt/virt.cpp
+++ b/kernel/eir/arch/arm/virt/virt.cpp
@@ -9,7 +9,6 @@ frg::manual_box<PL011> debugUart;
 void debugPrintChar(char c) { debugUart->send(c); }
 
 extern "C" [[noreturn]] void eirVirtMain(uintptr_t deviceTreePtr) {
-	eirRelocate();
 	debugUart.initialize(0x9000000, 24000000);
 	debugUart->init(115200);
 	GenericInfo info{

--- a/kernel/eir/arch/riscv/dtb.cpp
+++ b/kernel/eir/arch/riscv/dtb.cpp
@@ -3,8 +3,10 @@
 
 namespace eir {
 
-static initgraph::Task discoverMemory{&globalInitEngine, "riscv.discover-memory", [] {
-	                                      discoverMemoryFromDtb(eirDtbPtr);
-                                      }};
+static initgraph::Task discoverMemory{
+    &globalInitEngine, "riscv.discover-memory", initgraph::Entails{getInitrdAvailableStage()}, [] {
+	    discoverMemoryFromDtb(eirDtbPtr);
+    }
+};
 
 } // namespace eir

--- a/kernel/eir/arch/riscv/entry64.S
+++ b/kernel/eir/arch/riscv/entry64.S
@@ -1,12 +1,19 @@
 .global _start
+.section .text.start
 _start:
-	la sp, eirStackTop
+	# Note: We can only use "lla", not "la" before eirRelocate!
 
-	la t0, eirDtbPtr
-	sd a1, 0(t0)
+	lla sp, eirStackTop
 
-	jal eirRunConstructors
-	j eirMain
+	lla t0, eirDtbPtr
+	sd a1, (t0)
+
+#if defined(EIR_PIE)
+	call eirRelocate
+#endif
+	call eirRunConstructors
+	call eirMain
+	unimp
 
 .section .bss
 eirStackBase:

--- a/kernel/eir/arch/riscv/platform/virt/link.x
+++ b/kernel/eir/arch/riscv/platform/virt/link.x
@@ -4,10 +4,10 @@ ENTRY(_start)
 SECTIONS {
 	/* R-X segment. */
 	/* Firmware is linked to 0x80000000. */
-	. = 0x80100000;
+	. = 0;
 	eirImageFloor = .;
 
-	.text : { *(.text) *(.text.*) }
+	.text : { *(.text.start) *(.text) *(.text.*) }
 
 	/* R-- segment. */
 	. = ALIGN(0x1000) + (. & (0xFFF));
@@ -30,7 +30,7 @@ SECTIONS {
 	.data : { *(.data) *(.data.*) }
 	.got : { *(.got) }
 	.got.plt : { *(.got.plt) }
-	.bss : { *(.bss) *(.bss.*) }
+	.bss (TYPE = SHT_PROGBITS) : { *(.bss) *(.bss.*) LONG(0) }
 
 	eirImageCeiling = .;
 }

--- a/kernel/eir/arch/riscv/platform/virt/meson.build
+++ b/kernel/eir/arch/riscv/platform/virt/meson.build
@@ -1,14 +1,28 @@
+objcopy = find_program('riscv64-managarm-objcopy')
+
 exe = executable('eir-virt',
 	[
 		eir_sources,
 		'../../entry64.S',
 		'../../dtb.cpp',
+		'../../../../generic/elf-relocate.cpp',
 		'early-log.cpp',
 	],
 	include_directories : eir_includes,
-	cpp_args : eir_cpp_args,
-	link_args : [eir_link_args, '-Wl,-T,' + meson.current_source_dir() + '/link.x'],
+	c_args : ['-DEIR_PIE'], # Assembly is treated as C.
+	cpp_args : eir_cpp_args + ['-DEIR_PIE'],
+	link_args : [eir_link_args, '-Wl,-T,' + meson.current_source_dir() + '/link.x', '-static-pie'],
 	dependencies : eir_dependencies,
 	link_depends : files('link.x'),
-	install : true
+	pie : true,
+	install : true,
+)
+
+rawbin = custom_target('eir-virt.bin',
+	command : [ objcopy, '-O', 'binary', '@INPUT@', '@OUTPUT@' ],
+	input : exe,
+	output : 'eir-virt.bin',
+	build_by_default : true,
+	install : true,
+	install_dir : get_option('bindir'),
 )

--- a/kernel/eir/arch/x86/arch.cpp
+++ b/kernel/eir/arch/x86/arch.cpp
@@ -13,10 +13,12 @@ eirEnterKernel(uintptr_t pml4Pointer, uint64_t entryPtr, uint64_t stackPtr)
 namespace eir {
 
 void debugPrintChar(char c) {
-	static constexpr arch::scalar_register<uint8_t> data{0};
-	auto base = arch::global_io.subspace(0xe9);
+	if (log_e9) {
+		static constexpr arch::scalar_register<uint8_t> data{0};
+		auto base = arch::global_io.subspace(0xe9);
 
-	base.store(data, c);
+		base.store(data, c);
+	}
 }
 
 enum X86PageFlags {

--- a/kernel/eir/generic/debug.cpp
+++ b/kernel/eir/generic/debug.cpp
@@ -35,8 +35,10 @@ extern "C" void frg_panic(const char *cstring) {
 }
 
 void OutputSink::print(char c) {
-	if (log_e9)
-		debugPrintChar(c);
+	// Emit to the platform-specific device.
+	// For example, this can log to SBI on RISC-V which often yields expected results.
+	// Also, it can log to virtual devices (like e9) when run inside VMs.
+	debugPrintChar(c);
 
 	if (logHandler)
 		logHandler(c);

--- a/kernel/eir/generic/eir-internal/main.hpp
+++ b/kernel/eir/generic/eir-internal/main.hpp
@@ -20,6 +20,8 @@ extern "C" void eirMain();
 
 extern "C" void eirRunConstructors();
 
+initgraph::Stage *getInitrdAvailableStage();
+
 // achieved by parsing boot protocol-specific data to allow for setting up the CPU and memory
 initgraph::Stage *getReservedRegionsKnownStage();
 

--- a/kernel/eir/generic/elf-relocate.cpp
+++ b/kernel/eir/generic/elf-relocate.cpp
@@ -1,0 +1,41 @@
+#include <eir-internal/arch.hpp>
+#include <elf.h>
+
+extern "C" [[gnu::visibility("hidden")]] Elf64_Dyn _DYNAMIC[];
+
+namespace eir {
+
+extern "C" void eirRelocate() {
+	auto base = reinterpret_cast<uintptr_t>(&eirImageFloor);
+	uintptr_t relaAddr = 0;
+	uintptr_t relaSize = 0;
+
+	for (auto *dyn = _DYNAMIC; dyn->d_tag != DT_NULL; ++dyn) {
+		switch (dyn->d_tag) {
+			case DT_RELA:
+				relaAddr = dyn->d_ptr + base;
+				break;
+			case DT_RELASZ:
+				relaSize = dyn->d_val;
+				break;
+			default:
+				break;
+		}
+	}
+
+	for (uintptr_t i = 0; i < relaSize; i += sizeof(Elf64_Rela)) {
+		auto *rela = reinterpret_cast<const Elf64_Rela *>(relaAddr + i);
+#if defined(__aarch64__)
+		if (ELF64_R_TYPE(rela->r_info) != R_AARCH64_RELATIVE)
+			__builtin_trap();
+#elif defined(__riscv) && __riscv_xlen == 64
+		if (ELF64_R_TYPE(rela->r_info) != R_RISCV_RELATIVE)
+			__builtin_trap();
+#else
+#error "Platform does not support PIE in Eir"
+#endif
+		*reinterpret_cast<Elf64_Addr *>(rela->r_offset + base) = base + rela->r_addend;
+	}
+}
+
+} // namespace eir

--- a/kernel/eir/generic/main-function.cpp
+++ b/kernel/eir/generic/main-function.cpp
@@ -38,6 +38,11 @@ initgraph::Stage *getMemoryRegionsKnownStage() {
 	return &s;
 }
 
+initgraph::Stage *getInitrdAvailableStage() {
+	static initgraph::Stage s{&globalInitEngine, "generic.initrd-available"};
+	return &s;
+}
+
 initgraph::Stage *getKernelAvailableStage() {
 	static initgraph::Stage s{&globalInitEngine, "generic.kernel-available"};
 	return &s;
@@ -65,6 +70,7 @@ struct GlobalCtorTest {
 static initgraph::Task parseInitrdInfo{
     &globalInitEngine,
     "generic.parse-initrd",
+    initgraph::Requires{getInitrdAvailableStage()},
     initgraph::Entails{getReservedRegionsKnownStage()},
     [] {
 	    assert(initrd);

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -12,7 +12,7 @@
 
 // Pointer to the DTB.
 // Not in the eir namespace since some protocols set this from assembly.
-void *eirDtbPtr;
+constinit void *eirDtbPtr{nullptr};
 
 namespace eir {
 

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -536,6 +536,8 @@ EirInfo *generateInfo(frg::string_view cmdline) {
 	}
 
 	// Parse the kernel command line.
+	if (!cmdline.data())
+		cmdline = "";
 	const char *l = cmdline.data();
 	while (true) {
 		while (*l && *l == ' ')

--- a/kernel/eir/protos/uefi/entry.cpp
+++ b/kernel/eir/protos/uefi/entry.cpp
@@ -26,6 +26,11 @@ efi_handle handle = nullptr;
 
 namespace {
 
+// The console output protocol is not terribly useful. In particular, it is only available
+// before ExitBootServices. Also, it can easily collide with UART loggers provided by the platform
+// code, causing characters to be printed twice.
+constexpr bool useConOut = false;
+
 efi_graphics_output_protocol *gop = nullptr;
 efi_loaded_image_protocol *loadedImage = nullptr;
 
@@ -407,7 +412,8 @@ extern "C" efi_status eirUefiMain(const efi_handle h, const efi_system_table *sy
 	bs = st->boot_services;
 	handle = h;
 
-	logHandler = uefiBootServicesLogHandler;
+	if (useConOut)
+		logHandler = uefiBootServicesLogHandler;
 
 	// Reset the watchdog timer.
 	EFI_CHECK(bs->set_watchdog_timer(0, 0, 0, nullptr));

--- a/kernel/eir/system/dtb/discovery.cpp
+++ b/kernel/eir/system/dtb/discovery.cpp
@@ -4,6 +4,7 @@
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
+#include <eir-internal/main.hpp>
 #include <frg/array.hpp>
 
 namespace eir {
@@ -95,6 +96,7 @@ void discoverMemoryFromDtb(void *dtbPtr) {
 
 	eir::infoLogger() << "initrd is between 0x" << frg::hex_fmt(initrdStart) << " and 0x"
 	                  << frg::hex_fmt(initrdEnd) << frg::endlog;
+	initrd = physToVirt<void>(initrdStart);
 
 	// Determine all reserved memory areas.
 	InitialRegion reservedRegions[32];
@@ -182,22 +184,6 @@ void discoverMemoryFromDtb(void *dtbPtr) {
 		    }
 	    }
 	);
-
-	// Create and dump the resulting memory regions.
-	setupRegionStructs();
-
-	eir::infoLogger() << "Kernel memory regions:" << frg::endlog;
-	for (size_t i = 0; i < numRegions; ++i) {
-		if (regions[i].regionType == RegionType::null)
-			continue;
-		eir::infoLogger() << "    Memory region [" << i << "]."
-		                  << " Base: 0x" << frg::hex_fmt{regions[i].address} << ", length: 0x"
-		                  << frg::hex_fmt{regions[i].size} << frg::endlog;
-		if (regions[i].regionType == RegionType::allocatable)
-			eir::infoLogger() << "        Buddy tree at 0x" << frg::hex_fmt{regions[i].buddyTree}
-			                  << ", overhead: 0x" << frg::hex_fmt{regions[i].buddyOverhead}
-			                  << frg::endlog;
-	}
 }
 
 } // namespace eir

--- a/kernel/klibc/elf.h
+++ b/kernel/klibc/elf.h
@@ -80,6 +80,10 @@ enum {
 	R_AARCH64_RELATIVE = 1027
 };
 
+enum {
+	R_RISCV_RELATIVE = 3
+};
+
 struct Elf64_Rela {
 	Elf64_Addr r_offset;
 	Elf64_Xword r_info;


### PR DESCRIPTION
Make the virt target PIE (otherwise it is too annoying to use it on multiple SoCs with different load addresses). Also properly integrate DTB memory parsing code that we wrote when initially starting the RISC-V port a few years ago.