### PR TITLE
utils: enable waiting for network for `ci-boot.service`

### DIFF
--- a/utils/ci-boot/ci-boot.service
+++ b/utils/ci-boot/ci-boot.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=CI Boot
 Documentation=https://docs.managarm.org/
+Wants=dhcpcd.service
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
This is useful for running os-test via ci-boot, as otherwise some UDP tests fail.