### PR TITLE
posix: explicitly construct tokens for async::suspend_indefinitely

### DIFF
--- a/posix/subsystem/src/observations.cpp
+++ b/posix/subsystem/src/observations.cpp
@@ -615,7 +615,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 			if(killed) {			
 				if(debugFaults) {
 					launchGdbServer(self.get());
-					co_await async::suspend_indefinitely({});
+					co_await async::suspend_indefinitely(async::cancellation_token{});
 				}
 				break;
 			}
@@ -628,7 +628,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 
 			if(debugFaults) {
 				launchGdbServer(self.get());
-				co_await async::suspend_indefinitely({});
+				co_await async::suspend_indefinitely(async::cancellation_token{});
 			}
 		}else if(observe.observation() == kHelObservePageFault) {
 			if(logPageFaults) {
@@ -655,7 +655,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 
 				if(debugFaults) {
 					launchGdbServer(self.get());
-					co_await async::suspend_indefinitely({});
+					co_await async::suspend_indefinitely(async::cancellation_token{});
 				}
 				break;
 			}
@@ -676,7 +676,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 			if(killed) {			
 				if(debugFaults) {
 					launchGdbServer(self.get());
-					co_await async::suspend_indefinitely({});
+					co_await async::suspend_indefinitely(async::cancellation_token{});
 				}
 				break;
 			}
@@ -697,7 +697,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 			if(killed) {			
 				if(debugFaults) {
 					launchGdbServer(self.get());
-					co_await async::suspend_indefinitely({});
+					co_await async::suspend_indefinitely(async::cancellation_token{});
 				}
 				break;
 			}
@@ -718,7 +718,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 			if(killed) {			
 				if(debugFaults) {
 					launchGdbServer(self.get());
-					co_await async::suspend_indefinitely({});
+					co_await async::suspend_indefinitely(async::cancellation_token{});
 				}
 				break;
 			}
@@ -739,7 +739,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 			if(killed) {			
 				if(debugFaults) {
 					launchGdbServer(self.get());
-					co_await async::suspend_indefinitely({});
+					co_await async::suspend_indefinitely(async::cancellation_token{});
 				}
 				break;
 			}

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -662,7 +662,7 @@ async::result<void> SignalContext::raiseContext(SignalItem *item, Process *proce
 					std::cout << "posix: Thread killed as the result of signal "
 						<< item->signalNumber << std::endl;
 					launchGdbServer(process);
-					co_await async::suspend_indefinitely({});
+					co_await async::suspend_indefinitely(async::cancellation_token{});
 				}
 				[[fallthrough]];
 			default:


### PR DESCRIPTION
This is necessary due to the changes to that function that allow passing multiple tokens.