### PR TITLE
posix: Let chroot() and chdir() fail on non-directories

### DIFF
--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -312,12 +312,18 @@ ViewPath FsContext::getWorkingDirectory() {
 	return _workDir;
 }
 
-void FsContext::changeRoot(ViewPath root) {
+std::expected<void, Error> FsContext::changeRoot(ViewPath root) {
+	if(root.second->getTarget()->getType() != VfsType::directory)
+		return std::unexpected(Error::notDirectory);
 	_root = std::move(root);
+	return {};
 }
 
-void FsContext::changeWorkingDirectory(ViewPath workdir) {
+std::expected<void, Error> FsContext::changeWorkingDirectory(ViewPath workdir) {
+	if(workdir.second->getTarget()->getType() != VfsType::directory)
+		return std::unexpected(Error::notDirectory);
 	_workDir = std::move(workdir);
+	return {};
 }
 
 mode_t FsContext::getUmask() {

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -151,8 +151,8 @@ struct FsContext {
 	ViewPath getWorkingDirectory();
 	mode_t getUmask();
 
-	void changeRoot(ViewPath root);
-	void changeWorkingDirectory(ViewPath root);
+	std::expected<void, Error> changeRoot(ViewPath root);
+	std::expected<void, Error> changeWorkingDirectory(ViewPath path);
 	mode_t setUmask(mode_t mask);
 
 private:

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -44,7 +44,11 @@ async::result<void> handleChroot(RequestContext& ctx) {
 		}
 	}
 	auto path = pathResult.value();
-	ctx.self->fsContext()->changeRoot(path);
+	auto rootResult = ctx.self->fsContext()->changeRoot(path);
+	if(!rootResult) {
+		co_await sendErrorResponse<managarm::posix::ChrootResponse>(ctx, rootResult.error() | toPosixProtoError);
+		co_return;
+	}
 
 	managarm::posix::ChrootResponse resp;
 	resp.set_error(managarm::posix::Errors::SUCCESS);
@@ -90,7 +94,11 @@ async::result<void> handleChdir(RequestContext& ctx) {
 		}
 	}
 	auto path = pathResult.value();
-	ctx.self->fsContext()->changeWorkingDirectory(path);
+	auto cwdResult = ctx.self->fsContext()->changeWorkingDirectory(path);
+	if(!cwdResult) {
+		co_await sendErrorResponse<managarm::posix::ChdirResponse>(ctx, cwdResult.error() | toPosixProtoError);
+		co_return;
+	}
 
 	managarm::posix::ChdirResponse resp;
 	resp.set_error(managarm::posix::Errors::SUCCESS);


### PR DESCRIPTION
Fix #1219.