### PR TITLE
thor: Run fibers and page faults with interrupts enabled on RISC-V

### DIFF
--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -100,7 +100,7 @@ Executor::Executor(FiberContext *context, AbiParameters abi) {
 	general()->ip = abi.ip;
 	general()->sp() = (uintptr_t)context->stack.basePtr();
 	general()->a(0) = abi.argument;
-	general()->sstatus = riscv::sstatus::sppBit;
+	general()->sstatus = riscv::sstatus::sppBit | riscv::sstatus::spieBit;
 }
 
 Executor::~Executor() { kernelAlloc->free(_pointer); }

--- a/kernel/thor/arch/riscv/trap.cpp
+++ b/kernel/thor/arch/riscv/trap.cpp
@@ -237,6 +237,7 @@ void handleRiscvException(Frame *frame, uint64_t code) {
 		case codeLoadPageFault:
 		case codeStorePageFault:
 			iplEnterContext(ipl::exceptional, frame->iplState);
+			enableInts();
 
 			handleRiscvPageFault(frame, code, trapValue);
 			break;


### PR DESCRIPTION
This fixes crashes due to IPL de-sync on RISC-V.