### PR TITLE
thor: Introduce thread condition logic

### DIFF
--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -868,6 +868,7 @@ void handleSyscall(SyscallImageAccessor image) {
 
 	// Note: Thread::raiseSignals() only returns if nothing needs to be raised.
 	//       Otherwise, it saves the syscall image and suspends this thread.
+	Thread::handleConditions(image);
 	Thread::raiseSignals(image);
 }
 

--- a/kernel/thor/generic/thor-internal/thread.hpp
+++ b/kernel/thor/generic/thor-internal/thread.hpp
@@ -13,6 +13,18 @@
 
 namespace thor {
 
+// Bitwise flags that cause a thread to take some asynchronous action.
+using Condition = uint32_t;
+
+// Conditions are dequeued in descending order (i.e., high condition bits take priority).
+// TODO: Integrate asynchronous WorkQueue runs into Condition.
+// TODO: Integrate thread killing into Condition.
+// TODO: Integrate CPU migration into Condition.
+namespace condition {
+// Request kIntrRequested to be raised.
+inline constexpr Condition interrupt = Condition{1} << 0;
+} // namespace condition
+
 enum Interrupt {
 	kIntrNull,
 	kIntrDivByZero,
@@ -290,6 +302,7 @@ public:
 	static void interruptCurrent(Interrupt interrupt, FaultImageAccessor image, InterruptInfo info);
 	static void interruptCurrent(Interrupt interrupt, SyscallImageAccessor image, InterruptInfo info);
 
+	static void handleConditions(SyscallImageAccessor image);
 	static void raiseSignals(SyscallImageAccessor image);
 
 	// State transitions that apply to arbitrary threads.
@@ -298,14 +311,6 @@ public:
 	static void killOther(smarter::borrowed_ptr<Thread> thread);
 	static void interruptOther(smarter::borrowed_ptr<Thread> thread);
 	static Error resumeOther(smarter::borrowed_ptr<Thread> thread);
-
-	// These signals let the thread change its RunState.
-	// Do not confuse them with POSIX signals!
-	// TODO: Interrupt signals should be queued.
-	enum Signal {
-		kSigNone,
-		kSigInterrupt
-	};
 
 	enum Flags : uint32_t {
 		kFlagServer = 1
@@ -454,7 +459,12 @@ private:
 
 	// This is set by interruptOther() and polled by raiseSignals().
 	bool _pendingKill;
-	Signal _pendingSignal;
+	// Conditions are raised while holding the thread mutex.
+	// In particular, functions like blockCurrent() can be sure that no conditions
+	// become pending while they are modifying the thread state.
+	// Conditions can be read and cleared without holding the mutex.
+	// Conditions can only be cleared from the thread itself.
+	std::atomic<Condition> _pendingConditions{0};
 
 	// Number of references that keep this thread running.
 	// The thread is killed when this counter reaches zero.

--- a/kernel/thor/generic/thread.cpp
+++ b/kernel/thor/generic/thread.cpp
@@ -85,6 +85,10 @@ bool Thread::blockCurrent(bool interruptible) {
 	if(thisThread->_unblockLatch.exchange(false, std::memory_order_acquire))
 		return true;
 
+	// Avoid taking _mutex if we are interrupted anyway.
+	if (interruptible && thisThread->_pendingConditions.load(std::memory_order_relaxed))
+		return false;
+
 	StatelessIrqLock irqLock;
 	auto lock = frg::guard(&thisThread->_mutex);
 
@@ -92,6 +96,11 @@ bool Thread::blockCurrent(bool interruptible) {
 	// is ordered to the aquisition in unblockOther(), we are still correct.
 	if(thisThread->_unblockLatch.load(std::memory_order_relaxed))
 		return true;
+
+	// Conditions can only become pending if the _mutex is held,
+	// hence we never move to blocked state while conditions are pending.
+	if (interruptible && thisThread->_pendingConditions.load(std::memory_order_relaxed))
+		return false;
 
 	if(logRunStates)
 		infoLogger() << "thor: " << (void *)thisThread.get()
@@ -113,9 +122,6 @@ bool Thread::blockCurrent(bool interruptible) {
 		}, getCpuData()->detachedStack.base(), &thisThread->_executor, std::move(lock));
 	}, &thisThread->_executor);
 
-	// Check if we've been interrupted
-	if (interruptible && thisThread->_pendingSignal == kSigInterrupt)
-		return false;
 	return true;
 }
 
@@ -293,6 +299,29 @@ void Thread::interruptCurrent(Interrupt interrupt, SyscallImageAccessor image, I
 	}, getCpuData()->detachedStack.base(), image, interrupt, this_thread.get(), std::move(lock));
 }
 
+void Thread::handleConditions(SyscallImageAccessor image) {
+	assert(image.iplState()->current < ipl::schedule);
+	auto thisThread = getCurrentThread();
+
+	auto pending = thisThread->_pendingConditions.load(std::memory_order_relaxed);
+	while (pending) {
+		// Dequeue the highest pending bit.
+		auto c = Condition{1} << frg::floor_log2(pending);
+		pending = thisThread->_pendingConditions.fetch_and(~c, std::memory_order_relaxed);
+		// Holds because only the thread itself can clear _pendingConditions.
+		assert(pending & c);
+		switch (c) {
+			case condition::interrupt:
+				interruptCurrent(kIntrRequested, image, {});
+				break;
+			default:
+				panicLogger() << "Bad thread condition " << c << frg::endlog;
+		}
+		// Re-load in case new conditions were raised.
+		pending = thisThread->_pendingConditions.load(std::memory_order_relaxed);
+	}
+}
+
 void Thread::raiseSignals(SyscallImageAccessor image) {
 	assert(image.iplState()->current < ipl::schedule);
 
@@ -339,44 +368,6 @@ void Thread::raiseSignals(SyscallImageAccessor image) {
 				auto node = queue.pop_front();
 				async::execution::set_value(node->receiver,
 						frg::make_tuple(Error::threadExited, 0, kIntrNull));
-			}
-
-			scheduler->updateQueue();
-			scheduler->forceReschedule();
-			scheduler->commitReschedule();
-		}, getCpuData()->detachedStack.base(), image, this_thread.get(), std::move(lock));
-	}else if(this_thread->_pendingSignal == kSigInterrupt) {
-		if(logRunStates)
-			infoLogger() << "thor: " << (void *)this_thread.get()
-					<< " was (asynchronously) interrupted" << frg::endlog;
-
-		this_thread->_updateRunTime();
-		this_thread->_runState = kRunInterrupted;
-		this_thread->_lastInterrupt = kIntrRequested;
-		++this_thread->_stateSeq;
-		this_thread->_pendingSignal = kSigNone;
-		saveExecutor(&this_thread->_executor, image);
-		this_thread->_uninvoke();
-
-		localScheduler.get().updateState();
-		Scheduler::suspendCurrent();
-
-		runOnStack([] (Continuation cont, SyscallImageAccessor image,
-				Thread *thread, frg::unique_lock<Mutex> lock) {
-			scrubStack(image, cont);
-			auto *scheduler = &localScheduler.get();
-
-			ObserveQueue queue;
-			queue.splice(queue.end(), thread->_observeQueue);
-			auto sequence = thread->_stateSeq;
-
-			lock.unlock();
-
-			// Run observer callbacks before re-scheduling (as callbacks may unblock threads).
-			while(!queue.empty()) {
-				auto node = queue.pop_front();
-				async::execution::set_value(node->receiver,
-						frg::make_tuple(Error::success, sequence, kIntrRequested));
 			}
 
 			scheduler->updateQueue();
@@ -447,9 +438,12 @@ void Thread::interruptOther(smarter::borrowed_ptr<Thread> thread) {
 		auto lock = frg::guard(&thread->_mutex);
 
 		// TODO: Perform the interrupt immediately if possible.
-		// assert(thread->_pendingSignal == kSigNone);
 
-		thread->_pendingSignal = kSigInterrupt;
+		auto pending = thread->_pendingConditions.fetch_or(
+			condition::interrupt, std::memory_order_relaxed
+		);
+		if (pending & condition::interrupt)
+			return;
 
 		// If the thread is blocked and can be interrupted,
 		// then unblock it to notify.
@@ -483,7 +477,7 @@ Thread::Thread(smarter::shared_ptr<Universe> universe,
 		smarter::shared_ptr<AddressSpace, BindableHandle> address_space, AbiParameters abi)
 : flags{0}, _mainWorkQueue{this, ipl::passive}, _pagingWorkQueue{this, ipl::exceptional},
 		_runState{kRunInterrupted}, _lastInterrupt{kIntrNull}, _stateSeq{1},
-		_pendingKill{false}, _pendingSignal{kSigNone}, _runCount{1},
+		_pendingKill{false}, _runCount{1},
 		_executor{&_userContext, abi},
 		_universe{std::move(universe)}, _addressSpace{std::move(address_space)} {
 	_lastRunTimeUpdate = getClockNanos();


### PR DESCRIPTION
Right now, `Thread::raiseSignals()` handles various asynchronous actions that a thread can take, namely entering interrupted state if `_pendingSignals` is set, killing the thread if `_pendingKill` is set and CPU migration if we are not on `_lbCb->getAssignedCpu()`. It would be nicer to unify this in a single bitmask.

This PR adds such a `Thread::_pendingConditions` bitmask and converts the transition to the interrupted state to the new bitmask.