### PR TITLE
Misc aarch64 fixes for thor

### DIFF
--- a/kernel/thor/arch/arm/timer.cpp
+++ b/kernel/thor/arch/arm/timer.cpp
@@ -92,7 +92,7 @@ static initgraph::Task initTimerIrq{&globalInitEngine, "arm.init-timer-irq",
 		// the virtual one.
 
 		int idx = 0;
-		bool success = dt::walkInterrupts(
+		auto walkInterruptResult = dt::walkInterrupts(
 			[&] (DeviceTreeNode *parentNode, dtb::Cells irqCells) {
 				// This offset is defined in the Linux
 				// DTB binding for compatible nodes.
@@ -104,7 +104,7 @@ static initgraph::Task initTimerIrq{&globalInitEngine, "arm.init-timer-irq",
 				idx++;
 			}, timerNode);
 
-		assert(success && "Failed to parse generic timer interrupts");
+		assert(walkInterruptResult && walkInterruptResult.value() && "Failed to parse generic timer interrupts");
 
 		initTimerOnThisCpu();
 

--- a/kernel/thor/system/dtb/dtb_discover.cpp
+++ b/kernel/thor/system/dtb/dtb_discover.cpp
@@ -58,7 +58,7 @@ struct MbusNode final : private KernelBusObject {
 			);
 		}
 
-		bool success = dt::walkInterrupts(
+		auto walkInterruptResult = dt::walkInterrupts(
 			[&] (DeviceTreeNode *parentNode, dtb::Cells irqCells) {
 				auto object = smarter::allocate_shared<DtIrqObject>(*kernelAlloc,
 						frg::string<KernelAlloc>{*kernelAlloc, "dt-irq."}
@@ -67,7 +67,7 @@ struct MbusNode final : private KernelBusObject {
 						irqCells);
 				irqs.push_back(object);
 			}, node);
-		if(!success)
+		if(walkInterruptResult && !walkInterruptResult.value())
 			warningLogger()
 				<< node->path() << ": failed to parse interrupts for mbus node."
 				<< frg::endlog;

--- a/kernel/thor/system/dtb/thor-internal/dtb/dtb.hpp
+++ b/kernel/thor/system/dtb/thor-internal/dtb/dtb.hpp
@@ -5,6 +5,7 @@
 #include <thor-internal/kernel_heap.hpp>
 #include <initgraph.hpp>
 #include <thor-internal/irq.hpp>
+#include <frg/optional.hpp>
 #include <frg/hash_map.hpp>
 #include <frg/vector.hpp>
 #include <frg/array.hpp>
@@ -239,11 +240,10 @@ static inline frg::array<frg::string_view, 3> dtPciCompatible = {
 namespace dt {
 
 template<typename Fn>
-[[nodiscard]] bool walkInterrupts(Fn fn, DeviceTreeNode *node) {
+[[nodiscard]] frg::optional<bool> walkInterrupts(Fn fn, DeviceTreeNode *node) {
 	auto prop = node->dtNode().findProperty("interrupts");
 	if (!prop) {
-		warningLogger() << node->path() << " has no interrupts" << frg::endlog;
-		return false;
+		return frg::null_opt;
 	}
 
 	auto it = prop->access();


### PR DESCRIPTION
Support using misaligned initrd in thor as it is not always necessarily aligned, remove a spammy log from dt::walkInterrupts and fix an issue with the mbus dt node code where the parent property was sometimes being set to an invalid mbus id.