### PR TITLE
tools: Update gen-initrd with the new name of the dynamic linker

### DIFF
--- a/kernel/thor/generic/servers.cpp
+++ b/kernel/thor/generic/servers.cpp
@@ -270,8 +270,9 @@ coroutine<void> executeModule(frg::string_view name, MfsRegular *module,
 
 	ImageInfo exec_info = co_await loadModuleImage(space, 0, module->getMemory());
 
-	// FIXME: use actual interpreter name here
-	auto rtdl_module = resolveModule("usr/lib/ld-init.so");
+	if(size_t n = frg::string_view(exec_info.interpreter).find_first('\0'); n != size_t(-1))
+		exec_info.interpreter.resize(n);
+	auto rtdl_module = resolveModule(exec_info.interpreter);
 	assert(rtdl_module && rtdl_module->type == MfsType::regular);
 	ImageInfo interp_info = co_await loadModuleImage(space, 0x40000000,
 			static_cast<MfsRegular *>(rtdl_module)->getMemory());

--- a/tools/gen-initrd.py
+++ b/tools/gen-initrd.py
@@ -36,6 +36,7 @@ def add_file(src_prefix, tree_prefix, filename, rename_to=None):
 
 # Add all the files.
 
+add_dir('lib')
 add_dir('usr')
 add_dir('usr/bin')
 add_dir('usr/lib')
@@ -46,10 +47,10 @@ add_dir('usr/lib/managarm/server')
 add_file('usr/managarm/bin', '', 'thor')
 
 # Runtime libraries.
+add_file('lib', 'lib', args.arch + '-mlibc-ld.so')
 add_file('usr/lib', 'usr/lib', 'libhelix.so')
 add_file('usr/lib', 'usr/lib', 'libc.so')
 add_file('usr/lib', 'usr/lib', 'libm.so')
-add_file('usr/lib', 'usr/lib', 'ld.so', rename_to='ld-init.so')
 add_file('usr/lib', 'usr/lib', 'liblewis.so')
 add_file('usr/lib', 'usr/lib', 'libz.so.1')
 add_file('usr/lib', 'usr/lib', 'libvirtio_core.so')


### PR DESCRIPTION
This change is needed because we're switching the name of the dynamic linker. Additional PRs to mlibc, gcc, llvm and bootstrap will come later, therefore currently this is a draft.