### PR TITLE
thor: Rework globalIrqSlots to remove them on non-x86

### DIFF
--- a/kernel/thor/arch/arm/ints.cpp
+++ b/kernel/thor/arch/arm/ints.cpp
@@ -1,12 +1,16 @@
 #include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/arch-generic/ints.hpp>
 #include <thor-internal/arch/gic.hpp>
+#include <thor-internal/arch/system.hpp>
 #include <thor-internal/debug.hpp>
 #include <thor-internal/int-call.hpp>
 #include <thor-internal/thread.hpp>
 #include <assert.h>
 
 namespace thor {
+
+// TODO: Remove this on aarch64.
+extern frg::manual_box<IrqSlot> globalIrqSlots[numIrqSlots];
 
 extern "C" void *thorExcVectors;
 
@@ -205,7 +209,7 @@ extern "C" void onPlatformAsyncFault(FaultImageAccessor image) {
 		panicLogger() << "thor: Panic due to unrecoverable error" << frg::endlog;
 }
 
-void handleIrq(IrqImageAccessor image, int number);
+void handleIrq(IrqImageAccessor image, IrqPin *irq);
 void handlePreemption(IrqImageAccessor image);
 
 static constexpr bool logSGIs = false;
@@ -245,7 +249,7 @@ extern "C" void onPlatformIrq(IrqImageAccessor image) {
 			infoLogger() << "thor: on CPU " << getCpuData()->cpuIndex << ", spurious IRQ " << irq << " occured" << frg::endlog;
 		// no need to EOI spurious irqs
 	} else {
-		handleIrq(image, irq);
+		handleIrq(image, globalIrqSlots[irq]->pin());
 	}
 }
 

--- a/kernel/thor/arch/riscv/plic.cpp
+++ b/kernel/thor/arch/riscv/plic.cpp
@@ -8,9 +8,6 @@
 
 namespace thor {
 
-// TODO: Remove this on RISC-V.
-extern frg::manual_box<IrqSlot> globalIrqSlots[numIrqSlots];
-
 namespace {
 
 const frg::array<frg::string_view, 1> plicCompatible = {"riscv,plic0"};
@@ -82,12 +79,6 @@ struct Plic : dt::IrqController {
 		irqs_ = {numIrqs, *kernelAlloc};
 		for (size_t i = 0; i < numIrqs; ++i)
 			irqs_[i] = frg::construct<Irq>(*kernelAlloc, this, i);
-		// TODO: This assumes a single PLIC.
-		//       Get rid of globalIrqSlots for non-x86 systems.
-		for (size_t i = 0; i < numIrqs; ++i) {
-			assert(globalIrqSlots[i]->isAvailable());
-			globalIrqSlots[i]->link(irqs_[i]);
-		}
 
 		// Set all IRQs to the highest priority.
 		for (size_t i = 0; i < numIrqs; ++i)
@@ -234,8 +225,9 @@ IrqPin *claimExternalIrq() {
 	auto *ourExternalIrq = &riscvExternalIrq.get();
 	if (!ourExternalIrq->plic)
 		return nullptr;
-	auto idx = ourExternalIrq->plic->claim(ourExternalIrq->ctx);
-	return globalIrqSlots[idx]->pin();
+	auto *plic = ourExternalIrq->plic;
+	auto idx = plic->claim(ourExternalIrq->ctx);
+	return plic->getIrq(idx);
 }
 
 } // namespace thor

--- a/kernel/thor/arch/riscv/plic.cpp
+++ b/kernel/thor/arch/riscv/plic.cpp
@@ -230,11 +230,12 @@ initgraph::Task initPlic{
 
 } // namespace
 
-unsigned int claimExternalIrq() {
+IrqPin *claimExternalIrq() {
 	auto *ourExternalIrq = &riscvExternalIrq.get();
 	if (!ourExternalIrq->plic)
-		return 0;
-	return ourExternalIrq->plic->claim(ourExternalIrq->ctx);
+		return nullptr;
+	auto idx = ourExternalIrq->plic->claim(ourExternalIrq->ctx);
+	return globalIrqSlots[idx]->pin();
 }
 
 } // namespace thor

--- a/kernel/thor/arch/riscv/thor-internal/arch/ints.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/ints.hpp
@@ -5,6 +5,7 @@
 #include <riscv/csr.hpp>
 #include <thor-internal/arch/unimplemented.hpp>
 #include <thor-internal/debug.hpp>
+#include <thor-internal/irq.hpp>
 
 namespace thor {
 
@@ -24,6 +25,6 @@ inline void halt() { asm volatile("wfi"); }
 
 void suspendSelf();
 
-unsigned int claimExternalIrq();
+IrqPin *claimExternalIrq();
 
 } // namespace thor

--- a/kernel/thor/arch/riscv/thor-internal/arch/system.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/system.hpp
@@ -5,9 +5,8 @@
 
 namespace thor {
 
-// Maximal number of IRQs at a single PLIC.
 // TODO: Remove IRQ slots entirely on RISC-V.
-static inline constexpr int numIrqSlots = 1024;
+static inline constexpr int numIrqSlots = 0;
 
 extern ManagarmElfNote<RiscvConfig> riscvConfigNote;
 extern ManagarmElfNote<RiscvHartCaps> riscvHartCapsNote;

--- a/kernel/thor/arch/riscv/trap.cpp
+++ b/kernel/thor/arch/riscv/trap.cpp
@@ -11,7 +11,7 @@ extern "C" [[noreturn]] void thorRestoreExecutorRegs(void *frame);
 
 // TODO: Move declaration to header.
 void handlePreemption(IrqImageAccessor image);
-void handleIrq(IrqImageAccessor image, int number);
+void handleIrq(IrqImageAccessor image, IrqPin *irq);
 void handlePageFault(FaultImageAccessor image, uintptr_t address, Word errorCode);
 void handleOtherFault(FaultImageAccessor image, Interrupt fault);
 void handleSyscall(SyscallImageAccessor image);
@@ -168,9 +168,9 @@ void handleRiscvInterrupt(Frame *frame, uint64_t code) {
 	} else if (code == riscv::interrupts::sti) {
 		onTimerInterrupt(IrqImageAccessor{frame});
 	} else if (code == riscv::interrupts::sei) {
-		auto idx = claimExternalIrq();
-		if (idx) {
-			handleIrq(IrqImageAccessor{frame}, idx);
+		auto irq = claimExternalIrq();
+		if (irq) {
+			handleIrq(IrqImageAccessor{frame}, irq);
 		} else {
 			thor::infoLogger() << "Spurious external interrupt" << frg::endlog;
 		}

--- a/kernel/thor/generic/irq.cpp
+++ b/kernel/thor/generic/irq.cpp
@@ -123,6 +123,8 @@ IrqPin::IrqPin(frg::string<KernelAlloc> name)
 : _name{std::move(name)}, _strategy{IrqStrategy::null},
 		_inService{false}, _dueSinks{0},
 		_maskState{0} {
+	_hash = frg::hash<frg::string<KernelAlloc>>{}(name);
+
 	[] (IrqPin *self, enable_detached_coroutine = {}) -> void {
 		while(true) {
 			co_await self->_unstallEvent.async_wait_if([&] () -> bool {

--- a/kernel/thor/generic/thor-internal/irq.hpp
+++ b/kernel/thor/generic/thor-internal/irq.hpp
@@ -167,8 +167,11 @@ public:
 
 	IrqPin &operator= (const IrqPin &) = delete;
 
-	const frg::string<KernelAlloc> &name() {
+	const frg::string<KernelAlloc> &name() const {
 		return _name;
+	}
+	uint32_t hash() const {
+		return _hash;
 	}
 
 	void configure(IrqConfiguration cfg);
@@ -203,6 +206,8 @@ private:
 	void _updateMask();
 
 	frg::string<KernelAlloc> _name;
+	// Hash of the IRQ name. Mostly useful when extracting entropy from IRQs.
+	uint32_t _hash;
 
 	// Must be protected against IRQs.
 	frg::ticket_spinlock _mutex;


### PR DESCRIPTION
Refactor `handleIrq()` to directly take a `IrqPin *` and remove the use of `globalIrqSlots` on RISC-V.