### PR TITLE
hel: Fix argument types and parameter qualifiers

### DIFF
--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -7,7 +7,7 @@
 #include <hel-types.h>
 #include <hel-stubs.h>
 
-extern inline __attribute__ (( always_inline )) HelError helLog(const HelLogSeverity severity, const char *string,
+extern inline __attribute__ (( always_inline )) HelError helLog(const enum HelLogSeverity severity, const char *string,
 		size_t length) {
 	return helSyscall3(kHelCallLog, severity, (HelWord)string, length);
 };
@@ -61,7 +61,7 @@ extern inline __attribute__ (( always_inline )) HelError helCloseDescriptor(
 };
 
 extern inline __attribute__ (( always_inline )) HelError helCreateQueue(
-		struct HelQueueParameters *params, HelHandle *handle) {
+		const struct HelQueueParameters *params, HelHandle *handle) {
 	HelWord hel_handle;
 	HelError error = helSyscall1_1(kHelCallCreateQueue, (HelWord)params, &hel_handle);
 	*handle = (HelHandle)hel_handle;
@@ -74,7 +74,7 @@ extern inline __attribute__ (( always_inline )) HelError helCancelAsync(HelHandl
 };
 
 extern inline __attribute__ (( always_inline )) HelError helAllocateMemory(size_t size,
-		uint32_t flags, struct HelAllocRestrictions *restrictions, HelHandle *handle) {
+		uint32_t flags, const struct HelAllocRestrictions *restrictions, HelHandle *handle) {
 	HelWord hel_handle;
 	HelError error = helSyscall3_1(kHelCallAllocateMemory, (HelWord)size, (HelWord)flags,
 			(HelWord)restrictions, &hel_handle);

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -192,6 +192,7 @@ enum {
 };
 
 enum {
+	kHelActionNone = 0,
 	kHelActionDismiss = 11,
 	kHelActionOffer = 5,
 	kHelActionAccept = 6,
@@ -603,7 +604,7 @@ enum HelLogSeverity {
 //!    	Text to be written.
 //! @param[in] length
 //! 	Size of the text in bytes.
-HEL_C_LINKAGE HelError helLog(const HelLogSeverity severity, const char *string, size_t length);
+HEL_C_LINKAGE HelError helLog(const enum HelLogSeverity severity, const char *string, size_t length);
 
 //! Kills the current thread and writes an error message to the kernel's log.
 //! @param[in] string
@@ -666,7 +667,11 @@ HEL_C_LINKAGE HelError helCloseDescriptor(HelHandle universeHandle, HelHandle ha
 //! @{
 
 //! Creates an IPC queue.
-HEL_C_LINKAGE HelError helCreateQueue(struct HelQueueParameters *params,
+//! @param[in] params
+//!    	Parameters for the queue.
+//! @param[out] handle
+//!    	Handle to the newly created queue.
+HEL_C_LINKAGE HelError helCreateQueue(const struct HelQueueParameters *params,
 		HelHandle *handle);
 
 //! Cancels an ongoing asynchronous operation.
@@ -690,7 +695,7 @@ HEL_C_LINKAGE HelError helCancelAsync(HelHandle queueHandle, uint64_t asyncId);
 //! @param[out] handle
 //!    	Handle to the new memory object.
 HEL_C_LINKAGE HelError helAllocateMemory(size_t size, uint32_t flags,
-		struct HelAllocRestrictions *restrictions, HelHandle *handle);
+		const struct HelAllocRestrictions *restrictions, HelHandle *handle);
 
 //! Resizes a memory object.
 //! @param[in] handle

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -369,7 +369,7 @@ HelError helCloseDescriptor(HelHandle universeHandle, HelHandle handle) {
 	return kHelErrNone;
 }
 
-HelError helCreateQueue(HelQueueParameters *paramsPtr, HelHandle *handle) {
+HelError helCreateQueue(const HelQueueParameters *paramsPtr, HelHandle *handle) {
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
@@ -417,7 +417,7 @@ HelError helCancelAsync(HelHandle handle, uint64_t async_id) {
 }
 
 HelError helAllocateMemory(size_t size, uint32_t flags,
-		HelAllocRestrictions *restrictions, HelHandle *handle) {
+		const HelAllocRestrictions *restrictions, HelHandle *handle) {
 	if(!size)
 		return kHelErrIllegalArgs;
 	if(size & (kPageSize - 1))

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -579,7 +579,7 @@ void handleSyscall(SyscallImageAccessor image) {
 
 	case kHelCallCreateQueue: {
 		HelHandle handle;
-		*image.error() = helCreateQueue((HelQueueParameters *)arg0, &handle);
+		*image.error() = helCreateQueue((const HelQueueParameters *)arg0, &handle);
 		*image.out0() = handle;
 	} break;
 	case kHelCallCancelAsync: {
@@ -589,7 +589,7 @@ void handleSyscall(SyscallImageAccessor image) {
 	case kHelCallAllocateMemory: {
 		HelHandle handle;
 		*image.error() = helAllocateMemory((size_t)arg0, (uint32_t)arg1,
-				(HelAllocRestrictions *)arg2, &handle);
+				(const HelAllocRestrictions *)arg2, &handle);
 		*image.out0() = handle;
 	} break;
 	case kHelCallResizeMemory: {


### PR DESCRIPTION
This makes it possible to include the hel headers from C source files. Also added a `kHelActionNone` constant because there wasn't one and it's useful for my WIP Rust bindings.