### PR TITLE
posix/init: Make systemd boot be configurable from the kernel commandline

### DIFF
--- a/posix/init/src/stage1.cpp
+++ b/posix/init/src/stage1.cpp
@@ -233,6 +233,7 @@ int main() {
 
 	frg::array args = {
 		frg::option{"netserver.device", frg::as_string_view(uefiNetDevpath)},
+		frg::option{"systemd", frg::store_true(systemd)},
 	};
 	frg::parse_arguments(cmdline.c_str(), args);
 


### PR DESCRIPTION
This eases debugging systemd on Managarm.

Part of the systemd on Managarm project.