### PR TITLE
libblockfs, netserver: Fix UAF around serveFile()

### DIFF
--- a/drivers/libblockfs/src/common-ops.hpp
+++ b/drivers/libblockfs/src/common-ops.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <async/algorithm.hpp>
 #include <core/clock.hpp>
 #include <frg/scope_exit.hpp>
 #include "fs.hpp"
@@ -275,19 +276,18 @@ doOpen(std::shared_ptr<void> object, bool write, bool read, bool append) {
 
 	[] (smarter::shared_ptr<File> file, BaseFileSystem &fs, helix::UniqueLane localCtrl,
 			helix::UniqueLane localPt) -> async::detached {
-		async::cancellation_event cancelPt;
 		auto fileOps = fs.fileOps();
 
-		// Cancel the passthrough lane once the file line is closed.
-		async::detach(
-			protocols::fs::serveFile(std::move(localCtrl),
-					file.get(), fileOps),
-			[&] {
-				cancelPt.cancel();
-			});
-
-		co_await protocols::fs::servePassthrough(std::move(localPt),
-				file, fileOps, cancelPt);
+		co_await async::race_and_cancel(
+			[&](async::cancellation_token) {
+				return protocols::fs::serveFile(std::move(localCtrl),
+						file.get(), fileOps);
+			},
+			[&](async::cancellation_token ct) {
+				return protocols::fs::servePassthrough(std::move(localPt),
+						file, fileOps, ct);
+			}
+		);
 	}(file, self->fs, std::move(localCtrl), std::move(localPt));
 
 	co_return protocols::fs::OpenResult{std::move(remoteCtrl), std::move(remotePt)};

--- a/servers/netserver/src/ip/icmp.cpp
+++ b/servers/netserver/src/ip/icmp.cpp
@@ -5,6 +5,7 @@
 
 #include <arch/bit.hpp>
 #include <arpa/inet.h>
+#include <async/algorithm.hpp>
 #include <async/basic.hpp>
 #include <async/queue.hpp>
 #include <async/recurring-event.hpp>
@@ -359,13 +360,16 @@ static async::result<void> serveLanes(
 	helix::UniqueLane ptLane,
 	smarter::shared_ptr<IcmpSocket> sock
 ) {
-	async::cancellation_event cancelPt;
-	async::detach(protocols::fs::serveFile(std::move(ctrlLane),
-			sock.get(), &IcmpSocket::ops), [&] {
-		cancelPt.cancel();
-	});
-
-	co_await protocols::fs::servePassthrough(std::move(ptLane), sock, &IcmpSocket::ops, cancelPt);
+	co_await async::race_and_cancel(
+		[&](async::cancellation_token) {
+			return protocols::fs::serveFile(std::move(ctrlLane),
+					sock.get(), &IcmpSocket::ops);
+		},
+		[&](async::cancellation_token ct) {
+			return protocols::fs::servePassthrough(std::move(ptLane),
+					sock, &IcmpSocket::ops, ct);
+		}
+	);
 	sock->handleClose();
 }
 

--- a/servers/netserver/src/ip/tcp4.cpp
+++ b/servers/netserver/src/ip/tcp4.cpp
@@ -1,3 +1,4 @@
+#include <async/algorithm.hpp>
 #include <async/basic.hpp>
 #include <async/recurring-event.hpp>
 #include <async/result.hpp>
@@ -1213,14 +1214,16 @@ static async::result<void> serveLanes(
 	helix::UniqueLane ptLane,
 	smarter::shared_ptr<Tcp4Socket> sock
 ) {
-	// TODO: This could use race_and_cancel().
-	async::cancellation_event cancelPt;
-	async::detach(protocols::fs::serveFile(std::move(ctrlLane),
-			sock.get(), &Tcp4Socket::ops), [&] {
-		cancelPt.cancel();
-	});
-
-	co_await protocols::fs::servePassthrough(std::move(ptLane), sock, &Tcp4Socket::ops, cancelPt);
+	co_await async::race_and_cancel(
+		[&](async::cancellation_token) {
+			return protocols::fs::serveFile(std::move(ctrlLane),
+					sock.get(), &Tcp4Socket::ops);
+		},
+		[&](async::cancellation_token ct) {
+			return protocols::fs::servePassthrough(std::move(ptLane),
+					sock, &Tcp4Socket::ops, ct);
+		}
+	);
 	std::println("netserver: TCP socket closed");
 	co_await sock->disconnect();
 }

--- a/servers/netserver/src/ip/udp4.cpp
+++ b/servers/netserver/src/ip/udp4.cpp
@@ -3,6 +3,7 @@
 #include "ip4.hpp"
 #include "checksum.hpp"
 
+#include <async/algorithm.hpp>
 #include <async/basic.hpp>
 #include <async/recurring-event.hpp>
 #include <async/result.hpp>
@@ -761,14 +762,16 @@ static async::result<void> serveLanes(
 	helix::UniqueLane ptLane,
 	smarter::shared_ptr<Udp4Socket> sock
 ) {
-	// TODO: This could use race_and_cancel().
-	async::cancellation_event cancelPt;
-	async::detach(protocols::fs::serveFile(std::move(ctrlLane),
-			sock.get(), &Udp4Socket::ops), [&] {
-		cancelPt.cancel();
-	});
-
-	co_await protocols::fs::servePassthrough(std::move(ptLane), sock, &Udp4Socket::ops, cancelPt);
+	co_await async::race_and_cancel(
+		[&](async::cancellation_token) {
+			return protocols::fs::serveFile(std::move(ctrlLane),
+					sock.get(), &Udp4Socket::ops);
+		},
+		[&](async::cancellation_token ct) {
+			return protocols::fs::servePassthrough(std::move(ptLane),
+					sock, &Udp4Socket::ops, ct);
+		}
+	);
 	sock->handleClose();
 }
 

--- a/servers/netserver/src/main.cpp
+++ b/servers/netserver/src/main.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <async/algorithm.hpp>
 #include <async/result.hpp>
 #include <bragi/helpers-std.hpp>
 #include <core/clock.hpp>
@@ -498,13 +499,16 @@ static async::result<void> serveNetlinkLanes(
 	helix::UniqueLane ptLane,
 	smarter::shared_ptr<nl::NetlinkSocket> sock
 ) {
-	async::cancellation_event cancelPt;
-	async::detach(protocols::fs::serveFile(std::move(ctrlLane),
-			sock.get(), &nl::NetlinkSocket::ops), [&] {
-		cancelPt.cancel();
-	});
-
-	co_await servePassthrough(std::move(ptLane), sock, &nl::NetlinkSocket::ops, cancelPt);
+	co_await async::race_and_cancel(
+		[&](async::cancellation_token) {
+			return protocols::fs::serveFile(std::move(ctrlLane),
+					sock.get(), &nl::NetlinkSocket::ops);
+		},
+		[&](async::cancellation_token ct) {
+			return protocols::fs::servePassthrough(std::move(ptLane),
+					sock, &nl::NetlinkSocket::ops, ct);
+		}
+	);
 	sock->handleClose();
 }
 

--- a/servers/netserver/src/raw.cpp
+++ b/servers/netserver/src/raw.cpp
@@ -1,4 +1,5 @@
 #include <arpa/inet.h>
+#include <async/algorithm.hpp>
 #include <async/execution.hpp>
 #include <core/bpf.hpp>
 #include <linux/filter.h>
@@ -18,13 +19,16 @@ static async::result<void> serveLanes(
 	helix::UniqueLane ptLane,
 	smarter::shared_ptr<RawSocket> sock
 ) {
-	async::cancellation_event cancelPt;
-	async::detach(protocols::fs::serveFile(std::move(ctrlLane),
-			sock.get(), &RawSocket::ops), [&] {
-		cancelPt.cancel();
-	});
-
-	co_await servePassthrough(std::move(ptLane), sock, &RawSocket::ops, cancelPt);
+	co_await async::race_and_cancel(
+		[&](async::cancellation_token) {
+			return protocols::fs::serveFile(std::move(ctrlLane),
+					sock.get(), &RawSocket::ops);
+		},
+		[&](async::cancellation_token ct) {
+			return protocols::fs::servePassthrough(std::move(ptLane),
+					sock, &RawSocket::ops, ct);
+		}
+	);
 	sock->handleClose();
 }
 


### PR DESCRIPTION
Prior to this change, libblockfs's lifetime handling worked like this: (1) `serveFile()` was launched in a detached coroutine cancelling `servePassthrough()` when it completed, (2) `servePassthrough()` was awaited. This pattern is problematic if (for some reason) `servePassthrough()` completes first since in that case, the `cancellation_event` is deallocated before `serveFile()` finishes.

Fix this by simply using `race_and_cancel()`.