### PR TITLE
thor: Boot APs on RISC-V

### DIFF
--- a/kernel/common/riscv/sbi.hpp
+++ b/kernel/common/riscv/sbi.hpp
@@ -14,6 +14,7 @@ struct Result {
 constexpr int64_t eidBase = 0x10;
 constexpr int64_t eidTime = 0x54494D45;
 constexpr int64_t eidIpi = 0x735049;
+constexpr int64_t eidHsm = 0x48534D;
 constexpr int64_t eidDbcn = 0x4442434E;
 
 inline Result call1(uint64_t eid, uint64_t fid, uint64_t arg0) {
@@ -31,6 +32,16 @@ inline Result call2(uint64_t eid, uint64_t fid, uint64_t arg0, uint64_t arg1) {
 	register uint64_t a0 asm("a0") = arg0;
 	register uint64_t a1 asm("a1") = arg1;
 	asm volatile("ecall" : "+r"(a0), "+r"(a1) : "r"(rEid), "r"(rFid) : "memory");
+	return Result{static_cast<int64_t>(a0), static_cast<int64_t>(a1)};
+}
+
+inline Result call3(uint64_t eid, uint64_t fid, uint64_t arg0, uint64_t arg1, uint64_t arg2) {
+	register uint64_t rEid asm("a7") = eid;
+	register uint64_t rFid asm("a6") = fid;
+	register uint64_t a0 asm("a0") = arg0;
+	register uint64_t a1 asm("a1") = arg1;
+	register uint64_t a2 asm("a2") = arg2;
+	asm volatile("ecall" : "+r"(a0), "+r"(a1) : "r"(a2), "r"(rEid), "r"(rFid) : "memory");
 	return Result{static_cast<int64_t>(a0), static_cast<int64_t>(a1)};
 }
 
@@ -70,6 +81,17 @@ inline Error sendIpi(uint64_t hartMask, uint64_t hartMaskBase) {
 }
 
 } // namespace sbi::ipi
+
+namespace sbi::hsm {
+
+constexpr int64_t fidHartStart = 0;
+
+inline Error hartStart(uint64_t hartId, uint64_t ip, uint64_t a1) {
+	auto res = call3(eidHsm, fidHartStart, hartId, ip, a1);
+	return res.error;
+}
+
+} // namespace sbi::hsm
 
 namespace sbi::dbcn {
 

--- a/kernel/eir/protos/limine/entry.cpp
+++ b/kernel/eir/protos/limine/entry.cpp
@@ -27,7 +27,7 @@ namespace {
 [[gnu::used, gnu::section(".requests")]] volatile LIMINE_BASE_REVISION(3);
 LIMINE_REQUEST(memmap_request, LIMINE_MEMMAP_REQUEST, 0);
 LIMINE_REQUEST(hhdm_request, LIMINE_HHDM_REQUEST, 0);
-LIMINE_REQUEST(smp_request, LIMINE_SMP_REQUEST, 0);
+LIMINE_REQUEST(riscv_bsp_hartid_request, LIMINE_RISCV_BSP_HARTID_REQUEST, 0);
 LIMINE_REQUEST(framebuffer_request, LIMINE_FRAMEBUFFER_REQUEST, 1);
 LIMINE_REQUEST(module_request, LIMINE_MODULE_REQUEST, 0);
 LIMINE_REQUEST(kernel_file_request, LIMINE_KERNEL_FILE_REQUEST, 0);
@@ -43,7 +43,9 @@ initgraph::Task setupMiscInfo{
     initgraph::Entails{getEirDoneStage()},
     [] {
 #ifdef __riscv
-	    info_ptr->hartId = smp_request.response->bsp_hartid;
+	    if (!riscv_bsp_hartid_request.response)
+		    panicLogger() << "eir: Missing response for Limine BSP hart ID request" << frg::endlog;
+	    info_ptr->hartId = riscv_bsp_hartid_request.response->bsp_hartid;
 #endif
 
 	    if (dtb_request.response) {

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -155,9 +155,7 @@ namespace {
 
 constinit ReentrantRecordRing bootLogRing;
 
-void writeToTp(AssemblyCpuData *context) {
-	asm volatile("mv tp, %0" : : "r"(context));
-}
+} // namespace
 
 void initializeThisProcessor() {
 	auto cpuData = getCpuData();
@@ -211,8 +209,6 @@ void initializeThisProcessor() {
 	cpuData->generalWorkQueue = cpuData->wqFiber->associatedWorkQueue()->selfPtr.lock();
 	assert(cpuData->generalWorkQueue);
 }
-
-} // namespace
 
 void prepareCpuDataFor(CpuData *context, int cpu) {
 	cpuData.initialize(context);

--- a/kernel/thor/arch/riscv/entry.S
+++ b/kernel/thor/arch/riscv/entry.S
@@ -1,5 +1,6 @@
 .text
 .global thorRtEntry
+.p2align 2
 thorRtEntry:
 	.extern thorInitialize
 	.extern thorRunConstructors
@@ -7,3 +8,25 @@ thorRtEntry:
 	jal thorInitialize
 	jal thorRunConstructors
 	j thorMain
+
+.text
+.p2align 2
+.global thorSmpTrampolineStart
+.global thorSmpTrampolineEnd
+thorSmpTrampolineStart:
+	# Get the address of the trampoline page.
+	auipc t0, 0 # t0 = trampoline page + 8 (since code starts at offset 8)
+
+	# Ensure that the TLB is clear.
+	sfence.vma
+
+	# Enable paging.
+	ld t1, -8(t0)
+	csrw satp, t1
+
+	# Jump to the higher half.
+	ld sp, 0(a1) # sp.
+	ld t1, 8(a1) # entry.
+	mv a0, a1
+	jr t1
+thorSmpTrampolineEnd:

--- a/kernel/thor/arch/riscv/meson.build
+++ b/kernel/thor/arch/riscv/meson.build
@@ -5,6 +5,7 @@ src += files(
 	'fp-state.cpp',
 	'ints.cpp',
 	'paging.cpp',
+	'smp.cpp',
 	'stubs.S',
 	'system.cpp',
 	'timer.cpp',

--- a/kernel/thor/arch/riscv/paging.cpp
+++ b/kernel/thor/arch/riscv/paging.cpp
@@ -102,10 +102,10 @@ ClientPageSpace::ClientPageSpace() : PageSpace{physicalAllocator->allocate(kPage
 
 ClientPageSpace::~ClientPageSpace() {
 	if (riscvConfigNote->numPtLevels == 3) {
-		freePt<ClientCursorPolicy, 3, /*LowerHalfOnly=*/true>(rootTable());
+		freePt<ClientCursorPolicy, 2, /*LowerHalfOnly=*/true>(rootTable());
 	} else {
 		assert(riscvConfigNote->numPtLevels == 4);
-		freePt<ClientCursorPolicy, 4, /*LowerHalfOnly=*/true>(rootTable());
+		freePt<ClientCursorPolicy, 3, /*LowerHalfOnly=*/true>(rootTable());
 	}
 }
 

--- a/kernel/thor/arch/riscv/smp.cpp
+++ b/kernel/thor/arch/riscv/smp.cpp
@@ -1,0 +1,150 @@
+#include <riscv/sbi.hpp>
+#include <thor-internal/arch-generic/cpu.hpp>
+#include <thor-internal/arch-generic/paging.hpp>
+#include <thor-internal/cpu-data.hpp>
+#include <thor-internal/debug.hpp>
+#include <thor-internal/dtb/dtb.hpp>
+#include <thor-internal/fiber.hpp>
+#include <thor-internal/main.hpp>
+#include <thor-internal/physical.hpp>
+#include <thor-internal/ring-buffer.hpp>
+
+namespace thor {
+
+extern "C" uint8_t thorSmpTrampolineStart[];
+extern "C" uint8_t thorSmpTrampolineEnd[];
+
+namespace {
+
+const frg::array<frg::string_view, 1> cpuCompatible = {"riscv"};
+
+// RISC-V AP initialization is quite pleasant to work with.
+// In particular, SBI allows us to pass an opaque pointer to the SMP entry point.
+// Hence, we do not need to embed the StatusBlock pointer into the entry stub
+// and we can start all APs using the same code path (even in parallel).
+
+// Global helper struct that we embed into the entry stub.
+// Note: this struct needs to be synchronized with assembly.
+struct TrampolineHeader {
+	uint64_t satp;
+};
+
+// Per-AP helper struct that we pass as an opaque pointer to SBI.
+// Note: this struct needs to be synchronized with assembly.
+struct StatusBlock {
+	void *sp{nullptr};
+	void (*entry)(StatusBlock *){nullptr};
+	CpuData *smpCpu{nullptr};
+	UniqueKernelStack stack;
+};
+
+constinit PhysicalAddr smpTrampolinePage{};
+constinit frg::manual_box<ClientPageSpace> smpPageSpace;
+
+void setUpTrampoline() {
+	// Allocate a page and create a lower half mapping to identity map it.
+	smpTrampolinePage = physicalAllocator->allocate(kPageSize);
+
+	smpPageSpace.initialize();
+	ClientPageSpace::Cursor cursor{smpPageSpace.get(), smpTrampolinePage};
+	cursor.map4k(smpTrampolinePage, page_access::execute, CachingMode::null);
+	*cursor.getPtePtr() &= ~pteUser;  // Workaround: unset the U bit such that S-mode can execute.
+	*cursor.getPtePtr() |= pteAccess; // Workaround: set the A bit to avoid a page fault.
+
+	// Copy the trampoline and setup satp.
+	// Trampoline page starts with a uint64_t that contains the satp value.
+	auto trampolinePtr = reinterpret_cast<char *>(mapDirectPhysical(smpTrampolinePage));
+	memcpy(
+	    trampolinePtr + sizeof(TrampolineHeader),
+	    thorSmpTrampolineStart,
+	    reinterpret_cast<uintptr_t>(thorSmpTrampolineEnd)
+	        - reinterpret_cast<uintptr_t>(thorSmpTrampolineStart)
+	);
+	uint64_t mode = 8 + (ClientCursorPolicy::numLevels() - 3);
+	new (trampolinePtr) TrampolineHeader{.satp = (smpPageSpace->rootTable() >> 12) | (mode << 60)};
+}
+
+void smpMain(StatusBlock *statusBlock) {
+	writeToTp(statusBlock->smpCpu);
+
+	initializeThisProcessor();
+
+	runOnStack(
+	    [](Continuation, StatusBlock *statusBlock) {
+		    infoLogger() << "Hello world on CPU #" << getCpuData()->cpuIndex << frg::endlog;
+
+		    // Note: this will destroy the stack that smpMain ran on.
+		    //       It needs to happen on the detached stack!
+		    frg::destruct(*kernelAlloc, statusBlock);
+
+		    Scheduler::resume(getCpuData()->wqFiber);
+
+		    localScheduler()->update();
+		    localScheduler()->forceReschedule();
+		    localScheduler()->commitReschedule();
+	    },
+	    getCpuData()->detachedStack.base(),
+	    statusBlock
+	);
+}
+
+void bootAp(DeviceTreeNode *node) {
+	const auto &reg = node->reg();
+	if (reg.size() != 1)
+		panicLogger() << "thor: Expect exactly one 'reg' entry for RISC-V CPUs" << frg::endlog;
+	auto hartId = reg.front().addr;
+
+	// Skip the BSP.
+	if (hartId == getCpuData()->hartId)
+		return;
+
+	// Setup the CpuData.
+	auto [smpCpu, cpuNr] = extendPerCpuData();
+	prepareCpuDataFor(smpCpu, cpuNr);
+	smpCpu->hartId = hartId;
+
+	smpCpu->localLogRing = frg::construct<ReentrantRecordRing>(*kernelAlloc);
+
+	// Participate in global TLB invalidation *before* paging is used by the target CPU.
+	initializeAsidContext(smpCpu);
+
+	// Setup the stack and related data.
+	auto statusBlock = frg::construct<StatusBlock>(*kernelAlloc);
+	auto stack = UniqueKernelStack::make();
+	auto sp = stack.basePtr();
+
+	statusBlock->sp = sp;
+	statusBlock->entry = smpMain;
+	statusBlock->smpCpu = smpCpu;
+	statusBlock->stack = std::move(stack);
+
+	// Finally call into SBI to boot the hart.
+	// Since SBI guarantees on success that the CPU boots, we do not need to wait for smpMain.
+	infoLogger() << "Booting hart with hart ID " << hartId << frg::endlog;
+	auto sbiError = sbi::hsm::hartStart(
+	    hartId,
+	    smpTrampolinePage + sizeof(TrampolineHeader),
+	    reinterpret_cast<uintptr_t>(statusBlock)
+	);
+	if (sbiError)
+		panicLogger() << "SBI HSM hart start failed with error " << sbiError << frg::endlog;
+}
+
+initgraph::Task initAPs{
+    &globalInitEngine,
+    "riscv.init-aps",
+    initgraph::Requires{getDeviceTreeParsedStage(), getTaskingAvailableStage()},
+    [] {
+	    setUpTrampoline();
+
+	    getDeviceTreeRoot()->forEach([&](DeviceTreeNode *node) -> bool {
+		    if (node->isCompatible(cpuCompatible))
+			    bootAp(node);
+		    return false;
+	    });
+    }
+};
+
+} // namespace
+
+} // namespace thor

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -247,6 +247,8 @@ struct AssemblyCpuData {
 	IseqContext *iseqPtr;
 };
 
+inline void writeToTp(AssemblyCpuData *context) { asm volatile("mv tp, %0" : : "r"(context)); }
+
 struct Thread;
 
 struct PlatformCpuData : public AssemblyCpuData {
@@ -300,7 +302,9 @@ size_t getCpuCount();
 
 void saveCurrentSimdState(Executor *executor);
 
+void prepareCpuDataFor(CpuData *context, int cpu);
 void setupBootCpuContext();
+void initializeThisProcessor();
 
 initgraph::Stage *getBootProcessorReadyStage();
 


### PR DESCRIPTION
This PR boots APs on RISC-V (which is actually more pleasant than on x86 and ARM since SBI allows us to pass an opaque pointer to the entry stub).