### PR TITLE
hel: return futexRace error

### DIFF
--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -136,7 +136,8 @@ enum {
 	kHelErrRemoteFault = 21,
 	kHelErrAlreadyExists = 22,
 	kHelErrBadPermissions = 23,
-	kHelErrOther = 24
+	kHelErrOther = 24,
+	kHelErrFutexRace = 25
 };
 
 struct HelX86SegmentRegister {

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -113,7 +113,7 @@ HelError translateError(Error error) {
 	case Error::illegalState: return kHelErrIllegalState;
 	case Error::outOfBounds: return kHelErrOutOfBounds;
 	case Error::cancelled: return kHelErrCancelled;
-	case Error::futexRace: return kHelErrNone; // Note that the translation to success.
+	case Error::futexRace: return kHelErrFutexRace;
 	case Error::bufferTooSmall: return kHelErrBufferTooSmall;
 	case Error::threadExited: return kHelErrThreadTerminated;
 	case Error::transmissionMismatch: return kHelErrTransmissionMismatch;


### PR DESCRIPTION
This is equivalent to Linux's EAGAIN.