### PR TITLE
thor: Check preemption from faults and syscalls

### DIFF
--- a/kernel/thor/arch/arm/ints.cpp
+++ b/kernel/thor/arch/arm/ints.cpp
@@ -142,6 +142,10 @@ extern "C" void onPlatformSyncFault(FaultImageAccessor image) {
 	}
 
 	disableInts();
+
+	// This syscall/fault may have woken up threads on this CPU.
+	// See Scheduler::resume() for details.
+	checkThreadPreemption(image);
 }
 
 extern "C" void onPlatformAsyncFault(FaultImageAccessor image) {

--- a/kernel/thor/arch/riscv/trap.cpp
+++ b/kernel/thor/arch/riscv/trap.cpp
@@ -247,6 +247,10 @@ void handleRiscvException(Frame *frame, uint64_t code) {
 			              << frg::hex_fmt{trapValue} << " at IP 0x" << frg::hex_fmt{frame->ip}
 			              << frg::endlog;
 	}
+
+	// This syscall/fault may have woken up threads on this CPU.
+	// See Scheduler::resume() for details.
+	checkThreadPreemption(FaultImageAccessor{frame});
 }
 
 void writeSretCsrs(Frame *frame) {

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -856,16 +856,9 @@ void handleSyscall(SyscallImageAccessor image) {
 	// Run more worklets that were posted by the syscall.
 	this_thread->mainWorkQueue()->run();
 
-	Thread::raiseSignals(image);
-
 	// Note: Thread::raiseSignals() only returns if nothing needs to be raised.
 	//       Otherwise, it saves the syscall image and suspends this thread.
-
-	// This syscall may have woken up threads on this CPU.
-	// TODO: Call handlePreemption() to check for preemption (e.g., due to a change in priority)
-	// and to renew the schedule (e.g., if the length of the time slice has changed).
-	// See Scheduler::resume() for details.
-	// TODO: This needs an overload of handlePreemption() that takes a SyscallImageAccessor.
+	Thread::raiseSignals(image);
 }
 
 } // namespace thor

--- a/kernel/thor/generic/thor-internal/schedule.hpp
+++ b/kernel/thor/generic/thor-internal/schedule.hpp
@@ -142,6 +142,10 @@ public:
 		_mustCallPreemption = true;
 	}
 
+	// Suppress mustCallPreemption() if a scheduling interrupt is pending.
+	// This avoids unnecessary calls into checkPreemption().
+	void suppressRenewalUntilInterrupt();
+
 	void checkPreemption(IrqImageAccessor image) {
 		assert(image.inPreemptibleDomain());
 		if (mustCallPreemption())
@@ -219,6 +223,10 @@ private:
 		>
 	> _pendingList;
 };
+
+// Similar to Scheduler::checkPreemption() but specialized for threads.
+void checkThreadPreemption(FaultImageAccessor image);
+void checkThreadPreemption(SyscallImageAccessor image);
 
 extern PerCpu<Scheduler> localScheduler;
 

--- a/kernel/thor/generic/thor-internal/thread.hpp
+++ b/kernel/thor/generic/thor-internal/thread.hpp
@@ -274,9 +274,15 @@ public:
 
 	[[ noreturn ]] void invoke() override;
 
-	void handlePreemption(IrqImageAccessor accessor) override;
+	void handlePreemption(IrqImageAccessor image) override;
+	// Non-virtual since syscalls/faults know that they are called from a thread.
+	void handlePreemption(FaultImageAccessor image);
+	void handlePreemption(SyscallImageAccessor image);
 
 private:
+	template<typename ImageAccessor>
+	void doHandlePreemption(bool inManipulableDomain, ImageAccessor image);
+
 	void _updateRunTime();
 	void _uninvoke();
 	void _kill();


### PR DESCRIPTION
Fix remaining TODOs after the removal of self-ping-IPIs. This fixes a potential hangs if there is only a single runnable thread (such that we do not arm the preemption tick) and that thread never yields after waking up other threads.