### PR TITLE
Nvidia driver, part 2: fix IPC issues

### DIFF
--- a/core/drm/src/core.cpp
+++ b/core/drm/src/core.cpp
@@ -263,6 +263,8 @@ async::detached serveDrmDevice(std::shared_ptr<drm_core::Device> device,
 		auto conversation = accept.descriptor();
 		managarm::fs::CntRequest req;
 		req.ParseFromArray(recvHead.data(), recvHead.length());
+		recvHead.reset();
+
 		if(req.req_type() == managarm::fs::CntReqType::DEV_OPEN) {
 			if(req.flags() & ~(managarm::fs::OpenFlags::OF_NONBLOCK)) {
 				std::cout << "\e[31m" "core/drm: Illegal flags " << req.flags()

--- a/core/drm/src/ioctl.cpp
+++ b/core/drm/src/ioctl.cpp
@@ -115,6 +115,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 	if(id == managarm::fs::GenericIoctlRequest::message_id) {
 		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
+		msg.reset();
 		assert(req);
 
 		if(req->command() == DRM_IOCTL_VERSION) {
@@ -1290,6 +1291,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 		HEL_CHECK(send_resp.error());
 		logBragiReply(resp);
 	}else{
+		msg.reset();
 		std::cout << "\e[31m" "core/drm: Unknown ioctl() message with ID "
 				<< id << "\e[39m" << std::endl;
 

--- a/core/drm/src/ioctl.cpp
+++ b/core/drm/src/ioctl.cpp
@@ -118,7 +118,6 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 		assert(req);
 
 		if(req->command() == DRM_IOCTL_VERSION) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			auto version = self->_device->driverVersion();
@@ -134,14 +133,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_GET_CAP) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -173,14 +170,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			}
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_GETRESOURCES) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -229,15 +224,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			resp.set_drm_max_height(max_height);
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_GETCONNECTOR) {
-			helix::SendBuffer send_resp;
-			helix::SendBuffer send_list;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -292,18 +284,14 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				}
 			}
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size(), kHelItemChain),
-				helix::action(&send_list, conn->modeList().data(),
-						std::min(static_cast<size_t>(req->drm_max_modes()), conn->modeList().size())
-								* sizeof(drm_mode_modeinfo)));
-			co_await transmit.async_wait();
+			auto [send_resp, send_list] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
+				helix_ng::sendBuffer(conn->modeList().data(), std::min(static_cast<size_t>(req->drm_max_modes()), conn->modeList().size()) * sizeof(drm_mode_modeinfo))
+			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_list.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_GETENCODER) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -330,14 +318,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_GETPLANE) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -378,14 +364,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_CREATE_DUMB) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			auto pair = self->_device->createDumb(req->drm_width(), req->drm_height(), req->drm_bpp());
@@ -399,14 +383,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			if(logDrmRequests)
 				std::cout << "core/drm: CREATE_DUMB(" << req->drm_width() << "x" << req->drm_height() << ") -> <" << resp.drm_handle() << ">" << std::endl;
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_GETFB2) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -424,14 +406,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				resp.set_error(managarm::fs::Errors::SUCCESS);
 			}
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_ADDFB) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -451,14 +431,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			if(logDrmRequests)
 				std::cout << " -> [" << fb->id() << "]" << std::endl;
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_ADDFB2) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -477,14 +455,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			if(logDrmRequests)
 				std::cout << " -> [" << fb->id() << "]" << std::endl;
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_RMFB) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -497,14 +473,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			self->detachFrameBuffer(fb);
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_MAP_DUMB) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -517,15 +491,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			resp.set_drm_offset(buffer->getMapping());
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_GETCRTC) {
-			helix::SendBuffer send_resp;
-			helix::SendBuffer send_mode;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -557,14 +528,14 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			}
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size(), kHelItemChain),
-				helix::action(&send_mode, &mode_info, sizeof(drm_mode_modeinfo)));
-			co_await transmit.async_wait();
+			auto [send_resp, send_mode] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
+				helix_ng::sendBuffer(&mode_info, sizeof(drm_mode_modeinfo))
+			);
+
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_mode.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_SETCRTC) {
 			std::vector<char> mode_buffer;
 			mode_buffer.resize(sizeof(drm_mode_modeinfo));
@@ -572,13 +543,11 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			if(logDrmRequests)
 				std::cout << "core/drm: SETCRTC()" << std::endl;
 
-			helix::RecvBuffer recv_buffer;
-			auto &&buff = helix::submitAsync(conversation, helix::Dispatcher::global(),
-					helix::action(&recv_buffer, mode_buffer.data(), sizeof(drm_mode_modeinfo)));
-			co_await buff.async_wait();
+			auto [recv_buffer] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::recvBuffer(mode_buffer.data(), sizeof(drm_mode_modeinfo))
+			);
 			HEL_CHECK(recv_buffer.error());
 
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			auto obj = self->_device->findObject(req->drm_crtc_id());
@@ -625,14 +594,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_PAGE_FLIP) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -660,14 +627,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_DIRTYFB) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -684,14 +649,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				fb->notifyDirty();
 			}
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_CURSOR) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -705,10 +668,9 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			if (cursor_plane == nullptr) {
 				resp.set_error(managarm::fs::Errors::NO_BACKING_DEVICE);
-				auto ser = resp.SerializeAsString();
-				auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-				co_await transmit.async_wait();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+				);
 				HEL_CHECK(send_resp.error());
 				co_return;
 			}
@@ -750,12 +712,11 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			co_await config->waitForCompletion();
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-			helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_CURSOR2) {
 			managarm::fs::GenericIoctlReply resp;
 
@@ -821,19 +782,16 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			self->_buffers.erase(req->drm_handle());
 			self->_allocator.free(req->drm_handle());
 
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_SET_CLIENT_CAP) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -854,14 +812,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			}
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_OBJ_GETPROPERTIES) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			auto obj = self->_device->findObject(req->drm_obj_id());
@@ -911,14 +867,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				std::cout << "\e[31mcore/drm: No properties found for object [" << req->drm_obj_id() << "]\e[39m" << std::endl;
 			}
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_GETPROPERTY) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			uint32_t prop_id = req->drm_property_id();
@@ -965,14 +919,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			}
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_SETPROPERTY) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -1012,14 +964,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_GETPLANERESOURCES) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			auto &crtcs = self->_device->getCrtcs();
@@ -1036,14 +986,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			if(logDrmRequests)
 				std::cout << "core/drm: GETPLANERESOURCES()" << std::endl;
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_GETPROPBLOB) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			auto blob = self->_device->findBlob(req->drm_blob_id());
@@ -1062,23 +1010,20 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			}
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_CREATEPROPBLOB) {
 			std::vector<char> blob_data;
 			blob_data.resize(req->drm_blob_size());
 
-			helix::RecvBuffer recv_buffer;
-			auto &&buff = helix::submitAsync(conversation, helix::Dispatcher::global(),
-					helix::action(&recv_buffer, blob_data.data(), req->drm_blob_size()));
-			co_await buff.async_wait();
+			auto [recv_buffer] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::recvBuffer(blob_data.data(), sizeof(drm_mode_modeinfo))
+			);
 			HEL_CHECK(recv_buffer.error());
 
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(!req->drm_blob_size()) {
@@ -1093,14 +1038,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			if(logDrmRequests)
 				std::cout << "core/drm: CREATEPROPBLOB() -> [" << resp.drm_blob_id() << "]" << std::endl;
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_DESTROYPROPBLOB) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(!self->_device->deleteBlob(req->drm_blob_id())) {
@@ -1112,14 +1055,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			if(logDrmRequests)
 				std::cout << "core/drm: DESTROYPROPBLOB([" << req->drm_blob_id() << "])" << std::endl;
 
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_MODE_ATOMIC) {
-			helix::SendBuffer send_resp;
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logDrmRequests)
@@ -1222,12 +1163,11 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
 	send:
-			auto ser = resp.SerializeAsString();
-			auto &&transmit = helix::submitAsync(conversation, helix::Dispatcher::global(),
-				helix::action(&send_resp, ser.data(), ser.size()));
-			co_await transmit.async_wait();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
 			HEL_CHECK(send_resp.error());
-			logBragiSerializedReply(ser);
+			logBragiReply(resp);
 		}else if(req->command() == DRM_IOCTL_PRIME_HANDLE_TO_FD) {
 			managarm::fs::GenericIoctlReply resp;
 

--- a/core/lib/cmdline.cpp
+++ b/core/lib/cmdline.cpp
@@ -36,6 +36,7 @@ async::result<std::string> Cmdline::get() {
 	HEL_CHECK(recvResp.error());
 
 	auto resp = *bragi::parse_head_only<managarm::kerncfg::SvrResponse>(recvResp);
+	recvResp.reset();
 	assert(resp.error() == managarm::kerncfg::Error::SUCCESS);
 
 	std::vector<char> buffer(resp.size());

--- a/core/lib/kernel-logs.cpp
+++ b/core/lib/kernel-logs.cpp
@@ -40,6 +40,7 @@ async::result<size_t> KernelLogs::getMessage(std::span<uint8_t> buffer) {
 	HEL_CHECK(recvBuffer.error());
 
 	auto resp = *bragi::parse_head_only<managarm::kerncfg::SvrResponse>(recvResp);
+	recvResp.reset();
 	assert(resp.error() == managarm::kerncfg::Error::SUCCESS);
 
 	assert(offset_ == resp.effective_dequeue());

--- a/drivers/clocktracker/src/main.cpp
+++ b/drivers/clocktracker/src/main.cpp
@@ -84,6 +84,7 @@ async::detached serve(helix::UniqueLane lane) {
 
 		if (preamble.id() == bragi::message_id<managarm::clock::AccessPageRequest>) {
 			auto req = bragi::parse_head_only<managarm::clock::AccessPageRequest>(recvReq);
+			recvReq.reset();
 			if (!req) {
 				std::cout << "clocktracker: Ignoring IPC request due to decoding error." << std::endl;
 				continue;
@@ -101,6 +102,7 @@ async::detached serve(helix::UniqueLane lane) {
 			HEL_CHECK(sendMemory.error());
 
 		} else {
+			recvReq.reset();
 			managarm::clock::SvrResponse resp;
 			resp.set_error(managarm::clock::Error::ILLEGAL_REQUEST);
 

--- a/drivers/kernletcc/src/main.cpp
+++ b/drivers/kernletcc/src/main.cpp
@@ -108,7 +108,7 @@ async::detached serveCompiler(helix::UniqueLane lane) {
 
 		if(preamble.id() == bragi::message_id<managarm::kernlet::CompileRequest>) {
 			auto maybeReq = bragi::parse_head_tail<managarm::kernlet::CompileRequest>(recvHead, tailBuffer);
-
+			recvHead.reset();
 			if (!maybeReq) {
 				std::cout << "kernletcc: Ignoring request due to decoding failure.\n";
 				continue;

--- a/drivers/libevbackend/src/libevbackend.cpp
+++ b/drivers/libevbackend/src/libevbackend.cpp
@@ -177,6 +177,7 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 	if(id == managarm::fs::GenericIoctlRequest::message_id) {
 		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
+		msg.reset();
 		assert(req);
 		if(req->command() == EVIOCGBIT(0, 0)) {
 			assert(req->size());
@@ -275,6 +276,7 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			HEL_CHECK(dismiss.error());
 		}
 	} else if(id == managarm::fs::EvioGetNameRequest::message_id) {
+		msg.reset();
 		managarm::fs::EvioGetNameReply resp;
 
 		resp.set_error(managarm::fs::Errors::SUCCESS);
@@ -287,6 +289,7 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 		HEL_CHECK(send_head.error());
 		HEL_CHECK(send_tail.error());
 	} else if(id == managarm::fs::EvioGetIdRequest::message_id) {
+		msg.reset();
 		managarm::fs::EvioGetIdReply resp;
 
 		resp.set_error(managarm::fs::Errors::SUCCESS);
@@ -302,6 +305,7 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 		HEL_CHECK(send_resp.error());
 	} else if(id == managarm::fs::EvioGetMultitouchSlotsRequest::message_id) {
 		auto req = bragi::parse_head_only<managarm::fs::EvioGetMultitouchSlotsRequest>(msg);
+		msg.reset();
 		managarm::fs::EvioGetMultitouchSlotsReply resp;
 
 		for(auto &e : self->_device->_mtState) {
@@ -326,6 +330,7 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 		HEL_CHECK(send_head.error());
 		HEL_CHECK(send_tail.error());
 	}else{
+		msg.reset();
 		std::cout << "Unknown ioctl() message with ID " << id << std::endl;
 		auto [dismiss] = co_await helix_ng::exchangeMsgs(
 			conversation, helix_ng::dismiss());

--- a/drivers/nic/usb_net/src/usb-mbim.cpp
+++ b/drivers/nic/usb_net/src/usb-mbim.cpp
@@ -104,6 +104,7 @@ static async::result<void> ioctl(void *object, uint32_t id, helix_ng::RecvInline
 
 	if(id == managarm::fs::GenericIoctlRequest::message_id) {
 		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
+		msg.reset();
 		assert(req);
 
 		switch(req->command()) {
@@ -129,6 +130,7 @@ static async::result<void> ioctl(void *object, uint32_t id, helix_ng::RecvInline
 			}
 		}
 	} else {
+		msg.reset();
 		std::cout << std::format("drivers/usb-mbim: unexpected ioctl message type 0x{:x}\n", id);
 
 		auto [dismiss] = co_await helix_ng::exchangeMsgs(

--- a/drivers/usb/devices/serial/src/main.cpp
+++ b/drivers/usb/devices/serial/src/main.cpp
@@ -92,6 +92,7 @@ async::result<void> ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult 
 
 	if(id == managarm::fs::GenericIoctlRequest::message_id) {
 		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
+		msg.reset();
 		assert(req);
 
 		switch(req->command()) {
@@ -152,6 +153,7 @@ async::result<void> ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult 
 			}
 		}
 	} else {
+		msg.reset();
 		std::cout << "\e[31m" "usb-serial: Unknown ioctl() message with ID "
 			<< id << "\e[39m" << std::endl;
 	}

--- a/posix/subsystem/src/devices/kmsg.cpp
+++ b/posix/subsystem/src/devices/kmsg.cpp
@@ -40,6 +40,7 @@ private:
 		HEL_CHECK(recvBuffer.error());
 
 		auto resp = *bragi::parse_head_only<managarm::kerncfg::SvrResponse>(recvResp);
+		recvResp.reset();
 
 		if(resp.error() == managarm::kerncfg::Error::WOULD_BLOCK)
 			co_return Error::wouldBlock;

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -70,6 +70,7 @@ struct Node : FsNode {
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 
 		FileStats stats{};
@@ -316,6 +317,7 @@ private:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 
 		auto file = smarter::make_shared<OpenFile>(pull_ctrl.descriptor(),
@@ -354,6 +356,7 @@ private:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 
 		co_return std::string{static_cast<char *>(recv_target.data()), recv_target.length()};
@@ -637,6 +640,7 @@ private:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pull_node.error());
 
@@ -678,6 +682,7 @@ private:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pull_node.error());
 
@@ -713,6 +718,7 @@ private:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		if(resp.error() == managarm::fs::Errors::FILE_NOT_FOUND)
 			co_return Error::noSuchFile;
 		else if(resp.error() == managarm::fs::Errors::DIRECTORY_NOT_EMPTY)
@@ -791,6 +797,7 @@ private:
 
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+		recv_resp.reset();
 		assert(resp.error() == managarm::fs::Errors::SUCCESS);
 
 		auto file = smarter::make_shared<OpenFile>(pull_ctrl.descriptor(),
@@ -841,6 +848,7 @@ FutureMaybe<std::shared_ptr<FsNode>> Superblock::createRegular(Process *process)
 
 	managarm::fs::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	if(resp.error() == managarm::fs::Errors::SUCCESS) {
 		HEL_CHECK(pull_node.error());
 

--- a/posix/subsystem/src/fifo.cpp
+++ b/posix/subsystem/src/fifo.cpp
@@ -230,6 +230,7 @@ public:
 
 		if(id == managarm::fs::GenericIoctlRequest::message_id) {
 			auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
+			msg.reset();
 			assert(req);
 
 			switch(req->command()) {
@@ -264,6 +265,7 @@ public:
 			HEL_CHECK(send_resp.error());
 			co_return;
 		}else{
+			msg.reset();
 			std::cout << "\e[31m" "fifo: Unknown ioctl() message with ID "
 					<< id << "\e[39m" << std::endl;
 

--- a/posix/subsystem/src/file.cpp
+++ b/posix/subsystem/src/file.cpp
@@ -463,7 +463,7 @@ FutureMaybe<helix::UniqueDescriptor> File::accessMemory() {
 async::result<void> File::ioctl(Process *, uint32_t id, helix_ng::RecvInlineResult msg,
 		helix::UniqueLane conversation) {
 	(void) id;
-	(void) msg;
+	msg.reset();
 
 	std::cout << "posix \e[1;34m" << structName()
 			<< "\e[0m: Object does not implement ioctl()" << std::endl;

--- a/posix/subsystem/src/inotify.cpp
+++ b/posix/subsystem/src/inotify.cpp
@@ -219,6 +219,7 @@ public:
 
 		if(id == managarm::fs::GenericIoctlRequest::message_id) {
 			auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
+			msg.reset();
 			assert(req);
 
 			switch(req->command()) {

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -120,6 +120,7 @@ struct CmdlineNode final : public procfs::RegularNode {
 		HEL_CHECK(recvResp.error());
 
 		auto resp = *bragi::parse_head_only<managarm::kerncfg::SvrResponse>(recvResp);
+		recvResp.reset();
 		assert(resp.error() == managarm::kerncfg::Error::SUCCESS);
 
 		std::vector<char> recvCmdline(resp.size());

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -839,6 +839,7 @@ async::result<void> MasterFile::ioctl(Process *process, uint32_t id, helix_ng::R
 		helix::UniqueLane conversation) {
 	if(id == managarm::fs::GenericIoctlRequest::message_id) {
 		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
+		msg.reset();
 		assert(req);
 
 		if(req->command() == TIOCGPTN) {
@@ -940,6 +941,7 @@ async::result<void> MasterFile::ioctl(Process *process, uint32_t id, helix_ng::R
 					<< "\e[39m" << std::endl;
 		}
 	}else{
+		msg.reset();
 		std::cout << "\e[31m" "posix: Rejecting unknown PTS master ioctl message " << id
 				<< "\e[39m" << std::endl;
 	}
@@ -1063,6 +1065,7 @@ async::result<void> SlaveFile::ioctl(Process *process, uint32_t id, helix_ng::Re
 		helix::UniqueLane conversation) {
 	if(id == managarm::fs::GenericIoctlRequest::message_id) {
 		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
+		msg.reset();
 
 		if(req->command() == TCGETS) {
 			managarm::fs::GenericIoctlReply resp;
@@ -1246,6 +1249,7 @@ async::result<void> SlaveFile::ioctl(Process *process, uint32_t id, helix_ng::Re
 					<< "\e[39m" << std::endl;
 		}
 	}else{
+		msg.reset();
 		std::cout << "\e[31m" "posix: Rejecting unknown PTS slave ioctl message " << id
 				<< "\e[39m" << std::endl;
 	}

--- a/posix/subsystem/src/requests.cpp
+++ b/posix/subsystem/src/requests.cpp
@@ -512,6 +512,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			HEL_CHECK(offer.error());
 			HEL_CHECK(hwSendResp.error());
 			HEL_CHECK(hwResp.error());
+			hwResp.reset();
 
 			managarm::posix::SvrResponse resp;
 
@@ -3864,6 +3865,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 			HEL_CHECK(kerncfgResp.error());
 
 			auto kernResp = bragi::parse_head_only<managarm::kerncfg::GetMemoryInformationResponse>(kerncfgResp);
+			kerncfgResp.reset();
 
 			managarm::posix::GetMemoryInformationResponse resp;
 			resp.set_total_usable_memory(kernResp->total_usable_memory());
@@ -3903,6 +3905,7 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 				HEL_CHECK(kerncfgResp.error());
 
 				auto kernResp = bragi::parse_head_only<managarm::kerncfg::GetNumCpuResponse>(kerncfgResp);
+				kerncfgResp.reset();
 
 				resp.set_error(managarm::posix::Errors::SUCCESS);
 				resp.set_value(kernResp->num_cpu());

--- a/posix/subsystem/src/un-socket.cpp
+++ b/posix/subsystem/src/un-socket.cpp
@@ -753,6 +753,7 @@ public:
 
 		if(id == managarm::fs::GenericIoctlRequest::message_id) {
 			auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
+			msg.reset();
 			assert(req);
 
 			switch(req->command()) {

--- a/protocols/fs/src/client.cpp
+++ b/protocols/fs/src/client.cpp
@@ -225,6 +225,7 @@ async::result<frg::expected<Error, File>> File::createSocket(helix::BorrowedLane
 
 	managarm::fs::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 	if(resp.error() != managarm::fs::Errors::SUCCESS)
 		co_return static_cast<Error>(resp.error());
 
@@ -253,6 +254,7 @@ async::result<Error> File::connect(const struct sockaddr *addr_ptr, socklen_t ad
 
 	managarm::fs::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 
 	co_return static_cast<Error>(resp.error());
 }
@@ -287,6 +289,7 @@ File::sendto(const void *buf, size_t len, int flags, const struct sockaddr *addr
 
 	managarm::fs::SendMsgReply resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 
 	if(resp.error() != managarm::fs::Errors::SUCCESS)
 		co_return static_cast<Error>(resp.error());
@@ -322,6 +325,7 @@ File::recvfrom(void *buf, size_t len, int flags, struct sockaddr *addr_ptr, sock
 
 	managarm::fs::RecvMsgReply resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
 
 	if(resp.error() != managarm::fs::Errors::SUCCESS)
 		co_return static_cast<Error>(resp.error());

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -1551,6 +1551,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 			HEL_CHECK(send_resp.error());
 			logBragiSerializedReply(ser);
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_GET_LINK) {
+			recv_req.reset();
 			auto result = co_await node_ops->getLink(node, req.path());
 			if(!result) {
 				managarm::fs::SvrResponse resp;
@@ -1697,6 +1698,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 				HEL_CHECK(push_node.error());
 			}
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_MKDIR) {
+			recv_req.reset();
 			auto result = co_await node_ops->mkdir(node, req.path());
 
 			if (std::get<0>(result)) {
@@ -1730,6 +1732,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 				logBragiSerializedReply(ser);
 			}
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_SYMLINK) {
+			recv_req.reset();
 			std::string name;
 			std::string target;
 			name.resize(req.name_length());
@@ -1776,6 +1779,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 				logBragiSerializedReply(ser);
 			}
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_LINK) {
+			recv_req.reset();
 			auto result = co_await node_ops->link(node, req.path(), req.fd());
 			if(std::get<0>(result)) {
 				helix::UniqueLane local_lane, remote_lane;
@@ -1821,6 +1825,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 				logBragiSerializedReply(ser);
 			}
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_UNLINK) {
+			recv_req.reset();
 			auto result = co_await node_ops->unlink(node, req.path());
 			managarm::fs::SvrResponse resp;
 			if(!result) {
@@ -1847,6 +1852,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 			HEL_CHECK(send_resp.error());
 			logBragiSerializedReply(ser);
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_RMDIR) {
+			recv_req.reset();
 			// TODO: This should probably be it's own operation, for now, let it be
 			auto result = co_await node_ops->unlink(node, req.path());
 			managarm::fs::SvrResponse resp;
@@ -1871,6 +1877,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 			HEL_CHECK(send_resp.error());
 			logBragiSerializedReply(ser);
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_OPEN) {
+			recv_req.reset();
 			auto result = co_await node_ops->open(node, req.append());
 
 			managarm::fs::SvrResponse resp;
@@ -1888,6 +1895,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 			HEL_CHECK(push_pt.error());
 			logBragiSerializedReply(ser);
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_READ_SYMLINK) {
+			recv_req.reset();
 			auto link = co_await node_ops->readSymlink(node);
 
 			managarm::fs::SvrResponse resp;
@@ -1903,6 +1911,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 			HEL_CHECK(send_link.error());
 			logBragiSerializedReply(ser);
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_CHMOD) {
+			recv_req.reset();
 			co_await node_ops->chmod(node, req.mode());
 
 			managarm::fs::SvrResponse resp;
@@ -1916,6 +1925,7 @@ async::detached serveNode(helix::UniqueLane lane, std::shared_ptr<void> node,
 			HEL_CHECK(send_resp.error());
 			logBragiSerializedReply(ser);
 		}else if(req.req_type() == managarm::fs::CntReqType::NODE_OBSTRUCT_LINK) {
+			recv_req.reset();
 			co_await node_ops->obstructLink(node, req.link_name());
 
 			managarm::fs::SvrResponse resp;

--- a/protocols/mbus/src/client_ng.cpp
+++ b/protocols/mbus/src/client_ng.cpp
@@ -117,6 +117,7 @@ Instance::createEntity(std::string_view name, const Properties &properties) {
 	HEL_CHECK(pullLane.error());
 
 	auto maybeResp = bragi::parse_head_only<managarm::mbus::CreateObjectResponse>(recvResp);
+	recvResp.reset();
 	if (!maybeResp)
 		co_return Error::protocolViolation;
 
@@ -166,6 +167,7 @@ async::result<Result<Properties>> Entity::getProperties() const {
 	HEL_CHECK(recvTail.error());
 
 	auto maybeResp = bragi::parse_head_tail<managarm::mbus::GetPropertiesResponse>(recvHead, tail);
+	recvHead.reset();
 	if (!maybeResp)
 		co_return Error::protocolViolation;
 
@@ -211,6 +213,7 @@ async::result<Error> Entity::updateProperties(Properties properties) {
 	HEL_CHECK(recvResp.error());
 
 	auto maybeResp = bragi::parse_head_only<managarm::mbus::UpdatePropertiesResponse>(recvResp);
+	recvResp.reset();
 	if (!maybeResp)
 		co_return Error::protocolViolation;
 
@@ -243,6 +246,7 @@ async::result<Result<helix::UniqueLane>> Entity::getRemoteLane() const {
 	HEL_CHECK(pullLane.error());
 
 	auto maybeResp = bragi::parse_head_only<managarm::mbus::GetRemoteLaneResponse>(recvResp);
+	recvResp.reset();
 	if (!maybeResp)
 		co_return Error::protocolViolation;
 
@@ -282,6 +286,7 @@ async::result<Result<void>> EntityManager::serveRemoteLane(helix::UniqueLane lan
 		co_return Error::protocolViolation;
 
 	auto maybeResp = bragi::parse_head_only<managarm::mbus::ServeRemoteLaneResponse>(recvResp);
+	recvResp.reset();
 	if (!maybeResp)
 		co_return Error::protocolViolation;
 
@@ -357,6 +362,7 @@ async::result<Result<EnumerationResult>> Enumerator::nextEvents() {
 	HEL_CHECK(recvRespTail.error());
 
 	auto maybeResp = bragi::parse_head_tail<managarm::mbus::EnumerateResponse>(recvRespHead, tail);
+	recvRespHead.reset();
 	if (!maybeResp)
 		co_return Error::protocolViolation;
 

--- a/protocols/usb/src/client.cpp
+++ b/protocols/usb/src/client.cpp
@@ -109,6 +109,7 @@ async::result<frg::expected<UsbError, std::string>> DeviceState::deviceDescripto
 	HEL_CHECK(recvResp.error());
 
 	auto resp = bragi::parse_head_only<managarm::usb::SvrResponse>(recvResp);
+	recvResp.reset();
 
 	FRG_CO_TRY(transformProtocolError(resp->error()));
 
@@ -116,6 +117,7 @@ async::result<frg::expected<UsbError, std::string>> DeviceState::deviceDescripto
 
 	std::string data(recvData.length(), 0);
 	memcpy(&data[0], recvData.data(), recvData.length());
+	recvData.reset();
 	co_return std::move(data);
 }
 
@@ -137,6 +139,7 @@ async::result<frg::expected<UsbError, std::string>> DeviceState::configurationDe
 	HEL_CHECK(recvResp.error());
 
 	auto resp = bragi::parse_head_only<managarm::usb::SvrResponse>(recvResp);
+	recvResp.reset();
 
 	std::string recvBuffer(resp->size(), 0);
 	auto [recvData] = co_await helix_ng::exchangeMsgs(
@@ -170,6 +173,7 @@ async::result<frg::expected<UsbError, Configuration>> DeviceState::useConfigurat
 	HEL_CHECK(recvResp.error());
 
 	auto resp = bragi::parse_head_only<managarm::usb::SvrResponse>(recvResp);
+	recvResp.reset();
 
 	FRG_CO_TRY(transformProtocolError(resp->error()));
 
@@ -208,6 +212,7 @@ doControlTransfer(auto &lane, ControlTransfer info) {
 		HEL_CHECK(recvResp.error());
 
 		auto resp = bragi::parse_head_only<managarm::usb::SvrResponse>(recvResp);
+		recvResp.reset();
 
 		FRG_CO_TRY(transformProtocolError(resp->error()));
 
@@ -229,6 +234,7 @@ doControlTransfer(auto &lane, ControlTransfer info) {
 		HEL_CHECK(recvResp.error());
 
 		auto resp = bragi::parse_head_only<managarm::usb::SvrResponse>(recvResp);
+		recvResp.reset();
 
 		FRG_CO_TRY(transformProtocolError(resp->error()));
 
@@ -263,6 +269,7 @@ ConfigurationState::useInterface(int number, int alternative) {
 	HEL_CHECK(recvResp.error());
 
 	auto resp = bragi::parse_head_only<managarm::usb::SvrResponse>(recvResp);
+	recvResp.reset();
 
 	FRG_CO_TRY(transformProtocolError(resp->error()));
 
@@ -293,6 +300,7 @@ InterfaceState::getEndpoint(PipeType type, int number) {
 	HEL_CHECK(recvResp.error());
 
 	auto resp = bragi::parse_head_only<managarm::usb::SvrResponse>(recvResp);
+	recvResp.reset();
 
 	FRG_CO_TRY(transformProtocolError(resp->error()));
 
@@ -333,6 +341,7 @@ doTransferOfType(auto &lane, managarm::usb::XferType type, XferInfo info) {
 		HEL_CHECK(recvResp.error());
 
 		auto resp = bragi::parse_head_only<managarm::usb::SvrResponse>(recvResp);
+		recvResp.reset();
 
 		FRG_CO_TRY(transformProtocolError(resp->error()));
 
@@ -352,6 +361,7 @@ doTransferOfType(auto &lane, managarm::usb::XferType type, XferInfo info) {
 		HEL_CHECK(recvResp.error());
 
 		auto resp = bragi::parse_head_only<managarm::usb::SvrResponse>(recvResp);
+		recvResp.reset();
 
 		FRG_CO_TRY(transformProtocolError(resp->error()));
 

--- a/protocols/usb/src/server.cpp
+++ b/protocols/usb/src/server.cpp
@@ -77,6 +77,7 @@ async::detached serveEndpoint(Endpoint endpoint, helix::UniqueLane lane) {
 
 		if (preamble.id() == bragi::message_id<managarm::usb::TransferRequest>) {
 			auto req = bragi::parse_head_only<managarm::usb::TransferRequest>(recvReq);
+			recvReq.reset();
 			if (!req) {
 				co_return;
 			}
@@ -143,6 +144,7 @@ async::detached serveEndpoint(Endpoint endpoint, helix::UniqueLane lane) {
 				HEL_CHECK(sendResp.error());
 			}
 		}else{
+			recvReq.reset();
 			managarm::usb::SvrResponse resp;
 			resp.set_error(managarm::usb::Errors::ILLEGAL_REQUEST);
 
@@ -179,6 +181,7 @@ async::detached serveInterface(Interface interface, helix::UniqueLane lane) {
 
 		if (preamble.id() == bragi::message_id<managarm::usb::GetEndpointRequest>) {
 			auto req = bragi::parse_head_only<managarm::usb::GetEndpointRequest>(recvReq);
+			recvReq.reset();
 			if (!req) {
 				co_return;
 			}
@@ -210,6 +213,7 @@ async::detached serveInterface(Interface interface, helix::UniqueLane lane) {
 			HEL_CHECK(sendResp.error());
 			HEL_CHECK(sendLane.error());
 		}else {
+			recvReq.reset();
 			managarm::usb::SvrResponse resp;
 			resp.set_error(managarm::usb::Errors::ILLEGAL_REQUEST);
 
@@ -246,6 +250,7 @@ async::detached serveConfiguration(Configuration configuration, helix::UniqueLan
 
 		if (preamble.id() == bragi::message_id<managarm::usb::UseInterfaceRequest>) {
 			auto req = bragi::parse_head_only<managarm::usb::UseInterfaceRequest>(recvReq);
+			recvReq.reset();
 			if (!req) {
 				co_return;
 			}
@@ -276,6 +281,7 @@ async::detached serveConfiguration(Configuration configuration, helix::UniqueLan
 			HEL_CHECK(sendResp.error());
 			HEL_CHECK(sendLane.error());
 		}else {
+			recvReq.reset();
 			managarm::usb::SvrResponse resp;
 			resp.set_error(managarm::usb::Errors::ILLEGAL_REQUEST);
 
@@ -312,6 +318,7 @@ async::detached serve(Device device, helix::UniqueLane lane) {
 
 		if (preamble.id() == bragi::message_id<managarm::usb::GetConfigurationDescriptorRequest>) {
 			auto req = bragi::parse_head_only<managarm::usb::GetConfigurationDescriptorRequest>(recvReq);
+			recvReq.reset();
 			if (!req) {
 				co_return;
 			}
@@ -339,6 +346,7 @@ async::detached serve(Device device, helix::UniqueLane lane) {
 			HEL_CHECK(sendData.error());
 		} else if (preamble.id() == bragi::message_id<managarm::usb::GetDeviceDescriptorRequest>) {
 			auto req = bragi::parse_head_only<managarm::usb::GetDeviceDescriptorRequest>(recvReq);
+			recvReq.reset();
 			if (!req) {
 				co_return;
 			}
@@ -365,6 +373,7 @@ async::detached serve(Device device, helix::UniqueLane lane) {
 			HEL_CHECK(sendData.error());
 		} else if (preamble.id() == bragi::message_id<managarm::usb::TransferRequest>) {
 			auto req = bragi::parse_head_only<managarm::usb::TransferRequest>(recvReq);
+			recvReq.reset();
 			if (!req) {
 				co_return;
 			}
@@ -434,6 +443,7 @@ async::detached serve(Device device, helix::UniqueLane lane) {
 			}
 		} else if (preamble.id() == bragi::message_id<managarm::usb::UseConfigurationRequest>) {
 			auto req = bragi::parse_head_only<managarm::usb::UseConfigurationRequest>(recvReq);
+			recvReq.reset();
 			if (!req) {
 				co_return;
 			}
@@ -463,6 +473,7 @@ async::detached serve(Device device, helix::UniqueLane lane) {
 			HEL_CHECK(sendResp.error());
 			HEL_CHECK(sendLane.error());
 		}else {
+			recvReq.reset();
 			managarm::usb::SvrResponse resp;
 			resp.set_error(managarm::usb::Errors::ILLEGAL_REQUEST);
 

--- a/servers/netserver/src/ip/tcp4.cpp
+++ b/servers/netserver/src/ip/tcp4.cpp
@@ -268,6 +268,7 @@ struct Tcp4Socket {
 
 		if(id == managarm::fs::GenericIoctlRequest::message_id) {
 			auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
+			msg.reset();
 			assert(req);
 
 			switch(req->command()) {
@@ -295,6 +296,7 @@ struct Tcp4Socket {
 			);
 			HEL_CHECK(send_resp.error());
 		}else {
+			msg.reset();
 			std::cout << "Unknown ioctl() message with ID " << id << std::endl;
 			auto [dismiss] = co_await helix_ng::exchangeMsgs(
 			conversation, helix_ng::dismiss());

--- a/servers/netserver/src/main.cpp
+++ b/servers/netserver/src/main.cpp
@@ -763,6 +763,7 @@ async::detached serve(helix::UniqueLane lane) {
 			HEL_CHECK(send_tail.error());
 			logBragiReply(resp);
 		} else if(preamble.id() == managarm::fs::InitializePosixLane::message_id) {
+			recv_req.reset();
 			co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::dismiss()
@@ -770,6 +771,7 @@ async::detached serve(helix::UniqueLane lane) {
 
 			posixLane = std::move(conversation);
 		} else {
+			recv_req.reset();
 			std::cout << "netserver: received unknown message: "
 				<< preamble.id() << std::endl;
 			auto [dismiss] = co_await helix_ng::exchangeMsgs(

--- a/servers/netserver/src/netlink/netlink.cpp
+++ b/servers/netserver/src/netlink/netlink.cpp
@@ -80,6 +80,7 @@ async::result<protocols::fs::RecvResult> NetlinkSocket::recvMsg(void *obj,
 				helix_ng::recvInline()
 			)
 		);
+		recv_resp.reset();
 
 		memset(&ucreds, 0, sizeof(struct ucred));
 		ucreds.pid = senderPid;


### PR DESCRIPTION
This removes all uses of `helix::action` and removes it from the headers. The last commit came to be by checking all instances of recvInline and aggressively resetting the result to avoid a full queue.