### PR TITLE
thor: Avoid calling uACPI functions while not on a fiber

### DIFF
--- a/kernel/thor/system/acpi/madt.cpp
+++ b/kernel/thor/system/acpi/madt.cpp
@@ -227,8 +227,6 @@ initgraph::Stage *getNsAvailableStage() {
 	return &s;
 }
 
-KernelFiber *acpiFiber;
-
 static initgraph::Task initTablesTask{&globalInitEngine, "acpi.initialize",
 	initgraph::Entails{getTablesDiscoveredStage()},
 	[] {


### PR DESCRIPTION
Calling uACPI functions from work queues leads to issues like entering a work queue recursively.