### PR TITLE
inotify: Various fixes for inotify support

### DIFF
--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -193,7 +193,6 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::mksocket(st
 }
 
 void FsNode::notifyObservers(uint32_t events, const std::string &name, uint32_t cookie, bool isDir) {
-	assert(_defaultOps & defaultSupportsObservers);
 	for(const auto &[borrowed, observer] : _observers) {
 		borrowed->observeNotification(events, name, cookie, isDir);
 		(void)observer;

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -192,10 +192,10 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::mksocket(st
 	co_return Error::illegalOperationTarget;
 }
 
-void FsNode::notifyObservers(uint32_t events, const std::string &name, uint32_t cookie) {
+void FsNode::notifyObservers(uint32_t events, const std::string &name, uint32_t cookie, bool isDir) {
 	assert(_defaultOps & defaultSupportsObservers);
 	for(const auto &[borrowed, observer] : _observers) {
-		borrowed->observeNotification(events, name, cookie);
+		borrowed->observeNotification(events, name, cookie, isDir);
 		(void)observer;
 	}
 }

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -94,7 +94,12 @@ protected:
 
 public:
 	static constexpr uint32_t deleteEvent = 1;
-	static constexpr uint32_t createEvent = 2;
+	static constexpr uint32_t deleteSelfEvent = 2;
+	static constexpr uint32_t createEvent = 4;
+	static constexpr uint32_t modifyEvent = 8;
+	static constexpr uint32_t accessEvent = 16;
+	static constexpr uint32_t closeWriteEvent = 32;
+	static constexpr uint32_t closeNoWriteEvent = 64;
 
 	virtual void observeNotification(uint32_t events,
 			const std::string &name, uint32_t cookie, bool isDir) = 0;

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -100,6 +100,7 @@ public:
 	static constexpr uint32_t accessEvent = 16;
 	static constexpr uint32_t closeWriteEvent = 32;
 	static constexpr uint32_t closeNoWriteEvent = 64;
+	static constexpr uint32_t ignoredEvent = 128;
 
 	virtual void observeNotification(uint32_t events,
 			const std::string &name, uint32_t cookie, bool isDir) = 0;
@@ -197,7 +198,6 @@ public:
 	virtual bool hasTraverseLinks();
 	virtual async::result<frg::expected<Error, std::pair<std::shared_ptr<FsLink>, size_t>>> traverseLinks(std::deque<std::string> path);
 
-protected:
 	void notifyObservers(uint32_t inotifyEvents, const std::string &name, uint32_t cookie, bool isDir = false);
 
 private:

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -97,7 +97,7 @@ public:
 	static constexpr uint32_t createEvent = 2;
 
 	virtual void observeNotification(uint32_t events,
-			const std::string &name, uint32_t cookie) = 0;
+			const std::string &name, uint32_t cookie, bool isDir) = 0;
 };
 
 // ----------------------------------------------------------------------------
@@ -193,7 +193,7 @@ public:
 	virtual async::result<frg::expected<Error, std::pair<std::shared_ptr<FsLink>, size_t>>> traverseLinks(std::deque<std::string> path);
 
 protected:
-	void notifyObservers(uint32_t inotifyEvents, const std::string &name, uint32_t cookie);
+	void notifyObservers(uint32_t inotifyEvents, const std::string &name, uint32_t cookie, bool isDir = false);
 
 private:
 	FsSuperblock *_superblock;

--- a/posix/subsystem/src/inotify.hpp
+++ b/posix/subsystem/src/inotify.hpp
@@ -1,10 +1,12 @@
 
 #include "file.hpp"
+#include "fs.hpp"
 
 namespace inotify {
 
 smarter::shared_ptr<File, FileHandle> createFile(bool nonBlock);
 int addWatch(File *file, std::shared_ptr<FsNode> node, uint32_t mask);
+bool removeWatch(File *file, int wd);
 
 } // namespace inotify
 

--- a/posix/subsystem/src/inotify.hpp
+++ b/posix/subsystem/src/inotify.hpp
@@ -3,7 +3,7 @@
 
 namespace inotify {
 
-smarter::shared_ptr<File, FileHandle> createFile();
+smarter::shared_ptr<File, FileHandle> createFile(bool nonBlock);
 int addWatch(File *file, std::shared_ptr<FsNode> node, uint32_t mask);
 
 } // namespace inotify

--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -3235,7 +3235,10 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			logRequest(logRequests, "INOTIFY_CREATE");
 
-			assert(!(req->flags() & ~(managarm::posix::OpenFlags::OF_CLOEXEC | managarm::posix::OpenFlags::OF_NONBLOCK)));
+			if(req->flags() & ~(managarm::posix::OpenFlags::OF_CLOEXEC | managarm::posix::OpenFlags::OF_NONBLOCK)) {
+				co_await sendErrorResponse(managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+				continue;
+			}
 
 			auto file = inotify::createFile(req->flags() & managarm::posix::OpenFlags::OF_NONBLOCK);
 			auto fd = self->fileContext()->attachFile(file,

--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -3236,11 +3236,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 			assert(!(req->flags() & ~(managarm::posix::OpenFlags::OF_CLOEXEC | managarm::posix::OpenFlags::OF_NONBLOCK)));
 
-			// TODO: Implement blocking reads
-			if(!(req->flags() & managarm::posix::OpenFlags::OF_NONBLOCK))
-				std::cout << "posix: INOTIFY_CREATE doesn't do blocking reads" << std::endl;
-
-			auto file = inotify::createFile();
+			auto file = inotify::createFile(req->flags() & managarm::posix::OpenFlags::OF_NONBLOCK);
 			auto fd = self->fileContext()->attachFile(file,
 					req->flags() & managarm::posix::OpenFlags::OF_CLOEXEC);
 

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -354,7 +354,7 @@ private:
 
 		_entries.erase(it);
 
-		notifyObservers(FsObserver::deleteEvent, name, 0);
+		notifyObservers(FsObserver::deleteEvent, name, 0, true);
 		co_return {};
 	}
 
@@ -778,7 +778,7 @@ DirectoryNode::mkdir(std::string name) {
 	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(node));
 	the_node->_treeLink = link;
 	_entries.insert(link);
-	notifyObservers(FsObserver::createEvent, name, 0);
+	notifyObservers(FsObserver::createEvent, name, 0, true);
 	co_return link;
 }
 

--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -638,3 +638,14 @@ head(128):
 	Errors error;
 	int32 fd;
 }
+
+message InotifyRmRequest 103 {
+head(128):
+	int32 ifd;
+	int32 wd;
+}
+
+message InotifyRmReply 104 {
+head(128):
+	Errors error;
+}

--- a/testsuites/posix-tests/src/inotify.cpp
+++ b/testsuites/posix-tests/src/inotify.cpp
@@ -2,7 +2,6 @@
 #include <climits>
 #include <cstdlib>
 #include <cstring>
-#include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/inotify.h>
@@ -34,7 +33,7 @@ DEFINE_TEST(inotify_unlink_child, ([] {
 	e = unlink(filePath);
 	assert(!e);
 
-	char buffer[sizeof(inotify_event) + NAME_MAX + 1];
+	char buffer[(sizeof(inotify_event) + NAME_MAX + 1) * 2];
 	auto chunk = read(ifd, buffer, sizeof(inotify_event) + NAME_MAX + 1);
 	assert(chunk > 0);
 
@@ -49,4 +48,56 @@ DEFINE_TEST(inotify_unlink_child, ([] {
 	close(ifd);
 	//e = rmdir(dirPath);
 	//assert(!e);
+
+	ifd = inotify_init1(IN_NONBLOCK);
+	assert(ifd > 0);
+	char testfile[27] = "/tmp/posix-test-fileXXXXXX";
+	int fd = mkstemp(testfile);
+	assert(fd >= 0);
+
+	wd = inotify_add_watch(ifd, testfile, IN_MODIFY | IN_ACCESS | IN_DELETE_SELF | IN_CLOSE_WRITE);
+	assert(wd >= 0);
+	write(fd, &fd, sizeof(fd));
+	lseek(fd, 0, SEEK_SET);
+	int discard;
+	read(fd, &discard, sizeof(discard));
+	write(fd, &fd, sizeof(fd));
+
+	memset(buffer, 0, sizeof(buffer));
+	chunk = read(ifd, buffer, sizeof(buffer));
+	assert(chunk > 0 && chunk >= sizeof(inotify_event));
+
+	memcpy(&evtHeader, buffer, sizeof(inotify_event));
+	assert(evtHeader.wd == wd);
+	assert((evtHeader.mask & IN_MODIFY) == IN_MODIFY);
+	assert(chunk > sizeof(inotify_event) + evtHeader.len);
+
+	memcpy(&evtHeader, buffer + sizeof(inotify_event) + evtHeader.len, sizeof(inotify_event));
+	assert(evtHeader.wd == wd);
+	assert((evtHeader.mask & IN_ACCESS) == IN_ACCESS);
+
+	memset(buffer, 0, sizeof(buffer));
+	chunk = read(ifd, buffer, sizeof(inotify_event) + NAME_MAX + 1);
+	assert(chunk == -1);
+
+	close(fd);
+
+	memset(buffer, 0, sizeof(buffer));
+	chunk = read(ifd, buffer, sizeof(inotify_event) + NAME_MAX + 1);
+	assert(chunk > 0);
+
+	memcpy(&evtHeader, buffer, sizeof(inotify_event));
+	assert(evtHeader.wd == wd);
+	assert((evtHeader.mask & IN_CLOSE_WRITE) == IN_CLOSE_WRITE);
+
+	e = unlink(testfile);
+	assert(!e);
+
+	memset(buffer, 0, sizeof(buffer));
+	chunk = read(ifd, buffer, sizeof(inotify_event) + NAME_MAX + 1);
+	assert(chunk > 0);
+
+	memcpy(&evtHeader, buffer, sizeof(inotify_event));
+	assert(evtHeader.wd == wd);
+	assert((evtHeader.mask & IN_DELETE_SELF) == IN_DELETE_SELF);
 }))


### PR DESCRIPTION
More systemd bugfixes! This time adding support for `IN_ISDIR`, supporting blocking reads and fixing a bug where we potentially try to use the front of an empty queue. 