### PR TITLE
Add scsi abstraction

### DIFF
--- a/drivers/libblockfs/include/scsi.hpp
+++ b/drivers/libblockfs/include/scsi.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <blockfs.hpp>
+
+#include <arch/dma_structs.hpp>
+#include <async/recurring-event.hpp>
+#include <frg/list.hpp>
+
+#include <string>
+
+namespace scsi {
+
+enum class ErrorType {
+	success,
+	checkCondition,
+	conditionMet,
+	busy,
+	reservationConflict,
+	taskSetFull,
+	acaActive,
+	taskAborted,
+	deviceSpecific
+};
+
+struct Error {
+	constexpr bool operator==(const Error &other) const = default;
+
+	std::string toString();
+
+	ErrorType type;
+	uint32_t code;
+};
+
+struct CommandInfo {
+	arch::dma_buffer_view command;
+	arch::dma_buffer_view data;
+	bool isWrite;
+};
+
+Error statusToError(uint8_t status);
+
+struct Interface {
+	virtual ~Interface() = default;
+	virtual async::result<frg::expected<Error, size_t>> sendScsiCommand(const CommandInfo &info) = 0;
+
+	async::result<frg::expected<Error, std::vector<uint64_t>>> reportLuns();
+
+	bool enableRead6{};
+};
+
+struct StorageDevice : Interface, blockfs::BlockDevice {
+	StorageDevice(size_t sectorSize, int64_t parentId)
+	: blockfs::BlockDevice(sectorSize, parentId) { }
+
+	async::detached runScsi();
+
+	async::result<void> readSectors(uint64_t sector,
+			void *buffer, size_t numSectors) final;
+
+	async::result<void> writeSectors(uint64_t sector,
+			const void *buffer, size_t numSectors) final;
+
+	async::result<size_t> getSize() final;
+
+	size_t storageSize{};
+
+private:
+	struct Request {
+		Request(bool isWrite, uint64_t sector, void *buffer, size_t numSectors)
+		: isWrite{isWrite}, sector{sector}, buffer{buffer}, numSectors{numSectors} { }
+
+		bool isWrite;
+		uint64_t sector;
+		void *buffer;
+		size_t numSectors;
+		async::oneshot_event event;
+		frg::default_list_hook<Request> requestHook;
+	};
+
+	async::recurring_event doorbell_;
+
+	frg::intrusive_list<
+		Request,
+		frg::locate_member<Request, frg::default_list_hook<Request>, &Request::requestHook>
+	> queue_;
+};
+
+inline constexpr uint8_t WELL_KNOWN_REPORT_LUNS_LUN = 1;
+
+} // namespace scsi

--- a/drivers/libblockfs/meson.build
+++ b/drivers/libblockfs/meson.build
@@ -1,6 +1,12 @@
-src = [ 'src/libblockfs.cpp', 'src/gpt.cpp', 'src/ext2fs.cpp' , 'src/raw.cpp' ]
+src = [
+	'src/libblockfs.cpp',
+	'src/gpt.cpp',
+	'src/ext2fs.cpp',
+	'src/raw.cpp',
+	'src/scsi.cpp',
+]
 inc = [ 'include' ]
-deps = [ fs_proto_dep, mbus_proto_dep, ostrace_proto_dep ]
+deps = [ libarch, core_dep, fs_proto_dep, mbus_proto_dep, ostrace_proto_dep ]
 
 libblockfs_driver = shared_library('blockfs', src,
 	dependencies : deps,

--- a/drivers/libblockfs/src/scsi.cpp
+++ b/drivers/libblockfs/src/scsi.cpp
@@ -1,0 +1,288 @@
+#include "scsi.hpp"
+
+#include <arch/bit.hpp>
+#include <core/logging.hpp>
+
+#include <format>
+#include <print>
+
+namespace {
+	constexpr bool logRequests = false;
+	constexpr bool logSteps = false;
+}
+
+namespace scsi {
+
+struct Read6 {
+	uint8_t opCode;
+	uint8_t lba[3];
+	uint8_t transferLength;
+	uint8_t control;
+};
+static_assert(sizeof(Read6) == 6);
+
+struct Read10 {
+	uint8_t opCode;
+	uint8_t options;
+	uint8_t lba[4];
+	uint8_t groupNumber;
+	uint8_t transferLength[2];
+	uint8_t control;
+};
+static_assert(sizeof(Read10) == 10);
+
+struct Write10 {
+	uint8_t opCode;
+	uint8_t options;
+	uint8_t lba[4];
+	uint8_t groupNumber;
+	uint8_t transferLength[2];
+	uint8_t control;
+};
+static_assert(sizeof(Write10) == 10);
+
+struct Read12 {
+	uint8_t opCode;
+	uint8_t options;
+	uint8_t lba[4];
+	uint8_t transferLength[4];
+	uint8_t grpNumber;
+	uint8_t control;
+};
+
+struct Read16 {
+	uint8_t opCode;
+	uint8_t options;
+	uint8_t lba[8];
+	uint8_t transferLength[4];
+	uint8_t grpNumber;
+	uint8_t control;
+};
+
+struct Read32 {
+	uint8_t opCode;
+	uint8_t control;
+	uint32_t no_use;
+	uint8_t grpNumber;
+	uint8_t cdbLength;
+	uint8_t serviceAction[2];
+	uint8_t options;
+	uint8_t no_use2;
+	uint8_t lba[8];
+	uint8_t referenceTag[4];
+	uint8_t applicationTag[2];
+	uint8_t applicationTagMask[2];
+	uint8_t transferLength[4];
+};
+
+struct ReportLuns {
+	uint8_t opCode;
+	uint8_t reserved0;
+	uint8_t selectReport;
+	uint8_t reserved1[3];
+	uint8_t allocationLength[4];
+	uint8_t reserved2;
+	uint8_t control;
+};
+
+Error statusToError(uint8_t status) {
+	switch (status) {
+	case 0:
+		return {.type = ErrorType::success, .code = 0};
+	case 2:
+		return {.type = ErrorType::checkCondition, .code = 2};
+	case 4:
+		return {.type = ErrorType::conditionMet, .code = 4};
+	case 8:
+		return {.type = ErrorType::busy, .code = 8};
+	case 0x18:
+		return {.type = ErrorType::reservationConflict, .code = 0x18};
+	case 0x28:
+		return {.type = ErrorType::taskSetFull, .code = 0x28};
+	case 0x30:
+		return {.type = ErrorType::acaActive, .code = 0x30};
+	case 0x40:
+		return {.type = ErrorType::taskAborted, .code = 0x40};
+	default:
+		return {.type = ErrorType::deviceSpecific, .code = status};
+	}
+}
+
+std::string Error::toString() {
+	std::string_view errorName;
+	switch (type) {
+	case ErrorType::success:
+		errorName = "SCSI_SUCCESS";
+		break;
+	case ErrorType::checkCondition:
+		errorName = "SCSI_CHECK_CONDITION";
+		break;
+	case ErrorType::conditionMet:
+		errorName = "SCSI_CONDITION_MET";
+		break;
+	case ErrorType::busy:
+		errorName = "SCSI_BUSY";
+		break;
+	case ErrorType::reservationConflict:
+		errorName = "SCSI_RESERVATION_CONFLICT";
+		break;
+	case ErrorType::taskSetFull:
+		errorName = "SCSI_TASK_SET_FULL";
+		break;
+	case ErrorType::acaActive:
+		errorName = "SCSI_ACA_ACTIVE";
+		break;
+	case ErrorType::taskAborted:
+		errorName = "SCSI_TASK_ABORTED";
+		break;
+	case ErrorType::deviceSpecific:
+		errorName = "DEVICE_SPECIFIC";
+		break;
+	}
+
+	return std::format("{} (code {:#x})", errorName, code);
+}
+
+async::result<frg::expected<Error, std::vector<uint64_t>>> Interface::reportLuns() {
+	ReportLuns command{};
+	command.opCode = 0xa0;
+	command.selectReport = 0;
+	command.allocationLength[3] = 4;
+
+	uint32_t lunListLength = 0;
+
+	CommandInfo info{
+		.command{nullptr, &command, sizeof(command)},
+		.data{nullptr, &lunListLength, 4},
+		.isWrite = false
+	};
+	auto result = co_await sendScsiCommand(info);
+	if (!result) {
+		co_return result.error();
+	}
+
+	lunListLength = arch::from_endian<arch::big_endian, uint32_t>(lunListLength);
+
+	std::vector<uint64_t> data((lunListLength + 8) / 8);
+	info.data = arch::dma_buffer_view{nullptr, data.data(), data.size() * 8};
+
+	command.allocationLength[0] = data.size() >> 24;
+	command.allocationLength[1] = data.size() >> 16;
+	command.allocationLength[2] = data.size() >> 8;
+	command.allocationLength[3] = data.size();
+
+	result = co_await sendScsiCommand(info);
+	if (!result) {
+		co_return result.error();
+	}
+
+	data[0] = arch::from_endian<arch::big_endian, uint32_t>(data[0] & 0xffffffff);
+	co_return data;
+}
+
+async::detached StorageDevice::runScsi() {
+	while (true) {
+		if (queue_.empty()) {
+			co_await doorbell_.async_wait();
+			continue;
+		}
+
+		auto req = queue_.pop_front();
+
+		if (logRequests)
+			std::println(std::cout, "block-scsi: Reading {} sectors", req->numSectors);
+		assert(req->numSectors);
+		assert(req->numSectors <= 0xffff);
+
+		uint8_t commandData[16];
+		uint8_t commandLength;
+
+		if (!req->isWrite) {
+			if (enableRead6 && req->sector <= 0x1fffff && req->numSectors <= 0xff) {
+				Read6 command{};
+				command.opCode = 0x08;
+				command.lba[0] = req->sector >> 16;
+				command.lba[1] = (req->sector >> 8) & 0xff;
+				command.lba[2] = req->sector & 0xff;
+				command.transferLength = req->numSectors;
+
+				commandLength = sizeof(Read6);
+				memcpy(commandData, &command, sizeof(Read6));
+			} else if (req->sector <= 0xffffffff) {
+				Read10 command{};
+				command.opCode = 0x28;
+				command.lba[0] = req->sector >> 24;
+				command.lba[1] = (req->sector >> 16) & 0xff;
+				command.lba[2] = (req->sector >> 8) & 0xff;
+				command.lba[3] = req->sector & 0xff;
+				command.transferLength[0] = req->numSectors >> 8;
+				command.transferLength[1] = req->numSectors & 0xff;
+
+				commandLength = sizeof(Read10);
+				memcpy(commandData, &command, sizeof(Read10));
+			} else {
+				logPanic("block-scsi: High LBAs are not supported!");
+			}
+		} else {
+			if (req->sector <= 0xffffffff) {
+				Write10 command{};
+				command.opCode = 0x2a;
+				command.lba[0] = req->sector >> 24;
+				command.lba[1] = (req->sector >> 16) & 0xff;
+				command.lba[2] = (req->sector >> 8) & 0xff;
+				command.lba[3] = req->sector & 0xff;
+				command.transferLength[0] = req->numSectors >> 8;
+				command.transferLength[1] = req->numSectors & 0xff;
+
+				commandLength = sizeof(Write10);
+				memcpy(commandData, &command, sizeof(Write10));
+			} else {
+				logPanic("block-scsi: High LBAs are not supported!");
+			}
+		}
+
+		if (logSteps)
+			std::println(std::cout, "block-scsi: Sending command");
+
+		CommandInfo info{
+			.command{nullptr, commandData, commandLength},
+			.data{nullptr, req->buffer, req->numSectors * sectorSize},
+			.isWrite = req->isWrite
+		};
+		auto result = co_await sendScsiCommand(info);
+		if (!result) {
+			logPanic("block-scsi: Request failed with error {}",
+					result.error().toString());
+		}
+
+		if (logSteps)
+			std::println(std::cout, "block-scsi: Request complete");
+
+		req->event.raise();
+	}
+}
+
+async::result<void> StorageDevice::readSectors(uint64_t sector,
+		void *buffer, size_t numSectors) {
+	Request req{false, sector, buffer, numSectors};
+	queue_.push_back(&req);
+	doorbell_.raise();
+	co_await req.event.wait();
+}
+
+async::result<void> StorageDevice::writeSectors(uint64_t sector,
+		const void *buffer, size_t numSectors) {
+	Request req{true, sector, const_cast<void *>(buffer), numSectors};
+	queue_.push_back(&req);
+	doorbell_.raise();
+	co_await req.event.wait();
+}
+
+async::result<size_t> StorageDevice::getSize() {
+	if (!storageSize) {
+		std::println(std::cout, "block-scsi: StorageDevice has no size!");
+	}
+	co_return storageSize;
+}
+
+} // namespace scsi

--- a/drivers/usb/devices/storage/src/main.cpp
+++ b/drivers/usb/devices/storage/src/main.cpp
@@ -17,17 +17,16 @@
 
 namespace {
 	constexpr bool logEnumeration = false;
-	constexpr bool logRequests = false;
 	constexpr bool logSteps = false;
-
-	// I own a USB key that does not support the READ6 command. ~AvdG
-	constexpr bool enableRead6 = false;
 }
 
 namespace proto = protocols::usb;
 
 async::detached StorageDevice::run(int config_num, int intf_num) {
-	auto descriptor = (co_await _usbDevice.configurationDescriptor(0)).unwrap();
+	// I own a USB key that does not support the READ6 command. ~AvdG
+	enableRead6 = false;
+
+	auto descriptor = (co_await usbDevice_.configurationDescriptor(0)).unwrap();
 
 	std::optional<int> in_endp_number;
 	std::optional<int> out_endp_number;
@@ -50,152 +49,71 @@ async::detached StorageDevice::run(int config_num, int intf_num) {
 	if(logSteps)
 		std::cout << "block-usb: Setting up configuration" << std::endl;
 
-	auto config = (co_await _usbDevice.useConfiguration(0, config_num)).unwrap();
+	auto config = (co_await usbDevice_.useConfiguration(0, config_num)).unwrap();
 	auto intf = (co_await config.useInterface(intf_num, 0)).unwrap();
-	auto endp_in = (co_await intf.getEndpoint(proto::PipeType::in, in_endp_number.value())).unwrap();
-	auto endp_out = (co_await intf.getEndpoint(proto::PipeType::out, out_endp_number.value())).unwrap();
+	endp_in_ = (co_await intf.getEndpoint(proto::PipeType::in, in_endp_number.value())).unwrap();
+	endp_out_ = (co_await intf.getEndpoint(proto::PipeType::out, out_endp_number.value())).unwrap();
 
 	if(logSteps)
 		std::cout << "block-usb: Device is ready" << std::endl;
 
-	while(true) {
-		if(!_queue.empty()) {
-			auto req = &_queue.front();
-			_queue.pop_front();
+	runScsi();
+}
 
-			if(logRequests)
-				std::cout << "block-usb: Reading " << req->numSectors << " sectors" << std::endl;
-			assert(req->numSectors);
-			assert(req->numSectors <= 0xFFFF);
-
-			CommandBlockWrapper cbw;
-			memset(&cbw, 0, sizeof(CommandBlockWrapper));
-			cbw.signature = Signatures::kSignCbw;
-			cbw.tag = 1;
-			cbw.transferLength = req->numSectors * 512;
-			if(!req->isWrite) {
-				cbw.flags = 0x80; // Direction: Device-to-Host.
-			}else{
-				cbw.flags = 0; // Direction: Host-to-Device.
-			}
-			cbw.lun = 0;
-
-			if(!req->isWrite) {
-				if(enableRead6 && req->sector <= 0x1FFFFF && req->numSectors <= 0xFF) {
-					scsi::Read6 command;
-					memset(&command, 0, sizeof(scsi::Read6));
-					command.opCode = 0x08;
-					command.lba[0] = req->sector >> 16;
-					command.lba[1] = (req->sector >> 8) & 0xFF;
-					command.lba[2] = req->sector & 0xFF;
-					command.transferLength = req->numSectors;
-
-					cbw.cmdLength = sizeof(scsi::Read6);
-					memcpy(cbw.cmdData, &command, sizeof(scsi::Read6));
-				}else if(req->sector <= 0xFFFFFFFF) {
-					scsi::Read10 command;
-					memset(&command, 0, sizeof(scsi::Read10));
-					command.opCode = 0x28;
-					command.lba[0] = req->sector >> 24;
-					command.lba[1] = (req->sector >> 16) & 0xFF;
-					command.lba[2] = (req->sector >> 8) & 0xFF;
-					command.lba[3] = req->sector & 0xFF;
-					command.transferLength[0] = req->numSectors >> 8;
-					command.transferLength[1] = req->numSectors & 0xFF;
-
-					cbw.cmdLength = sizeof(scsi::Read10);
-					memcpy(cbw.cmdData, &command, sizeof(scsi::Read10));
-				}else{
-					throw std::logic_error("USB storage does not currently support high LBAs!");
-				}
-			}else{
-				if(req->sector <= 0xFFFFFFFF) {
-					scsi::Write10 command;
-					memset(&command, 0, sizeof(scsi::Write10));
-					command.opCode = 0x2A;
-					command.lba[0] = req->sector >> 24;
-					command.lba[1] = (req->sector >> 16) & 0xFF;
-					command.lba[2] = (req->sector >> 8) & 0xFF;
-					command.lba[3] = req->sector & 0xFF;
-					command.transferLength[0] = req->numSectors >> 8;
-					command.transferLength[1] = req->numSectors & 0xFF;
-
-					cbw.cmdLength = sizeof(scsi::Write10);
-					memcpy(cbw.cmdData, &command, sizeof(scsi::Write10));
-				}else{
-					throw std::logic_error("USB storage does not currently support high LBAs!");
-				}
-			}
-
-			// TODO: Respect USB device DMA requirements.
-
-			// TODO: Ideally, we want to post the IN-transfer first.
-			// We do this to try to avoid unnecessary IRQs
-			// and round-trips to the device and host-controller driver.
-			CommandStatusWrapper csw;
-
-			if(logSteps)
-				std::cout << "block-usb: Sending CBW" << std::endl;
-			(co_await endp_out.transfer(proto::BulkTransfer{proto::XferFlags::kXferToDevice,
-					arch::dma_buffer_view{nullptr, &cbw, sizeof(CommandBlockWrapper)}})).unwrap();
-
-			if(logSteps)
-				std::cout << "block-usb: Waiting for data" << std::endl;
-			if(!req->isWrite) {
-				proto::BulkTransfer data_info{proto::XferFlags::kXferToHost,
-						arch::dma_buffer_view{nullptr, req->buffer, req->numSectors * 512}};
-				// TODO: We want this to be lazy but that only works if can ensure that
-				// the next transaction is also posted to the queue.
-	//			data_info.lazyNotification = true;
-				(co_await endp_in.transfer(data_info)).unwrap();
-			}else{
-				(co_await endp_out.transfer(proto::BulkTransfer{proto::XferFlags::kXferToDevice,
-						arch::dma_buffer_view{nullptr, req->buffer, req->numSectors * 512}})).unwrap();
-			}
-
-			if(logSteps)
-				std::cout << "block-usb: Waiting for CSW" << std::endl;
-			(co_await endp_in.transfer(proto::BulkTransfer{proto::XferFlags::kXferToHost,
-					arch::dma_buffer_view{nullptr, &csw, sizeof(CommandStatusWrapper)}})).unwrap();
-
-			if(logSteps)
-				std::cout << "block-usb: Request complete" << std::endl;
-			assert(csw.signature == Signatures::kSignCsw);
-			assert(csw.tag == 1);
-			assert(!csw.dataResidue);
-			if(csw.status) {
-				std::cout << "block-usb: Error status 0x"
-						<< std::hex << (unsigned int)csw.status << std::dec
-						<<  " in CSW" << std::endl;
-				throw std::runtime_error("block-usb: Giving up");
-			}
-
-			req->event.raise();
-		}else{
-			co_await _doorbell.async_wait();
-		}
+async::result<frg::expected<scsi::Error, size_t>> StorageDevice::sendScsiCommand(const scsi::CommandInfo &info) {
+	CommandBlockWrapper cbw{};
+	cbw.signature = Signatures::kSignCbw;
+	cbw.tag = 1;
+	cbw.transferLength = info.data.size();
+	if(!info.isWrite) {
+		cbw.flags = 0x80; // Direction: Device-to-Host.
+	}else{
+		cbw.flags = 0; // Direction: Host-to-Device.
 	}
-}
+	cbw.lun = 0;
 
-async::result<void> StorageDevice::readSectors(uint64_t sector,
-		void *buffer, size_t numSectors) {
-	Request req{false, sector, buffer, numSectors};
-	_queue.push_back(req);
-	_doorbell.raise();
-	co_await req.event.wait();
-}
+	cbw.cmdLength = info.command.size();
+	memcpy(cbw.cmdData, info.command.data(), info.command.size());
 
-async::result<void> StorageDevice::writeSectors(uint64_t sector,
-		const void *buffer, size_t numSectors) {
-	Request req{true, sector, const_cast<void *>(buffer), numSectors};
-	_queue.push_back(req);
-	_doorbell.raise();
-	co_await req.event.wait();
-}
+	// TODO: Respect USB device DMA requirements.
 
-async::result<size_t> StorageDevice::getSize() {
-	std::cout << "usb: StorageDevice::getSize() is a stub!" << std::endl;
-	co_return 0;
+	// TODO: Ideally, we want to post the IN-transfer first.
+	// We do this to try to avoid unnecessary IRQs
+	// and round-trips to the device and host-controller driver.
+	CommandStatusWrapper csw;
+
+	if(logSteps)
+		std::cout << "block-usb: Sending CBW" << std::endl;
+	(co_await endp_out_.transfer(proto::BulkTransfer{proto::XferFlags::kXferToDevice,
+			arch::dma_buffer_view{nullptr, &cbw, sizeof(CommandBlockWrapper)}})).unwrap();
+
+	if(logSteps)
+		std::cout << "block-usb: Waiting for data" << std::endl;
+	if(!info.isWrite) {
+		proto::BulkTransfer data_info{proto::XferFlags::kXferToHost, info.data};
+		// TODO: We want this to be lazy but that only works if can ensure that
+		// the next transaction is also posted to the queue.
+//			data_info.lazyNotification = true;
+		(co_await endp_in_.transfer(data_info)).unwrap();
+	}else{
+		(co_await endp_out_.transfer(proto::BulkTransfer{proto::XferFlags::kXferToDevice, info.data})).unwrap();
+	}
+
+	if(logSteps)
+		std::cout << "block-usb: Waiting for CSW" << std::endl;
+	(co_await endp_in_.transfer(proto::BulkTransfer{proto::XferFlags::kXferToHost,
+			arch::dma_buffer_view{nullptr, &csw, sizeof(CommandStatusWrapper)}})).unwrap();
+
+	if(logSteps)
+		std::cout << "block-usb: Request complete" << std::endl;
+	assert(csw.signature == Signatures::kSignCsw);
+	assert(csw.tag == 1);
+	assert(!csw.dataResidue);
+	if(csw.status) {
+		co_return scsi::statusToError(csw.status);
+	}
+
+	co_return info.data.size();
 }
 
 async::detached bindDevice(mbus_ng::Entity entity) {
@@ -255,7 +173,7 @@ async::detached bindDevice(mbus_ng::Entity entity) {
 	if(logEnumeration)
 		std::cout << "block-usb: Detected USB device" << std::endl;
 
-	auto storage_device = new StorageDevice(device);
+	auto storage_device = new StorageDevice(device, entity.id());
 	storage_device->run(config_number.value(), intf_number.value());
 	blockfs::runDevice(storage_device);
 }

--- a/drivers/usb/devices/storage/src/storage.hpp
+++ b/drivers/usb/devices/storage/src/storage.hpp
@@ -1,8 +1,8 @@
-
 #include <async/recurring-event.hpp>
 #include <async/oneshot-event.hpp>
 #include <async/result.hpp>
 #include <blockfs.hpp>
+#include <scsi.hpp>
 #include <boost/intrusive/list.hpp>
 
 enum Signatures {
@@ -29,110 +29,18 @@ struct [[ gnu::packed ]] CommandStatusWrapper {
 };
 static_assert(sizeof(CommandStatusWrapper) == 13);
 
-namespace scsi {
-
-struct Read6 {
-	uint8_t opCode;
-	uint8_t lba[3];
-	uint8_t transferLength;
-	uint8_t control;
-};
-static_assert(sizeof(Read6) == 6);
-
-struct Read10 {
-	uint8_t opCode;
-	uint8_t options;
-	uint8_t lba[4];
-	uint8_t groupNumber;
-	uint8_t transferLength[2];
-	uint8_t control;
-};
-static_assert(sizeof(Read10) == 10);
-
-struct Write10 {
-	uint8_t opCode;
-	uint8_t options;
-	uint8_t lba[4];
-	uint8_t groupNumber;
-	uint8_t transferLength[2];
-	uint8_t control;
-};
-static_assert(sizeof(Write10) == 10);
-
-struct Read12 {
-	uint8_t opCode;
-	uint8_t options;
-	uint8_t lba[4];
-	uint8_t transferLength[4];
-	uint8_t grpNumber;
-	uint8_t control;
-};
-
-struct Read16 {
-	uint8_t opCode;
-	uint8_t options;
-	uint8_t lba[8];
-	uint8_t transferLength[4];
-	uint8_t grpNumber;
-	uint8_t control;
-};
-
-struct Read32 {
-	uint8_t opCode;
-	uint8_t control;
-	uint32_t no_use;
-	uint8_t grpNumber;
-	uint8_t cdbLength;
-	uint8_t serviceAction[2];
-	uint8_t options;
-	uint8_t no_use2;
-	uint8_t lba[8];
-	uint8_t referenceTag[4];
-	uint8_t applicationTag[2];
-	uint8_t applicationTagMask[2];
-	uint8_t transferLength[4];
-};
-
-} // namespace scsi
-
-struct StorageDevice : blockfs::BlockDevice {
-	//TODO(geert): hook up USB to sysfs too
-	StorageDevice(protocols::usb::Device usb_device)
-	: blockfs::BlockDevice(512, -1), _usbDevice(std::move(usb_device)) { }
+struct StorageDevice : scsi::StorageDevice {
+	StorageDevice(protocols::usb::Device usb_device, int64_t parent_id)
+	: scsi::StorageDevice(512, parent_id), usbDevice_(std::move(usb_device)),
+		endp_in_{nullptr}, endp_out_{nullptr} { }
 
 	async::detached run(int config_num, int intf_num);
 
-	async::result<void> readSectors(uint64_t sector,
-			void *buffer, size_t numSectors) override;
-
-	async::result<void> writeSectors(uint64_t sector,
-			const void *buffer, size_t numSectors) override;
-
-	async::result<size_t> getSize() override;
+	async::result<frg::expected<scsi::Error, size_t>> sendScsiCommand(const scsi::CommandInfo &info) override;
 
 private:
-	struct Request {
-		Request(bool isWrite, uint64_t sector, void *buffer, size_t numSectors)
-		: isWrite{isWrite}, sector{sector}, buffer{buffer}, numSectors{numSectors} { }
-
-		bool isWrite;
-		uint64_t sector;
-		void *buffer;
-		size_t numSectors;
-		async::oneshot_event event;
-		boost::intrusive::list_member_hook<> requestHook;
-	};
-
-	protocols::usb::Device _usbDevice;
-	async::recurring_event _doorbell;
-
-	boost::intrusive::list<
-		Request,
-		boost::intrusive::member_hook<
-			Request,
-			boost::intrusive::list_member_hook<>,
-			&Request::requestHook
-		>
-	> _queue;
+	protocols::usb::Device usbDevice_;
+	protocols::usb::Endpoint endp_in_;
+	protocols::usb::Endpoint endp_out_;
 };
 


### PR DESCRIPTION
Add an abstraction for scsi and use it for usb-storage. Also fill the parent property of BlockDevice to fix a regression introduced in 9760ccf552b7e96bec7515f6fb5fe545b77fe733 where if the device would have no parent it would create the device link in the subsystem's sysfs twice resulting in an assert fail.