### PR TITLE
thor: Fix uacpi calls outside of ACPI fiber

### DIFF
--- a/kernel/thor/system/acpi/battery.cpp
+++ b/kernel/thor/system/acpi/battery.cpp
@@ -135,7 +135,9 @@ coroutine<void> BatteryBusObject::run() {
 	// TODO(qookie): Better error handling here.
 	(co_await createObject("battery", std::move(properties))).unwrap();
 
-	uacpi_install_notify_handler(_node, BatteryBusObject::notification, this);
+	co_await onAcpiFiber([&] {
+		uacpi_install_notify_handler(_node, BatteryBusObject::notification, this);
+	});
 }
 
 coroutine<frg::expected<Error>> BatteryBusObject::handleRequest(LaneHandle lane) {

--- a/kernel/thor/system/acpi/thor-internal/acpi/acpi.hpp
+++ b/kernel/thor/system/acpi/thor-internal/acpi/acpi.hpp
@@ -59,12 +59,7 @@ void initEc();
 void initEvents();
 
 struct AcpiObject final : public KernelBusObject {
-	AcpiObject(uacpi_namespace_node *node, unsigned int id) : node{node}, instance{id} {
-		if (node) {
-			uacpi_eval_hid(node, &hid_name);
-			uacpi_eval_cid(node, &cid_name);
-		}
-	}
+	AcpiObject(uacpi_namespace_node *node, unsigned int id) : node{node}, instance{id} {}
 
 	~AcpiObject() {
 		if (hid_name)


### PR DESCRIPTION
Calling into uacpi from coroutines does not work since uacpi bindings may call into `KernelFiber::asyncBlockCurrent()`.

Fixes a crash reported by @no92.