### PR TITLE
kernel/eir: Parse riscv,isa DT property

### DIFF
--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -80,6 +80,7 @@ enum class RiscvExtension {
 	ziccrse,
 	zicntr,
 	zicsr,
+	zifencei,
 	zihintpause,
 	zihpm,
 
@@ -113,6 +114,7 @@ constexpr const char *stringifyRiscvExtension(RiscvExtension ext) {
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(ziccrse)
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zicntr)
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zicsr)
+		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zifencei)
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zihintpause)
 		EIR_STRINGIFY_RISCV_EXTENSION_CASE(zihpm)
 		case RiscvExtension::invalid:


### PR DESCRIPTION
This adds parsing of `riscv,isa`. While the `riscv,isa-base` and `riscv,isa-extensions` properties that we already handle should be preferred over `riscv,isa`, lots of DTs still use the less accurate `riscv,isa`.