### PR TITLE
Mount information in procfs

### DIFF
--- a/posix/subsystem/src/cgroupfs.hpp
+++ b/posix/subsystem/src/cgroupfs.hpp
@@ -109,7 +109,9 @@ protected:
 
 struct SuperBlock final : FsSuperblock {
 public:
-	SuperBlock() = default;
+	SuperBlock() {
+		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
+	}
 
 	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override;
 	FutureMaybe<std::shared_ptr<FsNode>> createSocket() override;
@@ -117,6 +119,17 @@ public:
 	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
 			rename(FsLink *source, FsNode *directory, std::string name) override;
 	async::result<frg::expected<Error, FsFileStats>> getFsstats() override;
+
+	std::string getFsType() override {
+		return "cgroup2";
+	}
+
+	dev_t deviceNumber() override {
+		return makedev(0, deviceMinor_);
+	}
+
+private:
+	unsigned int deviceMinor_;
 };
 
 struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode> {

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -74,7 +74,7 @@ openDevice(VfsType type, DeviceId id, std::shared_ptr<MountView> mount,
 // --------------------------------------------------------
 
 std::shared_ptr<FsLink> getDevtmpfs() {
-	static std::shared_ptr<FsLink> devtmpfs = tmp_fs::createRoot();
+	static std::shared_ptr<FsLink> devtmpfs = tmp_fs::createDevTmpFsRoot();
 	return devtmpfs;
 }
 
@@ -352,7 +352,7 @@ async::result<void> serveServerLane(helix::UniqueDescriptor lane) {
 	}
 }
 
-FutureMaybe<std::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lane) {
+FutureMaybe<std::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lane, std::shared_ptr<UnixDevice> device) {
 	managarm::fs::CntRequest req;
 	req.set_req_type(managarm::fs::CntReqType::DEV_MOUNT);
 
@@ -372,6 +372,6 @@ FutureMaybe<std::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lan
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 	recv_resp.reset();
 	assert(resp.error() == managarm::fs::Errors::SUCCESS);
-	co_return extern_fs::createRoot(lane.dup(), pull_node.descriptor());
+	co_return extern_fs::createRoot(lane.dup(), pull_node.descriptor(), device);
 }
 

--- a/posix/subsystem/src/device.hpp
+++ b/posix/subsystem/src/device.hpp
@@ -93,6 +93,6 @@ openExternalDevice(helix::BorrowedLane lane,
 		std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags);
 
-FutureMaybe<std::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lane);
+FutureMaybe<std::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lane, std::shared_ptr<UnixDevice> device);
 
 async::result<void> serveServerLane(helix::UniqueDescriptor lane);

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -147,7 +147,7 @@ struct Node : FsNode {
 
 
 public:
-	Node(uint64_t inode, helix::UniqueLane lane, Superblock *sb = nullptr)
+	Node(uint64_t inode, helix::UniqueLane lane, Superblock *sb)
 	: FsNode{sb}, _inode{inode}, _lane{std::move(lane)} { }
 
 protected:
@@ -361,8 +361,8 @@ private:
 	}
 
 public:
-	SymlinkNode(uint64_t inode, helix::UniqueLane lane)
-	: Node{inode, std::move(lane)} { }
+	SymlinkNode(Superblock *sb, uint64_t inode, helix::UniqueLane lane)
+	: Node{inode, std::move(lane), sb} { }
 };
 
 struct Link : FsLink {
@@ -950,7 +950,7 @@ std::shared_ptr<Node> Superblock::internalizePeripheralNode(int64_t type,
 		node = std::make_shared<RegularNode>(this, id, std::move(lane));
 		break;
 	case managarm::fs::FileType::SYMLINK:
-		node = std::make_shared<SymlinkNode>(id, std::move(lane));
+		node = std::make_shared<SymlinkNode>(this, id, std::move(lane));
 		break;
 	default:
 		throw std::runtime_error("extern_fs: Unexpected file type");

--- a/posix/subsystem/src/extern_fs.hpp
+++ b/posix/subsystem/src/extern_fs.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "device.hpp"
 #include "vfs.hpp"
 
 namespace extern_fs {
 
-std::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane);
+std::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device);
 
 smarter::shared_ptr<File, FileHandle>
 createFile(helix::UniqueLane lane, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link);

--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -467,7 +467,7 @@ public:
 	}
 
 	DummyFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, DefaultOps default_ops = 0)
-	: File{StructName::get("dummy-file"), std::move(mount), std::move(link), default_ops} { }
+	: File{StructName::get("dummy-file"), std::move(mount), std::move(link), default_ops | defaultPipeLikeSeek} { }
 
 	helix::BorrowedDescriptor getPassthroughLane() override {
 		return _passthrough;

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -103,8 +103,7 @@ helix::UniqueLane &getPmLane() {
 }
 
 struct CmdlineNode final : public procfs::RegularNode {
-	async::result<std::string> show() override {
-
+	async::result<std::string> show(Process *) override {
 		managarm::kerncfg::GetCmdlineRequest req;
 
 		auto [offer, sendReq, recvResp] =

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -63,13 +63,13 @@ async::result<frg::expected<Error, off_t>> RegularFile::seek(off_t offset, VfsSe
 }
 
 async::result<frg::expected<Error, size_t>>
-RegularFile::readSome(Process *, void *data, size_t max_length) {
+RegularFile::readSome(Process *process, void *data, size_t max_length) {
 	assert(max_length > 0);
 
 	if(!_cached) {
 		assert(!_offset);
 		auto node = static_cast<RegularNode *>(associatedLink()->getTarget().get());
-		_buffer = co_await node->show();
+		_buffer = co_await node->show(process);
 		_cached = true;
 	}
 
@@ -381,7 +381,7 @@ async::result<frg::expected<Error>> DirectoryNode::unlink(std::string name) {
 LinkNode::LinkNode()
 : FsNode{&procfsSuperblock} { }
 
-async::result<std::string> UptimeNode::show() {
+async::result<std::string> UptimeNode::show(Process *) {
 	auto uptime = clk::getTimeSinceBoot();
 	// See man 5 proc for more details.
 	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
@@ -397,7 +397,7 @@ async::result<void> UptimeNode::store(std::string) {
 	co_return;
 }
 
-async::result<std::string> OstypeNode::show() {
+async::result<std::string> OstypeNode::show(Process *) {
 	// See man 5 proc for more details.
 	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
 	std::stringstream stream;
@@ -411,7 +411,7 @@ async::result<void> OstypeNode::store(std::string) {
 	co_return;
 }
 
-async::result<std::string> OsreleaseNode::show() {
+async::result<std::string> OsreleaseNode::show(Process *) {
 	// See man 5 proc for more details.
 	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
 	// TODO: The version is a placeholder!
@@ -426,7 +426,7 @@ async::result<void> OsreleaseNode::store(std::string) {
 	co_return;
 }
 
-async::result<std::string> ArchNode::show() {
+async::result<std::string> ArchNode::show(Process *) {
 	// See man 5 proc for more details.
 	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
 	std::stringstream stream;
@@ -471,7 +471,7 @@ BootIdNode::BootIdNode() {
 		a, b, c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
 }
 
-async::result<std::string> BootIdNode::show() {
+async::result<std::string> BootIdNode::show(Process *) {
 	// See man 5 proc for more details.
 	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
 	co_return bootId_ + "\n";
@@ -495,7 +495,7 @@ expected<std::string> ExeLink::readSymlink(FsLink *, Process *) {
 	co_return _process->path();
 }
 
-async::result<std::string> MapNode::show() {
+async::result<std::string> MapNode::show(Process *) {
 	auto vmContext = _process->vmContext();
 	std::stringstream stream;
 	for (auto area : *vmContext) {
@@ -540,7 +540,7 @@ async::result<void> MapNode::store(std::string) {
 	co_return;
 }
 
-async::result<std::string> CommNode::show() {
+async::result<std::string> CommNode::show(Process *) {
 	// See man 5 proc for more details.
 	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
 	std::stringstream stream;
@@ -558,7 +558,7 @@ expected<std::string> RootLink::readSymlink(FsLink *, Process *) {
 	co_return _process->fsContext()->getRoot().getPath(_process->fsContext()->getRoot());
 }
 
-async::result<std::string> StatNode::show() {
+async::result<std::string> StatNode::show(Process *) {
 	// Everything that has a value of 0 is likely not implemented yet.
 	// See man 5 proc for more details.
 	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
@@ -628,7 +628,7 @@ async::result<void> StatNode::store(std::string) {
 	throw std::runtime_error("Can't store to a /proc/stat file!");
 }
 
-async::result<std::string> StatmNode::show() {
+async::result<std::string> StatmNode::show(Process *) {
 	(void)_process;
 	// All hardcoded to 0.
 	// See man 5 proc for more details.
@@ -649,7 +649,7 @@ async::result<void> StatmNode::store(std::string) {
 	throw std::runtime_error("Can't store to a /proc/statm file!");
 }
 
-async::result<std::string> StatusNode::show() {
+async::result<std::string> StatusNode::show(Process *) {
 	// Everything that has a value of N/A is not implemented yet.
 	// See man 5 proc for more details.
 	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
@@ -740,7 +740,7 @@ expected<std::string> CwdLink::readSymlink(FsLink *, Process *) {
 }
 
 // MASSIVE STUBS
-async::result<std::string> CgroupNode::show() {
+async::result<std::string> CgroupNode::show(Process *) {
 	// See man 7 cgroups for more details, I'm emulating cgroups2 here.
 	// Based on the man page from Linux man-pages 6.01, updated on 2022-10-09.
 	std::stringstream stream;

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -394,6 +394,13 @@ struct MountsNode final : RegularNode {
 	async::result<void> store(std::string) override;
 };
 
+struct MountInfoNode final : RegularNode {
+	MountInfoNode() = default;
+
+	async::result<std::string> show(Process *) override;
+	async::result<void> store(std::string) override;
+};
+
 } // namespace procfs
 
 std::shared_ptr<FsLink> getProcfs();

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -231,6 +231,10 @@ private:
 	Process *_process;
 };
 
+struct MountsLink final : LinkNode, std::enable_shared_from_this<MountsLink> {
+	expected<std::string> readSymlink(FsLink *link, Process *process) override;
+};
+
 struct MapNode final : RegularNode {
 	MapNode(Process *process)
 	: _process(process)
@@ -381,6 +385,13 @@ struct SymlinkNode final : LinkNode, std::enable_shared_from_this<SymlinkNode> {
 private:
 	std::shared_ptr<MountView> _mount;
 	std::weak_ptr<FsLink> _link;
+};
+
+struct MountsNode final : RegularNode {
+	MountsNode() = default;
+
+	async::result<std::string> show(Process *) override;
+	async::result<void> store(std::string) override;
 };
 
 } // namespace procfs

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -109,7 +109,9 @@ protected:
 
 struct SuperBlock final : FsSuperblock {
 public:
-	SuperBlock() = default;
+	SuperBlock() {
+		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
+	}
 
 	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override;
 	FutureMaybe<std::shared_ptr<FsNode>> createSocket() override;
@@ -117,6 +119,17 @@ public:
 	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
 			rename(FsLink *source, FsNode *directory, std::string name) override;
 	async::result<frg::expected<Error, FsFileStats>> getFsstats() override;
+
+	std::string getFsType() override {
+		return "proc";
+	}
+
+	dev_t deviceNumber() override {
+		return makedev(0, deviceMinor_);
+	}
+
+private:
+	unsigned int deviceMinor_;
 };
 
 struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode> {

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -42,6 +42,12 @@ public:
 	async::result<frg::expected<Error, size_t>>
 	writeAll(Process *, const void *data, size_t length) override;
 
+	async::result<frg::expected<Error, PollStatusResult>> pollStatus(Process *) override;
+
+	async::result<frg::expected<Error, PollWaitResult>> pollWait(Process *,
+		uint64_t sequence, int mask,
+		async::cancellation_token cancellation = {}) override;
+
 	helix::BorrowedDescriptor getPassthroughLane() override;
 
 private:

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -103,7 +103,7 @@ struct RegularNode : FsNode, std::enable_shared_from_this<RegularNode> {
 			SemanticFlags semantic_flags) override;
 
 protected:
-	virtual async::result<std::string> show() = 0;
+	virtual async::result<std::string> show(Process *) = 0;
 	virtual async::result<void> store(std::string buffer) = 0;
 };
 
@@ -230,7 +230,7 @@ struct MapNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show() override;
+	async::result<std::string> show(Process *) override;
 	async::result<void> store(std::string) override;
 private:
 	Process *_process;
@@ -239,35 +239,35 @@ private:
 struct UptimeNode final : RegularNode {
 	UptimeNode() {}
 
-	async::result<std::string> show() override;
+	async::result<std::string> show(Process *) override;
 	async::result<void> store(std::string) override;
 };
 
 struct OstypeNode final : RegularNode {
 	OstypeNode() {}
 
-	async::result<std::string> show() override;
+	async::result<std::string> show(Process *) override;
 	async::result<void> store(std::string) override;
 };
 
 struct OsreleaseNode final : RegularNode {
 	OsreleaseNode() {}
 
-	async::result<std::string> show() override;
+	async::result<std::string> show(Process *) override;
 	async::result<void> store(std::string) override;
 };
 
 struct ArchNode final : RegularNode {
 	ArchNode() {}
 
-	async::result<std::string> show() override;
+	async::result<std::string> show(Process *) override;
 	async::result<void> store(std::string) override;
 };
 
 struct BootIdNode final : RegularNode {
 	BootIdNode();
 
-	async::result<std::string> show() override;
+	async::result<std::string> show(Process *) override;
 	async::result<void> store(std::string) override;
 private:
 	std::string bootId_;
@@ -278,7 +278,7 @@ struct CommNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show() override;
+	async::result<std::string> show(Process *) override;
 	async::result<void> store(std::string) override;
 private:
 	Process *_process;
@@ -289,7 +289,7 @@ struct StatNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show() override;
+	async::result<std::string> show(Process *) override;
 	async::result<void> store(std::string) override;
 private:
 	Process *_process;
@@ -300,7 +300,7 @@ struct StatmNode final : RegularNode {
         : _process(process)
         { }
 
-        async::result<std::string> show() override;
+        async::result<std::string> show(Process *) override;
         async::result<void> store(std::string) override;
 private:
         Process *_process;
@@ -311,7 +311,7 @@ struct StatusNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show() override;
+	async::result<std::string> show(Process *) override;
 	async::result<void> store(std::string) override;
 private:
 	Process *_process;
@@ -343,7 +343,7 @@ struct CgroupNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show() override;
+	async::result<std::string> show(Process *) override;
 	async::result<void> store(std::string) override;
 private:
 	Process *_process;

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -282,7 +282,9 @@ void processIn(const char character, Packet &packet, std::shared_ptr<Channel> ch
 
 struct PtsSuperblock final : FsSuperblock {
 public:
-	PtsSuperblock() = default;
+	PtsSuperblock() {
+		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
+	}
 
 	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override {
 		std::cout << "posix: createRegular on PtsSuperblock unsupported" << std::endl;
@@ -304,6 +306,17 @@ public:
 		stats.f_type = DEVPTS_SUPER_MAGIC;
 		co_return stats;
 	}
+
+	std::string getFsType() override {
+		return "devpts";
+	}
+
+	dev_t deviceNumber() override {
+		return makedev(0, deviceMinor_);
+	}
+
+private:
+	unsigned int deviceMinor_;
 };
 
 PtsSuperblock ptsSuperblock{};

--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -1516,6 +1516,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			resp.set_ctime_secs(stats.ctimeSecs);
 			resp.set_ctime_nanos(stats.ctimeNanos);
 			resp.set_mount_id(target_mount ? target_mount->mountId() : 0);
+			resp.set_stat_dev(target_link->getTarget()->superblock()->deviceNumber());
 
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(
 					conversation,

--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -1410,6 +1410,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			ViewPath relative_to;
 			smarter::shared_ptr<File, FileHandle> file;
 			std::shared_ptr<FsLink> target_link;
+			std::shared_ptr<MountView> target_mount;
 
 			if (req->fd() == AT_FDCWD) {
 				relative_to = self->fsContext()->getWorkingDirectory();
@@ -1449,6 +1450,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 					}
 				}
 
+				target_mount = resolver.currentView();
 				target_link = resolver.currentLink();
 			}
 
@@ -1513,6 +1515,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			resp.set_mtime_nanos(stats.mtimeNanos);
 			resp.set_ctime_secs(stats.ctimeSecs);
 			resp.set_ctime_nanos(stats.ctimeNanos);
+			resp.set_mount_id(target_mount ? target_mount->mountId() : 0);
 
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(
 					conversation,

--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -772,7 +772,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				assert(source.second->getTarget()->getType() == VfsType::blockDevice);
 				auto device = blockRegistry.get(source.second->getTarget()->readDevice());
 				auto link = co_await device->mount();
-				co_await target.first->mount(target.second, std::move(link));
+				co_await target.first->mount(target.second, std::move(link), source);
 			}
 
 			logRequest(logRequests, "MOUNT", "succeeded");

--- a/posix/subsystem/src/subsystem/block.cpp
+++ b/posix/subsystem/src/subsystem/block.cpp
@@ -26,7 +26,7 @@ std::unordered_set<std::string_view> alphabetizedIds = {
 	"sd",
 };
 
-struct Device final : UnixDevice, drvcore::BlockDevice {
+struct Device final : UnixDevice, drvcore::BlockDevice, std::enable_shared_from_this<Device> {
 	Device(VfsType type, std::string name, helix::UniqueLane lane,
 			std::shared_ptr<drvcore::Device> parent, size_t size)
 	: UnixDevice{type},
@@ -49,7 +49,7 @@ struct Device final : UnixDevice, drvcore::BlockDevice {
 	}
 
 	FutureMaybe<std::shared_ptr<FsLink>> mount() override {
-		return mountExternalDevice(_lane);
+		return mountExternalDevice(_lane, shared_from_this());
 	}
 
 	void composeUevent(drvcore::UeventProperties &ue) override {

--- a/posix/subsystem/src/subsystem/generic.cpp
+++ b/posix/subsystem/src/subsystem/generic.cpp
@@ -14,7 +14,7 @@ namespace {
 
 id_allocator<uint32_t> minorAllocator{0};
 
-struct Device final : UnixDevice {
+struct Device final : UnixDevice, std::enable_shared_from_this<Device> {
 	Device(VfsType type, std::string name, helix::UniqueLane lane)
 	: UnixDevice{type},
 			_name{std::move(name)}, _lane{std::move(lane)} { }
@@ -22,7 +22,7 @@ struct Device final : UnixDevice {
 	std::string nodePath() override {
 		return _name;
 	}
-	
+
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
@@ -30,7 +30,7 @@ struct Device final : UnixDevice {
 	}
 
 	FutureMaybe<std::shared_ptr<FsLink>> mount() override {
-		return mountExternalDevice(_lane);
+		return mountExternalDevice(_lane, shared_from_this());
 	}
 
 private:

--- a/posix/subsystem/src/sysfs.hpp
+++ b/posix/subsystem/src/sysfs.hpp
@@ -24,7 +24,9 @@ struct Hierarchy;
 
 struct SysfsSuperblock final : FsSuperblock {
 public:
-	SysfsSuperblock() = default;
+	SysfsSuperblock() {
+		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
+	}
 
 	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override;
 	FutureMaybe<std::shared_ptr<FsNode>> createSocket() override;
@@ -33,12 +35,21 @@ public:
 			rename(FsLink *source, FsNode *directory, std::string name) override;
 	async::result<frg::expected<Error, FsFileStats>> getFsstats() override;
 
+	std::string getFsType() override {
+		return "sysfs";
+	}
+
+	dev_t deviceNumber() override {
+		return makedev(0, deviceMinor_);
+	}
+
 	id_allocator<uint64_t> &inodeAllocator() {
 		return inodeAllocator_;
 	}
 
 private:
 	id_allocator<uint64_t> inodeAllocator_{1};
+	unsigned int deviceMinor_;
 };
 
 struct LinkCompare {

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -471,7 +471,6 @@ struct MemoryNode final : Node {
 	}
 
 	async::result<frg::expected<Error, FileStats>> getStats() override {
-		std::cout << "\e[31mposix: Fix tmpfs getStats() in MemoryNode\e[39m" << std::endl;
 		FileStats stats{};
 		stats.inodeNumber = inodeNumber();
 		stats.fileSize = _fileSize;

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -515,6 +515,10 @@ private:
 };
 
 struct Superblock final : FsSuperblock {
+	Superblock(std::string name = "tmpfs") : fsType_{name} {
+		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
+	}
+
 	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override {
 		auto node = std::make_shared<MemoryNode>(this);
 		co_return std::move(node);
@@ -557,12 +561,23 @@ struct Superblock final : FsSuperblock {
 		co_return stats;
 	}
 
+	std::string getFsType() override {
+		return fsType_;
+	}
+
 	int64_t allocateInode() {
 		return _inodeCounter++;
 	}
 
+	dev_t deviceNumber() override {
+		return makedev(0, deviceMinor_);
+	}
+
 private:
 	int64_t _inodeCounter = 1;
+
+	std::string fsType_;
+	unsigned int deviceMinor_;
 };
 
 // ----------------------------------------------------------------------------
@@ -812,19 +827,19 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>> DirectoryNode::mkso
 	co_return link;
 }
 
-
-// TODO: File system should not have global superblocks.
-static Superblock globalSuperblock;
-
 } // anonymous namespace
 
 // Ironically, this function does not create a MemoryNode.
 std::shared_ptr<FsNode> createMemoryNode(std::string path) {
-	return std::make_shared<InheritedNode>(&globalSuperblock, std::move(path));
+	return std::make_shared<InheritedNode>(new Superblock{}, std::move(path));
 }
 
 std::shared_ptr<FsLink> createRoot() {
-	return DirectoryNode::createRootDirectory(&globalSuperblock);
+	return DirectoryNode::createRootDirectory(new Superblock{});
+}
+
+std::shared_ptr<FsLink> createDevTmpFsRoot() {
+	return DirectoryNode::createRootDirectory(new Superblock{"devtmpfs"});
 }
 
 } // namespace tmp_fs

--- a/posix/subsystem/src/tmp_fs.hpp
+++ b/posix/subsystem/src/tmp_fs.hpp
@@ -7,5 +7,6 @@ namespace tmp_fs {
 std::shared_ptr<FsNode> createMemoryNode(std::string path);
 
 std::shared_ptr<FsLink> createRoot();
+std::shared_ptr<FsLink> createDevTmpFsRoot();
 
 } // namespace tmp_fs

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -261,6 +261,7 @@ head(128):
 		tag(29) uint64 ru_user_time;
 
 		tag(32) uint32 mount_id;
+		tag(33) uint64 stat_dev;
 	}
 }
 

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -259,6 +259,8 @@ head(128):
 
 		// returned by GET_RESOURCE_USAGE
 		tag(29) uint64 ru_user_time;
+
+		tag(32) uint32 mount_id;
 	}
 }
 


### PR DESCRIPTION
Implements `/proc/mounts` and `/proc/[pid]/mountinfo`, which should allow for running `mount` on managarm.