### PR TITLE
thor: Make global log ring available early

### DIFF
--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -179,6 +179,9 @@ initgraph::Edge fibersTaskingEdge{
 };
 
 extern "C" void thorMain() {
+	initializeGlobalLog();
+	infoLogger() << "thor: Entering main function" << frg::endlog;
+
 	kernelCommandLine.initialize(*kernelAlloc,
 			reinterpret_cast<const char *>(getEirInfo()->commandLine));
 
@@ -206,6 +209,9 @@ extern "C" void thorMain() {
 		// Run all other initgraph tasks.
 		globalInitEngine.run();
 
+		// enableWakeups() requires all CPUs to be ready to handle IPIs.
+		// TODO: this could be avoided by changing SelfIpiCall to avoid IPIs on CPUs that are not yet ready.
+		getGlobalLogRing()->enableWakeups();
 		transitionBootFb();
 
 		pci::runAllBridges();

--- a/kernel/thor/generic/thor-internal/kernel-log.hpp
+++ b/kernel/thor/generic/thor-internal/kernel-log.hpp
@@ -9,6 +9,8 @@ namespace thor {
 struct GlobalLogRing {
 	void enable();
 
+	void enableWakeups();
+
 	auto wait(uint64_t deqPtr) {
 		return event_.async_wait_if([=, this] () -> bool {
 			return ring_.peekHeadPtr() == deqPtr;
@@ -43,9 +45,10 @@ private:
 	SingleContextRecordRing ring_;
 	SelfIntCall<Wakeup> wakeup_{this};
 	Handler handler_{this};
+	std::atomic<bool> callWakeup_{false};
 };
 
-void initializeLog();
+void initializeGlobalLog();
 
 GlobalLogRing *getGlobalLogRing();
 


### PR DESCRIPTION
This makes the global log buffer (which ultimately feeds into `dmesg`) available early during boot (= immediately after entering `thorMain()`).