### PR TITLE
posix: Remove various exceptions, replace by error returns

### DIFF
--- a/posix/subsystem/src/file.cpp
+++ b/posix/subsystem/src/file.cpp
@@ -328,7 +328,7 @@ void File::handleClose() {
 async::result<frg::expected<Error, size_t>> File::writeAll(Process *, const void *, size_t) {
 	std::cout << "posix \e[1;34m" << structName()
 			<< "\e[0m: Object does not implement writeAll()" << std::endl;
-	throw std::runtime_error("posix: Object has no File::writeAll()");
+	co_return Error::illegalOperationTarget;
 }
 
 async::result<frg::expected<Error, ControllingTerminalState *>> File::getControllingTerminal() {
@@ -354,7 +354,7 @@ File::recvMsg(Process *, uint32_t, void *, size_t,
 		void *, size_t, size_t) {
 	std::cout << "posix \e[1;34m" << structName()
 			<< "\e[0m: Object does not implement recvMsg()" << std::endl;
-	throw std::runtime_error("posix: Object has no File::recvMsg()");
+	co_return protocols::fs::Error::illegalOperationTarget;
 }
 
 async::result<frg::expected<protocols::fs::Error, size_t>>
@@ -364,7 +364,7 @@ File::sendMsg(Process *, uint32_t,
 		std::vector<smarter::shared_ptr<File, FileHandle>>, struct ucred) {
 	std::cout << "posix \e[1;34m" << structName()
 			<< "\e[0m: Object does not implement sendMsg()" << std::endl;
-	throw std::runtime_error("posix: Object has no File::sendMsg()");
+	co_return protocols::fs::Error::illegalOperationTarget;
 }
 
 async::result<frg::expected<protocols::fs::Error>> File::truncate(size_t) {
@@ -376,7 +376,7 @@ async::result<frg::expected<protocols::fs::Error>> File::truncate(size_t) {
 async::result<frg::expected<protocols::fs::Error>> File::allocate(int64_t, size_t) {
 	std::cout << "posix \e[1;34m" << structName()
 			<< "\e[0m: Object does not implement allocate()" << std::endl;
-	throw std::runtime_error("posix: Object has no File::allocate()");
+	co_return protocols::fs::Error::illegalOperationTarget;
 }
 
 async::result<frg::expected<Error, off_t>> File::seek(off_t, VfsSeek) {
@@ -385,14 +385,14 @@ async::result<frg::expected<Error, off_t>> File::seek(off_t, VfsSeek) {
 	}else{
 		std::cout << "posix \e[1;34m" << structName()
 				<< "\e[0m: Object does not implement seek()" << std::endl;
-		throw std::runtime_error("posix: Object has no File::seek()");
+		co_return Error::illegalOperationTarget;
 	}
 }
 
 expected<PollResult> File::poll(Process *, uint64_t, async::cancellation_token) {
 	std::cout << "posix \e[1;34m" << structName()
 			<< "\e[0m: Object does not implement poll()" << std::endl;
-	throw std::runtime_error("posix: Object has no File::poll()");
+	co_return Error::illegalOperationTarget;
 }
 
 async::result<frg::expected<Error, PollWaitResult>> File::pollWait(Process *process,
@@ -426,19 +426,19 @@ async::result<frg::expected<Error, PollStatusResult>> File::pollStatus(Process *
 async::result<frg::expected<Error, AcceptResult>> File::accept(Process *) {
 	std::cout << "posix \e[1;34m" << structName()
 			<< "\e[0m: Object does not implement accept()" << std::endl;
-	throw std::runtime_error("posix: Object has no File::accept()");
+	co_return Error::illegalOperationTarget;
 }
 
 async::result<protocols::fs::Error> File::bind(Process *, const void *, size_t) {
 	std::cout << "posix \e[1;34m" << structName()
 			<< "\e[0m: Object does not implement bind()" << std::endl;
-	throw std::runtime_error("posix: Object has no File::bind()");
+	co_return protocols::fs::Error::illegalOperationTarget;
 }
 
 async::result<protocols::fs::Error> File::connect(Process *, const void *, size_t) {
 	std::cout << "posix \e[1;34m" << structName()
 			<< "\e[0m: Object does not implement connect()" << std::endl;
-	throw std::runtime_error("posix: Object has no File::connect()");
+	co_return protocols::fs::Error::illegalOperationTarget;
 }
 
 async::result<protocols::fs::Error> File::listen() {

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -82,7 +82,8 @@ VfsType FsNode::getType() {
 }
 
 async::result<frg::expected<Error, FileStats>> FsNode::getStats() {
-	throw std::runtime_error("getStats() is not implemented for this FsNode");
+	std::cout << "posix: getStats() is not implemented for this FsNode" << std::endl;
+	co_return Error::illegalOperationTarget;
 }
 
 std::shared_ptr<FsLink> FsNode::treeLink() {
@@ -112,7 +113,8 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::getLink(std
 }
 
 async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::link(std::string, std::shared_ptr<FsNode>) {
-	throw std::runtime_error("link() is not implemented for this FsNode");
+	std::cout << "posix: link() is not implemented for this FsNode" << std::endl;
+	co_return Error::illegalOperationTarget;
 }
 
 async::result<std::variant<Error, std::shared_ptr<FsLink>>>
@@ -150,7 +152,8 @@ async::result<frg::expected<Error>> FsNode::rmdir(std::string) {
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 FsNode::open(std::shared_ptr<MountView>, std::shared_ptr<FsLink>, SemanticFlags) {
-	throw std::runtime_error("open() is not implemented for this FsNode");
+	std::cout << "posix: open() is not implemented for this FsNode" << std::endl;
+	co_return Error::illegalOperationTarget;
 }
 
 expected<std::string> FsNode::readSymlink(FsLink *, Process *) {
@@ -166,7 +169,8 @@ bool FsNode::hasTraverseLinks() {
 }
 
 async::result<frg::expected<Error, std::pair<std::shared_ptr<FsLink>, size_t>>> FsNode::traverseLinks(std::deque<std::string>) {
-	throw std::runtime_error("traverseLinks() is not implemented for this FsNode");
+	std::cout << "posix: traverseLinks() is not implemented for this FsNode" << std::endl;
+	co_return Error::illegalOperationTarget;
 }
 
 async::result<Error> FsNode::chmod(int mode) {

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -77,10 +77,6 @@ std::optional<std::string> FsLink::getProcFsDescription() {
 // FsNode implementation.
 // --------------------------------------------------------
 
-VfsType FsNode::getType() {
-	throw std::runtime_error("getType() is not implemented for this FsNode");
-}
-
 async::result<frg::expected<Error, FileStats>> FsNode::getStats() {
 	std::cout << "posix: getStats() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -134,7 +134,7 @@ protected:
 	~FsNode() = default;
 
 public:
-	virtual VfsType getType();
+	virtual VfsType getType() = 0;
 
 	// TODO: This should be async.
 	virtual async::result<frg::expected<Error, FileStats>> getStats();

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -1,5 +1,6 @@
 #include <functional>
 #include <linux/magic.h>
+#include <print>
 #include <string.h>
 #include <sstream>
 #include <iomanip>
@@ -705,7 +706,7 @@ async::result<std::string> StatNode::show(Process *) {
 
 async::result<void> StatNode::store(std::string) {
 	// TODO: proper error reporting.
-	throw std::runtime_error("Can't store to a /proc/stat file!");
+	std::println("Can't store to a /proc/stat file!");
 }
 
 async::result<frg::expected<Error, FileStats>> StatNode::getStats() {
@@ -730,7 +731,7 @@ async::result<std::string> StatmNode::show(Process *) {
 
 async::result<void> StatmNode::store(std::string) {
 	// TODO: proper error reporting.
-	throw std::runtime_error("Can't store to a /proc/statm file!");
+	std::println("Can't store to a /proc/statm file!");
 }
 
 async::result<frg::expected<Error, FileStats>> StatmNode::getStats() {
@@ -820,7 +821,7 @@ async::result<std::string> StatusNode::show(Process *) {
 
 async::result<void> StatusNode::store(std::string) {
 	// TODO: proper error reporting.
-	throw std::runtime_error("Can't store to a /proc/status file!");
+	std::println("Can't store to a /proc/status file!");
 }
 
 async::result<frg::expected<Error, FileStats>> StatusNode::getStats() {


### PR DESCRIPTION
This avoids crashes in posix-subsystem that can be triggered from user code.