### PR TITLE
thor: Reduce the number of self IPIs to ping the scheduler

### DIFF
--- a/kernel/thor/generic/schedule.cpp
+++ b/kernel/thor/generic/schedule.cpp
@@ -181,6 +181,11 @@ int64_t Scheduler::_liveRuntime(const ScheduleEntity *entity) {
 }
 
 void Scheduler::update() {
+	updateState();
+	updateQueue();
+}
+
+void Scheduler::updateState() {
 	// Returns the reciprocal in 0.8 fixed point format.
 	auto fixedInverse = [] (uint32_t x) -> uint32_t {
 		assert(x < (1 << 6));
@@ -202,8 +207,10 @@ void Scheduler::update() {
 		_systemProgress += deltaTime * fixedInverse(n);
 
 	_updateCurrentEntity();
+}
 
-	// Finally, process all pending entities.
+// Move entities from the pending queue to the waiting queue.
+void Scheduler::updateQueue() {
 	frg::intrusive_list<
 		ScheduleEntity,
 		frg::locate_member<

--- a/kernel/thor/generic/schedule.cpp
+++ b/kernel/thor/generic/schedule.cpp
@@ -131,7 +131,17 @@ void Scheduler::resume(ScheduleEntity *entity) {
 
 	if(wasEmpty) {
 		if(self == &getCpuData()->scheduler) {
-			sendPingIpi(self->_cpuContext);
+			// Note that IPIs have a significant cost (especially within virtual machines)
+			// that we want to avoid if possible.
+			//
+			// Resuming an entity on the current CPU never needs an IPI to guarantee progress:
+			// - If this function is called from a IRQ handler, fault handler or syscall,
+			//   no ping is necessary since the kernel checks whether we need to reschedule
+			//   before exiting the IRQ/fault/syscall handler.
+			// - Otherwise, this function is called from a kernel fiber that eventually blocks.
+
+			// TODO: In the case of kernel threads, it can be necessary to issue a self IPI
+			//       to ensure that a higher priority thread gets to run as soon as possible.
 		}else{
 			sendPingIpi(self->_cpuContext);
 		}

--- a/kernel/thor/generic/thor-internal/schedule.hpp
+++ b/kernel/thor/generic/thor-internal/schedule.hpp
@@ -113,6 +113,8 @@ private:
 
 public:
 	void update();
+	void updateState();
+	void updateQueue();
 
 	bool maybeReschedule();
 	void forceReschedule();


### PR DESCRIPTION
Avoid the need to self IPI when resuming threads. We previously used self IPIs to exit the idle task when a thread was resumed from thread observation handlers in the kernel. Avoid entering the idle task if any observation handlers are enqueued.