### PR TITLE
kernel/thor: Add parent to mbus dtb nodes

### DIFF
--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -208,8 +208,8 @@ extern "C" void thorMain() {
 		pci::runAllBridges();
 		pci::runAllDevices();
 
-#if __aarch64__
-		dtb::publishNodes();
+#ifdef __aarch64__
+		dt::publishNodes();
 #endif
 
 		// Parse the initrd image.

--- a/kernel/thor/system/dtb/thor-internal/dtb/dtb.hpp
+++ b/kernel/thor/system/dtb/thor-internal/dtb/dtb.hpp
@@ -15,6 +15,10 @@ namespace thor {
 
 namespace dt {
 struct IrqController;
+struct MbusNode;
+
+void publishNodes();
+
 } // namespace dt
 
 struct DeviceTreeNode {
@@ -207,6 +211,14 @@ struct DeviceTreeNode {
 		return associatedIrqController_;
 	}
 
+	void associateMbusNode(dt::MbusNode *node) {
+		associatedMbusNode_ = node;
+	}
+
+	dt::MbusNode *getAssociatedMbusNode() {
+		return associatedMbusNode_;
+	}
+
 private:
 	DeviceIrq parseIrq_(::DeviceTreeProperty *prop, size_t i);
 	frg::vector<DeviceIrq, KernelAlloc> parseIrqs_(frg::span<const std::byte> prop);
@@ -260,6 +272,7 @@ private:
 
 	// Kernel objects associated with this DeviceTreeNode.
 	dt::IrqController *associatedIrqController_{nullptr};
+	dt::MbusNode *associatedMbusNode_{nullptr};
 };
 
 DeviceTreeNode *getDeviceTreeNodeByPath(frg::string_view path);
@@ -267,10 +280,6 @@ DeviceTreeNode *getDeviceTreeNodeByPhandle(uint32_t phandle);
 DeviceTreeNode *getDeviceTreeRoot();
 
 initgraph::Stage *getDeviceTreeParsedStage();
-
-namespace dtb {
-	void publishNodes();
-} // namespace thor::dtb
 
 static inline frg::array<frg::string_view, 12> dtGicV2Compatible = {
 	"arm,arm11mp-gic",

--- a/protocols/hw/hw.bragi
+++ b/protocols/hw/hw.bragi
@@ -33,7 +33,7 @@ struct PciCapability {
 	uint64 length;
 }
 
-struct DtbRegister {
+struct DtRegister {
 	uint64 address;
 	uint64 length;
 	uint32 offset;
@@ -111,20 +111,6 @@ head(128):
 	int64 cmd;
 }
 
-message GetDtbInfoRequest 21 {
-head(128):
-}
-
-message AccessDtbRegisterRequest 22 {
-head(128):
-	uint32 index;
-}
-
-message InstallDtbIrqRequest 23 {
-head(128):
-	uint32 index;
-}
-
 message SvrResponse 13 {
 head(128):
 	Errors error;
@@ -143,8 +129,8 @@ tail:
 		tag(7) uint32 fb_bpp;
 		tag(8) uint32 fb_type;
 
-		tag(11) DtbRegister[] dtb_regs;
-		tag(12) uint32 num_dtb_irqs;
+		tag(11) DtRegister[] dt_regs;
+		tag(12) uint32 num_dt_irqs;
 	}
 }
 
@@ -189,4 +175,18 @@ tail:
 	uint16[] io_ports;
 	uint16[] fixed_io_ports;
 	uint8[] irqs;
+}
+
+message GetDtInfoRequest 21 {
+head(128):
+}
+
+message AccessDtRegisterRequest 22 {
+head(128):
+	uint32 index;
+}
+
+message InstallDtIrqRequest 23 {
+head(128):
+	uint32 index;
 }

--- a/protocols/hw/include/protocols/hw/client.hpp
+++ b/protocols/hw/include/protocols/hw/client.hpp
@@ -62,14 +62,14 @@ struct AcpiResources {
 	std::vector<uint8_t> irqs;
 };
 
-struct DtbRegister {
+struct DtRegister {
 	uintptr_t address;
 	size_t length;
 	ptrdiff_t offset;
 };
 
-struct DtbInfo {
-	std::vector<DtbRegister> regs;
+struct DtInfo {
+	std::vector<DtRegister> regs;
 	uint32_t numIrqs;
 };
 
@@ -83,9 +83,9 @@ struct Device {
 	async::result<helix::UniqueDescriptor> accessIrq(size_t index = 0);
 	async::result<helix::UniqueDescriptor> installMsi(int index);
 
-	async::result<DtbInfo> getDtbInfo();
-	async::result<helix::UniqueDescriptor> accessDtbRegister(uint32_t index);
-	async::result<helix::UniqueDescriptor> installDtbIrq(uint32_t index);
+	async::result<DtInfo> getDtInfo();
+	async::result<helix::UniqueDescriptor> accessDtRegister(uint32_t index);
+	async::result<helix::UniqueDescriptor> installDtIrq(uint32_t index);
 
 	async::result<void> claimDevice();
 	async::result<void> enableBusIrq();

--- a/protocols/hw/src/client.cpp
+++ b/protocols/hw/src/client.cpp
@@ -658,8 +658,8 @@ async::result<std::shared_ptr<AcpiResources>> Device::getResources() {
 	co_return res;
 }
 
-async::result<DtbInfo> Device::getDtbInfo() {
-	managarm::hw::GetDtbInfoRequest req;
+async::result<DtInfo> Device::getDtInfo() {
+	managarm::hw::GetDtInfoRequest req;
 
 	auto [offer, send_req, recv_head] = co_await helix_ng::exchangeMsgs(
 			_lane,
@@ -690,14 +690,14 @@ async::result<DtbInfo> Device::getDtbInfo() {
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
-	DtbInfo info{};
+	DtInfo info{};
 
-	info.numIrqs = resp.num_dtb_irqs();
+	info.numIrqs = resp.num_dt_irqs();
 
-	info.regs.resize(resp.dtb_regs_size());
+	info.regs.resize(resp.dt_regs_size());
 
-	for(size_t i = 0; i < resp.dtb_regs_size(); i++) {
-		auto &reg = resp.dtb_regs(i);
+	for(size_t i = 0; i < resp.dt_regs_size(); i++) {
+		auto &reg = resp.dt_regs(i);
 		info.regs[i].address = reg.address();
 		info.regs[i].length = reg.length();
 		info.regs[i].offset = reg.offset();
@@ -706,8 +706,8 @@ async::result<DtbInfo> Device::getDtbInfo() {
 	co_return info;
 }
 
-async::result<helix::UniqueDescriptor> Device::accessDtbRegister(uint32_t index) {
-	managarm::hw::AccessDtbRegisterRequest req;
+async::result<helix::UniqueDescriptor> Device::accessDtRegister(uint32_t index) {
+	managarm::hw::AccessDtRegisterRequest req;
 	req.set_index(index);
 
 	auto [offer, send_req, recv_head] = co_await helix_ng::exchangeMsgs(
@@ -745,8 +745,8 @@ async::result<helix::UniqueDescriptor> Device::accessDtbRegister(uint32_t index)
 	co_return std::move(reg);
 }
 
-async::result<helix::UniqueDescriptor> Device::installDtbIrq(uint32_t index) {
-	managarm::hw::InstallDtbIrqRequest req;
+async::result<helix::UniqueDescriptor> Device::installDtIrq(uint32_t index) {
+	managarm::hw::InstallDtIrqRequest req;
 	req.set_index(index);
 
 	auto [offer, send_req, recv_head] = co_await helix_ng::exchangeMsgs(


### PR DESCRIPTION
Add `drvcore.mbus-parent` property to the mbus dt nodes and rename Dtb -> Dt.