### PR TITLE
eir: Fix initgraph targets for CPU detection

### DIFF
--- a/kernel/eir/system/acpi/cpu-count.cpp
+++ b/kernel/eir/system/acpi/cpu-count.cpp
@@ -13,7 +13,7 @@ initgraph::Task detectCpusFromMadt{
     &globalInitEngine,
     "acpi.detect-cpu-count",
     initgraph::Requires{getTablesAvailableStage()},
-    initgraph::Entails{getReservedRegionsKnownStage()},
+    initgraph::Entails{getKernelLoadableStage()},
     [] {
 	    if (!haveTables())
 		    return;
@@ -33,7 +33,7 @@ initgraph::Task detectCpusFromMadt{
 		    memcpy(&generic, genericPtr, sizeof(generic));
 
 		    switch (generic.type) {
-#ifdef __x86_64__
+#if defined(__i386__) || defined(__x86_64__)
 			    case ACPI_MADT_ENTRY_TYPE_LAPIC: {
 				    acpi_madt_lapic entry;
 				    memcpy(&entry, genericPtr, sizeof(entry));
@@ -64,6 +64,8 @@ initgraph::Task detectCpusFromMadt{
 	    if (cpuCount > 0) {
 		    cpuConfig.totalCpus = cpuCount;
 		    infoLogger() << "eir: Detected " << cpuCount << " CPUs from MADT" << frg::endlog;
+	    } else {
+		    panicLogger() << "eir: Failed to detect CPUs from MADT" << frg::endlog;
 	    }
     }
 };

--- a/kernel/eir/system/dtb/cpu-count.cpp
+++ b/kernel/eir/system/dtb/cpu-count.cpp
@@ -8,10 +8,7 @@ namespace eir {
 namespace {
 
 initgraph::Task detectCpusFromDtb{
-    &globalInitEngine,
-    "dt.detect-cpu-count",
-    initgraph::Entails{getReservedRegionsKnownStage()},
-    [] {
+    &globalInitEngine, "dt.detect-cpu-count", initgraph::Entails{getKernelLoadableStage()}, [] {
 	    if (!eirDtbPtr)
 		    return;
 
@@ -41,6 +38,8 @@ initgraph::Task detectCpusFromDtb{
 	    if (cpuCount > 0) {
 		    cpuConfig.totalCpus = cpuCount;
 		    infoLogger() << "eir: Detected " << cpuCount << " CPUs from DTB" << frg::endlog;
+	    } else {
+		    panicLogger() << "eir: Failed to detect CPUs from DT" << frg::endlog;
 	    }
     }
 };


### PR DESCRIPTION
Fix the initgraph targets for CPU detection and recognize local APIC MADT entries on 32-bit x86. This broke mb2 (since it is compiled it in 32-bit mode).