### PR TITLE
thor: Support Sstc timer on RISC-V

### DIFF
--- a/kernel/common/riscv/csr.hpp
+++ b/kernel/common/riscv/csr.hpp
@@ -13,10 +13,11 @@ enum class Csr : uint16_t {
 	stvec = 0x105,   // Trap vector address.
 	// Supervisor trap handling.
 	sscratch = 0x140,
-	sepc = 0x141,   // Exception program counter.
-	scause = 0x142, // Cause of exception.
-	stval = 0x143,  // Trap value.
-	sip = 0x0144,   // Interrupt pending.
+	sepc = 0x141,     // Exception program counter.
+	scause = 0x142,   // Cause of exception.
+	stval = 0x143,    // Trap value.
+	sip = 0x144,      // Interrupt pending.
+	stimecmp = 0x14d, // Timer comparison register.
 	// Supervisor protection and translation.
 	satp = 0x180, // Address translation.
 };

--- a/kernel/eir/arch/riscv/arch.cpp
+++ b/kernel/eir/arch/riscv/arch.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <eir-internal/arch.hpp>
+#include <eir-internal/arch/riscv.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/memory-layout.hpp>
 
@@ -17,6 +18,11 @@ bool patchArchSpecificManagarmElfNote(unsigned int type, frg::span<char> desc) {
 		// Config must be known by now.
 		assert(riscvConfig.numPtLevels);
 		memcpy(desc.data(), &riscvConfig, sizeof(RiscvConfig));
+		return true;
+	} else if (type == elf_note_type::riscvHartCaps) {
+		if (desc.size() != sizeof(RiscvHartCaps))
+			panicLogger() << "RiscvHartCaps size does not match ELF note" << frg::endlog;
+		memcpy(desc.data(), &riscvHartCaps, sizeof(RiscvHartCaps));
 		return true;
 	}
 	return false;

--- a/kernel/eir/arch/riscv/eir-internal/arch/riscv.hpp
+++ b/kernel/eir/arch/riscv/eir-internal/arch/riscv.hpp
@@ -5,5 +5,6 @@
 namespace eir {
 
 extern RiscvConfig riscvConfig;
+extern RiscvHartCaps riscvHartCaps;
 
 } // namespace eir

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -66,6 +66,8 @@ enum class RiscvExtension {
 	f,
 	i,
 	m,
+	// S extensions.
+	sstc,
 	// Z extensions.
 	za64rs,
 	zic64b,
@@ -99,6 +101,7 @@ constexpr const char *stringifyRiscvExtension(RiscvExtension ext) {
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(f)
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(i)
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(m)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(sstc)
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(za64rs)
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zic64b)
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zicbom)

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+#include <frg/string.hpp>
 #include <stdint.h>
 
 static const uint64_t eirSignatureValue = 0x68692C2074686F72;
@@ -56,6 +58,87 @@ struct EirInfo {
 	uint64_t acpiRsdp;
 };
 
+// Please keep this sorted.
+enum class RiscvExtension {
+	a,
+	c,
+	d,
+	f,
+	i,
+	m,
+	// Z extensions.
+	za64rs,
+	zic64b,
+	zicbom,
+	zicbop,
+	zicboz,
+	ziccamoa,
+	ziccif,
+	zicclsm,
+	ziccrse,
+	zicntr,
+	zicsr,
+	zihintpause,
+	zihpm,
+
+	// Number of features. Must be last.
+	numExtensions,
+	invalid = numExtensions,
+};
+
+#define EIR_STRINGIFY_RISCV_EXTENSION_CASE(ext) case RiscvExtension::ext: return #ext;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic error "-Wswitch"
+constexpr const char *stringifyRiscvExtension(RiscvExtension ext) {
+	switch(ext) {
+		// Please keep this sorted.
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(a)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(c)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(d)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(f)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(i)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(m)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(za64rs)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zic64b)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zicbom)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zicbop)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zicboz)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(ziccamoa)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(ziccif)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zicclsm)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(ziccrse)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zicntr)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zicsr)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zihintpause)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zihpm)
+		case RiscvExtension::invalid:
+			break;
+	}
+	return nullptr;
+};
+#pragma GCC diagnostic pop
+
+constexpr auto riscvExtensionStrings = [] {
+	constexpr size_t n = static_cast<unsigned int>(RiscvExtension::numExtensions);
+	std::array<const char *, n> array;
+	for (size_t i = 0; i < n; ++i)
+		array[i] = stringifyRiscvExtension(static_cast<RiscvExtension>(i));
+	return array;
+}();
+
+inline RiscvExtension parseRiscvExtension(frg::string_view s) {
+	constexpr size_t n = static_cast<unsigned int>(RiscvExtension::numExtensions);
+	for (size_t i = 0; i < n; ++i) {
+		if (riscvExtensionStrings[i] == s)
+			return static_cast<RiscvExtension>(i);
+	}
+	return RiscvExtension::invalid;
+}
+
+const int extensionBitmaskWords = 1;
+static_assert(static_cast<unsigned int>(RiscvExtension::numExtensions) < extensionBitmaskWords * 64);
+
 namespace elf_note_type {
 
 // Values for Elf64_Nhdr::n_type of ELF notes embedded into Thor.
@@ -64,7 +147,9 @@ constexpr unsigned int memoryLayout = 0x1000'0000;
 // 0x11xx'xxxx range reserved for arch-specific notes in Thor.
 // 0x1100'0xxx range reserved for x86.
 // 0x1100'1xxx range reserved for aarch64.
+// 0x1100'2xxx range reserved for riscv64.
 constexpr unsigned int riscvConfig = 0x1100'2000;
+constexpr unsigned int riscvHartCaps = 0x1100'2001;
 
 inline bool isThorGeneric(unsigned int type) {
 	return (type & 0xFF00'0000) == 0x1000'0000;
@@ -95,4 +180,17 @@ struct RiscvConfig {
 	// 4 for Sv48,
 	// 5 for Sv57.
 	int numPtLevels{0};
+};
+
+struct RiscvHartCaps {
+	uint64_t extensions[extensionBitmaskWords]{};
+
+	void setExtension(RiscvExtension ext) {
+		auto n = static_cast<unsigned int>(ext);
+		extensions[n >> 6] |= (UINT64_C(1) << (n & 63));
+	}
+	bool hasExtension(RiscvExtension ext) {
+		auto n = static_cast<unsigned int>(ext);
+		return extensions[n >> 6] & (UINT64_C(1) << (n & 63));
+	}
 };

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -3,6 +3,7 @@
 #include <riscv/sbi.hpp>
 #include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/arch/fp-state.hpp>
+#include <thor-internal/arch/system.hpp>
 #include <thor-internal/arch/trap.hpp>
 #include <thor-internal/arch/unimplemented.hpp>
 #include <thor-internal/fiber.hpp>
@@ -237,7 +238,8 @@ static initgraph::Task probeSbiFeatures{
     [] {
 	    if (!sbi::base::probeExtension(sbi::eidIpi))
 		    panicLogger() << "SBI does not implement IPI extension" << frg::endlog;
-	    if (!sbi::base::probeExtension(sbi::eidTime))
+	    if (!riscvHartCapsNote->hasExtension(RiscvExtension::sstc)
+	        && !sbi::base::probeExtension(sbi::eidTime))
 		    panicLogger() << "SBI does not implement TIME extension" << frg::endlog;
     }
 };

--- a/kernel/thor/arch/riscv/system.cpp
+++ b/kernel/thor/arch/riscv/system.cpp
@@ -5,6 +5,7 @@
 namespace thor {
 
 THOR_DEFINE_ELF_NOTE(riscvConfigNote){elf_note_type::riscvConfig, {}};
+THOR_DEFINE_ELF_NOTE(riscvHartCapsNote){elf_note_type::riscvHartCaps, {}};
 
 void initializeArchitecture() {
 	sbi::dbcn::writeString("Hello RISC-V world from thor\n");

--- a/kernel/thor/arch/riscv/thor-internal/arch/system.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/system.hpp
@@ -8,6 +8,7 @@ namespace thor {
 static inline constexpr int numIrqSlots = 0;
 
 extern ManagarmElfNote<RiscvConfig> riscvConfigNote;
+extern ManagarmElfNote<RiscvHartCaps> riscvHartCapsNote;
 
 void initializeArchitecture();
 


### PR DESCRIPTION
The Sstc extension allows S-mode to set a timer comparison CSR. This avoids the need to call into SBI. In fact, some boards implement Sstc but not the TIME extension for SBI.