### PR TITLE
Initial systemd boot support

### DIFF
--- a/posix/subsystem/src/netlink/nl-socket.hpp
+++ b/posix/subsystem/src/netlink/nl-socket.hpp
@@ -35,7 +35,7 @@ public:
 				file, &File::fileOperations, file->_cancelServe));
 	}
 
-	OpenFile(int protocol, bool nonBlock = false);
+	OpenFile(int protocol, int type, bool nonBlock = false);
 
 	void deliver(core::netlink::Packet packet) override;
 
@@ -119,6 +119,8 @@ private:
 	// Group subscriptions
 	// TODO(no92): handle group IDs >= MAX_BITMAP_GROUP_ID
 	uint32_t joinedGroups_ = 0;
+
+	int type_ = 0;
 };
 
 // Configures the given netlink protocol.
@@ -130,7 +132,7 @@ void broadcast(int proto_idx, uint32_t grp_idx, std::string buffer);
 
 bool protocol_supported(int protocol);
 
-smarter::shared_ptr<File, FileHandle> createSocketFile(int proto_idx, bool nonBlock);
+smarter::shared_ptr<File, FileHandle> createSocketFile(int proto_idx, int type, bool nonBlock);
 
 } // namespace netlink::nl_socket
 

--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -2645,7 +2645,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 						req->flags() & SOCK_NONBLOCK
 					);
 				else if(netlink::nl_socket::protocol_supported(req->protocol()))
-					file = netlink::nl_socket::createSocketFile(req->protocol(), req->flags() & SOCK_NONBLOCK);
+					file = netlink::nl_socket::createSocketFile(req->protocol(), req->socktype(), req->flags() & SOCK_NONBLOCK);
 				else {
 					std::cout << std::format("posix: unhandled netlink protocol 0x{:X}",
 						req->protocol()) << std::endl;

--- a/posix/subsystem/src/un-socket.cpp
+++ b/posix/subsystem/src/un-socket.cpp
@@ -268,7 +268,7 @@ public:
 		if(logSockets)
 			std::cout << "posix: Send to socket \e[1;34m" << structName() << "\e[0m" << std::endl;
 
-		protocols::fs::utils::handleSoPasscred(_passCreds, ucreds, process->pid(), process->uid(), process->gid());
+		protocols::fs::utils::handleSoPasscred(_remote->_passCreds, ucreds, process->pid(), process->uid(), process->gid());
 
 		// We ignore MSG_DONTWAIT here as we never block anyway.
 


### PR DESCRIPTION
This PR adds the necessary infrastructure to stage1 to support booting with systemd. It also contains a quick fix for SO_PASSCREDS handling on unix sockets and an addition to getsockopt for netlink sockets. This PR is made to facilitate debugging, and does not conclude the work to get systemd working on Managarm.

Part of the systemd on Managarm project.