### PR TITLE
ci-boot: Add utility

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -217,7 +217,7 @@ if build_drivers or provide_deps
 		# misc
 		'kernletcc'
 	]
-	utils = [ 'runsvr', 'lsmbus', 'wait-for-devices' ]
+	utils = [ 'ci-boot', 'runsvr', 'lsmbus', 'wait-for-devices' ]
 
 	# delay these dirs until last as they require other libs
 	# to already be built
@@ -261,6 +261,8 @@ if build_drivers
 	units = [
 		'drivers/kbd/runsvr-atkbd.service',
 		'drivers/usb/runsvr-usbhid.service',
+		'utils/ci-boot/ci-boot.service',
+		'utils/ci-boot/ci-boot.target',
 	]
 
 	install_data(units, install_dir : 'lib/systemd/system')

--- a/utils/ci-boot/ci-boot.py
+++ b/utils/ci-boot/ci-boot.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3 -u
+
+import asyncio
+import base64
+import json
+
+DEBUG = False
+
+
+class CiBoot:
+    def __init__(self, pipe):
+        self.pipe = pipe
+
+    async def run(self):
+        print("Ready for commands")
+        self._emit({"m": "ready"})
+        for line in self.pipe:
+            if DEBUG:
+                print("Received line:", repr(line))
+            try:
+                msg = json.loads(line)
+                if msg["m"] == "launch":
+                    script = msg["script"]
+                    await self._launch(script)
+                else:
+                    raise RuntimeError("Bad message type: " + msg["m"])
+            except Exception as e:
+                print("Error:", str(e))
+                self._emit({"m": "error", "text": str(e)})
+
+    async def _launch(self, script):
+        print("Launching script:", repr(script))
+        process = await asyncio.create_subprocess_exec(
+            "/usr/bin/bash",
+            "-c",
+            script,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        await asyncio.gather(
+            self._handle_output("stdout", process.stdout),
+            self._handle_output("stderr", process.stderr),
+            process.wait(),
+        )
+
+        print(f"Script terminated with {process.returncode}")
+        self._emit({"m": "exit", "exitcode": process.returncode})
+
+    async def _handle_output(self, kind, stream):
+        async for line in stream:
+            print(f"{kind}: " + line.rstrip().decode("utf8", errors="backslashreplace"))
+            self._emit({"m": kind, "data": base64.b64encode(line).decode("ascii")})
+
+    def _emit(self, msg):
+        line = json.dumps(msg)
+        self.pipe.write(line.encode("utf8") + b"\n")
+
+
+async def main():
+    with open("/dev/ttyS0", "rb+", buffering=0) as f:
+        ciboot = CiBoot(f)
+        await ciboot.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/utils/ci-boot/ci-boot.service
+++ b/utils/ci-boot/ci-boot.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=CI Boot
+Documentation=https://docs.managarm.org/
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ci-boot.py
+
+[Install]
+WantedBy=ci-boot.target

--- a/utils/ci-boot/ci-boot.target
+++ b/utils/ci-boot/ci-boot.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=CI Boot
+Documentation=https://docs.managarm.org/
+Requires=basic.target
+Conflicts=rescue.service rescue.target
+After=basic.target rescue.service rescue.target
+AllowIsolate=yes

--- a/utils/ci-boot/meson.build
+++ b/utils/ci-boot/meson.build
@@ -1,0 +1,4 @@
+install_data(
+	'ci-boot.py',
+	install_dir : get_option('bindir'),
+)


### PR DESCRIPTION
`ci-boot.py` takes commands from `vm-util.py` on `/dev/ttyS0` as newline-delimited JSON. This allows us to launch `kernel-tests` / `posix-tests` etc. on CI.