### PR TITLE
Fix aarch64 gdbservers

### DIFF
--- a/kernel/thor/generic/gdbserver.cpp
+++ b/kernel/thor/generic/gdbserver.cpp
@@ -348,9 +348,9 @@ coroutine<frg::expected<ProtocolError>> GdbServer::handleRequest_() {
 				resp.appendString("xx");
 #elif defined (__aarch64__)
 		for (int i = 0; i < 31; i++)
-			resp.appendLeHex32(thread_->_executor.general()->x[i]);
-		resp.appendLeHex32(thread_->_executor.general()->sp);
-		resp.appendLeHex32(thread_->_executor.general()->elr);
+			resp.appendLeHex64(thread_->_executor.general()->x[i]);
+		resp.appendLeHex64(thread_->_executor.general()->sp);
+		resp.appendLeHex64(thread_->_executor.general()->elr);
 		resp.appendLeHex32(thread_->_executor.general()->spsr);
 #elif defined(__riscv) && __riscv_xlen == 64
 		warningLogger() << "GDB server is unimplemented for RISC-V" << frg::endlog;

--- a/posix/subsystem/src/gdbserver.cpp
+++ b/posix/subsystem/src/gdbserver.cpp
@@ -375,6 +375,13 @@ async::result<frg::expected<ProtocolError>> GdbServer::handleRequest_() {
 		for(int i = 0; i < 8; ++i) // 8 FPU control registers.
 			for(int j = 0; j < 4; ++j)
 				resp.appendString("xx");
+#elif defined (__aarch64__)
+			for (int i = 0; i < 31; i++)
+				resp.appendLeHex64(gprs[i]);
+			resp.appendLeHex64(pcrs[kHelRegSp]);
+			resp.appendLeHex64(pcrs[kHelRegIp]);
+			for(int j = 0; j < 4; ++j)
+				resp.appendString("xx");
 #else
 		std::cout << "posix, gdbserver: Register access is not implemented for this architecture"
 				<< std::endl;


### PR DESCRIPTION
Fix the aarch64 register sizes in thor gdbserver and add support for aarch64 register read in the posix one.