### PR TITLE
eir: Drop -lld-allow-duplicate-weak

### DIFF
--- a/kernel/eir/arch/arm/platform/raspi4/raspi4.cpp
+++ b/kernel/eir/arch/arm/platform/raspi4/raspi4.cpp
@@ -236,6 +236,8 @@ frg::manual_box<PL011> debugUart;
 
 void debugPrintChar(char c) { debugUart->send(c); }
 
+void initPlatform() {}
+
 extern "C" [[noreturn]] void eirRaspi4Main() {
 	debugUart.initialize(mmioBase + 0x201000, 4000000);
 	debugUart->disable();

--- a/kernel/eir/arch/arm/platform/virt/virt.cpp
+++ b/kernel/eir/arch/arm/platform/virt/virt.cpp
@@ -18,9 +18,7 @@ void initPlatform() {
 }
 
 extern "C" [[noreturn]] void eirVirtMain() {
-	if (initPlatform) {
-		initPlatform();
-	}
+	initPlatform();
 	eirRunConstructors();
 
 	GenericInfo info{.cmdline = nullptr, .fb{}, .debugFlags = eirDebugSerial, .hasFb = false};

--- a/kernel/eir/arch/riscv/platform/allwinner-d1/early-log.cpp
+++ b/kernel/eir/arch/riscv/platform/allwinner-d1/early-log.cpp
@@ -16,4 +16,6 @@ void sbiCall1(int ext, int func, SbiWord arg0) {
 
 void debugPrintChar(char c) { sbiCall1(1, 0, c); }
 
+void initPlatform() {}
+
 } // namespace eir

--- a/kernel/eir/arch/riscv/platform/virt/early-log.cpp
+++ b/kernel/eir/arch/riscv/platform/virt/early-log.cpp
@@ -16,4 +16,6 @@ void sbiCall1(int ext, int func, SbiWord arg0) {
 
 void debugPrintChar(char c) { sbiCall1(1, 0, c); }
 
+void initPlatform() {}
+
 } // namespace eir

--- a/kernel/eir/arch/x86/arch.cpp
+++ b/kernel/eir/arch/x86/arch.cpp
@@ -21,6 +21,8 @@ void debugPrintChar(char c) {
 	}
 }
 
+void initPlatform() {}
+
 enum X86PageFlags {
 	kPagePresent = 1,
 	kPageWrite = 2,

--- a/kernel/eir/generic/eir-internal/arch.hpp
+++ b/kernel/eir/generic/eir-internal/arch.hpp
@@ -35,7 +35,7 @@ void mapSingle4kPage(
 );
 address_t getSingle4kPage(address_t address);
 
-[[gnu::weak]] void initPlatform();
+void initPlatform();
 void initProcessorEarly();
 void initProcessorPaging();
 

--- a/kernel/eir/protos/limine/entry.cpp
+++ b/kernel/eir/protos/limine/entry.cpp
@@ -114,9 +114,8 @@ initgraph::Task setupMemoryRegions{
 } // namespace
 
 extern "C" void eirLimineMain(void) {
-	if (initPlatform) {
-		initPlatform();
-	}
+	initPlatform();
+
 	eir::infoLogger() << "Booting Eir from Limine" << frg::endlog;
 	eirRunConstructors();
 

--- a/kernel/eir/protos/multiboot2/multiboot2.cpp
+++ b/kernel/eir/protos/multiboot2/multiboot2.cpp
@@ -80,9 +80,8 @@ initgraph::Task setupMemoryRegions{
 } // namespace
 
 extern "C" void eirMultiboot2Main(uint32_t info, uint32_t magic) {
-	if (initPlatform) {
-		initPlatform();
-	}
+	initPlatform();
+
 	if (magic != MB2_MAGIC)
 		eir::panicLogger() << "eir: Invalid multiboot2 signature, halting..." << frg::endlog;
 

--- a/kernel/eir/protos/uefi/entry.cpp
+++ b/kernel/eir/protos/uefi/entry.cpp
@@ -706,9 +706,7 @@ initgraph::Task setupFramebufferInfo{
 } // namespace
 
 extern "C" efi_status eirUefiMain(const efi_handle h, const efi_system_table *system_table) {
-	if (initPlatform) {
-		initPlatform();
-	}
+	initPlatform();
 
 	eirRunConstructors();
 

--- a/kernel/eir/protos/uefi/meson.build
+++ b/kernel/eir/protos/uefi/meson.build
@@ -15,7 +15,6 @@ if native_pe_toolchain
 	eir_uefi_ld_args += [
 		'-Wl,-entry:eirUefiMain',
 		'-Wl,-subsystem:efi_application',
-		'-Wl,-lld-allow-duplicate-weak',
 		'-gdwarf'
 	]
 	eir_uefi_exe_name = 'eir-uefi'


### PR DESCRIPTION
`-lld-allow-duplicate-weak` causes lld to select on of the definitions for each weak symbol. However, it does not select a non-null definition over a null definition which makes it unsuitable for our purposes.

Drop the flag such that we get compile time errors on weak symbols.

Depends on https://github.com/managarm/frigg/pull/94