### PR TITLE
posix: add umask support

### DIFF
--- a/posix/subsystem/src/debug-options.hpp
+++ b/posix/subsystem/src/debug-options.hpp
@@ -2,6 +2,7 @@
 
 namespace {
 	constexpr bool logRequests = false;
+	constexpr bool logSpammyRequests = false;
 	constexpr bool logPaths = false;
 	constexpr bool logSignals = false;
 	constexpr bool logCleanup = false;

--- a/posix/subsystem/src/observations.cpp
+++ b/posix/subsystem/src/observations.cpp
@@ -496,7 +496,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 			HEL_CHECK(helStoreRegisters(thread.getHandle(), kHelRegsGeneral, &gprs));
 			HEL_CHECK(helResume(thread.getHandle()));
 		}else if(observe.observation() == kHelObserveSuperCall + posix::superGetTid){
-			if(logRequests)
+			if(logSpammyRequests)
 				std::cout << "posix: GET_TID supercall" << std::endl;
 
 			uintptr_t gprs[kHelNumGprs];

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -281,6 +281,7 @@ std::shared_ptr<FsContext> FsContext::create() {
 
 	context->_root = rootPath();
 	context->_workDir = rootPath();
+	context->_umask = 022;
 
 	return context;
 }
@@ -290,6 +291,7 @@ std::shared_ptr<FsContext> FsContext::clone(std::shared_ptr<FsContext> original)
 
 	context->_root = original->_root;
 	context->_workDir = original->_workDir;
+	context->_umask = original->_umask;
 
 	return context;
 }
@@ -308,6 +310,16 @@ void FsContext::changeRoot(ViewPath root) {
 
 void FsContext::changeWorkingDirectory(ViewPath workdir) {
 	_workDir = std::move(workdir);
+}
+
+int FsContext::getUmask() {
+	return _umask;
+}
+
+int FsContext::changeUmask(int mask) {
+	int old = _umask;
+	_umask = mask;
+	return old;
 }
 
 // ----------------------------------------------------------------------------

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -141,13 +141,16 @@ struct FsContext {
 
 	ViewPath getRoot();
 	ViewPath getWorkingDirectory();
+	int getUmask();
 
 	void changeRoot(ViewPath root);
 	void changeWorkingDirectory(ViewPath root);
+	int changeUmask(int mask);
 
 private:
 	ViewPath _root;
 	ViewPath _workDir;
+	int _umask;
 };
 
 struct FileDescriptor {

--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -890,9 +890,9 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 		}else if(preamble.id() == managarm::posix::MkdirAtRequest::message_id) {
 			std::vector<std::byte> tail(preamble.tail_size());
 			auto [recv_tail] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::recvBuffer(tail.data(), tail.size())
-				);
+				conversation,
+				helix_ng::recvBuffer(tail.data(), tail.size())
+			);
 			HEL_CHECK(recv_tail.error());
 
 			auto req = bragi::parse_head_tail<managarm::posix::MkdirAtRequest>(recv_head, tail);
@@ -965,6 +965,14 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				continue;
 			}
 
+			auto target = std::get<std::shared_ptr<FsLink>>(result)->getTarget();
+			auto chmodResult = co_await target->chmod(req->mode() & ~self->fsContext()->getUmask() & 0777);
+			if (chmodResult != Error::success) {
+				std::cout << "posix: chmod failed when creating directory for MkdirAtRequest!" << std::endl;
+				co_await sendErrorResponse(managarm::posix::Errors::INTERNAL_ERROR);
+				continue;
+			}
+
 			co_await sendErrorResponse(managarm::posix::Errors::SUCCESS);
 		}else if(preamble.id() == managarm::posix::MkfifoAtRequest::message_id) {
 			std::vector<std::byte> tail(preamble.tail_size());
@@ -1029,7 +1037,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				continue;
 			}
 
-			auto result = co_await parent->mkfifo(resolver.nextComponent(), req->mode());
+			auto result = co_await parent->mkfifo(
+				resolver.nextComponent(),
+				req->mode() & ~self->fsContext()->getUmask()
+			);
 			if(!result) {
 				std::cout << "posix: Unexpected failure from mkfifo()" << std::endl;
 				co_return;
@@ -1858,7 +1869,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 						co_await sendErrorResponse(managarm::posix::Errors::FILE_NOT_FOUND);
 						continue;
 					}
-					auto chmodResult = co_await node->chmod(req->mode());
+					auto chmodResult = co_await node->chmod(req->mode() & ~self->fsContext()->getUmask());
 					if (chmodResult != Error::success) {
 						std::cout << "posix: chmod failed when creating file for OpenAtRequest!" << std::endl;
 						co_await sendErrorResponse(managarm::posix::Errors::INTERNAL_ERROR);
@@ -3299,7 +3310,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					}
 				}
 			} else if(type == VfsType::fifo) {
-				auto result = co_await parent->mkfifo(resolver.nextComponent(), req->mode());
+				auto result = co_await parent->mkfifo(
+					resolver.nextComponent(),
+					req->mode() & ~self->fsContext()->getUmask()
+				);
 				if(!result) {
 					if(result.error() == Error::illegalOperationTarget) {
 						co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
@@ -3749,6 +3763,15 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				resp.set_error(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
 				std::cout << "posix: ITIMER_VIRTUAL and ITIMER_PROF are unsupported" << std::endl;
 			}
+		} else if (preamble.id() == managarm::posix::UmaskRequest::message_id) {
+			auto req = bragi::parse_head_only<managarm::posix::UmaskRequest>(recv_head);
+			if (logRequests)
+				std::cout << "posix: UMASK newmask: " << req->newmask() << std::endl;
+
+			managarm::posix::UmaskResponse resp;
+
+			int oldmask = self->fsContext()->changeUmask(req->newmask() & 0777);
+			resp.set_oldmask(oldmask);
 
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(
 				conversation,

--- a/posix/subsystem/src/un-socket.cpp
+++ b/posix/subsystem/src/un-socket.cpp
@@ -549,6 +549,8 @@ public:
 						conversation,
 						helix_ng::sendBuffer(ser.data(), ser.size())
 					);
+
+					HEL_CHECK(send_resp.error());
 					co_return;
 				}
 			}

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -180,7 +180,7 @@ head(128):
 		// used by PT_IOCTL, PT_SET_OPTION.
 		tag(8) int64 command;
 
-		//used by FLOCK
+		// used by FLOCK
 		tag(9) int32 flock_flags;
 
 		// used by PT_SET_OPTION.

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -516,6 +516,7 @@ tail:
 message MkdirAtRequest 40 {
 head(128):
 	int32 fd;
+	int32 mode;
 tail:
 	string path;
 }
@@ -624,4 +625,14 @@ head(128):
 	uint64 value_usec;
 	uint64 interval_sec;
 	uint64 interval_usec;
+}
+
+message UmaskRequest 101 {
+head(128):
+	int32 newmask;
+}
+
+message UmaskResponse 102 {
+head(128):
+	int32 oldmask;
 }


### PR DESCRIPTION
This adds the `sys_umask` mlibc sysdep, and makes it work with the usual system calls. Hopefully, unless I screwed it up.