### PR TITLE
posix-tests: Enable build on Linux and fix/workaround various bugs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,7 @@ build_kernel = get_option('build_kernel')
 build_uefi = get_option('build_uefi')
 build_drivers = get_option('build_drivers')
 build_tools = get_option('build_tools')
+build_testsuite = get_option('build_testsuite')
 provide_deps = get_option('provide_deps')
 any_userspace = build_drivers or build_tools
 
@@ -49,7 +50,7 @@ if build_kernel or build_drivers
 	add_languages('c', 'cpp', native: false)
 endif
 
-if build_tools
+if build_tools or build_testsuite
 	add_languages('c', 'cpp')
 endif
 
@@ -205,7 +206,6 @@ if build_drivers or provide_deps
 		'kernletcc'
 	]
 	utils = [ 'runsvr', 'lsmbus' ]
-	testsuites = [ 'kernel-bench', 'kernel-tests', 'posix-torture', 'posix-tests', 'virt-test' ]
 
 	# delay these dirs until last as they require other libs
 	# to already be built
@@ -233,10 +233,6 @@ if build_drivers
 		subdir('utils'/dir)
 	endforeach
 
-	foreach dir : testsuites
-		subdir('testsuites'/dir)
-	endforeach
-
 	foreach dir : delay
 		subdir(dir)
 	endforeach
@@ -249,6 +245,18 @@ if build_drivers
 	]
 
 	install_data(rules, install_dir : 'lib/udev/rules.d')
+endif
+
+if build_testsuite
+	testsuites = ['posix-tests']
+
+	if host_machine.system() == 'managarm'
+		testsuites += ['kernel-bench', 'kernel-tests', 'posix-torture', 'virt-test']
+	endif
+
+	foreach dir : testsuites
+		subdir('testsuites'/dir)
+	endforeach
 endif
 
 # when building these tools make sure they stay below everything else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,6 +18,11 @@ option('build_tools',
     value : false
 )
 
+option('build_testsuite',
+    type : 'boolean',
+    value : false
+)
+
 option('provide_deps',
     type : 'boolean',
     value : false

--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -854,7 +854,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if(!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -910,7 +910,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -989,7 +989,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -1060,7 +1060,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if(!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -1090,7 +1090,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->newfd());
 
 				if(!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -1156,7 +1156,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			} else {
 				file = self->fileContext()->getFile(req->fd());
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -1232,7 +1232,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -1265,7 +1265,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->newfd());
 
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -1345,7 +1345,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -1472,7 +1472,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -1554,7 +1554,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -1640,7 +1640,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				} else {
 					file = self->fileContext()->getFile(req->fd());
 					if (!file) {
-						co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+						co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 						continue;
 					}
 
@@ -1696,7 +1696,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -1821,7 +1821,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -2043,7 +2043,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				helix::SendBuffer send_resp;
 
 				managarm::posix::SvrResponse resp;
-				resp.set_error(managarm::posix::Errors::BAD_FD);
+				resp.set_error(managarm::posix::Errors::NO_SUCH_FD);
 
 				auto ser = resp.SerializeAsString();
 				auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
@@ -2095,7 +2095,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			managarm::posix::Dup2Response resp;
 
 			if (!file || req->newfd() < 0) {
-				resp.set_error(managarm::posix::Errors::BAD_FD);
+				resp.set_error(managarm::posix::Errors::NO_SUCH_FD);
 				auto [send_resp] = co_await helix_ng::exchangeMsgs(
 					conversation,
 					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
@@ -2247,7 +2247,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->fd());
 
 				if (!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 
@@ -2740,7 +2740,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			auto sockfile = self->fileContext()->getFile(req->fd());
 			if(!sockfile) {
-				co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+				co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 				continue;
 			}
 
@@ -2891,7 +2891,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			auto epfile = self->fileContext()->getFile(req.fd());
 			auto file = self->fileContext()->getFile(req.newfd());
 			if(!file || !epfile) {
-				co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+				co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 				continue;
 			}
 
@@ -2948,7 +2948,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			auto file = self->fileContext()->getFile(req.newfd());
 			if(!epfile || !file) {
 				std::cout << "posix: Illegal FD for EPOLL_DELETE" << std::endl;
-				co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+				co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 				continue;
 			}
 
@@ -2976,7 +2976,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			auto epfile = self->fileContext()->getFile(req.fd());
 			if(!epfile) {
-				co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+				co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 				continue;
 			}
 			if(req.sigmask_needed()) {
@@ -3139,7 +3139,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			auto ifile = self->fileContext()->getFile(req->fd());
 			if(!ifile) {
-				co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+				co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 				continue;
 			}
 
@@ -3240,7 +3240,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				file = self->fileContext()->getFile(req->dirfd());
 
 				if(!file) {
-					co_await sendErrorResponse(managarm::posix::Errors::BAD_FD);
+					co_await sendErrorResponse(managarm::posix::Errors::NO_SUCH_FD);
 					continue;
 				}
 

--- a/testsuites/posix-tests/src/faults.cpp
+++ b/testsuites/posix-tests/src/faults.cpp
@@ -64,6 +64,7 @@ namespace {
 	}
 }
 
+#if !defined(__linux__)
 DEFINE_TEST(div_by_zero_fpe_fault, ([] {
 	runChecks([&]{
 		assert(testDivFault(1, 0));
@@ -73,3 +74,4 @@ DEFINE_TEST(div_by_zero_fpe_fault, ([] {
 		assert(testDivFault(INT_MAX, 0));
 	});
 }))
+#endif

--- a/testsuites/posix-tests/src/inotify.cpp
+++ b/testsuites/posix-tests/src/inotify.cpp
@@ -43,7 +43,7 @@ DEFINE_TEST(inotify_unlink_child, ([] {
 	assert(evtHeader.wd == wd);
 	assert(evtHeader.mask & IN_DELETE);
 
-	std::string evtName{buffer + sizeof(inotify_event), evtHeader.len};
+	std::string evtName{buffer + sizeof(inotify_event), strnlen(buffer + sizeof(inotify_event), evtHeader.len)};
 	assert(evtName == "foobar");
 
 	close(ifd);

--- a/testsuites/posix-tests/src/mmap.cpp
+++ b/testsuites/posix-tests/src/mmap.cpp
@@ -1,5 +1,7 @@
 #include <cassert>
 
+#include <stddef.h>
+#include <stdint.h>
 #include <signal.h>
 #include <setjmp.h>
 #include <unistd.h>

--- a/testsuites/posix-tests/src/parent-dead-signal.cpp
+++ b/testsuites/posix-tests/src/parent-dead-signal.cpp
@@ -14,7 +14,9 @@ int child_end = -1;
 void handle_signal(int sig) {
 	if(sig == SIGUSR1) {
 		printf("Received signal %d. Success!\n", sig);
+#if !defined(__linux__)
 		assert(getppid() == 1);
+#endif
 		int data = 42;
 		write(child_end, &data, sizeof(data));
 		exit(0);

--- a/testsuites/posix-tests/src/sigaltstack.cpp
+++ b/testsuites/posix-tests/src/sigaltstack.cpp
@@ -10,6 +10,8 @@ namespace {
 	stack_t ss, old_ss;
 } // namespace anonymous
 
+#if !defined(__linux__)
+
 DEFINE_TEST(sigaltstack, ([] {
 	if (setjmp(env)) {
 		int ret = sigaltstack(&old_ss, nullptr);
@@ -48,3 +50,5 @@ DEFINE_TEST(sigaltstack, ([] {
 #	error Unknown architecture
 #endif
 }))
+
+#endif

--- a/testsuites/posix-tests/src/signal.cpp
+++ b/testsuites/posix-tests/src/signal.cpp
@@ -14,6 +14,7 @@ namespace {
 
 constexpr uint64_t magic_expected = 0xDEADBEEFCAFEBABE;
 
+#if !defined(__linux__)
 DEFINE_TEST(signal_save_simd, ([] {
 	int ret;
 
@@ -70,3 +71,5 @@ DEFINE_TEST(signal_save_simd, ([] {
 
 	assert(magic == magic_expected);
 }))
+
+#endif


### PR DESCRIPTION
This enables us to build the POSIX testsuite on Linux to allow for easier comparisons to Managarm.

Merge together with https://github.com/managarm/bootstrap-managarm/pull/458.