### PR TITLE
kernel: allow the managarm kernel to work correctly on Apple M1 in KVM

### DIFF
--- a/kernel/eir/arch/arm/arch.cpp
+++ b/kernel/eir/arch/arm/arch.cpp
@@ -154,7 +154,7 @@ void initProcessorEarly() {
 	uint64_t aa64mmfr0;
 	asm volatile("mrs %0, id_aa64mmfr0_el1" : "=r"(aa64mmfr0));
 
-	if (aa64mmfr0 & (0xF << 28))
+	if (aa64mmfr0 & (uint64_t(0xF) << 28))
 		eir::panicLogger() << "PANIC! This CPU doesn't support 4K memory translation granules"
 		                   << frg::endlog;
 

--- a/kernel/thor/arch/arm/gic_v2.cpp
+++ b/kernel/thor/arch/arm/gic_v2.cpp
@@ -59,6 +59,7 @@ GicDistributorV2::GicDistributorV2(uintptr_t addr)
 	auto register_ptr = KernelVirtualMemory::global().allocate(0x1000);
 	KernelPageSpace::global().mapSingle4k(VirtualAddr(register_ptr), addr,
 			page_access::write, CachingMode::mmio);
+	pageTableUpdateBarrier();
 	space_ = arch::mem_space{register_ptr};
 }
 
@@ -297,6 +298,7 @@ GicCpuInterfaceV2::GicCpuInterfaceV2(GicDistributorV2 *dist, uintptr_t addr, siz
 		KernelPageSpace::global().mapSingle4k(VirtualAddr(ptr) + i, addr + i,
 				page_access::write, CachingMode::mmio);
 	}
+	pageTableUpdateBarrier();
 	space_ = arch::mem_space{ptr};
 }
 

--- a/kernel/thor/arch/arm/paging.cpp
+++ b/kernel/thor/arch/arm/paging.cpp
@@ -47,6 +47,10 @@ void switchToPageTable(PhysicalAddr root, int asid, bool invalidate) {
 		: "memory");
 }
 
+void pageTableUpdateBarrier() {
+	asm volatile("dsb ishst; isb");
+}
+
 namespace {
 
 PhysicalAddr nullTable = PhysicalAddr(-1);

--- a/kernel/thor/arch/arm/thor-internal/arch/gic_v3.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic_v3.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <thor-internal/arch/gic.hpp>
+#include <thor-internal/dtb/irq.hpp>
 #include <frg/manual_box.hpp>
 
 namespace thor {
@@ -60,7 +61,7 @@ private:
 	uint32_t irq_;
 };
 
-struct GicV3 : public Gic {
+struct GicV3 : public Gic, public dt::IrqController {
 	GicV3();
 
 	void sendIpi(int cpuId, uint8_t id) override;
@@ -71,6 +72,8 @@ struct GicV3 : public Gic {
 
 	Pin *setupIrq(uint32_t irq, TriggerMode trigger) override;
 	Pin *getPin(uint32_t irq) override;
+
+	IrqPin *resolveDtIrq(dtb::Cells irq) override;
 
 private:
 	frg::vector<GicPinV3 *, KernelAlloc> irqPins_;

--- a/kernel/thor/arch/arm/timer.cpp
+++ b/kernel/thor/arch/arm/timer.cpp
@@ -77,7 +77,7 @@ struct VirtualGenericTimer : IrqSink, AlarmTracker {
 	}
 
 	void disarm() {
-		asm volatile ("msr cntv_cval_el0, %0" :: "r"(0xFFFFFFFFFFFFFFFF));
+		asm volatile ("msr cntv_cval_el0, %0" :: "r"(0xFFFF'FFFF'FFFF'FFFFULL));
 	}
 };
 
@@ -103,7 +103,10 @@ void armPreemption(uint64_t nanos) {
 }
 
 void disarmPreemption() {
-	asm volatile ("msr cntp_cval_el0, %0" :: "r"(0xFFFFFFFFFFFFFFFF));
+	// although it *should* be correct to set this to 0xFFFF'FFFF'FFFF'FFFFULL,
+	// this does not work on apple platforms for whatever reason. work around this
+	// by setting a smaller value that still works.
+	asm volatile ("msr cntp_cval_el0, %0" :: "r"(0xFFFF'FFFF'FFF0'0000ULL));
 	getCpuData()->preemptionIsArmed = false;
 }
 

--- a/kernel/thor/arch/riscv/paging.cpp
+++ b/kernel/thor/arch/riscv/paging.cpp
@@ -37,6 +37,8 @@ void invalidatePage(int asid, const void *address) {
 	asm volatile("sfence.vma" : : : "memory"); // This is too coarse (also invalidates global).
 }
 
+void pageTableUpdateBarrier() {}
+
 void initializeAsidContext(CpuData *cpuData) {
 	auto irqLock = frg::guard(&irqMutex());
 

--- a/kernel/thor/arch/x86/paging.cpp
+++ b/kernel/thor/arch/x86/paging.cpp
@@ -67,6 +67,8 @@ void invalidatePage(int asid, const void *address) {
 	}
 }
 
+void pageTableUpdateBarrier() {}
+
 // --------------------------------------------------------
 // Kernel paging management.
 // --------------------------------------------------------

--- a/kernel/thor/generic/core.cpp
+++ b/kernel/thor/generic/core.cpp
@@ -229,6 +229,7 @@ uintptr_t KernelVirtualAlloc::map(size_t length) {
 		KernelPageSpace::global().mapSingle4k(VirtualAddr(p) + offset, physical,
 				page_access::write, CachingMode::null);
 	}
+	pageTableUpdateBarrier();
 	kernelMemoryUsage += length;
 
 	return uintptr_t(p);

--- a/kernel/thor/generic/cpu-data.cpp
+++ b/kernel/thor/generic/cpu-data.cpp
@@ -69,6 +69,7 @@ std::tuple<CpuData *, size_t> extendPerCpuData() {
 
 		KernelPageSpace::global().mapSingle4k(base + pg, page, page_access::write, CachingMode::null);
 	}
+	pageTableUpdateBarrier();
 	unpoisonKasanShadow(reinterpret_cast<void *>(base), size);
 
 	auto context = reinterpret_cast<CpuData *>(base);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3428,6 +3428,7 @@ HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num
 				KernelPageSpace::global().mapSingle4k(reinterpret_cast<uintptr_t>(window + off),
 						range.get<0>(), page_access::write, range.get<1>());
 			}
+			pageTableUpdateBarrier();
 
 			bound->setupMemoryViewBinding(i, window);
 		}else{

--- a/kernel/thor/generic/kernel-stack.cpp
+++ b/kernel/thor/generic/kernel-stack.cpp
@@ -17,6 +17,7 @@ UniqueKernelStack UniqueKernelStack::make() {
 				reinterpret_cast<VirtualAddr>(pointer) + guardedSize - kSize + offset,
 				physical, page_access::write, CachingMode::null);
 	}
+	pageTableUpdateBarrier();
 
 	return UniqueKernelStack(reinterpret_cast<char *>(pointer) + guardedSize);
 }

--- a/kernel/thor/generic/kernlet.cpp
+++ b/kernel/thor/generic/kernlet.cpp
@@ -149,6 +149,7 @@ smarter::shared_ptr<KernletObject> processElfDso(const char *buffer,
 				KernelPageSpace::global().mapSingle4k(va, physical,
 						pf, CachingMode::null);
 			}
+			pageTableUpdateBarrier();
 
 			// Fill the segment.
 			memset(base + phdr.p_vaddr, 0, phdr.p_memsz);

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -227,6 +227,7 @@ extern "C" void thorMain() {
 			for(size_t pg = 0; pg < modules[0].length; pg += kPageSize)
 				KernelPageSpace::global().mapSingle4k(reinterpret_cast<VirtualAddr>(base) + pg,
 						modules[0].physicalBase + pg, 0, CachingMode::null);
+			pageTableUpdateBarrier();
 
 			struct Header {
 				char magic[6];

--- a/kernel/thor/generic/thor-internal/arch-generic/asid.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/asid.hpp
@@ -294,6 +294,10 @@ void invalidateAsid(int asid);
 // (globalBindingId for the global page tables).
 void invalidatePage(int asid, const void *address);
 
+// Wait for all preceding page table updates to finish. This is required
+// after mapping new page table entries for the newly created entries to be
+// observable.
+void pageTableUpdateBarrier();
 
 struct CpuData;
 

--- a/kernel/thor/system/dtb/dtb.cpp
+++ b/kernel/thor/system/dtb/dtb.cpp
@@ -517,6 +517,7 @@ static initgraph::Task initTablesTask{&globalInitEngine, "dtb.parse-dtb",
 			va += kPageSize;
 			pa += kPageSize;
 		}
+		pageTableUpdateBarrier();
 
 		ptr = reinterpret_cast<void *>(
 				reinterpret_cast<uintptr_t>(ptr) + dtbPageOff);

--- a/kernel/thor/system/framebuffer/fb.cpp
+++ b/kernel/thor/system/framebuffer/fb.cpp
@@ -123,6 +123,7 @@ void transitionBootFb() {
 	for(size_t pg = 0; pg < windowSize; pg += kPageSize)
 		KernelPageSpace::global().mapSingle4k(VirtualAddr(window) + pg,
 				bootInfo->address + pg, page_access::write, CachingMode::writeCombine);
+	pageTableUpdateBarrier();
 
 	// Transition to the kernel mapping window.
 	bootDisplay->setWindow(window);

--- a/kernel/thor/system/pci/dmalog.cpp
+++ b/kernel/thor/system/pci/dmalog.cpp
@@ -64,6 +64,7 @@ struct DmalogDevice final : IrqSink, KernelIoChannel {
 				inPhysical_, page_access::write, CachingMode::writeBack);
 		KernelPageSpace::global().mapSingle4k(reinterpret_cast<uintptr_t>(inView_) + kPageSize,
 				inPhysical_, page_access::write, CachingMode::writeBack);
+		pageTableUpdateBarrier();
 
 		PageAccessor ctrlAccessor{ctrlPhysical_};
 		auto ctrlPtr = reinterpret_cast<std::byte *>(ctrlAccessor.get());
@@ -262,6 +263,7 @@ static initgraph::Task enumerateDmalog{&globalInitEngine, "pci.enumerate-dmalog"
 			auto mmioPtr = KernelVirtualMemory::global().allocate(0x10000);
 			KernelPageSpace::global().mapSingle4k(reinterpret_cast<uintptr_t>(mmioPtr),
 					pciDevice->bars[0].address, page_access::write, CachingMode::null);
+			pageTableUpdateBarrier();
 
 			char tag[64]{};
 			size_t n;

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -1884,6 +1884,7 @@ void configureDevice(PciDevice *device) {
 					reinterpret_cast<uintptr_t>(window) + page,
 					(bar.address + tableOffset + page) & ~(kPageSize - 1),
 					page_access::write, CachingMode::null);
+		pageTableUpdateBarrier();
 		device->msixMapping = reinterpret_cast<std::byte *>(window) + mappingDisp;
 
 		// Mask all MSIs.

--- a/kernel/thor/system/pci/pci_dtb.cpp
+++ b/kernel/thor/system/pci/pci_dtb.cpp
@@ -117,9 +117,6 @@ DtbPciIrqRouter::DtbPciIrqRouter(PciIrqRouter *parent_, PciBus *associatedBus_,
 			if (!childIrq.read(index))
 				panicLogger() << "Failed to read pin index from interrupt-map" << frg::endlog;
 
-			if (parentAddress.numCells())
-				panicLogger() << "thor: ECAM interrupt-maps with non-zero parent #address-cells are unsupported" << frg::endlog;
-
 			auto *irqController = parentNode->getAssociatedIrqController();
 			if (!irqController)
 				panicLogger() << "No IRQ controller associated with "

--- a/kernel/thor/system/pci/pcie_brcmstb.cpp
+++ b/kernel/thor/system/pci/pcie_brcmstb.cpp
@@ -118,6 +118,7 @@ BrcmStbPcie::BrcmStbPcie(DeviceTreeNode *node, uint16_t seg, uint8_t busStart, u
 				VirtualAddr(ptr) + i, addr + i,
 				page_access::write, CachingMode::mmioNonPosted);
 	}
+	pageTableUpdateBarrier();
 
 	regSpace_ = arch::mem_space{ptr};
 

--- a/kernel/thor/system/pci/pcie_ecam.cpp
+++ b/kernel/thor/system/pci/pcie_ecam.cpp
@@ -26,6 +26,7 @@ arch::mem_space EcamPcieConfigIo::spaceForBus_(uint32_t bus) {
 				VirtualAddr(ptr) + i, mmioBase_ + i + offset,
 				page_access::write, CachingMode::mmio);
 	}
+	pageTableUpdateBarrier();
 
 	busMappings_.insert(bus, ptr);
 


### PR DESCRIPTION
The Apple M1 timer seems to be weird and breaks if you set a deadline of `0xffff'ffff'ffff'ffff`. Work around this by setting a lower value. Also, add memory barriers after changing page tables because it is a requirement on arm.