### PR TITLE
drivers/nvme: request a number of I/O queues as mandated by spec

### DIFF
--- a/drivers/block/nvme/src/controller.hpp
+++ b/drivers/block/nvme/src/controller.hpp
@@ -94,6 +94,7 @@ private:
 	async::result<void> enable();
 	async::result<void> disable();
 
+	async::result<Command::Result> requestIoQueues(uint16_t sqs, uint16_t cqs);
 	async::result<bool> setupIoQueue(PciExpressQueue *q);
 	async::result<Command::Result> createCQ(PciExpressQueue *q);
 	async::result<Command::Result> createSQ(PciExpressQueue *q);


### PR DESCRIPTION
The NVMe specification requires a `Set Features` command with Feature ID 0x07 (Number of Queues) to be issued before setting up I/O queues. This has been the case since version 1.0 of the spec. For reference, see section 7.6.1 "Initialization" of the NVMe 1.3d spec (p. 115), point 8.