### PR TITLE
core: Rewrite DMA allocator to use external meta data

### DIFF
--- a/core/arch/include/arch/os/dma_pool.hpp
+++ b/core/arch/include/arch/os/dma_pool.hpp
@@ -11,6 +11,11 @@ namespace arch {
 
 struct contiguous_pool_options {
 	size_t addressBits{32};
+	// Gap in bytes between the base addresses of two allocations.
+	// When doing non-coherent DMA, this is needed to ensure that different allocations
+	// end up on different cache lines (such that writes to an allocation cannot cause
+	// adjacent cache lines to become dirty).
+	size_t minAllocationGap{64};
 };
 
 struct contiguous_pool : dma_pool {

--- a/core/arch/src/dma_pool.cpp
+++ b/core/arch/src/dma_pool.cpp
@@ -69,7 +69,9 @@ void contiguous_pool::deallocate(dma_ptr ptr, size_t size, size_t count, size_t 
 
 // Power-of-two that is used for a particular allocation.
 int contiguous_pool::shift_of_(size_t size, size_t count, size_t align) {
-	return frg::ceil_log2(std::max({size * count, align, min_size_class}));
+	return frg::ceil_log2(
+		std::max({size * count, align, min_size_class, options_.minAllocationGap})
+	);
 }
 
 void *contiguous_pool::allocate_pages_(size_t region_size) {


### PR DESCRIPTION
Fix #1263 