### PR TITLE
thor: Make copy-on-write non-hierarchical

### DIFF
--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -328,12 +328,6 @@ CowChain::~CowChain() {
 	if(logCleanup)
 		infoLogger() << "thor: Releasing CowChain" << frg::endlog;
 
-	for(auto it = _pages.begin(); it != _pages.end(); ++it) {
-		auto physical = it->load(std::memory_order_relaxed);
-		assert(physical != PhysicalAddr(-1));
-		physicalAllocator->free(physical, kPageSize);
-	}
-
 	// Iteratively release the whole chain of super pointers to avoid
 	// a potentially very deep call stack (in the worst case leading
 	// to a stack overflow and a kernel panic).

--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -320,19 +320,13 @@ coroutine<void> Mapping::runEvictionLoop() {
 // CowMapping
 // --------------------------------------------------------
 
-CowChain::CowChain(smarter::shared_ptr<CowChain> chain)
-: _superChain{std::move(chain)}, _pages{*kernelAlloc} {
+CowChain::CowChain()
+: _pages{*kernelAlloc} {
 }
 
 CowChain::~CowChain() {
 	if(logCleanup)
 		infoLogger() << "thor: Releasing CowChain" << frg::endlog;
-
-	// Iteratively release the whole chain of super pointers to avoid
-	// a potentially very deep call stack (in the worst case leading
-	// to a stack overflow and a kernel panic).
-	while(_superChain)
-		_superChain = _superChain->_superChain;
 }
 
 // --------------------------------------------------------

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -1039,14 +1039,13 @@ struct CowPage {
 };
 
 struct CowChain {
-	CowChain(smarter::shared_ptr<CowChain> chain);
+	CowChain();
 
 	~CowChain();
 
 // TODO: Either this private again or make this class POD-like.
 	frg::ticket_spinlock _mutex;
 
-	smarter::shared_ptr<CowChain> _superChain;
 	frg::rcu_radixtree<smarter::shared_ptr<CowPage>, KernelAlloc> _pages;
 };
 

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -1087,7 +1087,7 @@ private:
 	uintptr_t _viewOffset;
 	size_t _length;
 	smarter::shared_ptr<CowChain> _copyChain;
-	frg::rcu_radixtree<CowPage, KernelAlloc> _ownedPages;
+	frg::rcu_radixtree<smarter::shared_ptr<CowPage>, KernelAlloc> _ownedPages;
 	async::recurring_event _copyEvent;
 	EvictionQueue _evictQueue;
 };

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -1024,6 +1024,20 @@ private:
 	frg::vector<smarter::shared_ptr<IndirectionSlot>, KernelAlloc> indirections_;
 };
 
+enum class CowState {
+	null,
+	inProgress,
+	hasCopy
+};
+
+struct CowPage {
+	~CowPage();
+
+	PhysicalAddr physical = -1;
+	CowState state = CowState::null;
+	unsigned int lockCount = 0;
+};
+
 struct CowChain {
 	CowChain(smarter::shared_ptr<CowChain> chain);
 
@@ -1033,7 +1047,7 @@ struct CowChain {
 	frg::ticket_spinlock _mutex;
 
 	smarter::shared_ptr<CowChain> _superChain;
-	frg::rcu_radixtree<std::atomic<PhysicalAddr>, KernelAlloc> _pages;
+	frg::rcu_radixtree<smarter::shared_ptr<CowPage>, KernelAlloc> _pages;
 };
 
 struct CopyOnWriteMemory final : MemoryView, GlobalFutexSpace /*, MemoryObserver */ {
@@ -1069,18 +1083,6 @@ public:
 	// Contract: set by the code that constructs this object.
 	smarter::borrowed_ptr<CopyOnWriteMemory> selfPtr;
 private:
-	enum class CowState {
-		null,
-		inProgress,
-		hasCopy
-	};
-
-	struct CowPage {
-		PhysicalAddr physical = -1;
-		CowState state = CowState::null;
-		unsigned int lockCount = 0;
-	};
-
 	frg::ticket_spinlock _mutex;
 
 	smarter::shared_ptr<MemoryView> _view;


### PR DESCRIPTION
While the current hierarchical implementation of CoW does not require a lot of work in `fork()`, it adds a lot of memory footprint and it can potentially cause OOM in unexpected ways (e.g., if a process forks repeatedly). Switch to a non-hierarchical implementation that just keeps per-page refcounts.