### PR TITLE
eir: Handle boot framebuffer consistently on all boot protocols

### DIFF
--- a/kernel/eir/arch/arm/generic.cpp
+++ b/kernel/eir/arch/arm/generic.cpp
@@ -1,13 +1,12 @@
 #include <dtb.hpp>
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/framebuffer.hpp>
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
 #include <eir-internal/memory-layout.hpp>
 
 namespace {
-EirFramebuffer genericFb;
-bool hasGenericFb = false;
 uint32_t genericDebugFlags = 0;
 } // namespace
 
@@ -21,29 +20,13 @@ initgraph::Task setupMiscInfo{
     [] { info_ptr->debugFlags |= genericDebugFlags; }
 };
 
-initgraph::Task setupFramebufferInfo{
-    &globalInitEngine,
-    "aarch64.setup-framebuffer-info",
-    initgraph::Requires{getInfoStructAvailableStage()},
-    initgraph::Entails{getEirDoneStage()},
-    [] {
-	    if (hasGenericFb) {
-		    fb = &info_ptr->frameBuffer;
-		    info_ptr->frameBuffer = genericFb;
-	    } else {
-		    infoLogger() << "eir: Got no framebuffer!" << frg::endlog;
-	    }
-    }
-};
-
 [[noreturn]] void eirGenericMain(const GenericInfo &genericInfo) {
 	if (genericInfo.cmdline) {
 		cmdline = genericInfo.cmdline;
 	}
 
 	if (genericInfo.hasFb) {
-		genericFb = genericInfo.fb;
-		hasGenericFb = true;
+		initFramebuffer(genericInfo.fb);
 	}
 
 	genericDebugFlags = genericInfo.debugFlags;

--- a/kernel/eir/arch/arm/platform/raspi4/raspi4.cpp
+++ b/kernel/eir/arch/arm/platform/raspi4/raspi4.cpp
@@ -299,7 +299,6 @@ extern "C" [[noreturn]] void eirRaspi4Main() {
 			eir::infoLogger() << "Mode setting failed..." << frg::endlog;
 		} else {
 			eir::infoLogger() << "Success!" << frg::endlog;
-			setFbInfo(ptr, actualW, actualH, pitch);
 			fb_ptr = reinterpret_cast<uintptr_t>(ptr);
 			fb_width = actualW;
 			fb_height = actualH;

--- a/kernel/eir/arch/x86/generic32_link.x
+++ b/kernel/eir/arch/x86/generic32_link.x
@@ -23,6 +23,7 @@ SECTIONS {
 	.rodata : ALIGN(0x1000) {
 		*(.rodata*)
 	}
+	.note.gnu.build-id : { *(.note.gnu.build-id) }
 	.init_array : {
 		PROVIDE_HIDDEN (__init_array_start = .);
 		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))

--- a/kernel/eir/arch/x86/generic64_link.x
+++ b/kernel/eir/arch/x86/generic64_link.x
@@ -20,6 +20,7 @@ SECTIONS {
 	.rodata : ALIGN(0x1000) {
 		*(.rodata*)
 	}
+	.note.gnu.build-id : { *(.note.gnu.build-id) }
 	.init_array : {
 		PROVIDE_HIDDEN (__init_array_start = .);
 		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))

--- a/kernel/eir/generic/debug.cpp
+++ b/kernel/eir/generic/debug.cpp
@@ -2,7 +2,6 @@
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
 #include <frg/logging.hpp>
-#include <render-text.hpp>
 
 namespace eir {
 
@@ -25,23 +24,6 @@ constinit OutputSink infoSink;
 constinit frg::stack_buffer_logger<LogSink, 128> infoLogger;
 constinit frg::stack_buffer_logger<PanicSink, 128> panicLogger;
 
-constexpr int fontWidth = 8;
-constexpr int fontHeight = 16;
-
-static void *displayFb;
-static int displayWidth;
-static int displayHeight;
-static size_t displayPitch;
-static int outputX;
-static int outputY;
-
-void setFbInfo(void *ptr, int width, int height, size_t pitch) {
-	displayFb = ptr;
-	displayWidth = width;
-	displayHeight = height;
-	displayPitch = pitch;
-}
-
 extern "C" void frg_panic(const char *cstring) {
 	panicLogger() << "frg: Panic! " << cstring << frg::endlog;
 }
@@ -51,32 +33,6 @@ void OutputSink::print(char c) {
 	// For example, this can log to SBI on RISC-V which often yields expected results.
 	// Also, it can log to virtual devices (like e9) when run inside VMs.
 	debugPrintChar(c);
-
-	if (displayFb) {
-		if (c == '\n') {
-			outputX = 0;
-			outputY++;
-		} else if (outputX >= displayWidth / fontWidth) {
-			outputX = 0;
-			outputY++;
-		} else if (outputY >= displayHeight / fontHeight) {
-			// TODO: Scroll.
-		} else {
-			renderChars(
-			    displayFb,
-			    displayPitch / sizeof(uint32_t),
-			    outputX,
-			    outputY,
-			    &c,
-			    1,
-			    15,
-			    -1,
-			    std::integral_constant<int, fontWidth>{},
-			    std::integral_constant<int, fontHeight>{}
-			);
-			outputX++;
-		}
-	}
 }
 
 void OutputSink::print(const char *str) {

--- a/kernel/eir/generic/eir-internal/debug.hpp
+++ b/kernel/eir/generic/eir-internal/debug.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <frg/formatting.hpp>
+#include <frg/list.hpp>
 #include <frg/logging.hpp>
 
 namespace eir {
@@ -20,9 +21,18 @@ struct PanicSink {
 };
 
 extern bool log_e9;
-extern void (*logHandler)(const char c);
 
 extern frg::stack_buffer_logger<LogSink, 128> infoLogger;
 extern frg::stack_buffer_logger<PanicSink, 128> panicLogger;
+
+struct LogHandler {
+	virtual void emit(frg::string_view line) = 0;
+
+	frg::default_list_hook<LogHandler> hook;
+	bool active{false};
+};
+
+void enableLogHandler(LogHandler *handler);
+void disableLogHandler(LogHandler *handler);
 
 } // namespace eir

--- a/kernel/eir/generic/eir-internal/framebuffer.hpp
+++ b/kernel/eir/generic/eir-internal/framebuffer.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <eir/interface.hpp>
+
+namespace eir {
+
+void initFramebuffer(const EirFramebuffer &fb);
+
+// Return the known framebuffer or nullptr if there is none.
+const EirFramebuffer *getFramebuffer();
+
+} // namespace eir

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -80,8 +80,6 @@ void loadKernelImage(void *image);
 
 EirInfo *generateInfo(frg::string_view cmdline);
 
-void setFbInfo(void *ptr, int width, int height, size_t pitch);
-
 template <typename T>
 T *bootAlloc(size_t n = 1) {
 	auto pointer = physToVirt<T>(bootReserve(sizeof(T) * n, alignof(T)));

--- a/kernel/eir/generic/eir-internal/main.hpp
+++ b/kernel/eir/generic/eir-internal/main.hpp
@@ -44,7 +44,6 @@ initgraph::Stage *getInfoStructAvailableStage();
 initgraph::Stage *getEirDoneStage();
 
 extern void *initrd;
-extern EirFramebuffer *fb;
 extern EirInfo *info_ptr;
 
 extern frg::array<InitialRegion, 32> reservedRegions;

--- a/kernel/eir/generic/framebuffer.cpp
+++ b/kernel/eir/generic/framebuffer.cpp
@@ -1,0 +1,92 @@
+#include <assert.h>
+
+#include <eir-internal/debug.hpp>
+#include <eir-internal/framebuffer.hpp>
+#include <eir-internal/generic.hpp>
+#include <render-text.hpp>
+
+namespace eir {
+
+namespace {
+
+constexpr int fontWidth = 8;
+constexpr int fontHeight = 16;
+
+frg::optional<EirFramebuffer> &accessGlobalFb() {
+	static frg::eternal<frg::optional<EirFramebuffer>> singleton;
+	return *singleton;
+}
+
+struct FbLogHandler : LogHandler {
+	// Check whether eir can log to this framebuffer.
+	static bool suitable(const EirFramebuffer &fb) {
+		if (fb.fbBpp != 32)
+			return false;
+		if (fb.fbAddress + fb.fbHeight * fb.fbPitch > UINTPTR_MAX)
+			return false;
+		return true;
+	}
+
+	void emit(frg::string_view line) override {
+		auto &fb = *accessGlobalFb();
+		for (size_t i = 0; i < line.size(); ++i) {
+			auto c = line[i];
+			if (c == '\n') {
+				outputX_ = 0;
+				outputY_++;
+			} else if (outputX_ >= fb.fbWidth / fontWidth) {
+				outputX_ = 0;
+				outputY_++;
+			} else if (outputY_ >= fb.fbHeight / fontHeight) {
+				// TODO: Scroll.
+			} else {
+				renderChars(
+				    physToVirt<void>(fb.fbAddress),
+				    fb.fbPitch / sizeof(uint32_t),
+				    outputX_,
+				    outputY_,
+				    &c,
+				    1,
+				    15,
+				    -1,
+				    std::integral_constant<int, fontWidth>{},
+				    std::integral_constant<int, fontHeight>{}
+				);
+				outputX_++;
+			}
+		}
+		outputX_ = 0;
+		outputY_++;
+	}
+
+private:
+	unsigned int outputX_{0};
+	unsigned int outputY_{0};
+};
+
+constinit FbLogHandler fbLogHandler;
+
+} // anonymous namespace
+
+void initFramebuffer(const EirFramebuffer &fb) {
+	auto &globalFb = accessGlobalFb();
+	// Right now, we only support a single FB.
+	// If we want to support multiple ones, we may also need multiple log handlers
+	// (e.g., because some may be suitable for eir logging while others may not be).
+	assert(!globalFb);
+	globalFb = fb;
+
+	if (FbLogHandler::suitable(fb)) {
+		enableLogHandler(&fbLogHandler);
+	} else {
+		infoLogger() << "eir: Framebuffer is not suitable for logging" << frg::endlog;
+	}
+}
+
+const EirFramebuffer *getFramebuffer() {
+	auto &globalFb = accessGlobalFb();
+	if (!globalFb)
+		return nullptr;
+	return &(*globalFb);
+}
+} // namespace eir

--- a/kernel/eir/generic/main-function.cpp
+++ b/kernel/eir/generic/main-function.cpp
@@ -1,6 +1,7 @@
 #include <dtb.hpp>
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/framebuffer.hpp>
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
 #include <eir-internal/memory-layout.hpp>
@@ -8,7 +9,6 @@
 
 namespace eir {
 
-EirFramebuffer *fb = nullptr;
 EirInfo *info_ptr = nullptr;
 
 frg::array<eir::InitialRegion, 32> reservedRegions;
@@ -154,6 +154,7 @@ static initgraph::Task prepareFramebufferForThor{
     "generic.prepare-framebuffer-for-thor",
     initgraph::Requires{getEirDoneStage()},
     [] {
+	    auto *fb = getFramebuffer();
 	    if (fb) {
 		    // Map the framebuffer.
 		    assert(fb->fbAddress & ~static_cast<EirPtr>(pageSize - 1));
@@ -166,7 +167,9 @@ static initgraph::Task prepareFramebufferForThor{
 			    );
 		    mapKasanShadow(getKernelFrameBuffer(), fb->fbPitch * fb->fbHeight);
 		    unpoisonKasanShadow(getKernelFrameBuffer(), fb->fbPitch * fb->fbHeight);
-		    fb->fbEarlyWindow = getKernelFrameBuffer();
+
+		    info_ptr->frameBuffer = *fb;
+		    info_ptr->frameBuffer.fbEarlyWindow = getKernelFrameBuffer();
 	    }
     }
 };

--- a/kernel/eir/meson.build
+++ b/kernel/eir/meson.build
@@ -4,6 +4,7 @@ eir_generic_sources = files(
 	'generic/main.cpp',
 	'generic/memory-layout.cpp',
 	'generic/debug.cpp',
+	'generic/framebuffer.cpp',
 	'system/acpi/acpi.cpp',
 	'system/acpi/glue.cpp',
 )

--- a/kernel/eir/protos/limine/entry.cpp
+++ b/kernel/eir/protos/limine/entry.cpp
@@ -3,6 +3,7 @@
 #include <eir-internal/acpi/acpi.hpp>
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/framebuffer.hpp>
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
 #include <eir/interface.hpp>
@@ -74,14 +75,17 @@ initgraph::Task setupFramebufferInfo{
     [] {
 	    if (framebuffer_request.response && framebuffer_request.response->framebuffer_count > 0
 	        && framebuffer_request.response->framebuffers) {
-		    auto *limine_fb = framebuffer_request.response->framebuffers[0];
-		    fb = &info_ptr->frameBuffer;
-		    fb->fbAddress = virtToPhys(limine_fb->address);
-		    fb->fbPitch = limine_fb->pitch;
-		    fb->fbWidth = limine_fb->width;
-		    fb->fbHeight = limine_fb->height;
-		    fb->fbBpp = limine_fb->bpp;
-		    fb->fbType = limine_fb->memory_model; // TODO: Maybe inaccurate
+		    auto *limineFb = framebuffer_request.response->framebuffers[0];
+
+		    initFramebuffer(
+		        EirFramebuffer{
+		            .fbAddress = virtToPhys(limineFb->address),
+		            .fbPitch = limineFb->pitch,
+		            .fbWidth = limineFb->width,
+		            .fbHeight = limineFb->height,
+		            .fbBpp = limineFb->bpp,
+		        }
+		    );
 	    } else {
 		    infoLogger() << "eir: Got no framebuffer!" << frg::endlog;
 	    }

--- a/kernel/eir/protos/multiboot2/multiboot2.cpp
+++ b/kernel/eir/protos/multiboot2/multiboot2.cpp
@@ -24,6 +24,7 @@ eir::Mb2Tag *acpiTag = nullptr;
 initgraph::Task setupAcpiInfo{
     &globalInitEngine,
     "mb2.setup-acpi-info",
+    initgraph::Requires{getAllocationAvailableStage()},
     initgraph::Entails{getInfoStructAvailableStage(), acpi::getRsdpAvailableStage()},
     [] {
 	    if (acpiTag) {

--- a/kernel/eir/protos/multiboot2/multiboot2.cpp
+++ b/kernel/eir/protos/multiboot2/multiboot2.cpp
@@ -2,6 +2,7 @@
 #include <eir-internal/acpi/acpi.hpp>
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/framebuffer.hpp>
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
 #include <eir-internal/spec.hpp>
@@ -18,7 +19,6 @@ eir::Mb2Info *mbInfo = nullptr;
 uintptr_t mmapStart = 0;
 uintptr_t mmapEnd = 0;
 
-eir::Mb2TagFramebuffer *framebuffer = nullptr;
 eir::Mb2Tag *acpiTag = nullptr;
 
 initgraph::Task setupAcpiInfo{
@@ -30,24 +30,6 @@ initgraph::Task setupAcpiInfo{
 		    auto *rsdpPtr = bootAlloc<uint8_t>(acpiTag->size - sizeof(Mb2TagRSDP));
 		    memcpy(rsdpPtr, acpiTag->data, acpiTag->size - sizeof(Mb2TagRSDP));
 		    eirRsdpAddr = reinterpret_cast<uint64_t>(rsdpPtr);
-	    }
-    }
-};
-
-initgraph::Task setupFramebufferInfo{
-    &globalInitEngine,
-    "mb2.setup-framebuffer-info",
-    initgraph::Requires{getInfoStructAvailableStage()},
-    initgraph::Entails{getEirDoneStage()},
-    [] {
-	    if (framebuffer) {
-		    fb = &info_ptr->frameBuffer;
-		    fb->fbAddress = framebuffer->address;
-		    fb->fbPitch = framebuffer->pitch;
-		    fb->fbWidth = framebuffer->width;
-		    fb->fbHeight = framebuffer->height;
-		    fb->fbBpp = framebuffer->bpp;
-		    fb->fbType = framebuffer->type;
 	    }
     }
 };
@@ -107,23 +89,16 @@ extern "C" void eirMultiboot2Main(uint32_t info, uint32_t magic) {
 		switch (tag->type) {
 			case kMb2TagFramebuffer: {
 				auto *framebuffer_tag = reinterpret_cast<Mb2TagFramebuffer *>(tag);
-				if (framebuffer_tag->address + framebuffer_tag->width * framebuffer_tag->pitch
-				    >= UINTPTR_MAX) {
-					eir::infoLogger()
-					    << "eir: Framebuffer outside of addressable memory!" << frg::endlog;
-					framebuffer = framebuffer_tag;
-				} else if (framebuffer_tag->bpp != 32) {
-					eir::infoLogger() << "eir: Framebuffer does not use 32 bpp!" << frg::endlog;
-				} else {
-					setFbInfo(
-					    reinterpret_cast<void *>(framebuffer_tag->address),
-					    framebuffer_tag->width,
-					    framebuffer_tag->height,
-					    framebuffer_tag->pitch
-					);
 
-					framebuffer = framebuffer_tag;
-				}
+				initFramebuffer(
+				    EirFramebuffer{
+				        .fbAddress = framebuffer_tag->address,
+				        .fbPitch = framebuffer_tag->pitch,
+				        .fbWidth = framebuffer_tag->width,
+				        .fbHeight = framebuffer_tag->height,
+				        .fbBpp = framebuffer_tag->bpp,
+				    }
+				);
 				break;
 			}
 

--- a/kernel/eir/system/acpi/acpi.cpp
+++ b/kernel/eir/system/acpi/acpi.cpp
@@ -14,6 +14,10 @@ initgraph::Task setupTables{
 		    infoLogger() << "eir: No RSDP available, skipping ACPI table setup" << frg::endlog;
 		    return;
 	    }
+	    if (physOffset) {
+		    infoLogger() << "eir: ACPI is broken on the Limine boot protocol" << frg::endlog;
+		    return;
+	    }
 
 	    checkOrPanic(
 	        uacpi_setup_early_table_access(earlyTableBuffer.data(), earlyTableBuffer.size())


### PR DESCRIPTION
This moves the boot framebuffer handling to its own file and it fixes a few small issues (in MB2 and Limine protocols).