### PR TITLE
thor: Rework IrqStrategy to make IrqPin logic more flexible

### DIFF
--- a/kernel/thor/arch/arm/gic_v2.cpp
+++ b/kernel/thor/arch/arm/gic_v2.cpp
@@ -158,10 +158,10 @@ IrqStrategy GicDistributorV2::Pin::program(TriggerMode mode, Polarity polarity) 
 	unmask();
 
 	if (mode == TriggerMode::edge) {
-		return IrqStrategy::justEoi;
+		return irq_strategy::maskable | irq_strategy::endOfInterrupt;
 	} else {
 		assert(mode == TriggerMode::level);
-		return IrqStrategy::maskThenEoi;
+		return irq_strategy::maskable | irq_strategy::maskInService | irq_strategy::endOfInterrupt;
 	}
 }
 

--- a/kernel/thor/arch/arm/gic_v2.cpp
+++ b/kernel/thor/arch/arm/gic_v2.cpp
@@ -179,7 +179,7 @@ void GicDistributorV2::Pin::unmask() {
 	arch::scalar_store_relaxed<uint32_t>(parent_->space_, dist_reg::irqSetEnableBase + regOff, (1 << bitOff));
 }
 
-void GicDistributorV2::Pin::sendEoi() {
+void GicDistributorV2::Pin::endOfInterrupt() {
 	getCpuData()->gicCpuInterfaceV2->eoi(0, irq_);
 }
 

--- a/kernel/thor/arch/arm/gic_v3.cpp
+++ b/kernel/thor/arch/arm/gic_v3.cpp
@@ -190,10 +190,10 @@ IrqStrategy GicPinV3::program(TriggerMode mode, Polarity polarity) {
 	unmask();
 
 	if(mode == TriggerMode::edge) {
-		return IrqStrategy::justEoi;
+		return irq_strategy::maskable | irq_strategy::endOfInterrupt;
 	} else {
 		assert(mode == TriggerMode::level);
-		return IrqStrategy::maskThenEoi;
+		return irq_strategy::maskable | irq_strategy::maskInService | irq_strategy::endOfInterrupt;
 	}
 }
 

--- a/kernel/thor/arch/arm/gic_v3.cpp
+++ b/kernel/thor/arch/arm/gic_v3.cpp
@@ -213,7 +213,7 @@ void GicPinV3::unmask() {
 	arch::scalar_store_relaxed(space, dist_reg::irqSetEnableBase + offset, 1U << bit);
 }
 
-void GicPinV3::sendEoi() {
+void GicPinV3::endOfInterrupt() {
 	gicV3->eoi(0, irq_);
 }
 

--- a/kernel/thor/arch/arm/thor-internal/arch/gic.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic.hpp
@@ -33,7 +33,7 @@ struct Gic : dt::IrqController {
 		virtual void mask() override = 0;
 		virtual void unmask() override = 0;
 
-		virtual void sendEoi() override = 0;
+		virtual void endOfInterrupt() override = 0;
 	};
 
 	virtual Pin *setupIrq(uint32_t irq, TriggerMode trigger) = 0;

--- a/kernel/thor/arch/arm/thor-internal/arch/gic_v2.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic_v2.hpp
@@ -32,7 +32,7 @@ struct GicDistributorV2 {
 		IrqStrategy program(TriggerMode mode, Polarity polarity) override;
 		void mask() override;
 		void unmask() override;
-		void sendEoi() override;
+		void endOfInterrupt() override;
 
 		void activate();
 		void deactivate();

--- a/kernel/thor/arch/arm/thor-internal/arch/gic_v3.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic_v3.hpp
@@ -48,7 +48,7 @@ struct GicPinV3 : public Gic::Pin {
 	void mask() override;
 	void unmask() override;
 
-	void sendEoi() override;
+	void endOfInterrupt() override;
 
 private:
 	friend struct GicV3;

--- a/kernel/thor/arch/riscv/aplic.cpp
+++ b/kernel/thor/arch/riscv/aplic.cpp
@@ -197,7 +197,7 @@ struct Aplic : dt::IrqController {
 					assert(polarity == Polarity::low);
 					mode = 5;
 				}
-				strategy = IrqStrategy::justEoi;
+				strategy = irq_strategy::maskable;
 			} else {
 				assert(trigger == TriggerMode::level);
 				if (polarity == Polarity::high) {
@@ -206,7 +206,7 @@ struct Aplic : dt::IrqController {
 					assert(polarity == Polarity::low);
 					mode = 7;
 				}
-				strategy = IrqStrategy::maskThenEoi;
+				strategy = irq_strategy::maskable | irq_strategy::maskInService;
 			}
 
 			// Set the source mode, ensure that this source mode is supported.

--- a/kernel/thor/arch/riscv/aplic.cpp
+++ b/kernel/thor/arch/riscv/aplic.cpp
@@ -262,7 +262,7 @@ struct Aplic : dt::IrqController {
 			aplic_->space_.store(aplicSetieRegister(idx_ >> 5), bits);
 		}
 
-		void sendEoi() override {
+		void endOfInterrupt() override {
 			// The APLIC does not require EOIs.
 		}
 

--- a/kernel/thor/arch/riscv/plic.cpp
+++ b/kernel/thor/arch/riscv/plic.cpp
@@ -51,7 +51,7 @@ struct Plic : dt::IrqController {
 
 		IrqStrategy program(TriggerMode mode, Polarity polarity) override {
 			unmask();
-			return IrqStrategy::justEoi;
+			return irq_strategy::maskable | irq_strategy::endOfInterrupt;
 		}
 
 		void mask() override { plic_->mask(plic_->bspCtx_, idx_); }

--- a/kernel/thor/arch/riscv/plic.cpp
+++ b/kernel/thor/arch/riscv/plic.cpp
@@ -51,13 +51,16 @@ struct Plic : dt::IrqController {
 
 		IrqStrategy program(TriggerMode mode, Polarity polarity) override {
 			unmask();
-			return irq_strategy::maskable | irq_strategy::endOfInterrupt;
+			return irq_strategy::maskable | irq_strategy::endOfService;
 		}
 
 		void mask() override { plic_->mask(plic_->bspCtx_, idx_); }
 		void unmask() override { plic_->unmask(plic_->bspCtx_, idx_); }
 
-		void sendEoi() override { plic_->complete(plic_->bspCtx_, idx_); }
+		// The PLIC does not know whether interrupts are edge- or level-triggered.
+		// We can handle both cases transparently by sending completion only when
+		// an interrupt is serviced successfully.
+		void endOfService() override { plic_->complete(plic_->bspCtx_, idx_); }
 
 	private:
 		Plic *plic_;

--- a/kernel/thor/arch/x86/pic.cpp
+++ b/kernel/thor/arch/x86/pic.cpp
@@ -470,7 +470,7 @@ namespace {
 			// TODO: This may be worth implementing (but it is not needed for correctness).
 		}
 
-		void sendEoi() override {
+		void endOfInterrupt() override {
 			acknowledgeIrq(0);
 		}
 
@@ -553,7 +553,7 @@ namespace {
 			IrqStrategy program(TriggerMode mode, Polarity polarity) override;
 			void mask() override;
 			void unmask() override;
-			void sendEoi() override;
+			void endOfInterrupt() override;
 
 		private:
 			IoApic *_chip;
@@ -693,7 +693,7 @@ namespace {
 				| pin_word1::activeLow(_activeLow)));
 	}
 
-	void IoApic::Pin::sendEoi() {
+	void IoApic::Pin::endOfInterrupt() {
 		acknowledgeIrq(0);
 	}
 

--- a/kernel/thor/arch/x86/pic.cpp
+++ b/kernel/thor/arch/x86/pic.cpp
@@ -459,7 +459,7 @@ namespace {
 
 		IrqStrategy program(TriggerMode mode, Polarity) override {
 			assert(mode == TriggerMode::edge);
-			return IrqStrategy::justEoi;
+			return irq_strategy::endOfInterrupt;
 		}
 
 		void mask() override {
@@ -629,11 +629,11 @@ namespace {
 		IrqStrategy strategy;
 		if(mode == TriggerMode::edge) {
 			_levelTriggered = false;
-			strategy = IrqStrategy::justEoi;
+			strategy = irq_strategy::maskable | irq_strategy::endOfInterrupt;
 		}else{
 			assert(mode == TriggerMode::level);
 			_levelTriggered = true;
-			strategy = IrqStrategy::maskThenEoi;
+			strategy = irq_strategy::maskable | irq_strategy::maskInService | irq_strategy::endOfInterrupt;
 		}
 
 		if(polarity == Polarity::high) {

--- a/kernel/thor/generic/thor-internal/irq.hpp
+++ b/kernel/thor/generic/thor-internal/irq.hpp
@@ -147,8 +147,10 @@ namespace irq_strategy {
 constexpr IrqStrategy maskable = IrqStrategy{1} << 0;
 // Mask the interrupt while its being serviced.
 constexpr IrqStrategy maskInService = IrqStrategy{1} << 1;
-// Whether sendEoi() should be called.
+// Whether endOfInterrupt() should be called.
 constexpr IrqStrategy endOfInterrupt = IrqStrategy{1} << 8;
+// Whether endOfService() should be called.
+constexpr IrqStrategy endOfService = IrqStrategy{1} << 9;
 
 } // namespace irq_strategy
 
@@ -203,7 +205,9 @@ protected:
 	virtual void unmask() = 0;
 
 	// Sends an end-of-interrupt signal to the interrupt controller.
-	virtual void sendEoi() = 0;
+	virtual void endOfInterrupt();
+	// Called when an interrupt exits service (i.e., when it is acked).
+	virtual void endOfService();
 
 	~IrqPin() = default;
 

--- a/kernel/thor/generic/thor-internal/irq.hpp
+++ b/kernel/thor/generic/thor-internal/irq.hpp
@@ -140,11 +140,17 @@ private:
 	IrqStatus _status = IrqStatus::standBy;
 };
 
-enum class IrqStrategy {
-	null,
-	justEoi,
-	maskThenEoi
-};
+using IrqStrategy = uint32_t;
+
+namespace irq_strategy {
+
+constexpr IrqStrategy maskable = IrqStrategy{1} << 0;
+// Mask the interrupt while its being serviced.
+constexpr IrqStrategy maskInService = IrqStrategy{1} << 1;
+// Whether sendEoi() should be called.
+constexpr IrqStrategy endOfInterrupt = IrqStrategy{1} << 8;
+
+} // namespace irq_strategy
 
 // Represents a (not necessarily physical) "pin" of an interrupt controller.
 // This class handles the IRQ configuration and acknowledgement.


### PR DESCRIPTION
This makes it easier to support the PLIC (and in a future PR, also the IMSIC). In particular, level-triggered PLIC interrupts need to be completed when they exit service (and not when the synchronous IRQ handler completes).