### PR TITLE
UHCI fixes

### DIFF
--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -1070,6 +1070,7 @@ async::detached bindController(mbus_ng::Entity entity) {
 	auto legsup = co_await device.loadPciSpace(kPciLegacySupport, 2);
 	std::cout << "uhci: Legacy support register: " << legsup << std::endl;
 
+	co_await device.enableBusmaster();
 	HEL_CHECK(helEnableIo(bar.getHandle()));
 
 	arch::io_space base = arch::global_io.subspace(info.barInfo[4].address);

--- a/protocols/usb/src/server.cpp
+++ b/protocols/usb/src/server.cpp
@@ -45,8 +45,7 @@ auto handleXferReq(auto req, auto &endpoint, auto &&...xferArgs) {
 		std::forward<decltype(xferArgs)>(xferArgs)...
 	};
 
-	if (req->dir() == managarm::usb::XferDirection::TO_DEVICE)
-		xfer.allowShortPackets = req->allow_short_packets();
+	xfer.allowShortPackets = req->allow_short_packets();
 	xfer.lazyNotification = req->lazy_notification();
 
 	return endpoint.transfer(xfer);


### PR DESCRIPTION
This makes UHCI work in QEMU again; tested with QEMU's keyboard and tablet devices in weston and kmscon using evtest.