### PR TITLE
posix: allow error returns for procfs attribute reads

### DIFF
--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -82,6 +82,9 @@ enum class Error {
 	notSocket,
 
 	interrupted,
+
+	// Corresponds to ESRCH
+	noSuchProcess,
 };
 
 inline protocols::fs::Error operator|(Error e, protocols::fs::ToFsProtoError) {
@@ -112,6 +115,7 @@ inline protocols::fs::Error operator|(Error e, protocols::fs::ToFsProtoError) {
 		case Error::alreadyConnected: return protocols::fs::Error::alreadyConnected;
 		case Error::notSocket: return protocols::fs::Error::notSocket;
 		case Error::interrupted: return protocols::fs::Error::interrupted;
+		case Error::noSuchProcess: return protocols::fs::Error::noSuchProcess;
 		default:
 			std::cout << std::format("posix: unmapped Error {}", static_cast<int>(e)) << std::endl;
 			return protocols::fs::Error::internalError;
@@ -147,6 +151,7 @@ inline managarm::posix::Errors operator|(Error e, ToPosixProtoError) {
 		case Error::alreadyConnected: return managarm::posix::Errors::ALREADY_CONNECTED;
 		case Error::unsupportedSocketType: return managarm::posix::Errors::UNSUPPORTED_SOCKET_TYPE;
 		case Error::interrupted: return managarm::posix::Errors::INTERRUPTED;
+		case Error::noSuchProcess: return managarm::posix::Errors::NO_SUCH_RESOURCE;
 		case Error::fileClosed:
 		case Error::badExecutable:
 		case Error::seekOnPipe:
@@ -185,8 +190,9 @@ inline Error operator|(protocols::fs::Error e, ToPosixError) {
 		case protocols::fs::Error::isDirectory: return Error::isDirectory;
 		case protocols::fs::Error::directoryNotEmpty: return Error::directoryNotEmpty;
 		case protocols::fs::Error::internalError: return Error::fileClosed;
+		case protocols::fs::Error::noSuchProcess: return Error::noSuchProcess;
 		default:
-			std::cout << std::format("posix: unmapped Error {}", static_cast<int>(e)) << std::endl;
+			std::cout << std::format("posix: unmapped protocols::fs::Error {}", static_cast<int>(e)) << std::endl;
 			return Error::ioError;
 	}
 }

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -103,7 +103,7 @@ helix::UniqueLane &getPmLane() {
 }
 
 struct CmdlineNode final : public procfs::RegularNode {
-	async::result<std::string> show(Process *) override {
+	async::result<std::expected<std::string, Error>> show(Process *) override {
 		managarm::kerncfg::GetCmdlineRequest req;
 
 		auto [offer, sendReq, recvResp] =

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -110,7 +110,7 @@ struct RegularNode : FsNode, std::enable_shared_from_this<RegularNode> {
 			SemanticFlags semantic_flags) override;
 
 protected:
-	virtual async::result<std::string> show(Process *) = 0;
+	virtual async::result<std::expected<std::string, Error>> show(Process *) = 0;
 	virtual async::result<void> store(std::string buffer) = 0;
 
 	async::result<frg::expected<Error, FileStats>> getStatsInternal(Process *);
@@ -254,7 +254,7 @@ struct MapNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 
 	async::result<frg::expected<Error, FileStats>> getStats() override;
@@ -265,35 +265,35 @@ private:
 struct UptimeNode final : RegularNode {
 	UptimeNode() {}
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 };
 
 struct OstypeNode final : RegularNode {
 	OstypeNode() {}
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 };
 
 struct OsreleaseNode final : RegularNode {
 	OsreleaseNode() {}
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 };
 
 struct ArchNode final : RegularNode {
 	ArchNode() {}
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 };
 
 struct BootIdNode final : RegularNode {
 	BootIdNode();
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 private:
 	std::string bootId_;
@@ -304,7 +304,7 @@ struct CommNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 
 	async::result<frg::expected<Error, FileStats>> getStats() override;
@@ -317,7 +317,7 @@ struct StatNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 
 	async::result<frg::expected<Error, FileStats>> getStats() override;
@@ -330,7 +330,7 @@ struct StatmNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 
 	async::result<frg::expected<Error, FileStats>> getStats() override;
@@ -343,7 +343,7 @@ struct StatusNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 
 	async::result<frg::expected<Error, FileStats>> getStats() override;
@@ -377,7 +377,7 @@ struct CgroupNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 
 	async::result<frg::expected<Error, FileStats>> getStats() override;
@@ -418,7 +418,7 @@ struct MountsNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 
 	async::result<frg::expected<Error, FileStats>> getStats() override;
@@ -432,7 +432,7 @@ struct MountInfoNode final : RegularNode {
 	: _process(process)
 	{ }
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 
 	async::result<frg::expected<Error, FileStats>> getStats() override;
@@ -484,7 +484,7 @@ struct FdInfoNode final : RegularNode {
 	FdInfoNode(std::shared_ptr<MountView> mountView, smarter::shared_ptr<File, FileHandle> file)
 	: mountView_{std::move(mountView)}, file_{std::move(file)} {}
 
-	async::result<std::string> show(Process *) override;
+	async::result<std::expected<std::string, Error>> show(Process *) override;
 	async::result<void> store(std::string) override;
 private:
 	std::shared_ptr<MountView> mountView_;

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -90,6 +90,7 @@ struct Link final : FsLink, std::enable_shared_from_this<Link> {
 	std::shared_ptr<FsNode> getOwner() override;
 	std::string getName() override;
 	std::shared_ptr<FsNode> getTarget() override;
+	void unlinkSelf();
 
 private:
 	std::shared_ptr<FsNode> _owner;
@@ -172,6 +173,8 @@ struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode>
 			SemanticFlags semantic_flags) override;
 	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override;
 	async::result<frg::expected<Error>> unlink(std::string name) override;
+
+	Error directUnlink(std::string name);
 
 private:
 	Link *_treeLink;
@@ -339,7 +342,7 @@ private:
 };
 
 struct StatusNode final : RegularNode {
-	StatusNode(Process *process)
+	StatusNode(std::weak_ptr<Process> process)
 	: _process(process)
 	{ }
 
@@ -348,7 +351,7 @@ struct StatusNode final : RegularNode {
 
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 private:
-	Process *_process;
+	std::weak_ptr<Process> _process;
 };
 
 struct FdDirectoryFile final : File {

--- a/posix/subsystem/src/util.cpp
+++ b/posix/subsystem/src/util.cpp
@@ -31,6 +31,7 @@ std::ostream& operator<<(std::ostream& os, const Error& err) {
 		case Error::unsupportedSocketType: err_string = "unsupportedSocketType"; break;
 		case Error::notSocket: err_string = "notSocket"; break;
 		case Error::interrupted: err_string = "interrupted"; break;
+		case Error::noSuchProcess: err_string = "noSuchProcess"; break;
 	}
 
 	return os << err_string;

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -31,7 +31,8 @@ enum Errors {
 	INTERNAL_ERROR = 28,
 	ALREADY_CONNECTED = 29,
 	NOT_A_SOCKET = 30,
-	INTERRUPTED = 31
+	INTERRUPTED = 31,
+	NO_SUCH_PROCESS = 32
 }
 
 consts FileType int64 {

--- a/protocols/fs/include/protocols/fs/common.hpp
+++ b/protocols/fs/include/protocols/fs/common.hpp
@@ -46,6 +46,7 @@ enum class Error {
 	alreadyConnected = 29,
 	notSocket = 30,
 	interrupted = 31,
+	noSuchProcess = 32,
 };
 
 struct ToFsError {
@@ -87,6 +88,7 @@ inline managarm::fs::Errors operator|(Error e, ToFsError) {
 		case Error::alreadyConnected: return managarm::fs::Errors::ALREADY_CONNECTED;
 		case Error::notSocket: return managarm::fs::Errors::NOT_A_SOCKET;
 		case Error::interrupted: return managarm::fs::Errors::INTERRUPTED;
+		case Error::noSuchProcess: return managarm::fs::Errors::NO_SUCH_PROCESS;
 	}
 }
 
@@ -129,6 +131,7 @@ inline Error operator|(managarm::fs::Errors e, ToFsProtoError) {
 		case managarm::fs::Errors::ALREADY_CONNECTED: return Error::alreadyConnected;
 		case managarm::fs::Errors::NOT_A_SOCKET: return Error::notSocket;
 		case managarm::fs::Errors::INTERRUPTED: return Error::interrupted;
+		case managarm::fs::Errors::NO_SUCH_PROCESS: return Error::noSuchProcess;
 	}
 }
 

--- a/testsuites/posix-tests/meson.build
+++ b/testsuites/posix-tests/meson.build
@@ -20,6 +20,7 @@ src = [
 	'src/posix-timers.cpp',
 	'src/eventfd.cpp',
 	'src/pty.cpp',
+	'src/procfs.cpp',
 ]
 
 executable('posix-tests', src, dependencies: [cli11_dep], install : true)

--- a/testsuites/posix-tests/src/procfs.cpp
+++ b/testsuites/posix-tests/src/procfs.cpp
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "testsuite.hpp"
+
+DEFINE_TEST(procfs_status_after_wait, ([] {
+	pid_t pid = fork();
+	assert(pid >= 0);
+
+	if(!pid) {
+		_exit(0);
+	}
+
+	char path[64];
+	snprintf(path, sizeof(path), "/proc/%d/status", pid);
+
+	int fd = open(path, O_RDONLY);
+	assert(fd >= 0);
+
+	siginfo_t dummy;
+	int ret = waitid(P_PID, pid, &dummy, WEXITED | WNOWAIT);
+	assert(ret == 0);
+
+	char buf[128];
+	ret = read(fd, buf, sizeof(buf));
+	assert(ret == 128);
+	// rewind to invalidate caching
+	lseek(fd, 0, SEEK_SET);
+
+	int status;
+	ret = waitpid(pid, &status, 0);
+	assert(ret == pid);
+
+	ret = read(fd, buf, sizeof(buf));
+	assert(ret == -1);
+	assert(errno == ESRCH);
+
+	close(fd);
+}))


### PR DESCRIPTION
This fixes the inconsistent boot failures that dereferenced a pointer to `0x40`.