### PR TITLE
thor: Fix missing checks for preemption on all archs

### DIFF
--- a/kernel/thor/arch/arm/timer.cpp
+++ b/kernel/thor/arch/arm/timer.cpp
@@ -33,6 +33,7 @@ struct PhysicalGenericTimer : IrqSink, ClockSource {
 
 	IrqStatus raise() override {
 		disarmPreemption();
+		getCpuData()->scheduler.forcePreemptionCall();
 		return IrqStatus::acked;
 	}
 

--- a/kernel/thor/arch/riscv/paging.cpp
+++ b/kernel/thor/arch/riscv/paging.cpp
@@ -27,7 +27,13 @@ void switchToPageTable(PhysicalAddr root, int asid, bool invalidate) {
 	asm volatile("sfence.vma" : : : "memory"); // This is too coarse (also invalidates global).
 }
 
-void switchAwayFromPageTable(int asid) { unimplementedOnRiscv(); }
+void switchAwayFromPageTable(int asid) {
+	// Switch to kernel page tables and invalidate.
+	auto root = KernelPageSpace::global().rootTable();
+	uint64_t mode = 8 + (ClientCursorPolicy::numLevels() - 3);
+	riscv::writeCsr<riscv::Csr::satp>((root >> 12) | (mode << 60));
+	asm volatile("sfence.vma" : : : "memory"); // This is too coarse (also invalidates global).
+}
 
 void invalidateAsid(int asid) {
 	asm volatile("sfence.vma" : : : "memory"); // This is too coarse (also invalidates global).

--- a/kernel/thor/arch/riscv/timer.cpp
+++ b/kernel/thor/arch/riscv/timer.cpp
@@ -10,9 +10,6 @@
 
 namespace thor {
 
-// TODO: Move declaration to header.
-void handlePreemption(IrqImageAccessor image);
-
 extern ClockSource *globalClockSource;
 extern PrecisionTimerEngine *globalTimerEngine;
 
@@ -148,13 +145,13 @@ void onTimerInterrupt(IrqImageAccessor image) {
 	updateSmodeTimer();
 
 	// Finally, take action for the deadlines that have expired.
-	// Note that preemption has to be done last.
-
 	if (timerExpired)
 		riscvTimer->fireAlarm();
 
 	if (preemptionExpired)
-		handlePreemption(image);
+		cpuData->scheduler.forcePreemptionCall();
+
+	cpuData->scheduler.checkPreemption(image);
 }
 
 } // namespace thor

--- a/kernel/thor/arch/x86/pic.cpp
+++ b/kernel/thor/arch/x86/pic.cpp
@@ -152,8 +152,10 @@ void LocalApicContext::handleTimerIrq() {
 	auto self = localApicContext();
 	auto now = systemClockSource()->currentNanos();
 
-	if(self->_preemptionDeadline && now > self->_preemptionDeadline)
+	if(self->_preemptionDeadline && now > self->_preemptionDeadline) {
 		self->_preemptionDeadline = 0;
+		localScheduler()->forcePreemptionCall();
+	}
 
 	if(self->_globalDeadline && now > self->_globalDeadline) {
 		self->_globalDeadline = 0;

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -497,12 +497,9 @@ void handleIrq(IrqImageAccessor image, IrqPin *irq) {
 	entropy[5] = (tsc >> 24) & 0xFF;
 	injectEntropy(entropySrcIrqs, cpuData->irqEntropySeq++, entropy, 6);
 
-	// This IRQ may have woken up threads on this CPU.
-	// Call handlePreemption() to check for preemption (e.g., due to a change in priority)
-	// and to renew the schedule (e.g., if the length of the time slice has changed).
 	// See Scheduler::resume() for details.
-	assert(image.inPreemptibleDomain());
-	localScheduler()->currentRunnable()->handlePreemption(image);
+	auto *scheduler = &cpuData->scheduler;
+	scheduler->checkPreemption(image);
 }
 
 void handlePreemption(IrqImageAccessor image) {

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -31,7 +31,6 @@ static constexpr bool logEveryPageFault = false;
 static constexpr bool logUnhandledPageFaults = false;
 static constexpr bool logEveryIrq = false;
 static constexpr bool logOtherFaults = false;
-static constexpr bool logPreemptionIrq = false;
 static constexpr bool logEverySyscall = false;
 
 bool debugToSerial = false;
@@ -500,16 +499,6 @@ void handleIrq(IrqImageAccessor image, IrqPin *irq) {
 	// See Scheduler::resume() for details.
 	auto *scheduler = &cpuData->scheduler;
 	scheduler->checkPreemption(image);
-}
-
-void handlePreemption(IrqImageAccessor image) {
-	assert(!intsAreEnabled());
-
-	if(logPreemptionIrq)
-		infoLogger() << "thor: Preemption IRQ" << frg::endlog;
-
-	assert(image.inPreemptibleDomain());
-	localScheduler()->currentRunnable()->handlePreemption(image);
 }
 
 void handleSyscall(SyscallImageAccessor image) {

--- a/kernel/thor/generic/schedule.cpp
+++ b/kernel/thor/generic/schedule.cpp
@@ -143,6 +143,7 @@ void Scheduler::resume(ScheduleEntity *entity) {
 
 			// TODO: In the case of kernel threads, it can be necessary to issue a self IPI
 			//       to ensure that a higher priority thread gets to run as soon as possible.
+			self->_mustCallPreemption = true;
 		}else{
 			sendPingIpi(self->_cpuContext);
 		}
@@ -301,6 +302,7 @@ void Scheduler::forceReschedule() {
 	_current = _scheduled;
 	_scheduled = nullptr;
 	_sliceClock = _refClock;
+	_mustCallPreemption = false;
 
 	if(!preemptionIsArmed())
 		_updatePreemption();
@@ -309,6 +311,8 @@ void Scheduler::forceReschedule() {
 }
 
 void Scheduler::renewSchedule() {
+	_mustCallPreemption = false;
+
 	if(!preemptionIsArmed())
 		_updatePreemption();
 }

--- a/kernel/thor/system/pci/pci_dtb.cpp
+++ b/kernel/thor/system/pci/pci_dtb.cpp
@@ -66,7 +66,7 @@ DtbPciIrqRouter::DtbPciIrqRouter(PciIrqRouter *parent_, PciBus *associatedBus_,
 			}
 		}
 
-#ifdef __aarch64
+#ifdef __aarch64__
 		// TODO: Get rid of this case, the one below is more general.
 		for (auto ent : map) {
 			auto addr = ent.childAddrHi + disp;


### PR DESCRIPTION
After removing self IPIs when resuming tasks, we were missing checks for preemption in some code paths (in particular, IPI exit code paths).

Add the missing checks. Also add a mechanism to determine whether calling into `handlePreemption()` is necessary or not.

Finally, we fix some issues that complicate testing the PR (namely a fix for aarch64 PCI enumeration + RISC-V paging).