### PR TITLE
eir: Let Eir's UART subsystem pass boot UART tag

### DIFF
--- a/kernel/eir/arch/arm/platform/raspi4/raspi4.cpp
+++ b/kernel/eir/arch/arm/platform/raspi4/raspi4.cpp
@@ -5,7 +5,7 @@
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
 #include <eir-internal/memory-layout.hpp>
-#include <eir-internal/uart/pl011.hpp>
+#include <eir-internal/uart/uart.hpp>
 #include <eir/interface.hpp>
 #include <frg/eternal.hpp> // for aligned_storage
 #include <frg/manual_box.hpp>
@@ -348,9 +348,8 @@ static initgraph::Task setupBootUartMmio{
 	    mapKasanShadow(addr, 0x1000);
 	    unpoisonKasanShadow(addr, 0x1000);
 
-	    extern BootUartConfig bootUartConfig;
-	    bootUartConfig.address = addr;
-	    bootUartConfig.type = BootUartType::pl011;
+	    uart::bootUartConfig.window = addr;
+	    uart::bootUartConfig.type = BootUartType::pl011;
     }
 };
 

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -4,6 +4,7 @@
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
 #include <eir-internal/memory-layout.hpp>
+#include <eir-internal/uart/uart.hpp>
 
 #include <elf.h>
 #include <frg/array.hpp>
@@ -404,8 +405,6 @@ void parseInitrd(void *initrd) {
 		eir::panicLogger() << "eir: could not find thor in the initrd.cpio" << frg::endlog;
 }
 
-BootUartConfig bootUartConfig;
-
 namespace {
 
 bool patchGenericManagarmElfNote(unsigned int type, frg::span<char> desc) {
@@ -427,7 +426,7 @@ bool patchGenericManagarmElfNote(unsigned int type, frg::span<char> desc) {
 	} else if (type == elf_note_type::bootUartConfig) {
 		if (desc.size() != sizeof(BootUartConfig))
 			panicLogger() << "BootUartConfig size does not match ELF note" << frg::endlog;
-		memcpy(desc.data(), &bootUartConfig, sizeof(BootUartConfig));
+		memcpy(desc.data(), &uart::bootUartConfig, sizeof(BootUartConfig));
 		return true;
 	}
 	return false;

--- a/kernel/eir/system/acpi/console.cpp
+++ b/kernel/eir/system/acpi/console.cpp
@@ -13,7 +13,11 @@ constinit uart::AnyUart acpiUart;
 constinit frg::manual_box<uart::UartLogHandler> acpiUartLogHandler;
 
 initgraph::Task parseSpcrDbg2{
-    &globalInitEngine, "acpi.parse-spcr-dbg2", initgraph::Requires{getTablesAvailableStage()}, [] {
+    &globalInitEngine,
+    "acpi.parse-spcr-dbg2",
+    initgraph::Requires{getTablesAvailableStage()},
+    initgraph::Entails{uart::getBootUartDeterminedStage()},
+    [] {
 	    if (!haveTables())
 		    return;
 
@@ -48,6 +52,7 @@ initgraph::Task parseSpcrDbg2{
 		    if (!std::holds_alternative<std::monostate>(acpiUart)) {
 			    acpiUartLogHandler.initialize(&acpiUart);
 			    enableLogHandler(acpiUartLogHandler.get());
+			    setBootUart(&acpiUart);
 			    return;
 		    }
 	    }
@@ -84,6 +89,7 @@ initgraph::Task parseSpcrDbg2{
 			    if (!std::holds_alternative<std::monostate>(acpiUart)) {
 				    acpiUartLogHandler.initialize(&acpiUart);
 				    enableLogHandler(acpiUartLogHandler.get());
+				    setBootUart(&acpiUart);
 				    return;
 			    }
 		    }

--- a/kernel/eir/system/uart/eir-internal/uart/ns16550.hpp
+++ b/kernel/eir/system/uart/eir-internal/uart/ns16550.hpp
@@ -4,6 +4,7 @@
 
 #include <arch/io_space.hpp>
 #include <arch/mem_space.hpp>
+#include <eir/interface.hpp>
 
 namespace eir::uart {
 
@@ -15,6 +16,8 @@ struct Ns16550 {
 	Ns16550 &operator=(const Ns16550 &) = delete;
 
 	void write(char c);
+
+	void getBootUartConfig(BootUartConfig &) {}
 
 private:
 	Space regs_;

--- a/kernel/eir/system/uart/eir-internal/uart/pl011.hpp
+++ b/kernel/eir/system/uart/eir-internal/uart/pl011.hpp
@@ -2,6 +2,8 @@
 
 #include <arch/mem_space.hpp>
 #include <arch/register.hpp>
+#include <eir-internal/generic.hpp>
+#include <eir/interface.hpp>
 #include <stdint.h>
 
 namespace eir::uart {
@@ -32,7 +34,7 @@ static constexpr arch::field<uint32_t, bool> fifo_en{4, 1};
 } // namespace pl011_line_control
 
 struct PL011 {
-	PL011(uintptr_t base, uint64_t clock) : space_{base}, clock_{clock} {}
+	PL011(uintptr_t base, uint64_t clock) : base_{base}, space_{base}, clock_{clock} {}
 
 	void disable() { space_.store(pl011_reg::control, pl011_control::uart_en(false)); }
 
@@ -66,7 +68,14 @@ struct PL011 {
 		space_.store(pl011_reg::data, val);
 	}
 
+	void getBootUartConfig(BootUartConfig &out) {
+		out.type = BootUartType::pl011;
+		out.address = base_;
+		out.size = 0x1000;
+	}
+
 private:
+	address_t base_;
 	arch::mem_space space_;
 	uint64_t clock_;
 };

--- a/kernel/eir/system/uart/eir-internal/uart/uart.hpp
+++ b/kernel/eir/system/uart/eir-internal/uart/uart.hpp
@@ -4,6 +4,7 @@
 
 #include <dtb.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/main.hpp>
 #include <eir-internal/uart/ns16550.hpp>
 #include <eir-internal/uart/pl011.hpp>
 #include <uacpi/acpi.h>
@@ -25,11 +26,19 @@ private:
 	AnyUart *uart_;
 };
 
+// This is consumed by Eir's generic code to fill the boot UART tag.
+extern BootUartConfig bootUartConfig;
+
+void setBootUart(AnyUart *uartPtr);
+
 // Initialize a UART from the DBG2 or SPCR tables.
 // For DBG2, the type (not subtype) must be serial (= 0x8000).
 // The subtype that is passed to this function is also defined by DBG2.
 void initFromAcpi(AnyUart &uart, unsigned int subtype, const acpi_gas &base);
 
 void initFromDtb(AnyUart &uart, const DeviceTree &tree, const DeviceTreeNode &node);
+
+// The boot UART must be determined before this stage.
+initgraph::Stage *getBootUartDeterminedStage();
 
 } // namespace eir::uart

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -219,5 +219,7 @@ enum class BootUartType {
 
 struct BootUartConfig {
 	uint64_t address = 0;
+	uint64_t size = 0;
+	uint64_t window = 0;
 	BootUartType type = BootUartType::none;
 };

--- a/kernel/thor/arch/arm/debug.cpp
+++ b/kernel/thor/arch/arm/debug.cpp
@@ -50,7 +50,7 @@ void UartLogHandler::printChar(char c) {
 	if (bootUartConfig->type != BootUartType::pl011)
 		return;
 
-	arch::mem_space space{bootUartConfig->address};
+	arch::mem_space space{bootUartConfig->window};
 
 	// We assume here that Eir has mapped the UART as device memory, and
 	// configured the UART to some sensible settings (115200 8N1).


### PR DESCRIPTION
The move to `eir-linux` temporarily dropped the code to set the boot UART tag. Re-introduce code to do this but make it more generic this time (such that it works for DT and ACPI provided UARTs).