### PR TITLE
thor: Support IMSIC interrupt controller on RISC-V

### DIFF
--- a/kernel/common/riscv/csr.hpp
+++ b/kernel/common/riscv/csr.hpp
@@ -18,6 +18,11 @@ enum class Csr : uint16_t {
 	stval = 0x143,    // Trap value.
 	sip = 0x144,      // Interrupt pending.
 	stimecmp = 0x14d, // Timer comparison register.
+	// Indirect access CSRs.
+	siselect = 0x150,
+	sireg = 0x151,
+	// Supervisor level interrupts.
+	stopei = 0x15c,
 	// Supervisor protection and translation.
 	satp = 0x180, // Address translation.
 };
@@ -67,14 +72,21 @@ constexpr uint64_t sei = 9; // Supervisor external interrupt.
 
 template <Csr csr>
 uint64_t readCsr() {
-	uint64_t v;
-	asm volatile("csrr %0, %1" : "=r"(v) : "i"(static_cast<uint16_t>(csr)) : "memory");
-	return v;
+	uint64_t u;
+	asm volatile("csrr %0, %1" : "=r"(u) : "i"(static_cast<uint16_t>(csr)) : "memory");
+	return u;
 }
 
 template <Csr csr>
 void writeCsr(uint64_t v) {
 	asm volatile("csrw %1, %0" : : "r"(v), "i"(static_cast<uint16_t>(csr)) : "memory");
+}
+
+template <Csr csr>
+uint64_t readWriteCsr(uint64_t v) {
+	uint64_t u;
+	asm volatile("csrrw %0, %1, %2" : "=r"(u) : "i"(static_cast<uint16_t>(csr)), "r"(v) : "memory");
+	return u;
 }
 
 template <Csr csr>

--- a/kernel/thor/arch/riscv/aplic.cpp
+++ b/kernel/thor/arch/riscv/aplic.cpp
@@ -10,12 +10,126 @@ namespace thor {
 
 namespace {
 
+const frg::array<frg::string_view, 1> intcCompatible = {"riscv,cpu-intc"};
+const frg::array<frg::string_view, 1> cpuCompatible = {"riscv"};
+
+// ----------------------------------------------------------------------------
+// IMSIC
+// ----------------------------------------------------------------------------
+
+namespace indirect {
+constexpr uint64_t edelivery = 0x70;
+constexpr uint64_t ethreshold = 0x72;
+constexpr uint64_t eie0 = 0xC0;
+}; // namespace indirect
+
+uint64_t readIndirect(uint64_t sel) {
+	riscv::writeCsr<riscv::Csr::siselect>(sel);
+	return riscv::readCsr<riscv::Csr::sireg>();
+}
+void writeIndirect(uint64_t sel, uint64_t v) {
+	riscv::writeCsr<riscv::Csr::siselect>(sel);
+	riscv::writeCsr<riscv::Csr::sireg>(v);
+}
+
+const frg::array<frg::string_view, 1> imsciCompatible = {"riscv,imsics"};
+
+struct ImsicContext;
+
+struct Imsic {
+	// TODO: Store a dyn_array of all contexts instead of just the BSP's context.
+	ImsicContext *bspContext{nullptr};
+};
+
+// Per-CPU IMSIC context.
+struct ImsicContext {
+	uint32_t hartIndex{~UINT32_C(0)};
+	frg::dyn_array<IrqPin *, KernelAlloc> irqs{*kernelAlloc};
+};
+
+// Only written before APs are booted (no locks needed).
+frg::manual_box<frg::hash_map<uint32_t, Imsic *, frg::hash<uint32_t>, KernelAlloc>> phandleToImsic;
+
+void enumerateImsic(DeviceTreeNode *imsicNode) {
+	infoLogger() << "thor: Found IMSIC " << imsicNode->path() << frg::endlog;
+
+	size_t bspIdx{~size_t{0}};
+	size_t i = 0;
+	bool success = dt::walkInterruptsExtended(
+	    [&](DeviceTreeNode *intcNode, dtb::Cells intcIrq) {
+		    if (!intcNode->isCompatible(intcCompatible))
+			    panicLogger() << "Expected interrupt parent of IMSIC to be cpu-intc device"
+			                  << frg::endlog;
+
+		    // Find the CPU corresponding to the IMSIC hard index based on the cpu-intc node.
+		    auto cpuNode = intcNode->parent();
+		    if (!cpuNode || !cpuNode->isCompatible(cpuCompatible))
+			    panicLogger() << "Expected parent of cpu-intc device to be CPU" << frg::endlog;
+		    auto hartId = cpuNode->reg().front().addr;
+
+		    // Get the IRQ index at the parent cpu-intc.
+		    uint32_t intcIdx;
+		    if (!intcIrq.read(intcIdx))
+			    panicLogger() << "Failed to read cpu-intc interrupt index" << frg::endlog;
+		    infoLogger() << "    Hart index " << i << " connected to hart ID " << hartId
+		                 << ", interrupt " << intcIdx << frg::endlog;
+
+		    if (hartId == getCpuData()->hartId && intcIdx == riscv::interrupts::sei)
+			    bspIdx = i;
+		    ++i;
+	    },
+	    imsicNode
+	);
+	if (!success)
+		panicLogger() << "Failed to walk interrupts of " << imsicNode->path() << frg::endlog;
+
+	if (bspIdx == ~size_t{0}) {
+		infoLogger() << "    Failed to determine IMSIC hart index of BSP" << frg::endlog;
+		return;
+	}
+	infoLogger() << "    Hard index " << bspIdx << " corresponds to BSP S-mode external interrupt"
+	             << frg::endlog;
+
+	auto numIdsProp = imsicNode->dtNode().findProperty("riscv,num-ids");
+	if (!numIdsProp)
+		panicLogger() << "thor: IMSIC has no riscv,num-ids property" << frg::endlog;
+	uint32_t numIds;
+	if (!numIdsProp->access().readCells(numIds, 1))
+		panicLogger() << "thor: Failed to read riscv,num-ids from IMSIC" << frg::endlog;
+
+	// Unmask all IRQs at the IMSIC level (then can be masked at the APLIC level).
+	writeIndirect(indirect::ethreshold, 0);
+	for (uint32_t i = 0; i < numIds; i += 64) {
+		// Note: In 64-bit S-mode, only even eieN registers exist.
+		writeIndirect(indirect::eie0 + 2 * (i / 64), ~UINT64_C(0));
+	}
+	// Enable IMSIC interrupt delivery (not APLIC delivery mode).
+	writeIndirect(indirect::edelivery, 1);
+	if (readIndirect(indirect::edelivery) != 1)
+		panicLogger() << "thor: Failed to enable IMSIC interrupt delivery" << frg::endlog;
+
+	auto *imsic = frg::construct<Imsic>(*kernelAlloc);
+
+	auto *bspContext = frg::construct<ImsicContext>(*kernelAlloc);
+	bspContext->hartIndex = bspIdx;
+	bspContext->irqs = {numIds, *kernelAlloc};
+	imsic->bspContext = bspContext;
+
+	phandleToImsic->insert(imsicNode->phandle(), imsic);
+
+	auto *ourExternalIrq = &riscvExternalIrq.get();
+	ourExternalIrq->type = ExternalIrqType::imsic;
+	ourExternalIrq->controller = bspContext;
+}
+
+// ----------------------------------------------------------------------------
+// APLIC
+// ----------------------------------------------------------------------------
+
 constexpr bool logMaskUnmask = false;
 constexpr bool logClaim = false;
 
 const frg::array<frg::string_view, 1> aplicCompatible = {"riscv,aplic"};
-const frg::array<frg::string_view, 1> intcCompatible = {"riscv,cpu-intc"};
-const frg::array<frg::string_view, 1> cpuCompatible = {"riscv"};
 
 constexpr arch::scalar_register<uint32_t> aplicDomaincfgRegister{0};
 
@@ -50,7 +164,7 @@ constexpr auto aplicIdeliveryRegister(size_t idx) {
 constexpr auto aplicIthresholdRegister(size_t idx) {
 	return arch::scalar_register<uint32_t>{static_cast<ptrdiff_t>(0x4000 + 32 * idx + 0x8)};
 }
-constexpr auto aplicTopiRegister(size_t idx) {
+[[maybe_unused]] constexpr auto aplicTopiRegister(size_t idx) {
 	return arch::scalar_register<uint32_t>{static_cast<ptrdiff_t>(0x4000 + 32 * idx + 0x18)};
 }
 constexpr auto aplicClaimiRegister(size_t idx) {
@@ -103,8 +217,19 @@ struct Aplic : dt::IrqController {
 				panicLogger() << "APLIC source " << name() << " does not support source mode "
 				              << mode << frg::endlog;
 
-			// Program the source to target the BSP, set priority to 1.
-			aplic_->space_.store(aplicTargetRegister(idx_), (aplic_->bspIdx_ << 18) | 1);
+			if (aplic_->imsic_) {
+				auto *ctx = aplic_->imsic_->bspContext;
+				// TODO: Fix this limitation by properly allocating IMSIC interrupts.
+				if (idx_ >= ctx->irqs.size())
+					panicLogger(
+					) << "thor: Cannot identity route APLIC interrupt to IMSIC interrupt "
+					  << idx_ << frg::endlog;
+				ctx->irqs[idx_] = this;
+				aplic_->space_.store(aplicTargetRegister(idx_), (ctx->hartIndex << 18) | idx_);
+			} else {
+				// Program the source to target the BSP, set priority to 1.
+				aplic_->space_.store(aplicTargetRegister(idx_), (aplic_->bspIdx_ << 18) | 1);
+			}
 
 			unmask();
 
@@ -146,9 +271,10 @@ struct Aplic : dt::IrqController {
 		size_t idx_;
 	};
 
-	Aplic(PhysicalAddr base, size_t size, size_t numIrqs, size_t bspIdx)
+	Aplic(PhysicalAddr base, size_t size, size_t numIrqs, Imsic *imsic, size_t bspIdx)
 	: base_{base},
 	  size_{size},
+	  imsic_{imsic},
 	  bspIdx_{bspIdx} {
 		auto ptr = KernelVirtualMemory::global().allocate(size);
 		for (size_t i = 0; i < size; i += kPageSize) {
@@ -178,11 +304,14 @@ struct Aplic : dt::IrqController {
 		for (size_t i = 1; i < numIrqs; ++i)
 			space_.store(aplicSourcecfgRegister(i), 0);
 
-		space_.store(aplicIdeliveryRegister(bspIdx_), 1);
-		space_.store(aplicIthresholdRegister(bspIdx_), 0);
+		// TODO: Move this to a per-CPU AplicContext class.
+		if (!imsic_) {
+			space_.store(aplicIdeliveryRegister(bspIdx_), 1);
+			space_.store(aplicIthresholdRegister(bspIdx_), 0);
+		}
 
-		// Set IE.
-		space_.store(aplicDomaincfgRegister, 0x100);
+		// Set IE (+ DM if routing as MSIs).
+		space_.store(aplicDomaincfgRegister, 0x100 | ((imsic_ ? 1 : 0) << 2));
 	}
 
 	Aplic(const Aplic &) = delete;
@@ -228,7 +357,10 @@ struct Aplic : dt::IrqController {
 		return pin;
 	}
 
+	// TODO: Move this to a per-CPU AplicContext class.
 	uint32_t claim(size_t idx) {
+		assert(!imsic_); // claim() is only valid for direct routing.
+
 		auto claimi = space_.load(aplicClaimiRegister(idx));
 		auto srcIdx = claimi >> 16;
 		if (logClaim)
@@ -240,55 +372,19 @@ private:
 	PhysicalAddr base_;
 	size_t size_;
 	arch::mem_space space_;
+	Imsic *imsic_{nullptr};
 	frg::dyn_array<Irq *, KernelAlloc> irqs_{*kernelAlloc};
 	// TODO: The current implementation routes all IRQs to the BSP.
 	//       We should allow routing of IRQs to other harts as well.
-	size_t bspIdx_;
+	size_t bspIdx_; // Only relevant in direct routing mode.
 };
 
 void enumerateAplic(DeviceTreeNode *aplicNode) {
-	infoLogger() << "thor: Found APLIC " << aplicNode->path() << frg::endlog; // FIXME
+	infoLogger() << "thor: Found APLIC " << aplicNode->path() << frg::endlog;
 
 	const auto &reg = aplicNode->reg();
 	if (reg.size() != 1)
 		panicLogger() << "thor: Expect exactly one 'reg' entry for APLICs" << frg::endlog;
-
-	size_t bspIdx{~size_t{0}};
-	size_t i = 0;
-	bool success = dt::walkInterruptsExtended(
-	    [&](DeviceTreeNode *intcNode, dtb::Cells intcIrq) {
-		    if (!intcNode->isCompatible(intcCompatible))
-			    panicLogger() << "Expected interrupt parent of APLIC to be cpu-intc device"
-			                  << frg::endlog;
-
-		    // Find the CPU corresponding to the APLIC hard index based on the cpu-intc node.
-		    auto cpuNode = intcNode->parent();
-		    if (!cpuNode || !cpuNode->isCompatible(cpuCompatible))
-			    panicLogger() << "Expected parent of cpu-intc device to be CPU" << frg::endlog;
-		    auto hartId = cpuNode->reg().front().addr;
-
-		    // Get the IRQ index at the parent cpu-intc.
-		    uint32_t intcIdx;
-		    if (!intcIrq.read(intcIdx))
-			    panicLogger() << "Failed to read cpu-intc interrupt index" << frg::endlog;
-		    infoLogger() << "    Hart index " << i << " connected to hart ID " << hartId
-		                 << ", interrupt " << intcIdx << frg::endlog;
-
-		    if (hartId == getCpuData()->hartId && intcIdx == riscv::interrupts::sei)
-			    bspIdx = i;
-		    ++i;
-	    },
-	    aplicNode
-	);
-	if (!success)
-		panicLogger() << "Failed to walk interrupts of " << aplicNode->path() << frg::endlog;
-
-	if (bspIdx == ~size_t{0}) {
-		infoLogger() << "    Failed to determine APLIC hart index of BSP" << frg::endlog;
-		return;
-	}
-	infoLogger() << "    Hard index " << bspIdx << " corresponds to BSP S-mode external interrupt"
-	             << frg::endlog;
 
 	auto numSourcesProp = aplicNode->dtNode().findProperty("riscv,num-sources");
 	if (!numSourcesProp)
@@ -297,14 +393,78 @@ void enumerateAplic(DeviceTreeNode *aplicNode) {
 	if (!numSourcesProp->access().readCells(numSources, 1))
 		panicLogger() << "thor: Failed to read riscv,num-sources from APLIC" << frg::endlog;
 
-	auto aplic =
-	    frg::construct<Aplic>(*kernelAlloc, reg.front().addr, reg.front().size, numSources, bspIdx);
-	aplicNode->associateIrqController(aplic);
-
 	auto *ourExternalIrq = &riscvExternalIrq.get();
-	ourExternalIrq->type = ExternalIrqType::aplic;
-	ourExternalIrq->controller = aplic;
-	ourExternalIrq->context = bspIdx;
+	if (ourExternalIrq->type == ExternalIrqType::imsic) {
+		auto msiParentProp = aplicNode->dtNode().findProperty("msi-parent");
+		if (!msiParentProp)
+			panicLogger() << "thor: APLIC has no msi-parent property" << frg::endlog;
+		uint32_t msiParent;
+		if (!msiParentProp->access().readCells(msiParent, 1))
+			panicLogger() << "thor: Failed to read msi-parent from APLIC" << frg::endlog;
+
+		auto imsicIt = phandleToImsic->find(msiParent);
+		if (imsicIt == phandleToImsic->end()) {
+			infoLogger() << "thor: APLIC is attached to unknown IMSIC" << frg::endlog;
+			return;
+		}
+		auto *imsic = imsicIt->get<1>();
+
+		infoLogger() << "thor: APLIC is attached to BSP S-mode IMISC" << frg::endlog;
+
+		auto aplic = frg::construct<Aplic>(
+		    *kernelAlloc, reg.front().addr, reg.front().size, numSources, imsic, ~size_t{0}
+		);
+		aplicNode->associateIrqController(aplic);
+	} else {
+		size_t bspIdx{~size_t{0}};
+		size_t i = 0;
+		bool success = dt::walkInterruptsExtended(
+		    [&](DeviceTreeNode *intcNode, dtb::Cells intcIrq) {
+			    if (!intcNode->isCompatible(intcCompatible))
+				    panicLogger() << "Expected interrupt parent of APLIC to be cpu-intc device"
+				                  << frg::endlog;
+
+			    // Find the CPU corresponding to the APLIC hard index based on the cpu-intc node.
+			    auto cpuNode = intcNode->parent();
+			    if (!cpuNode || !cpuNode->isCompatible(cpuCompatible))
+				    panicLogger() << "Expected parent of cpu-intc device to be CPU" << frg::endlog;
+			    auto hartId = cpuNode->reg().front().addr;
+
+			    // Get the IRQ index at the parent cpu-intc.
+			    uint32_t intcIdx;
+			    if (!intcIrq.read(intcIdx))
+				    panicLogger() << "Failed to read cpu-intc interrupt index" << frg::endlog;
+			    infoLogger() << "    Hart index " << i << " connected to hart ID " << hartId
+			                 << ", interrupt " << intcIdx << frg::endlog;
+
+			    if (hartId == getCpuData()->hartId && intcIdx == riscv::interrupts::sei)
+				    bspIdx = i;
+			    ++i;
+		    },
+		    aplicNode
+		);
+		if (!success)
+			panicLogger() << "Failed to walk interrupts of " << aplicNode->path() << frg::endlog;
+
+		if (bspIdx == ~size_t{0}) {
+			infoLogger() << "    Failed to determine APLIC hart index of BSP" << frg::endlog;
+			return;
+		}
+		infoLogger() << "    Hard index " << bspIdx
+		             << " corresponds to BSP S-mode external interrupt" << frg::endlog;
+		if (ourExternalIrq->type != ExternalIrqType::none)
+			panicLogger() << "Multiple APLIC nodes are routed to BSP S-mode external interrupt"
+			              << frg::endlog;
+
+		auto aplic = frg::construct<Aplic>(
+		    *kernelAlloc, reg.front().addr, reg.front().size, numSources, nullptr, bspIdx
+		);
+		aplicNode->associateIrqController(aplic);
+
+		ourExternalIrq->type = ExternalIrqType::aplic;
+		ourExternalIrq->controller = aplic;
+		ourExternalIrq->context = bspIdx;
+	}
 }
 
 initgraph::Task initPlic{
@@ -313,6 +473,13 @@ initgraph::Task initPlic{
     initgraph::Requires{getDeviceTreeParsedStage()},
     initgraph::Entails{getTaskingAvailableStage()},
     [] {
+	    phandleToImsic.initialize(frg::hash<uint32_t>{}, *kernelAlloc);
+
+	    getDeviceTreeRoot()->forEach([&](DeviceTreeNode *node) -> bool {
+		    if (node->isCompatible(imsciCompatible))
+			    enumerateImsic(node);
+		    return false;
+	    });
 	    getDeviceTreeRoot()->forEach([&](DeviceTreeNode *node) -> bool {
 		    if (node->isCompatible(aplicCompatible))
 			    enumerateAplic(node);
@@ -322,6 +489,22 @@ initgraph::Task initPlic{
 };
 
 } // namespace
+
+IrqPin *claimImsicIrq() {
+	auto idx = riscv::readWriteCsr<riscv::Csr::stopei>(0) >> 16;
+	if (!idx)
+		return nullptr;
+
+	auto *ourExternalIrq = &riscvExternalIrq.get();
+	assert(ourExternalIrq->type == ExternalIrqType::imsic);
+	assert(ourExternalIrq->controller);
+	auto *ctx = static_cast<ImsicContext *>(ourExternalIrq->controller);
+	if (idx >= ctx->irqs.size()) {
+		warningLogger() << "thor: IMSIC IRQ index " << idx << " out of bounds" << frg::endlog;
+		return nullptr;
+	}
+	return ctx->irqs[idx];
+}
 
 IrqPin *claimAplicIrq() {
 	auto *ourExternalIrq = &riscvExternalIrq.get();

--- a/kernel/thor/arch/riscv/thor-internal/arch/trap.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/trap.hpp
@@ -13,6 +13,7 @@ void handleRiscvWorkOnExecutor(Executor *executor, Frame *frame);
 enum ExternalIrqType {
 	none,
 	plic,
+	imsic,
 	aplic,
 };
 
@@ -27,6 +28,7 @@ struct ExternalIrq {
 extern PerCpu<ExternalIrq> riscvExternalIrq;
 
 IrqPin *claimPlicIrq();
+IrqPin *claimImsicIrq();
 IrqPin *claimAplicIrq();
 
 } // namespace thor

--- a/kernel/thor/arch/riscv/trap.cpp
+++ b/kernel/thor/arch/riscv/trap.cpp
@@ -175,6 +175,8 @@ void handleRiscvInterrupt(Frame *frame, uint64_t code) {
 		IrqPin *irq = nullptr;
 		if (ourExternalIrq->type == ExternalIrqType::plic) {
 			irq = claimPlicIrq();
+		} else if (ourExternalIrq->type == ExternalIrqType::imsic) {
+			irq = claimImsicIrq();
 		} else if (ourExternalIrq->type == ExternalIrqType::aplic) {
 			irq = claimAplicIrq();
 		} else {

--- a/kernel/thor/system/dtb/thor-internal/dtb/dtb.hpp
+++ b/kernel/thor/system/dtb/thor-internal/dtb/dtb.hpp
@@ -103,6 +103,10 @@ struct DeviceTreeNode {
 		return path_;
 	}
 
+	uint32_t phandle() {
+		return phandle_;
+	}
+
 	uint64_t translateAddress(uint64_t addr) const;
 
 	auto addressCells() const {


### PR DESCRIPTION
Add support for the IMISC controller. The IMSIC is an MSI-based interrupt controller that is directly integrated into the CPU.

To support non-MSI interrupts, the APLIC can be programmed to convert non-MSI interrupts to MSIs that are forwarded to the IMSIC.