### PR TITLE
thor: Implement most remaining RISC-V stubs

### DIFF
--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -93,6 +93,8 @@ Executor::Executor(FiberContext *context, AbiParameters abi) {
 	general()->sstatus = riscv::sstatus::sppBit;
 }
 
+Executor::~Executor() { kernelAlloc->free(_pointer); }
+
 void scrubStack(FaultImageAccessor accessor, Continuation cont) {
 	scrubStackFrom(reinterpret_cast<uintptr_t>(accessor.frameBase()), cont);
 	;

--- a/kernel/thor/arch/riscv/paging.cpp
+++ b/kernel/thor/arch/riscv/paging.cpp
@@ -73,7 +73,13 @@ void KernelPageSpace::mapSingle4k(
 	cursor.map4k(physical, flags, cachingMode);
 }
 
-PhysicalAddr KernelPageSpace::unmapSingle4k(VirtualAddr pointer) { unimplementedOnRiscv(); }
+PhysicalAddr KernelPageSpace::unmapSingle4k(VirtualAddr pointer) {
+	assert(!(pointer & (kPageSize - 1)));
+
+	Cursor cursor{this, pointer};
+	auto [_, addr] = cursor.unmap4k();
+	return addr;
+}
 
 // --------------------------------------------------------
 // User page management.

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -193,11 +193,11 @@ struct Executor {
 
 	Executor(const Executor &other) = delete;
 
-	~Executor() { unimplementedOnRiscv(); }
+	~Executor();
 
 	Executor &operator=(const Executor &other) = delete;
 
-	Word *ip() { unimplementedOnRiscv(); }
+	Word *ip() { return &general()->ip; }
 	Word *sp() { return &general()->sp(); }
 
 	// Note: a0 is used for the supercall code.


### PR DESCRIPTION
After this PR, only ASID-related `thor-internal/arch/` functions are still unimplemented on RISC-V.