### PR TITLE
drivers/libblockfs: Support non-native gpt block sizes

### DIFF
--- a/drivers/libblockfs/src/gpt.hpp
+++ b/drivers/libblockfs/src/gpt.hpp
@@ -1,6 +1,7 @@
 
 #include <string.h>
 #include <vector>
+#include <utility>
 
 #include <blockfs.hpp>
 
@@ -49,7 +50,7 @@ struct DiskHeader {
 	uint64_t firstLba;
 	uint64_t lastLba;
 	uint8_t diskGuid[16];
-	uint64_t startingLba;
+	uint64_t entryTableLba;
 	uint32_t numEntries;
 	uint32_t entrySize;
 	uint32_t tableCheckSum;
@@ -86,8 +87,11 @@ public:
 	Partition &getPartition(int index);
 
 private:
-	BlockDevice *device;
-	std::vector<Partition> partitions;
+	async::result<std::pair<char *, DiskHeader *>> probeSectorSize_(size_t sectorSize);
+
+	BlockDevice *device_;
+	std::vector<Partition> partitions_;
+	size_t gptSectorSize_;
 };
 
 // --------------------------------------------------------

--- a/drivers/libblockfs/src/raw.cpp
+++ b/drivers/libblockfs/src/raw.cpp
@@ -31,7 +31,7 @@ async::detached RawFs::manageMapping() {
 		if(manage.type() == kHelManageInitialize) {
 			helix::Mapping file_map{helix::BorrowedDescriptor{backingMemory},
 				static_cast<ptrdiff_t>(manage.offset()), manage.length(), kHelMapProtWrite};
-			assert(!(manage.offset() & device->sectorSize));
+			assert(!(manage.offset() & (device->sectorSize - 1)));
 
 			size_t backed_size = std::min(manage.length(), device_size - manage.offset());
 			size_t num_blocks = (backed_size + device->sectorSize - 1) / device->sectorSize;
@@ -48,7 +48,7 @@ async::detached RawFs::manageMapping() {
 			helix::Mapping file_map{helix::BorrowedDescriptor{backingMemory},
 				static_cast<ptrdiff_t>(manage.offset()), manage.length(), kHelMapProtRead};
 
-			assert(!(manage.offset() & device->sectorSize));
+			assert(!(manage.offset() & (device->sectorSize - 1)));
 
 			size_t backed_size = std::min(manage.length(), device_size - manage.offset());
 			size_t num_blocks = (backed_size + device->sectorSize - 1) / device->sectorSize;


### PR DESCRIPTION
Add support for reading the gpt on devices where the device block size doesn't match what the gpt was created with by probing for the gpt at different locations for the common block sizes and fix some hardcoded usages of 512 byte block size. This is useful for an example to boot a Managarm image created with the typical 512 byte block size using UFS which only supports hardware block sizes greater than 4kb.