### PR TITLE
Introduce request dispatcher infrastructure

### DIFF
--- a/core/drm/include/core/drm/core.hpp
+++ b/core/drm/include/core/drm/core.hpp
@@ -41,6 +41,8 @@ struct Event {
 struct File {
 	File(std::shared_ptr<Device> device);
 
+	struct HandleIoctl;
+
 	static async::result<protocols::fs::ReadResult>
 
 	/**

--- a/core/drm/src/ioctl.cpp
+++ b/core/drm/src/ioctl.cpp
@@ -1,6 +1,7 @@
 #include <libdrm/drm_fourcc.h>
 
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 #include "fs.bragi.hpp"
 #include <helix/ipc.hpp>
 #include "posix.bragi.hpp"
@@ -60,31 +61,35 @@ async::detached drm_core::File::pageFlipEvent(std::unique_ptr<drm_core::Configur
 		self->_retirePageFlip(cookie, id);
 }
 
-async::result<void>
-drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
-		helix::UniqueLane conversation) {
-	if(!ostraceInitialized) {
-		co_await initOstrace();
-		ostraceInitialized = true;
-	}
-
-	auto self = static_cast<drm_core::File *>(object);
-
+struct drm_core::File::HandleIoctl {
+	uint32_t id;
 	timespec requestTimestamp = {};
-	auto logBragiRequest = [&requestTimestamp]<typename T>(T &req, std::span<uint8_t> tail) {
+
+	template <typename T>
+	void logBragiRequest(T &req) {
 		if(!ostContext.isActive())
 			return;
 
 		requestTimestamp = clk::getTimeSinceBoot();
+		std::string reqHead;
+		std::string reqTail;
+		reqHead.resize(req.size_of_head());
+		reqTail.resize(req.size_of_tail());
+		bragi::limited_writer headWriter{reqHead.data(), reqHead.size()};
+		bragi::limited_writer tailWriter{reqTail.data(), reqTail.size()};
+		auto headOk = req.encode_head(headWriter);
+		auto tailOk = req.encode_tail(tailWriter);
+		assert(headOk);
+		assert(tailOk);
 		ostContext.emitWithTimestamp(
 			ostEvtRequest,
 			(requestTimestamp.tv_sec * 1'000'000'000) + requestTimestamp.tv_nsec,
 			ostAttrTime((requestTimestamp.tv_sec * 1'000'000'000) + requestTimestamp.tv_nsec),
-			ostBragi(std::span<uint8_t>{reinterpret_cast<uint8_t *>(req.data()), req.size()}, tail)
+			ostBragi({reinterpret_cast<uint8_t *>(reqHead.data()), reqHead.size()}, {reinterpret_cast<uint8_t *>(reqTail.data()), reqTail.size()})
 		);
-	};
+	}
 
-	auto logBragiReply = [&requestTimestamp, &id](auto &resp) {
+	void logBragiReply(auto &resp) {
 		if(!ostContext.isActive())
 			return;
 
@@ -106,9 +111,9 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			ostAttrTime((requestTimestamp.tv_sec * 1'000'000'000) + requestTimestamp.tv_nsec),
 			ostBragi({reinterpret_cast<uint8_t *>(replyHead.data()), replyHead.size()}, {reinterpret_cast<uint8_t *>(replyTail.data()), replyTail.size()})
 		);
-	};
+	}
 
-	auto logBragiSerializedReply = [&requestTimestamp, &id](std::string &ser) {
+	void logBragiSerializedReply(std::string &ser) {
 		if(!ostContext.isActive())
 			return;
 
@@ -120,18 +125,16 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			ostAttrTime((requestTimestamp.tv_sec * 1'000'000'000) + requestTimestamp.tv_nsec),
 			ostBragi({reinterpret_cast<uint8_t *>(ser.data()), ser.size()}, {})
 		);
-	};
+	}
 
-	auto preamble = bragi::read_preamble(msg);
-	if(!preamble.tail_size())
-		logBragiRequest(msg, {});
-
-	if(id == managarm::fs::GenericIoctlRequest::message_id) {
-		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-		msg.reset();
-		assert(req);
-
-		if(req->command() == DRM_IOCTL_VERSION) {
+	async::result<std::expected<void, DispatchError>> operator() (
+		managarm::fs::GenericIoctlRequest &&req,
+		helix::BorrowedDescriptor conversation,
+		bragi::preamble,
+		drm_core::File *self
+	) {
+		logBragiRequest(req);
+		if(req.command() == DRM_IOCTL_VERSION) {
 			managarm::fs::GenericIoctlReply resp;
 
 			auto version = self->_device->driverVersion();
@@ -152,7 +155,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_GET_CAP) {
+		}else if(req.command() == DRM_IOCTL_GET_CAP) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
@@ -160,38 +163,38 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			if (req->drm_capability() == DRM_CAP_TIMESTAMP_MONOTONIC) {
+			if (req.drm_capability() == DRM_CAP_TIMESTAMP_MONOTONIC) {
 				resp.set_drm_value(1);
 				if (logDrmRequests)
 					std::println("\tCAP_TIMESTAMP_MONOTONIC supported");
-			} else if (req->drm_capability() == DRM_CAP_DUMB_BUFFER) {
+			} else if (req.drm_capability() == DRM_CAP_DUMB_BUFFER) {
 				resp.set_drm_value(1);
 				if (logDrmRequests)
 					std::println("\tCAP_DUMB_BUFFER supported");
-			} else if (req->drm_capability() == DRM_CAP_CRTC_IN_VBLANK_EVENT) {
+			} else if (req.drm_capability() == DRM_CAP_CRTC_IN_VBLANK_EVENT) {
 				resp.set_drm_value(1);
 				if (logDrmRequests)
 					std::println("\tCAP_CRTC_IN_VBLANK_EVENT supported");
-			} else if (req->drm_capability() == DRM_CAP_CURSOR_WIDTH) {
+			} else if (req.drm_capability() == DRM_CAP_CURSOR_WIDTH) {
 				resp.set_drm_value(self->_device->getCursorWidth());
 				if (logDrmRequests)
 					std::println("\tCAP_CURSOR_WIDTH supported");
-			} else if (req->drm_capability() == DRM_CAP_CURSOR_HEIGHT) {
+			} else if (req.drm_capability() == DRM_CAP_CURSOR_HEIGHT) {
 				resp.set_drm_value(self->_device->getCursorHeight());
 				if (logDrmRequests)
 					std::println("\tCAP_CURSOR_HEIGHT supported");
-			} else if (req->drm_capability() == DRM_CAP_PRIME) {
+			} else if (req.drm_capability() == DRM_CAP_PRIME) {
 				resp.set_drm_value(DRM_PRIME_CAP_IMPORT | DRM_PRIME_CAP_EXPORT);
 				if (logDrmRequests)
 					std::println("\tCAP_PRIME supported");
-			} else if (req->drm_capability() == DRM_CAP_ADDFB2_MODIFIERS) {
+			} else if (req.drm_capability() == DRM_CAP_ADDFB2_MODIFIERS) {
 				resp.set_drm_value(self->_device->getAddFb2ModifiersSupport());
 				if (logDrmRequests)
 					std::println(
-					    "\tCAP_ADDFB2_MODIFIERS {}supported", resp.drm_value() ? "" : "un"
+						"\tCAP_ADDFB2_MODIFIERS {}supported", resp.drm_value() ? "" : "un"
 					);
 			} else {
-				std::println("\tUnknown capability {}", req->drm_capability());
+				std::println("\tUnknown capability {}", req.drm_capability());
 				resp.set_drm_value(0);
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			}
@@ -201,7 +204,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_GETRESOURCES) {
+		}else if(req.command() == DRM_IOCTL_MODE_GETRESOURCES) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
@@ -255,13 +258,13 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_GETCONNECTOR) {
+		}else if(req.command() == DRM_IOCTL_MODE_GETCONNECTOR) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
 				std::println("core/drm: GETCONNECTOR()");
 
-			auto obj = self->_device->findObject(req->drm_connector_id());
+			auto obj = self->_device->findObject(req.drm_connector_id());
 			assert(obj);
 			auto conn = obj->asConnector();
 			assert(conn);
@@ -272,7 +275,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			}
 
 			// TODO: check if we're current master
-			if(req->drm_max_modes() == 0)
+			if(req.drm_max_modes() == 0)
 				co_await conn->probe();
 
 			resp.set_drm_encoder_id(conn->currentEncoder() ? conn->currentEncoder()->id() : 0);
@@ -319,18 +322,18 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			auto [send_resp, send_list] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-				helix_ng::sendBuffer(conn->modeList().data(), std::min(static_cast<size_t>(req->drm_max_modes()), conn->modeList().size()) * sizeof(drm_mode_modeinfo))
+				helix_ng::sendBuffer(conn->modeList().data(), std::min(static_cast<size_t>(req.drm_max_modes()), conn->modeList().size()) * sizeof(drm_mode_modeinfo))
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_list.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_GETENCODER) {
+		}else if(req.command() == DRM_IOCTL_MODE_GETENCODER) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
-				std::println("core/drm: GETENCODER([{}])", req->drm_encoder_id());
+				std::println("core/drm: GETENCODER([{}])", req.drm_encoder_id());
 
-			auto obj = self->_device->findObject(req->drm_encoder_id());
+			auto obj = self->_device->findObject(req.drm_encoder_id());
 			assert(obj);
 			auto enc = obj->asEncoder();
 			assert(enc);
@@ -356,15 +359,15 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_GETPLANE) {
+		}else if(req.command() == DRM_IOCTL_MODE_GETPLANE) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
-				std::println("core/drm: GETPLANE({})", req->drm_plane_id());
+				std::println("core/drm: GETPLANE({})", req.drm_plane_id());
 
 			resp.set_drm_encoder_type(0);
 
-			auto obj = self->_device->findObject(req->drm_plane_id());
+			auto obj = self->_device->findObject(req.drm_plane_id());
 			assert(obj);
 			auto plane = obj->asPlane();
 			assert(plane);
@@ -401,15 +404,15 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			auto [send_resp, send_formats] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
 				helix_ng::sendBuffer(plane->getFormats().data(),
-					std::min(size_t{req->drm_format_types()}, plane->getFormats().size()) * sizeof(uint32_t))
+					std::min(size_t{req.drm_format_types()}, plane->getFormats().size()) * sizeof(uint32_t))
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_formats.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_CREATE_DUMB) {
+		}else if(req.command() == DRM_IOCTL_MODE_CREATE_DUMB) {
 			managarm::fs::GenericIoctlReply resp;
 
-			auto pair = self->_device->createDumb(req->drm_width(), req->drm_height(), req->drm_bpp());
+			auto pair = self->_device->createDumb(req.drm_width(), req.drm_height(), req.drm_bpp());
 			auto handle = self->createHandle(pair.first);
 			resp.set_drm_handle(handle);
 
@@ -419,8 +422,8 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			if (logDrmRequests)
 				std::println("core/drm: CREATE_DUMB({}x{}) -> <{}>",
-					req->drm_width(),
-					req->drm_height(),
+					req.drm_width(),
+					req.drm_height(),
 					resp.drm_handle()
 				);
 
@@ -429,13 +432,13 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_GETFB2) {
+		}else if(req.command() == DRM_IOCTL_MODE_GETFB2) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
-				std::println("core/drm: GETFB2({})", req->drm_fb_id());
+				std::println("core/drm: GETFB2({})", req.drm_fb_id());
 
-			auto obj = self->_device->findObject(req->drm_fb_id());
+			auto obj = self->_device->findObject(req.drm_fb_id());
 			if(!obj || !obj->asFrameBuffer()) {
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			} else {
@@ -452,25 +455,25 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_ADDFB) {
+		}else if(req.command() == DRM_IOCTL_MODE_ADDFB) {
 			managarm::fs::GenericIoctlReply resp;
 
-			auto bo = self->resolveHandle(req->drm_handle());
+			auto bo = self->resolveHandle(req.drm_handle());
 			assert(bo);
 			auto buffer = bo->sharedBufferObject();
 
-			auto fourcc = convertLegacyFormat(req->drm_bpp(), req->drm_depth());
-			auto fb = self->_device->createFrameBuffer(buffer, req->drm_width(), req->drm_height(),
-					fourcc, req->drm_pitch(), DRM_FORMAT_MOD_LINEAR);
+			auto fourcc = convertLegacyFormat(req.drm_bpp(), req.drm_depth());
+			auto fb = self->_device->createFrameBuffer(buffer, req.drm_width(), req.drm_height(),
+					fourcc, req.drm_pitch(), DRM_FORMAT_MOD_LINEAR);
 			self->attachFrameBuffer(fb);
 			resp.set_drm_fb_id(fb->id());
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
 			if (logDrmRequests)
 				std::println("core/drm: ADDFB({}x{}, pitch {}) -> [{}]",
-					req->drm_width(),
-					req->drm_height(),
-					req->drm_pitch(),
+					req.drm_width(),
+					req.drm_height(),
+					req.drm_pitch(),
 					fb->id()
 				);
 
@@ -479,26 +482,26 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_ADDFB2) {
+		}else if(req.command() == DRM_IOCTL_MODE_ADDFB2) {
 			managarm::fs::GenericIoctlReply resp;
 
-			auto bo = self->resolveHandle(req->drm_handle());
+			auto bo = self->resolveHandle(req.drm_handle());
 			assert(bo);
 			auto buffer = bo->sharedBufferObject();
 
-			auto modifier = req->drm_flags() & DRM_MODE_FB_MODIFIERS ? req->drm_modifier() : DRM_FORMAT_MOD_LINEAR;
+			auto modifier = req.drm_flags() & DRM_MODE_FB_MODIFIERS ? req.drm_modifier() : DRM_FORMAT_MOD_LINEAR;
 
-			auto fb = self->_device->createFrameBuffer(buffer, req->drm_width(), req->drm_height(),
-					req->drm_fourcc(), req->drm_pitch(), modifier);
+			auto fb = self->_device->createFrameBuffer(buffer, req.drm_width(), req.drm_height(),
+					req.drm_fourcc(), req.drm_pitch(), modifier);
 			self->attachFrameBuffer(fb);
 			resp.set_drm_fb_id(fb->id());
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
 			if (logDrmRequests)
 				std::println("core/drm: ADDFB2({}x{}, pitch {}) -> [{}]",
-					req->drm_width(),
-					req->drm_height(),
-					req->drm_pitch(),
+					req.drm_width(),
+					req.drm_height(),
+					req.drm_pitch(),
 					fb->id()
 				);
 
@@ -507,13 +510,13 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_RMFB) {
+		}else if(req.command() == DRM_IOCTL_MODE_RMFB) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
-				std::println("core/drm: RMFB([{}])", req->drm_fb_id());
+				std::println("core/drm: RMFB([{}])", req.drm_fb_id());
 
-			auto obj = self->_device->findObject(req->drm_fb_id());
+			auto obj = self->_device->findObject(req.drm_fb_id());
 			assert(obj);
 			auto fb = obj->asFrameBuffer();
 			assert(fb);
@@ -525,13 +528,13 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_MAP_DUMB) {
+		}else if(req.command() == DRM_IOCTL_MODE_MAP_DUMB) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
-				std::println("core/drm: MAP_DUMB(<{}>)", req->drm_handle());
+				std::println("core/drm: MAP_DUMB(<{}>)", req.drm_handle());
 
-			auto bo = self->resolveHandle(req->drm_handle());
+			auto bo = self->resolveHandle(req.drm_handle());
 			assert(bo);
 			auto buffer = bo->sharedBufferObject();
 
@@ -543,15 +546,15 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_GETCRTC) {
+		}else if(req.command() == DRM_IOCTL_MODE_GETCRTC) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
-				std::println("core/drm: GETCRTC([{}])", req->drm_crtc_id());
+				std::println("core/drm: GETCRTC([{}])", req.drm_crtc_id());
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto obj = self->_device->findObject(req->drm_crtc_id());
+			auto obj = self->_device->findObject(req.drm_crtc_id());
 			drm_mode_modeinfo mode_info;
 			memset(&mode_info, 0, sizeof(mode_info));
 
@@ -583,7 +586,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_mode.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_SETCRTC) {
+		}else if(req.command() == DRM_IOCTL_MODE_SETCRTC) {
 			std::vector<char> mode_buffer;
 			mode_buffer.resize(sizeof(drm_mode_modeinfo));
 
@@ -597,15 +600,15 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			managarm::fs::GenericIoctlReply resp;
 
-			auto obj = self->_device->findObject(req->drm_crtc_id());
+			auto obj = self->_device->findObject(req.drm_crtc_id());
 			assert(obj);
 			auto crtc = obj->asCrtc();
 			assert(crtc);
 
 			std::vector<drm_core::Assignment> assignments;
-			if(req->drm_mode_valid()) {
+			if(req.drm_mode_valid()) {
 				auto mode_blob = self->_device->registerBlob(std::move(mode_buffer));
-				auto fb = self->_device->findObject(req->drm_fb_id());
+				auto fb = self->_device->findObject(req.drm_fb_id());
 				assert(fb);
 
 				assignments.push_back(Assignment::withInt(crtc->sharedModeObject(), self->_device->activeProperty(), true));
@@ -620,7 +623,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				assignments.push_back(Assignment::withInt(crtc->primaryPlane()->sharedModeObject(), self->_device->crtcXProperty(), 0));
 				assignments.push_back(Assignment::withInt(crtc->primaryPlane()->sharedModeObject(), self->_device->crtcYProperty(), 0));
 
-				for(auto connectorId : req->drm_connector_ids()) {
+				for(auto connectorId : req.drm_connector_ids()) {
 					auto con = self->_device->findObject(connectorId);
 					assert(con);
 
@@ -646,20 +649,20 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_PAGE_FLIP) {
+		}else if(req.command() == DRM_IOCTL_MODE_PAGE_FLIP) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
 				std::println("core/drm: PAGE_FLIP()");
 
-			auto obj = self->_device->findObject(req->drm_crtc_id());
+			auto obj = self->_device->findObject(req.drm_crtc_id());
 			assert(obj);
 			auto crtc = obj->asCrtc();
 			assert(crtc);
 
 			std::vector<drm_core::Assignment> assignments;
 
-			auto fb = self->_device->findObject(req->drm_fb_id());
+			auto fb = self->_device->findObject(req.drm_fb_id());
 			assert(fb);
 			assignments.push_back(Assignment::withModeObj(crtc->primaryPlane()->sharedModeObject(), self->_device->fbIdProperty(), fb));
 			assignments.push_back(Assignment::withModeObj(crtc->primaryPlane()->sharedModeObject(), self->_device->crtcIdProperty(), crtc->sharedModeObject()));
@@ -670,8 +673,8 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			assert(valid);
 			config->commit(std::move(state));
 
-			if(req->drm_flags() & DRM_MODE_PAGE_FLIP_EVENT)
-				self->pageFlipEvent(std::move(config), self, req->drm_cookie(), crtc->id());
+			if(req.drm_flags() & DRM_MODE_PAGE_FLIP_EVENT)
+				self->pageFlipEvent(std::move(config), self, req.drm_cookie(), crtc->id());
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
@@ -680,7 +683,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_DIRTYFB) {
+		}else if(req.command() == DRM_IOCTL_MODE_DIRTYFB) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
@@ -688,7 +691,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			auto obj = self->_device->findObject(req->drm_fb_id());
+			auto obj = self->_device->findObject(req.drm_fb_id());
 			if(!obj) {
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			} else {
@@ -702,13 +705,13 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_CURSOR) {
+		}else if(req.command() == DRM_IOCTL_MODE_CURSOR) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
 				std::println("core/drm: MODE_CURSOR()");
 
-			auto crtc_obj = self->_device->findObject(req->drm_crtc_id());
+			auto crtc_obj = self->_device->findObject(req.drm_crtc_id());
 			assert(crtc_obj);
 			auto crtc = crtc_obj->asCrtc();
 
@@ -720,15 +723,15 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
 				);
 				HEL_CHECK(send_resp.error());
-				co_return;
+				co_return {};
 			}
 
 			std::vector<Assignment> assignments;
-			if (req->drm_flags() == DRM_MODE_CURSOR_BO) {
+			if (req.drm_flags() == DRM_MODE_CURSOR_BO) {
 				resp.set_error(managarm::fs::Errors::SUCCESS);
-				auto bo = self->resolveHandle(req->drm_handle());
-				auto width = req->drm_width();
-				auto height = req->drm_height();
+				auto bo = self->resolveHandle(req.drm_handle());
+				auto width = req.drm_width();
+				auto height = req.drm_height();
 
 				assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->srcWProperty(), width << 16));
 				assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->srcHProperty(), height << 16));
@@ -740,10 +743,10 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				} else {
 					assignments.push_back(Assignment::withModeObj(crtc->cursorPlane()->sharedModeObject(), self->_device->fbIdProperty(), nullptr));
 				}
-			}else if (req->drm_flags() == DRM_MODE_CURSOR_MOVE) {
+			}else if (req.drm_flags() == DRM_MODE_CURSOR_MOVE) {
 				resp.set_error(managarm::fs::Errors::SUCCESS);
-				auto x = req->drm_x();
-				auto y = req->drm_y();
+				auto x = req.drm_x();
+				auto y = req.drm_y();
 
 				assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->crtcXProperty(), x));
 				assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->crtcYProperty(), y));
@@ -765,13 +768,13 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_CURSOR2) {
+		}else if(req.command() == DRM_IOCTL_MODE_CURSOR2) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
 				std::println("core/drm: MODE_CURSOR2()");
 
-			auto crtc_obj = self->_device->findObject(req->drm_crtc_id());
+			auto crtc_obj = self->_device->findObject(req.drm_crtc_id());
 			assert(crtc_obj);
 			auto crtc = crtc_obj->asCrtc();
 
@@ -784,14 +787,14 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
 				);
 				HEL_CHECK(send_resp.error());
-				co_return;
+				co_return {};
 			}
 
 			std::vector<Assignment> assignments;
 			resp.set_error(managarm::fs::Errors::SUCCESS);
-			auto bo = self->resolveHandle(req->drm_handle());
-			auto width = req->drm_width();
-			auto height = req->drm_height();
+			auto bo = self->resolveHandle(req.drm_handle());
+			auto width = req.drm_width();
+			auto height = req.drm_height();
 
 			assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->srcWProperty(), width << 16));
 			assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->srcHProperty(), height << 16));
@@ -804,8 +807,8 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				assignments.push_back(Assignment::withModeObj(crtc->cursorPlane()->sharedModeObject(), self->_device->fbIdProperty(), nullptr));
 			}
 
-			auto x = req->drm_x();
-			auto y = req->drm_y();
+			auto x = req.drm_x();
+			auto y = req.drm_y();
 
 			assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->crtcXProperty(), x));
 			assignments.push_back(Assignment::withInt(cursor_plane->sharedModeObject(), self->_device->crtcYProperty(), y));
@@ -823,12 +826,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_DESTROY_DUMB){
+		}else if(req.command() == DRM_IOCTL_MODE_DESTROY_DUMB){
 			if (logDrmRequests)
-				std::println("core/drm: DESTROY_DUMB({})", req->drm_handle());
+				std::println("core/drm: DESTROY_DUMB({})", req.drm_handle());
 
-			self->_buffers.erase(req->drm_handle());
-			self->_allocator.free(req->drm_handle());
+			self->_buffers.erase(req.drm_handle());
+			self->_allocator.free(req.drm_handle());
 
 			managarm::fs::GenericIoctlReply resp;
 
@@ -839,24 +842,24 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_SET_CLIENT_CAP) {
+		}else if(req.command() == DRM_IOCTL_SET_CLIENT_CAP) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
 				std::println("core/drm: SET_CLIENT_CAP()");
 
-			if(req->drm_capability() == DRM_CLIENT_CAP_STEREO_3D) {
+			if(req.drm_capability() == DRM_CLIENT_CAP_STEREO_3D) {
 				std::println("\e[31mcore/drm: DRM client cap for stereo 3D unsupported\e[39m");
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
-			} else if(req->drm_capability() == DRM_CLIENT_CAP_UNIVERSAL_PLANES) {
+			} else if(req.drm_capability() == DRM_CLIENT_CAP_UNIVERSAL_PLANES) {
 				self->universalPlanes = true;
 				resp.set_error(managarm::fs::Errors::SUCCESS);
-			} else if(req->drm_capability() == DRM_CLIENT_CAP_ATOMIC) {
+			} else if(req.drm_capability() == DRM_CLIENT_CAP_ATOMIC) {
 				self->atomic = true;
 				self->universalPlanes = true;
 				resp.set_error(managarm::fs::Errors::SUCCESS);
 			} else {
-				std::println("\e[31mcore/drm: Attempt to set unknown client capability {}\e[39m", req->drm_capability());
+				std::println("\e[31mcore/drm: Attempt to set unknown client capability {}\e[39m", req.drm_capability());
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			}
 
@@ -865,15 +868,15 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_OBJ_GETPROPERTIES) {
+		}else if(req.command() == DRM_IOCTL_MODE_OBJ_GETPROPERTIES) {
 			managarm::fs::GenericIoctlReply resp;
 
-			auto obj = self->_device->findObject(req->drm_obj_id());
+			auto obj = self->_device->findObject(req.drm_obj_id());
 			assert(obj);
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
 			if (logDrmRequests)
-				std::println("core/drm: GETPROPERTIES([{}])", req->drm_obj_id());
+				std::println("core/drm: GETPROPERTIES([{}])", req.drm_obj_id());
 
 			for(auto ass : obj->getAssignments(self->_device)) {
 				resp.add_drm_obj_property_ids(ass.property->id());
@@ -912,7 +915,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			}
 
 			if(!resp.drm_obj_property_ids_size()) {
-				std::println("\e[31mcore/drm: No properties found for object [{}]\e[39m", req->drm_obj_id());
+				std::println("\e[31mcore/drm: No properties found for object [{}]\e[39m", req.drm_obj_id());
 			}
 
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
@@ -920,10 +923,10 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_GETPROPERTY) {
+		}else if(req.command() == DRM_IOCTL_MODE_GETPROPERTY) {
 			managarm::fs::GenericIoctlReply resp;
 
-			uint32_t prop_id = req->drm_property_id();
+			uint32_t prop_id = req.drm_property_id();
 			auto prop = self->_device->getProperty(prop_id);
 
 			if (logDrmRequests) {
@@ -972,7 +975,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_SETPROPERTY) {
+		}else if(req.command() == DRM_IOCTL_MODE_SETPROPERTY) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
@@ -983,12 +986,12 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			auto config = self->_device->createConfiguration();
 			auto state = self->_device->atomicState();
 
-			auto mode_obj = self->_device->findObject(req->drm_obj_id());
+			auto mode_obj = self->_device->findObject(req.drm_obj_id());
 			assert(mode_obj);
 
-			auto prop = self->_device->getProperty(req->drm_property_id());
+			auto prop = self->_device->getProperty(req.drm_property_id());
 			assert(prop);
-			auto value = req->drm_property_value();
+			auto value = req.drm_property_value();
 			auto prop_type = prop->propertyType();
 
 
@@ -1017,7 +1020,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_GETPLANERESOURCES) {
+		}else if(req.command() == DRM_IOCTL_MODE_GETPLANERESOURCES) {
 			managarm::fs::GenericIoctlReply resp;
 
 			auto &crtcs = self->_device->getCrtcs();
@@ -1039,14 +1042,14 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_GETPROPBLOB) {
+		}else if(req.command() == DRM_IOCTL_MODE_GETPROPBLOB) {
 			managarm::fs::GenericIoctlReply resp;
 
-			auto blob = self->_device->findBlob(req->drm_blob_id());
+			auto blob = self->_device->findBlob(req.drm_blob_id());
 
 			if (logDrmRequests)
 				std::println("core/drm: GETPROPBLOB([{}]{})",
-					req->drm_blob_id(),
+					req.drm_blob_id(),
 					(!blob) ? " (invalid)" : ""
 				);
 
@@ -1060,14 +1063,14 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			auto [send_resp, send_data] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
 				helix_ng::sendBuffer(blob ? blob->data() : nullptr,
-					std::min(blob ? blob->size() : 0, size_t{req->drm_blob_size()}))
+					std::min(blob ? blob->size() : 0, size_t{req.drm_blob_size()}))
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_data.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_CREATEPROPBLOB) {
+		}else if(req.command() == DRM_IOCTL_MODE_CREATEPROPBLOB) {
 			std::vector<char> blob_data;
-			blob_data.resize(req->drm_blob_size());
+			blob_data.resize(req.drm_blob_size());
 
 			auto [recv_buffer] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::recvBuffer(blob_data.data(), sizeof(drm_mode_modeinfo))
@@ -1076,7 +1079,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 
 			managarm::fs::GenericIoctlReply resp;
 
-			if(!req->drm_blob_size()) {
+			if(!req.drm_blob_size()) {
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			} else {
 				auto blob = self->_device->registerBlob(std::move(blob_data));
@@ -1093,24 +1096,24 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_DESTROYPROPBLOB) {
+		}else if(req.command() == DRM_IOCTL_MODE_DESTROYPROPBLOB) {
 			managarm::fs::GenericIoctlReply resp;
 
-			if(!self->_device->deleteBlob(req->drm_blob_id())) {
+			if(!self->_device->deleteBlob(req.drm_blob_id())) {
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 			} else {
 				resp.set_error(managarm::fs::Errors::SUCCESS);
 			}
 
 			if (logDrmRequests)
-				std::println("core/drm: DESTROYPROPBLOB([{}])", req->drm_blob_id());
+				std::println("core/drm: DESTROYPROPBLOB([{}])", req.drm_blob_id());
 
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_MODE_ATOMIC) {
+		}else if(req.command() == DRM_IOCTL_MODE_ATOMIC) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
@@ -1124,13 +1127,13 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			auto config = self->_device->createConfiguration();
 			auto state = self->_device->atomicState();
 
-			if(!self->atomic || req->drm_flags() & ~DRM_MODE_ATOMIC_FLAGS || ((req->drm_flags() & DRM_MODE_ATOMIC_TEST_ONLY) && (req->drm_flags() & DRM_MODE_PAGE_FLIP_EVENT))) {
+			if(!self->atomic || req.drm_flags() & ~DRM_MODE_ATOMIC_FLAGS || ((req.drm_flags() & DRM_MODE_ATOMIC_TEST_ONLY) && (req.drm_flags() & DRM_MODE_PAGE_FLIP_EVENT))) {
 				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
 				goto send;
 			}
 
-			for(size_t i = 0; i < req->drm_obj_ids_size(); i++) {
-				auto mode_obj = self->_device->findObject(req->drm_obj_ids(i));
+			for(size_t i = 0; i < req.drm_obj_ids_size(); i++) {
+				auto mode_obj = self->_device->findObject(req.drm_obj_ids(i));
 				assert(mode_obj);
 
 				if (logDrmRequests) {
@@ -1157,10 +1160,10 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 					crtc_ids.push_back(mode_obj->id());
 				}
 
-				for(size_t j = 0; j < req->drm_prop_counts(i); j++) {
-					auto prop = self->_device->getProperty(req->drm_props(prop_count + j));
+				for(size_t j = 0; j < req.drm_prop_counts(i); j++) {
+					auto prop = self->_device->getProperty(req.drm_props(prop_count + j));
 					assert(prop);
-					auto value = req->drm_prop_values(prop_count + j);
+					auto value = req.drm_prop_values(prop_count + j);
 
 					auto prop_type = prop->propertyType();
 
@@ -1187,7 +1190,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 					}
 				}
 
-				prop_count += req->drm_prop_counts(i);
+				prop_count += req.drm_prop_counts(i);
 			}
 
 			{
@@ -1195,37 +1198,37 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				assert(valid);
 			}
 
-			if(!(req->drm_flags() & DRM_MODE_ATOMIC_TEST_ONLY)) {
+			if(!(req.drm_flags() & DRM_MODE_ATOMIC_TEST_ONLY)) {
 				if (logDrmRequests)
 					std::println("\tCommitting configuration ...");
 				config->commit(std::move(state));
-				if(!(req->drm_flags() & DRM_MODE_ATOMIC_NONBLOCK))
+				if(!(req.drm_flags() & DRM_MODE_ATOMIC_NONBLOCK))
 					co_await config->waitForCompletion();
 			}
 
-			if(req->drm_flags() & DRM_MODE_PAGE_FLIP_EVENT) {
-				self->pageFlipEvent(std::move(config), self, req->drm_cookie(), std::move(crtc_ids));
+			if(req.drm_flags() & DRM_MODE_PAGE_FLIP_EVENT) {
+				self->pageFlipEvent(std::move(config), self, req.drm_cookie(), std::move(crtc_ids));
 			}
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-	send:
+		send:
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiReply(resp);
-		}else if(req->command() == DRM_IOCTL_PRIME_HANDLE_TO_FD) {
+		}else if(req.command() == DRM_IOCTL_PRIME_HANDLE_TO_FD) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
-				std::println("core/drm: PRIME_HANDLE_TO_FD(<{}>)", req->drm_prime_handle());
+				std::println("core/drm: PRIME_HANDLE_TO_FD(<{}>)", req.drm_prime_handle());
 
 			// Extract the credentials of the calling thread in order to locate it in POSIX for attaching the file
 			auto [proc_creds] = co_await helix_ng::exchangeMsgs(conversation, helix_ng::extractCredentials());
 			HEL_CHECK(proc_creds.error());
 
-			auto bo = self->resolveHandle(req->drm_prime_handle());
+			auto bo = self->resolveHandle(req.drm_prime_handle());
 			assert(bo);
 			auto buffer = bo->sharedBufferObject();
 
@@ -1266,7 +1269,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			HEL_CHECK(helGetCredentials(remote_lane.getHandle(), 0, creds_data));
 			helix_ng::Credentials creds{{creds_data}};
 
-			if(self->exportBufferObject(req->drm_prime_handle(), creds)) {
+			if(self->exportBufferObject(req.drm_prime_handle(), creds)) {
 				resp.set_error(managarm::fs::Errors::SUCCESS);
 				resp.set_drm_prime_fd(posix_resp.fd());
 				if (logDrmRequests)
@@ -1282,7 +1285,7 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			logBragiSerializedReply(ser);
-		}else if(req->command() == DRM_IOCTL_PRIME_FD_TO_HANDLE) {
+		}else if(req.command() == DRM_IOCTL_PRIME_FD_TO_HANDLE) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if (logDrmRequests)
@@ -1313,21 +1316,29 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			HEL_CHECK(send_resp.error());
 			logBragiSerializedReply(ser);
 		}else{
-			std::println("\e[31mcore/drm: Unknown ioctl() with ID {}\e[39m", req->command());
+			std::println("\e[31mcore/drm: Unknown ioctl() with ID {}\e[39m", req.command());
 
 			auto [dismiss] = co_await helix_ng::exchangeMsgs(
 				conversation, helix_ng::dismiss());
 			HEL_CHECK(dismiss.error());
+			co_return {};
 		}
-	}else if(id == managarm::fs::DrmIoctlGemCloseRequest::message_id) {
-		auto req = bragi::parse_head_only<managarm::fs::DrmIoctlGemCloseRequest>(msg);
-		assert(req);
+		co_return {};
+	}
+
+	async::result<std::expected<void, DispatchError>> operator() (
+		managarm::fs::DrmIoctlGemCloseRequest &&req,
+		helix::BorrowedDescriptor conversation,
+		bragi::preamble,
+		drm_core::File *self
+	) {
+		logBragiRequest(req);
 		managarm::fs::DrmIoctlGemCloseReply resp;
 
 		if (logDrmRequests)
-			std::println("core/drm: DRM_IOCTL_GEM_CLOSE({})", req->handle());
+			std::println("core/drm: DRM_IOCTL_GEM_CLOSE({})", req.handle());
 
-		self->_buffers.erase(req->handle());
+		self->_buffers.erase(req.handle());
 
 		auto [send_resp] = co_await helix_ng::exchangeMsgs(
 			conversation,
@@ -1335,10 +1346,28 @@ drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 		);
 		HEL_CHECK(send_resp.error());
 		logBragiReply(resp);
-	}else{
-		msg.reset();
-		std::println("\e[31mcore/drm: Unknown ioctl() message with ID {}\e[39m", id);
+			co_return {};
+	}
+};
 
+async::result<void>
+drm_core::File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
+		helix::UniqueLane conversation) {
+	if(!ostraceInitialized) {
+		co_await initOstrace();
+		ostraceInitialized = true;
+	}
+
+	auto self = static_cast<drm_core::File *>(object);
+
+	HandleIoctl visitor{id};
+
+	auto res = co_await dispatchRequest<
+		managarm::fs::GenericIoctlRequest,
+		managarm::fs::DrmIoctlGemCloseRequest
+	>(conversation, std::move(msg), visitor, self);
+
+	if (!res) {
 		auto [dismiss] = co_await helix_ng::exchangeMsgs(
 			conversation, helix_ng::dismiss());
 		HEL_CHECK(dismiss.error());

--- a/core/include/core/dispatch.hpp
+++ b/core/include/core/dispatch.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <expected>
+#include <vector>
+
+#include <async/result.hpp>
+#include <bragi/helpers-all.hpp>
+#include <bragi/helpers-std.hpp>
+#include <helix/ipc.hpp>
+
+enum class DispatchError {
+	none, ///< No error
+	shutdown, ///< The IPC lane was shut down (e.g. due to a client exit)
+	ipcError, ///< An IPC error occured
+	malformedMessage, ///< The received message could not be decoded
+};
+
+// Helper function for dispatchRequests().
+template <typename Message, typename Visitor, typename ...Args>
+async::result<DispatchError>
+doDispatch(helix_ng::RecvInlineResult &recvHead, helix::BorrowedDescriptor conversation, bragi::preamble preamble, Visitor &&visitor, Args &&...args) {
+	// Eagerly reset() after parsing to free up space in IPC queue.
+	auto maybeMessage = bragi::parse_head_only<Message>(recvHead);
+	recvHead.reset();
+	if (!maybeMessage)
+		co_return DispatchError::malformedMessage;
+
+	auto res = co_await visitor(
+		std::move(*maybeMessage), conversation, preamble,
+		std::forward<Args>(args)...);
+	if (!res)
+		co_return res.error();
+	co_return DispatchError::none;
+}
+
+//! Receive and dispatch the incoming message to the provided handler.
+//!
+//! This function accepts a new conversation lane, receives a Bragi message head,
+//! and invokes the given function object with the message, conversation lane, preamble,
+//! and any extra arguments specified.
+//!
+//! The function object is expected to be callable with all possible message
+//! types. Handling different message types can be done by having multiple
+//! overloads for operator() for each message type.
+//!
+//! For messages that have a tail, the handler should call dispatchTail() to
+//! receive and parse it.
+//!
+//! @param[in] lane
+//! Lane on which to accept.
+//! @param[in] visitor
+//! Visitor function object invoked to handle the message.
+//! @param[in] args
+//! Extra arguments to pass when invoking message handler.
+template <typename ...Messages, typename Visitor, typename ...Args>
+async::result<std::expected<void, DispatchError>>
+dispatchRequest(helix::BorrowedLane lane, Visitor &&visitor, Args &&...args) {
+	auto [accept, recvHead] = co_await helix_ng::exchangeMsgs(
+		lane,
+		helix_ng::accept(
+			helix_ng::recvInline()
+		)
+	);
+
+	// Note: only accept can ever return in DispatchError::shutdown.
+	//       Failures in any other message item are always protocol violations (and hence ipcError).
+	if (accept.error() == kHelErrLaneShutdown || accept.error() == kHelErrEndOfLane)
+		co_return std::unexpected(DispatchError::shutdown);
+	if (accept.error() != kHelErrNone)
+		co_return std::unexpected(DispatchError::ipcError);
+	if (recvHead.error() != kHelErrNone)
+		co_return std::unexpected(DispatchError::ipcError);
+
+	auto conversation = accept.descriptor();
+
+	auto preamble = bragi::read_preamble(recvHead);
+
+	if (preamble.error())
+		co_return std::unexpected(DispatchError::malformedMessage);
+
+	DispatchError err = DispatchError::none;
+
+	bool found = (
+		(
+			preamble.id() == bragi::message_id<Messages>
+			? (err = co_await doDispatch<Messages>(recvHead, std::move(conversation), preamble,
+				std::forward<Visitor>(visitor), std::forward<Args>(args)...), true)
+			: false
+		) || ...
+	);
+	if (!found)
+		co_return std::unexpected(DispatchError::malformedMessage);
+	if (err != DispatchError::none)
+		co_return std::unexpected(err);
+	co_return {};
+}
+
+//! dispatchRequest() overload that takes an already received RecvInlineResult.
+template <typename ...Messages, typename Visitor, typename ...Args>
+async::result<std::expected<void, DispatchError>>
+dispatchRequest(helix::BorrowedLane conversation, helix_ng::RecvInlineResult recvHead, Visitor &&visitor, Args &&...args) {
+	auto preamble = bragi::read_preamble(recvHead);
+
+	if (preamble.error())
+		co_return std::unexpected(DispatchError::malformedMessage);
+
+	DispatchError err = DispatchError::none;
+
+	bool found = (
+		(
+			preamble.id() == bragi::message_id<Messages>
+			? (err = co_await doDispatch<Messages>(recvHead, conversation, preamble,
+				std::forward<Visitor>(visitor), std::forward<Args>(args)...), true)
+			: false
+		) || ...
+	);
+	if (!found)
+		co_return std::unexpected(DispatchError::malformedMessage);
+	if (err != DispatchError::none)
+		co_return std::unexpected(err);
+	co_return {};
+}
+
+//! Receive the tail of a message and decode it into an existing message.
+//!
+//! Optionally receives additional message items alongside the tail in a single
+//! exchangeMsgs call. The results of the additional items are returned on success.
+//!
+//! @param[in] conversation
+//! Lane on which to receive the tail.
+//! @param[in] preamble
+//! The preamble (containing the tail size) obtained from dispatchRequest.
+//! @param[in,out] msg
+//! The message object into which the tail will be decoded.
+//! @param[in] items
+//! Additional message items to receive alongside the tail.
+template <typename Message, typename ...Items>
+async::result<std::expected<decltype(helix_ng::createResultsTuple(std::declval<Items>()...)), DispatchError>>
+dispatchTail(Message &msg, helix::BorrowedDescriptor conversation, bragi::preamble preamble, Items &&...items) {
+	using ExtraResults = decltype(helix_ng::createResultsTuple(std::declval<Items>()...));
+
+	std::vector<char> tail(preamble.tail_size());
+	auto results = co_await helix_ng::exchangeMsgs(
+		conversation,
+		helix_ng::recvBuffer(tail.data(), tail.size()),
+		std::forward<Items>(items)...
+	);
+
+	bool anyError = [&]<std::size_t ...Is>(std::index_sequence<Is...>) {
+		return ((results.template get<Is>().error() != kHelErrNone) || ...);
+	}(std::make_index_sequence<1 + sizeof...(Items)>{});
+	if (anyError)
+		co_return std::unexpected(DispatchError::ipcError);
+
+	bragi::limited_reader reader{tail.data(), tail.size()};
+	if (!msg.decode_tail(reader))
+		co_return std::unexpected(DispatchError::malformedMessage);
+
+	co_return [&]<std::size_t ...Is>(std::index_sequence<Is...>) -> ExtraResults {
+		return ExtraResults{std::move(results.template get<Is + 1>())...};
+	}(std::make_index_sequence<std::tuple_size_v<ExtraResults>>{});
+}

--- a/core/meson.build
+++ b/core/meson.build
@@ -7,6 +7,7 @@ headers = [
 	'include/core/clock.hpp',
 	'include/core/cmdline.hpp',
 	'include/core/device-path.hpp',
+	'include/core/dispatch.hpp',
 	'include/core/logging.hpp',
 	'include/core/id-allocator.hpp',
 	'include/core/kernel-logs.hpp',

--- a/drivers/block/nvme/src/namespace.cpp
+++ b/drivers/block/nvme/src/namespace.cpp
@@ -66,7 +66,7 @@ async::result<size_t> Namespace::getSize() {
 	co_return lbaCount_ << lbaShift_;
 }
 
-async::result<void> Namespace::handleIoctl(managarm::fs::GenericIoctlRequest &req, helix::UniqueDescriptor conversation) {
+async::result<void> Namespace::handleIoctl(managarm::fs::GenericIoctlRequest &req, helix::BorrowedDescriptor conversation) {
 	if(req.command() == NVME_IOCTL_ID) {
 		managarm::fs::GenericIoctlReply resp;
 

--- a/drivers/block/nvme/src/namespace.hpp
+++ b/drivers/block/nvme/src/namespace.hpp
@@ -16,7 +16,7 @@ struct Namespace : blockfs::BlockDevice {
 	async::result<void> writeSectors(uint64_t sector, const void *buf, size_t numSectors) override;
 	async::result<size_t> getSize() override;
 
-	async::result<void> handleIoctl(managarm::fs::GenericIoctlRequest &req, helix::UniqueDescriptor conversation) override;
+	async::result<void> handleIoctl(managarm::fs::GenericIoctlRequest &req, helix::BorrowedDescriptor conversation) override;
 
 private:
 	Controller *controller_;

--- a/drivers/kernletcc/meson.build
+++ b/drivers/kernletcc/meson.build
@@ -1,6 +1,6 @@
 lewis_dep = cxx.find_library('lewis')
 
 executable('kernletcc', [ 'src/main.cpp', 'src/fafnir.cpp' ],
-	dependencies : [ lewis_dep, mbus_proto_dep, kernlet_proto_dep ],
+	dependencies : [ core_dep, lewis_dep, mbus_proto_dep, kernlet_proto_dep ],
 	install : true
 )

--- a/drivers/kernletcc/src/main.cpp
+++ b/drivers/kernletcc/src/main.cpp
@@ -7,6 +7,7 @@
 #include <helix/memory.hpp>
 #include <protocols/mbus/client.hpp>
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 #include <kernlet.bragi.hpp>
 #include "common.hpp"
 
@@ -76,92 +77,71 @@ async::result<helix::UniqueDescriptor> upload(const void *elf, size_t size,
 // kernletcc mbus interface.
 // ----------------------------------------------------------------------------
 
+struct HandleRequest {
+	async::result<std::expected<void, DispatchError>> operator() (managarm::kernlet::CompileRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble preamble) {
+		// TODO(qookie): What about kernlets larger than 128 bytes?
+		auto [recvCode] = FRG_CO_TRY(co_await dispatchTail(req, conversation, preamble, helix_ng::recvInline()));
+
+		std::vector<BindType> bind_types;
+		for(size_t i = 0; i < req.bind_types_size(); i++) {
+			auto proto = req.bind_types(i);
+			BindType bt;
+			switch(proto) {
+			case managarm::kernlet::ParameterType::OFFSET: bt = BindType::offset; break;
+			case managarm::kernlet::ParameterType::MEMORY_VIEW: bt = BindType::memoryView; break;
+			case managarm::kernlet::ParameterType::BITSET_EVENT: bt = BindType::bitsetEvent; break;
+			default:
+				assert(!"Unexpected binding type");
+			}
+			bind_types.push_back(bt);
+		}
+
+		auto elf = compileFafnir(reinterpret_cast<const uint8_t *>(recvCode.data()),
+				recvCode.length(), bind_types);
+		recvCode.reset();
+
+		if(dumpHex) {
+			for(size_t i = 0; i < elf.size(); i++) {
+				printf("%02x", elf[i]);
+				if((i % 32) == 31)
+					putchar('\n');
+				else if((i % 8) == 7)
+					putchar(' ');
+			}
+			putchar('\n');
+		}
+
+		auto object = co_await upload(elf.data(), elf.size(), bind_types);
+
+		managarm::kernlet::SvrResponse resp;
+		resp.set_error(managarm::kernlet::Error::SUCCESS);
+
+		auto [sendResp, pushKernlet] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
+			helix_ng::pushDescriptor(object)
+		);
+		if(sendResp.error() == kHelErrEndOfLane) {
+			std::cout << "\e[31m" "kernletcc: Client unexpectedly closed its connection"
+					"\e[39m" << std::endl;
+			co_return {};
+		}
+		HEL_CHECK(sendResp.error());
+		HEL_CHECK(pushKernlet.error());
+		co_return {};
+	}
+};
+
 async::detached serveCompiler(helix::UniqueLane lane) {
 	while(true) {
-		auto [accept, recvHead] = co_await helix_ng::exchangeMsgs(
-			lane,
-			helix_ng::accept(
-				helix_ng::recvInline())
-		);
-		if(accept.error() == kHelErrEndOfLane) {
-			std::cout << "kernletcc: Client closed its connection" << std::endl;
-			co_return;
-		}
-		HEL_CHECK(accept.error());
-		HEL_CHECK(recvHead.error());
-
-		auto conversation = accept.descriptor();
-
-		auto preamble = bragi::read_preamble(recvHead);
-		assert(!preamble.error());
-
-		std::vector<std::byte> tailBuffer(preamble.tail_size());
-		auto [recvTail, recvCode] = co_await helix_ng::exchangeMsgs(
-			conversation,
-			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::recvInline() // TODO(qookie): What about kernlets larger than 128 bytes?
-		);
-
-		HEL_CHECK(recvTail.error());
-		HEL_CHECK(recvCode.error());
-
-		if(preamble.id() == bragi::message_id<managarm::kernlet::CompileRequest>) {
-			auto maybeReq = bragi::parse_head_tail<managarm::kernlet::CompileRequest>(recvHead, tailBuffer);
-			recvHead.reset();
-			if (!maybeReq) {
-				std::cout << "kernletcc: Ignoring request due to decoding failure.\n";
-				continue;
-			}
-
-			auto &req = *maybeReq;
-
-			std::vector<BindType> bind_types;
-			for(size_t i = 0; i < req.bind_types_size(); i++) {
-				auto proto = req.bind_types(i);
-				BindType bt;
-				switch(proto) {
-				case managarm::kernlet::ParameterType::OFFSET: bt = BindType::offset; break;
-				case managarm::kernlet::ParameterType::MEMORY_VIEW: bt = BindType::memoryView; break;
-				case managarm::kernlet::ParameterType::BITSET_EVENT: bt = BindType::bitsetEvent; break;
-				default:
-					assert(!"Unexpected binding type");
-				}
-				bind_types.push_back(bt);
-			}
-
-			auto elf = compileFafnir(reinterpret_cast<const uint8_t *>(recvCode.data()),
-					recvCode.length(), bind_types);
-			recvCode.reset();
-
-			if(dumpHex) {
-				for(size_t i = 0; i < elf.size(); i++) {
-					printf("%02x", elf[i]);
-					if((i % 32) == 31)
-						putchar('\n');
-					else if((i % 8) == 7)
-						putchar(' ');
-				}
-				putchar('\n');
-			}
-
-			auto object = co_await upload(elf.data(), elf.size(), bind_types);
-
-			managarm::kernlet::SvrResponse resp;
-			resp.set_error(managarm::kernlet::Error::SUCCESS);
-
-			auto [sendResp, pushKernlet] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(object)
-			);
-			if(sendResp.error() == kHelErrEndOfLane) {
-				std::cout << "\e[31m" "kernletcc: Client unexpectedly closed its connection"
-						"\e[39m" << std::endl;
+		auto res = co_await dispatchRequest<
+			managarm::kernlet::CompileRequest
+		>(lane, HandleRequest{});
+		if(!res) {
+			if(res.error() == DispatchError::shutdown) {
+				std::cout << "kernletcc: Client closed its connection" << std::endl;
 				co_return;
 			}
-			HEL_CHECK(sendResp.error());
-			HEL_CHECK(pushKernlet.error());
-		}else{
 			throw std::runtime_error("Unexpected request type");
 		}
 	}

--- a/drivers/libblockfs/include/blockfs.hpp
+++ b/drivers/libblockfs/include/blockfs.hpp
@@ -22,7 +22,7 @@ struct BlockDevice {
 
 	virtual async::result<size_t> getSize() = 0;
 
-	virtual async::result<void> handleIoctl(managarm::fs::GenericIoctlRequest &req, helix::UniqueDescriptor conversation) {
+	virtual async::result<void> handleIoctl(managarm::fs::GenericIoctlRequest &req, helix::BorrowedDescriptor conversation) {
 		std::cout << "\e[31m" "libblockfs: Unknown ioctl() message with ID "
 				<< req.command() << "\e[39m" << std::endl;
 

--- a/drivers/libblockfs/src/raw.cpp
+++ b/drivers/libblockfs/src/raw.cpp
@@ -3,6 +3,7 @@
 #include <linux/cdrom.h>
 
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 #include "fs.bragi.hpp"
 
 namespace blockfs {
@@ -71,6 +72,25 @@ async::detached RawFs::manageMapping() {
 OpenFile::OpenFile(RawFs *rawFs)
 : rawFs(rawFs) { }
 
+struct OpenFile::HandleIoctl {
+	async::result<std::expected<void, DispatchError>> operator() (managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble, raw::OpenFile *self) {
+		if (req.command() == CDROM_GET_CAPABILITY) {
+			managarm::fs::GenericIoctlReply rsp;
+			rsp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
+
+			auto ser = rsp.SerializeAsString();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size())
+			);
+			HEL_CHECK(send_resp.error());
+		} else {
+			co_await self->rawFs->device->handleIoctl(req, conversation);
+		}
+
+		co_return {};
+	}
+};
 
 namespace {
 
@@ -174,26 +194,19 @@ async::result<protocols::fs::SeekResult> rawSeekEof(void *object, int64_t offset
 	self->offset = offset + size;
 	co_return static_cast<ssize_t>(self->offset);
 }
-async::result<void> rawIoctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
+
+async::result<void> rawIoctl(void *object, uint32_t, helix_ng::RecvInlineResult msg,
 		helix::UniqueLane conversation) {
 	auto self = static_cast<raw::OpenFile *>(object);
 
-	if(id == managarm::fs::GenericIoctlRequest::message_id) {
-		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-		assert(req);
-		if (req->command() == CDROM_GET_CAPABILITY) {
-			managarm::fs::GenericIoctlReply rsp;
-			rsp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
+	auto res = co_await dispatchRequest<
+		managarm::fs::GenericIoctlRequest
+	>(conversation, std::move(msg), OpenFile::HandleIoctl{}, self);
 
-			auto ser = rsp.SerializeAsString();
-			auto [send_resp] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBuffer(ser.data(), ser.size())
-			);
-			HEL_CHECK(send_resp.error());
-		} else {
-			co_await self->rawFs->device->handleIoctl(req.value(), std::move(conversation));
-		}
+	if (!res) {
+		auto [dismiss] = co_await helix_ng::exchangeMsgs(
+			conversation, helix_ng::dismiss());
+		HEL_CHECK(dismiss.error());
 	}
 }
 

--- a/drivers/libblockfs/src/raw.hpp
+++ b/drivers/libblockfs/src/raw.hpp
@@ -28,6 +28,8 @@ struct RawFs {
 struct OpenFile {
 	OpenFile(RawFs *rawFs);
 
+	struct HandleIoctl;
+
 	RawFs *rawFs;
 	uint64_t offset;
 	Flock flock;

--- a/drivers/libevbackend/include/libevbackend.hpp
+++ b/drivers/libevbackend/include/libevbackend.hpp
@@ -45,6 +45,8 @@ struct File {
 	friend struct EventDevice;
 	friend async::detached serveDevice(std::shared_ptr<EventDevice>, helix::UniqueLane);
 
+	struct HandleIoctl;
+
 	// ------------------------------------------------------------------------
 	// File operations.
 	// ------------------------------------------------------------------------

--- a/drivers/libevbackend/src/libevbackend.cpp
+++ b/drivers/libevbackend/src/libevbackend.cpp
@@ -17,6 +17,7 @@
 #include <frg/std_compat.hpp>
 #include <bragi/helpers-all.hpp>
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 
 #include "fs.bragi.hpp"
 #include "hw.bragi.hpp"
@@ -180,17 +181,10 @@ File::pollStatus(void *object) {
 	};
 }
 
-async::result<void>
-File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
-		helix::UniqueLane conversation) {
-	auto self = static_cast<File *>(object);
-
-	if(id == managarm::fs::GenericIoctlRequest::message_id) {
-		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-		msg.reset();
-		assert(req);
-		if(req->command() == EVIOCGBIT(0, 0)) {
-			assert(req->size());
+struct File::HandleIoctl {
+	async::result<std::expected<void, DispatchError>> operator() (managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble, File *self) {
+		if(req.command() == EVIOCGBIT(0, 0)) {
+			assert(req.size());
 			if(logRequests)
 				std::cout << "EVIOCGBIT()" << std::endl;
 
@@ -199,7 +193,7 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
 			auto ser = resp.SerializeAsString();
-			auto chunk = std::min(size_t(req->size()), self->_device->_typeBits.size());
+			auto chunk = std::min(size_t(req.size()), self->_device->_typeBits.size());
 			auto [send_resp, send_data] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
@@ -207,21 +201,21 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_data.error());
-		}else if(req->command() == EVIOCGBIT(1, 0)) {
-			assert(req->size());
+		}else if(req.command() == EVIOCGBIT(1, 0)) {
+			assert(req.size());
 			if(logRequests)
-				std::cout << "EVIOCGBIT(" << req->input_type() << ")" << std::endl;
+				std::cout << "EVIOCGBIT(" << req.input_type() << ")" << std::endl;
 
 			managarm::fs::GenericIoctlReply resp;
 
 			std::pair<const uint8_t *, size_t> p;
-			if(req->input_type() == EV_KEY) {
+			if(req.input_type() == EV_KEY) {
 				resp.set_error(managarm::fs::Errors::SUCCESS);
 				p = {self->_device->_keyBits.data(), self->_device->_keyBits.size()};
-			}else if(req->input_type() == EV_REL) {
+			}else if(req.input_type() == EV_REL) {
 				resp.set_error(managarm::fs::Errors::SUCCESS);
 				p = {self->_device->_relBits.data(), self->_device->_relBits.size()};
-			}else if(req->input_type() == EV_ABS) {
+			}else if(req.input_type() == EV_ABS) {
 				resp.set_error(managarm::fs::Errors::SUCCESS);
 				p = {self->_device->_absBits.data(), self->_device->_absBits.size()};
 			}else{
@@ -230,7 +224,7 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			}
 
 			auto ser = resp.SerializeAsString();
-			auto chunk = std::min(size_t(req->size()), p.second);
+			auto chunk = std::min(size_t(req.size()), p.second);
 			auto [send_resp, send_data] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
@@ -238,14 +232,14 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_data.error());
-		}else if(req->command() == EVIOCSCLOCKID) {
+		}else if(req.command() == EVIOCSCLOCKID) {
 			managarm::fs::GenericIoctlReply resp;
 
 			// TODO: Does this setting affect already queued events in Linux?
-			switch(req->input_clock()) {
+			switch(req.input_clock()) {
 			case CLOCK_REALTIME:
 			case CLOCK_MONOTONIC:
-				self->_clockId = req->input_clock();
+				self->_clockId = req.input_clock();
 				resp.set_error(managarm::fs::Errors::SUCCESS);
 				break;
 			default:
@@ -258,14 +252,14 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-		}else if(req->command() == EVIOCGABS(0)) {
+		}else if(req.command() == EVIOCGABS(0)) {
 			managarm::fs::GenericIoctlReply resp;
 			if(logRequests)
-				std::cout << "EVIOCGABS(" << req->input_type() << ")" << std::endl;
+				std::cout << "EVIOCGABS(" << req.input_type() << ")" << std::endl;
 
-			assert(static_cast<size_t>(req->input_type())
+			assert(static_cast<size_t>(req.input_type())
 					< self->_device->_absoluteSlots.size());
-			auto slot = &self->_device->_absoluteSlots[req->input_type()];
+			auto slot = &self->_device->_absoluteSlots[req.input_type()];
 			resp.set_input_value(slot->value);
 			resp.set_input_min(slot->minimum);
 			resp.set_input_max(slot->maximum);
@@ -280,13 +274,16 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			);
 			HEL_CHECK(send_resp.error());
 		}else{
-			std::cout << "Unknown ioctl() with ID " << std::to_string(req->command()) << std::endl;
+			std::cout << "Unknown ioctl() with ID " << std::to_string(req.command()) << std::endl;
 			auto [dismiss] = co_await helix_ng::exchangeMsgs(
 				conversation, helix_ng::dismiss());
 			HEL_CHECK(dismiss.error());
 		}
-	} else if(id == managarm::fs::EvioGetNameRequest::message_id) {
-		msg.reset();
+
+		co_return {};
+	}
+
+	async::result<std::expected<void, DispatchError>> operator() (managarm::fs::EvioGetNameRequest &&, helix::BorrowedDescriptor conversation, bragi::preamble, File *self) {
 		managarm::fs::EvioGetNameReply resp;
 
 		resp.set_error(managarm::fs::Errors::SUCCESS);
@@ -298,8 +295,11 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 		);
 		HEL_CHECK(send_head.error());
 		HEL_CHECK(send_tail.error());
-	} else if(id == managarm::fs::EvioGetIdRequest::message_id) {
-		msg.reset();
+
+		co_return {};
+	}
+
+	async::result<std::expected<void, DispatchError>> operator() (managarm::fs::EvioGetIdRequest &&, helix::BorrowedDescriptor conversation, bragi::preamble, File *self) {
 		managarm::fs::EvioGetIdReply resp;
 
 		resp.set_error(managarm::fs::Errors::SUCCESS);
@@ -313,19 +313,21 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
 		);
 		HEL_CHECK(send_resp.error());
-	} else if(id == managarm::fs::EvioGetMultitouchSlotsRequest::message_id) {
-		auto req = bragi::parse_head_only<managarm::fs::EvioGetMultitouchSlotsRequest>(msg);
-		msg.reset();
+
+		co_return {};
+	}
+
+	async::result<std::expected<void, DispatchError>> operator() (managarm::fs::EvioGetMultitouchSlotsRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble, File *self) {
 		managarm::fs::EvioGetMultitouchSlotsReply resp;
 
 		for(auto &e : self->_device->_mtState) {
-			resp.add_values(e.second.abs.at(req->code() - ABS_MT_FIRST));
+			resp.add_values(e.second.abs.at(req.code() - ABS_MT_FIRST));
 		}
 
 		assert(resp.values_size() < maxMultitouchSlots);
 
 		for(size_t i = 0; i < (maxMultitouchSlots - resp.values_size()); i++) {
-			if(req->code() == ABS_MT_TRACKING_ID)
+			if(req.code() == ABS_MT_TRACKING_ID)
 				resp.add_values(-1);
 			else
 				resp.add_values(0);
@@ -339,9 +341,25 @@ File::ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
 		);
 		HEL_CHECK(send_head.error());
 		HEL_CHECK(send_tail.error());
-	}else{
-		msg.reset();
-		std::cout << "Unknown ioctl() message with ID " << id << std::endl;
+
+		co_return {};
+	}
+};
+
+async::result<void>
+File::ioctl(void *object, uint32_t, helix_ng::RecvInlineResult msg,
+		helix::UniqueLane conversation) {
+	auto self = static_cast<File *>(object);
+
+
+	auto res = co_await dispatchRequest<
+		managarm::fs::GenericIoctlRequest,
+		managarm::fs::EvioGetNameRequest,
+		managarm::fs::EvioGetIdRequest,
+		managarm::fs::EvioGetMultitouchSlotsRequest
+	>(conversation, std::move(msg), HandleIoctl{}, self);
+
+	if (!res) {
 		auto [dismiss] = co_await helix_ng::exchangeMsgs(
 			conversation, helix_ng::dismiss());
 		HEL_CHECK(dismiss.error());

--- a/drivers/nic/usb_net/src/usb-mbim.cpp
+++ b/drivers/nic/usb_net/src/usb-mbim.cpp
@@ -1,4 +1,5 @@
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 #include <fcntl.h>
 #include <format>
 #include <linux/usb/cdc-wdm.h>
@@ -99,16 +100,9 @@ static async::result<protocols::fs::ReadResult> read(void *object, helix_ng::Cre
 	co_return p->size();
 }
 
-static async::result<void> ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg,
-			helix::UniqueLane conversation) {
-	auto self = static_cast<CdcWdmDevice *>(object);
-
-	if(id == managarm::fs::GenericIoctlRequest::message_id) {
-		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-		msg.reset();
-		assert(req);
-
-		switch(req->command()) {
+struct CdcWdmDevice::HandleIoctl {
+	async::result<std::expected<void, DispatchError>> operator() (managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble, CdcWdmDevice *self) {
+		switch(req.command()) {
 			case IOCTL_WDM_MAX_COMMAND: {
 				managarm::fs::GenericIoctlReply resp;
 				resp.set_error(managarm::fs::Errors::SUCCESS);
@@ -123,17 +117,27 @@ static async::result<void> ioctl(void *object, uint32_t id, helix_ng::RecvInline
 				break;
 			}
 			default: {
-				std::cout << std::format("drivers/usb-mbim: unexpected ioctl request 0x{:x}", req->command());
+				std::cout << std::format("drivers/usb-mbim: unexpected ioctl request 0x{:x}", req.command());
 				auto [dismiss] = co_await helix_ng::exchangeMsgs(
 					conversation, helix_ng::dismiss());
 				HEL_CHECK(dismiss.error());
 				break;
 			}
 		}
-	} else {
-		msg.reset();
-		std::cout << std::format("drivers/usb-mbim: unexpected ioctl message type 0x{:x}\n", id);
 
+		co_return {};
+	}
+};
+
+static async::result<void> ioctl(void *object, uint32_t, helix_ng::RecvInlineResult msg,
+			helix::UniqueLane conversation) {
+	auto self = static_cast<CdcWdmDevice *>(object);
+
+	auto res = co_await dispatchRequest<
+		managarm::fs::GenericIoctlRequest
+	>(conversation, std::move(msg), CdcWdmDevice::HandleIoctl{}, self);
+
+	if (!res) {
 		auto [dismiss] = co_await helix_ng::exchangeMsgs(
 			conversation, helix_ng::dismiss());
 		HEL_CHECK(dismiss.error());

--- a/drivers/nic/usb_net/src/usb-mbim.hpp
+++ b/drivers/nic/usb_net/src/usb-mbim.hpp
@@ -13,6 +13,8 @@ namespace nic::usb_mbim {
 struct UsbMbimNic;
 
 struct CdcWdmDevice {
+	struct HandleIoctl;
+
 	UsbMbimNic *nic;
 
 	bool nonBlock_ = false;

--- a/drivers/usb/devices/serial/src/controller.hpp
+++ b/drivers/usb/devices/serial/src/controller.hpp
@@ -31,6 +31,8 @@ async::result<frg::expected<protocols::usb::UsbError, size_t>> transferControl(p
 struct Controller {
 	Controller(protocols::usb::Device hw);
 
+	struct HandleIoctl;
+
 	virtual async::result<void> initialize() = 0;
 	virtual async::result<protocols::usb::UsbError> send(protocols::usb::BulkTransfer transfer) = 0;
 

--- a/drivers/usb/devices/serial/src/main.cpp
+++ b/drivers/usb/devices/serial/src/main.cpp
@@ -11,6 +11,7 @@
 #include <core/cmdline.hpp>
 #include <core/kernel-logs.hpp>
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 #include <frg/cmdline.hpp>
 #include <frg/string.hpp>
 #include <helix/ipc.hpp>
@@ -87,15 +88,9 @@ async::result<protocols::fs::SeekResult> seek(void *, int64_t) {
 	co_return protocols::fs::Error::seekOnPipe;
 }
 
-async::result<void> ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) {
-	auto self = static_cast<Controller *>(object);
-
-	if(id == managarm::fs::GenericIoctlRequest::message_id) {
-		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-		msg.reset();
-		assert(req);
-
-		switch(req->command()) {
+struct Controller::HandleIoctl {
+	async::result<std::expected<void, DispatchError>> operator() (managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble, Controller *self) {
+		switch(req.command()) {
 			case TCGETS: {
 				managarm::fs::GenericIoctlReply resp;
 				struct termios attrs;
@@ -145,20 +140,30 @@ async::result<void> ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult 
 			}
 			default: {
 				std::cout << "\e[31m" "usb-serial: Unknown ioctl() 0x"
-					<< std::hex << req->command() << std::dec << "\e[39m" << std::endl;
+					<< std::hex << req.command() << std::dec << "\e[39m" << std::endl;
 
 				auto [dismiss] = co_await helix_ng::exchangeMsgs(
 					conversation, helix_ng::dismiss());
 				HEL_CHECK(dismiss.error());
 			}
 		}
-	} else {
-		msg.reset();
-		std::cout << "\e[31m" "usb-serial: Unknown ioctl() message with ID "
-			<< id << "\e[39m" << std::endl;
-	}
 
-	co_return;
+		co_return {};
+	}
+};
+
+async::result<void> ioctl(void *object, uint32_t, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) {
+	auto self = static_cast<Controller *>(object);
+
+	auto res = co_await dispatchRequest<
+		managarm::fs::GenericIoctlRequest
+	>(conversation, std::move(msg), Controller::HandleIoctl{}, self);
+
+	if (!res) {
+		auto [dismiss] = co_await helix_ng::exchangeMsgs(
+			conversation, helix_ng::dismiss());
+		HEL_CHECK(dismiss.error());
+	}
 }
 
 static async::result<void> setFileFlags(void *object, int flags) {

--- a/mbus/meson.build
+++ b/mbus/meson.build
@@ -1,4 +1,4 @@
 executable('mbus', 'src/main.cpp',
-	dependencies : [mbus_proto_dep, frigg, libasync_dep],
+	dependencies : [core_dep, mbus_proto_dep, frigg, libasync_dep],
 	install : true
 )

--- a/mbus/src/main.cpp
+++ b/mbus/src/main.cpp
@@ -25,6 +25,7 @@
 
 #include <bragi/helpers-all.hpp>
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 
 #include "mbus.bragi.hpp"
 
@@ -342,206 +343,179 @@ async::detached doGetRemoteLane(helix::UniqueLane conversation, std::shared_ptr<
 	HEL_CHECK(pushLane.error());
 }
 
-async::detached serveMgmtLane(helix::UniqueLane lane, std::shared_ptr<Entity> entity) {
-	while(true) {
-		auto [accept, recvHead] = co_await helix_ng::exchangeMsgs(
-				lane,
-				helix_ng::accept(
-					helix_ng::recvInline()
-				)
+struct HandleMgmtRequest {
+	async::result<std::expected<void, DispatchError>> operator() (managarm::mbus::ServeRemoteLaneRequest &&, helix::BorrowedDescriptor conversation, bragi::preamble, std::shared_ptr<Entity> entity) {
+		auto [pullLane] =
+			co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::pullDescriptor()
 			);
+		HEL_CHECK(pullLane.error());
 
-		// TODO(qookie): Destroy the entity once the lane is closed.
-		HEL_CHECK(accept.error());
-		HEL_CHECK(recvHead.error());
+		co_await entity->submitRemoteLane(pullLane.descriptor());
 
-		auto conversation = accept.descriptor();
+		managarm::mbus::ServeRemoteLaneResponse resp;
+		resp.set_error(managarm::mbus::Error::SUCCESS);
 
-		auto preamble = bragi::read_preamble(recvHead);
-		assert(!preamble.error());
+		auto [sendResp] =
+			co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
+		HEL_CHECK(sendResp.error());
+		co_return {};
+	}
 
-		if(preamble.id() == bragi::message_id<managarm::mbus::ServeRemoteLaneRequest>) {
-			/* Don't care about the request contents */
-			recvHead.reset();
+	async::result<std::expected<void, DispatchError>> operator() (managarm::mbus::UpdatePropertiesRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble preamble, std::shared_ptr<Entity> entity) {
+		auto tailRes = co_await dispatchTail(req, conversation, preamble);
+		if (!tailRes)
+			co_return std::unexpected(tailRes.error());
 
-			auto [pullLane] =
-				co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::pullDescriptor()
-				);
-			HEL_CHECK(pullLane.error());
-
-			co_await entity->submitRemoteLane(pullLane.descriptor());
-
-			managarm::mbus::ServeRemoteLaneResponse resp;
-			resp.set_error(managarm::mbus::Error::SUCCESS);
-
-			auto [sendResp] =
-				co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
-				);
-			HEL_CHECK(sendResp.error());
-		}else if(preamble.id() == bragi::message_id<managarm::mbus::UpdatePropertiesRequest>) {
-			std::vector<std::byte> tail(preamble.tail_size());
-			auto [recvTail] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::recvBuffer(tail.data(), tail.size())
-				);
-			HEL_CHECK(recvTail.error());
-
-			auto req = bragi::parse_head_tail<managarm::mbus::UpdatePropertiesRequest>(recvHead, tail);
-			recvHead.reset();
-
-			for(auto p : req->properties()) {
-				entity->updateProperty(p.name(), mbus_ng::decodeItem(p.item()));
-			}
-
-			entitySeqTree.remove(entity.get());
-			auto seq = globalSeq.next_sequence() - 1;
-			entity->updateSeq(seq);
-			entitySeqTree.insert(entity.get());
-			globalSeq.raise();
-
-			managarm::mbus::UpdatePropertiesResponse resp;
-			resp.set_error(managarm::mbus::Error::SUCCESS);
-
-			auto [sendResp] =
-				co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
-				);
-			HEL_CHECK(sendResp.error());
-		}else{
-			throw std::runtime_error("Unexpected request type");
+		for(auto p : req.properties()) {
+			entity->updateProperty(p.name(), mbus_ng::decodeItem(p.item()));
 		}
+
+		entitySeqTree.remove(entity.get());
+		auto seq = globalSeq.next_sequence() - 1;
+		entity->updateSeq(seq);
+		entitySeqTree.insert(entity.get());
+		globalSeq.raise();
+
+		managarm::mbus::UpdatePropertiesResponse resp;
+		resp.set_error(managarm::mbus::Error::SUCCESS);
+
+		auto [sendResp] =
+			co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
+		HEL_CHECK(sendResp.error());
+		co_return {};
+	}
+};
+
+async::detached serveMgmtLane(helix::UniqueLane lane, std::shared_ptr<Entity> entity) {
+	// TODO(qookie): Destroy the entity once the lane is closed.
+	while(true) {
+		auto res = co_await dispatchRequest<
+			managarm::mbus::ServeRemoteLaneRequest,
+			managarm::mbus::UpdatePropertiesRequest
+		>(lane, HandleMgmtRequest{}, entity);
+		if(!res)
+			throw std::runtime_error("Unexpected request type");
 	}
 }
 
-async::detached serve(helix::UniqueLane lane) {
-	while(true) {
-		auto [accept, recvHead] = co_await helix_ng::exchangeMsgs(
-				lane,
-				helix_ng::accept(
-					helix_ng::recvInline()
-				)
-			);
+struct HandleRequest {
+	async::result<std::expected<void, DispatchError>> operator() (managarm::mbus::GetPropertiesRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble) {
+		managarm::mbus::GetPropertiesResponse resp;
+		auto entity = getEntityById(req.id());
 
-		HEL_CHECK(accept.error());
-		HEL_CHECK(recvHead.error());
-
-		auto conversation = accept.descriptor();
-
-		auto preamble = bragi::read_preamble(recvHead);
-		assert(!preamble.error());
-
-		if(preamble.id() == bragi::message_id<managarm::mbus::GetPropertiesRequest>) {
-			auto req = bragi::parse_head_only<managarm::mbus::GetPropertiesRequest>(recvHead);
-			recvHead.reset();
-
-			managarm::mbus::GetPropertiesResponse resp;
-			auto entity = getEntityById(req->id());
-
-			if(!entity) {
-				resp.set_error(managarm::mbus::Error::NO_SUCH_ENTITY);
-			} else {
-				resp.set_error(managarm::mbus::Error::SUCCESS);
-				for(auto kv : entity->getProperties()) {
-					managarm::mbus::Property prop;
-					prop.set_name(kv.first);
-					prop.set_item(mbus_ng::encodeItem(kv.second));
-					resp.add_properties(prop);
-				}
-			}
-
-			auto [sendHead, sendTail] =
-				co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBragiHeadTail(resp, frg::stl_allocator{})
-				);
-			HEL_CHECK(sendHead.error());
-			HEL_CHECK(sendTail.error());
-		} else if(preamble.id() == bragi::message_id<managarm::mbus::GetRemoteLaneRequest>) {
-			auto req = bragi::parse_head_only<managarm::mbus::GetRemoteLaneRequest>(recvHead);
-			recvHead.reset();
-
-			auto entity = getEntityById(req->id());
-			if(!entity) {
-				managarm::mbus::GetRemoteLaneResponse resp;
-				resp.set_error(managarm::mbus::Error::NO_SUCH_ENTITY);
-
-				auto [sendResp] =
-					co_await helix_ng::exchangeMsgs(
-						conversation,
-						helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
-					);
-				HEL_CHECK(sendResp.error());
-				continue;
-			}
-
-			doGetRemoteLane(std::move(conversation), std::move(entity));
-		} else if(preamble.id() == bragi::message_id<managarm::mbus::EnumerateRequest>) {
-			std::vector<std::byte> tail(preamble.tail_size());
-			auto [recvTail] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::recvBuffer(tail.data(), tail.size())
-				);
-			HEL_CHECK(recvTail.error());
-
-			auto req = bragi::parse_head_tail<managarm::mbus::EnumerateRequest>(recvHead, tail);
-			recvHead.reset();
-
-			doEnumerate(std::move(conversation), req->seq(),
-					decodeFilter(req->filter()));
-		} else if(preamble.id() == bragi::message_id<managarm::mbus::CreateObjectRequest>) {
-			std::vector<std::byte> tail(preamble.tail_size());
-			auto [recvTail] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::recvBuffer(tail.data(), tail.size())
-				);
-			HEL_CHECK(recvTail.error());
-
-			auto req = bragi::parse_head_tail<managarm::mbus::CreateObjectRequest>(recvHead, tail);
-			recvHead.reset();
-
-			std::unordered_map<std::string, mbus_ng::AnyItem> properties;
-			for(auto &kv : req->properties()) {
-				properties.insert({kv.name(), mbus_ng::decodeItem(kv.item())});
-			}
-
-			// TODO(qookie): Introduce async::sequenced_event::current_sequence?
-			//               We want the current seq because the input seq from the
-			//               user is the seq of the first item to be returned
-			//               (e.g. see doEnumerate pagination logic).
-			auto seq = globalSeq.next_sequence() - 1;
-			auto child = std::make_shared<Entity>(nextEntityId++, seq,
-					std::move(req->name()), std::move(properties));
-
-			allEntities.insert({ child->id(), child });
-			entitySeqTree.insert(child.get());
-
-			// Wake up all pending enumeration operations.
-			globalSeq.raise();
-
-			// Set up the management lane
-			auto [localLane, remoteLane] = helix::createStream();
-			serveMgmtLane(std::move(localLane), child);
-
-			managarm::mbus::CreateObjectResponse resp;
+		if(!entity) {
+			resp.set_error(managarm::mbus::Error::NO_SUCH_ENTITY);
+		} else {
 			resp.set_error(managarm::mbus::Error::SUCCESS);
-			resp.set_id(child->id());
+			for(auto kv : entity->getProperties()) {
+				managarm::mbus::Property prop;
+				prop.set_name(kv.first);
+				prop.set_item(mbus_ng::encodeItem(kv.second));
+				resp.add_properties(prop);
+			}
+		}
 
-			auto [sendResp, pushLane] =
+		auto [sendHead, sendTail] =
+			co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBragiHeadTail(resp, frg::stl_allocator{})
+			);
+		HEL_CHECK(sendHead.error());
+		HEL_CHECK(sendTail.error());
+		co_return {};
+	}
+
+	async::result<std::expected<void, DispatchError>> operator() (managarm::mbus::GetRemoteLaneRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble) {
+		auto entity = getEntityById(req.id());
+		if(!entity) {
+			managarm::mbus::GetRemoteLaneResponse resp;
+			resp.set_error(managarm::mbus::Error::NO_SUCH_ENTITY);
+
+			auto [sendResp] =
 				co_await helix_ng::exchangeMsgs(
 					conversation,
-					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-					helix_ng::pushDescriptor(remoteLane)
+					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
 				);
 			HEL_CHECK(sendResp.error());
-			HEL_CHECK(pushLane.error());
-		}else{
-			throw std::runtime_error("Unexpected request type");
+			co_return {};
 		}
+
+		doGetRemoteLane(helix::UniqueLane{conversation.dup()}, std::move(entity));
+		co_return {};
+	}
+
+	async::result<std::expected<void, DispatchError>> operator() (managarm::mbus::EnumerateRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble preamble) {
+		auto tailRes = co_await dispatchTail(req, conversation, preamble);
+		if (!tailRes)
+			co_return std::unexpected(tailRes.error());
+
+		doEnumerate(helix::UniqueLane{conversation.dup()}, req.seq(),
+				decodeFilter(req.filter()));
+		co_return {};
+	}
+
+	async::result<std::expected<void, DispatchError>> operator() (managarm::mbus::CreateObjectRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble preamble) {
+		auto tailRes = co_await dispatchTail(req, conversation, preamble);
+		if (!tailRes)
+			co_return std::unexpected(tailRes.error());
+
+		std::unordered_map<std::string, mbus_ng::AnyItem> properties;
+		for(auto &kv : req.properties()) {
+			properties.insert({kv.name(), mbus_ng::decodeItem(kv.item())});
+		}
+
+		// TODO(qookie): Introduce async::sequenced_event::current_sequence?
+		//               We want the current seq because the input seq from the
+		//               user is the seq of the first item to be returned
+		//               (e.g. see doEnumerate pagination logic).
+		auto seq = globalSeq.next_sequence() - 1;
+		auto child = std::make_shared<Entity>(nextEntityId++, seq,
+				std::move(req.name()), std::move(properties));
+
+		allEntities.insert({ child->id(), child });
+		entitySeqTree.insert(child.get());
+
+		// Wake up all pending enumeration operations.
+		globalSeq.raise();
+
+		// Set up the management lane
+		auto [localLane, remoteLane] = helix::createStream();
+		serveMgmtLane(std::move(localLane), child);
+
+		managarm::mbus::CreateObjectResponse resp;
+		resp.set_error(managarm::mbus::Error::SUCCESS);
+		resp.set_id(child->id());
+
+		auto [sendResp, pushLane] =
+			co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
+				helix_ng::pushDescriptor(remoteLane)
+			);
+		HEL_CHECK(sendResp.error());
+		HEL_CHECK(pushLane.error());
+		co_return {};
+	}
+};
+
+async::detached serve(helix::UniqueLane lane) {
+	while(true) {
+		auto res = co_await dispatchRequest<
+			managarm::mbus::GetPropertiesRequest,
+			managarm::mbus::GetRemoteLaneRequest,
+			managarm::mbus::EnumerateRequest,
+			managarm::mbus::CreateObjectRequest
+		>(lane, HandleRequest{});
+		if(!res)
+			throw std::runtime_error("Unexpected request type");
 	}
 }
 

--- a/posix/subsystem/src/devices/ttyn.cpp
+++ b/posix/subsystem/src/devices/ttyn.cpp
@@ -5,6 +5,7 @@
 #include "../common.hpp"
 #include "ttyn.hpp"
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 
 #include <bitset>
 
@@ -44,13 +45,11 @@ private:
 		co_return PollStatusResult{1, EPOLLOUT};
 	}
 
-	async::result<void>
-	ioctl(Process *, uint32_t id, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) override {
-		if(id == managarm::fs::GenericIoctlRequest::message_id) {
-			auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-			assert(req);
-
-			if(req->command() == TIOCSCTTY) {
+	struct HandleIoctl {
+		async::result<std::expected<void, DispatchError>> operator()(
+				managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation,
+				bragi::preamble, TTYNFile *) {
+			if(req.command() == TIOCSCTTY) {
 				auto [extractCreds] = co_await helix_ng::exchangeMsgs(
 					conversation,
 					helix_ng::extractCredentials()
@@ -67,12 +66,23 @@ private:
 				);
 				HEL_CHECK(sendResp.error());
 			}else{
-				std::cout << "\e[31m" "posix: Rejecting unknown PTS ioctl (commonIoctl) " << req->command()
+				std::cout << "\e[31m" "posix: Rejecting unknown PTS ioctl (commonIoctl) " << req.command()
 						<< "\e[39m" << std::endl;
 			}
-		}else{
-			std::cout << "\e[31m" "posix: Rejecting unknown PTS ioctl message (commonIoctl) " << id
-					<< "\e[39m" << std::endl;
+			co_return {};
+		}
+	};
+
+	async::result<void>
+	ioctl(Process *, uint32_t, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) override {
+		auto res = co_await dispatchRequest<
+			managarm::fs::GenericIoctlRequest
+		>(conversation, std::move(msg), HandleIoctl{}, this);
+
+		if (!res) {
+			auto [dismiss] = co_await helix_ng::exchangeMsgs(
+				conversation, helix_ng::dismiss());
+			HEL_CHECK(dismiss.error());
 		}
 	}
 

--- a/posix/subsystem/src/fifo.cpp
+++ b/posix/subsystem/src/fifo.cpp
@@ -8,6 +8,7 @@
 
 #include <async/recurring-event.hpp>
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 #include <frg/ringbuffer.hpp>
 #include <helix/ipc.hpp>
 #include "fifo.hpp"
@@ -235,20 +236,17 @@ public:
 		co_return flags;
 	}
 
-	async::result<void>
-	ioctl(Process *, uint32_t id, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) override {
-		managarm::fs::GenericIoctlReply resp;
+	struct HandleIoctl {
+		async::result<std::expected<void, DispatchError>> operator()(
+				managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation,
+				bragi::preamble, OpenFile *self) {
+			managarm::fs::GenericIoctlReply resp;
 
-		if(id == managarm::fs::GenericIoctlRequest::message_id) {
-			auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-			msg.reset();
-			assert(req);
-
-			switch(req->command()) {
+			switch(req.command()) {
 				case FIONREAD: {
 					size_t count = 0;
-					if (isReader_)
-						count = _channel->ring.size();
+					if (self->isReader_)
+						count = self->_channel->ring.size();
 
 					resp.set_fionread_count(count);
 					resp.set_error(managarm::fs::Errors::SUCCESS);
@@ -259,7 +257,7 @@ public:
 					auto [dismiss] = co_await helix_ng::exchangeMsgs(
 						conversation, helix_ng::dismiss());
 					HEL_CHECK(dismiss.error());
-					co_return;
+					co_return {};
 				}
 			}
 
@@ -269,12 +267,17 @@ public:
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-			co_return;
-		}else{
-			msg.reset();
-			std::cout << "\e[31m" "fifo: Unknown ioctl() message with ID "
-					<< id << "\e[39m" << std::endl;
+			co_return {};
+		}
+	};
 
+	async::result<void>
+	ioctl(Process *, uint32_t, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) override {
+		auto res = co_await dispatchRequest<
+			managarm::fs::GenericIoctlRequest
+		>(conversation, std::move(msg), HandleIoctl{}, this);
+
+		if (!res) {
 			auto [dismiss] = co_await helix_ng::exchangeMsgs(
 				conversation, helix_ng::dismiss());
 			HEL_CHECK(dismiss.error());

--- a/posix/subsystem/src/inotify.cpp
+++ b/posix/subsystem/src/inotify.cpp
@@ -1,6 +1,7 @@
 #include <async/cancellation.hpp>
 #include <async/recurring-event.hpp>
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 #include <helix/ipc.hpp>
 #include <iostream>
 #include <print>
@@ -221,23 +222,20 @@ public:
 		return true;
 	}
 
-	async::result<void>
-	ioctl(Process *, uint32_t id, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) override {
-		managarm::fs::GenericIoctlReply resp;
+	struct HandleIoctl {
+		async::result<std::expected<void, DispatchError>> operator()(
+				managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation,
+				bragi::preamble, OpenFile *self) {
+			managarm::fs::GenericIoctlReply resp;
 
-		if(id == managarm::fs::GenericIoctlRequest::message_id) {
-			auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-			msg.reset();
-			assert(req);
-
-			switch(req->command()) {
+			switch(req.command()) {
 				case FIONREAD: {
 					resp.set_error(managarm::fs::Errors::SUCCESS);
 
-					if(_queue.empty()) {
+					if(self->_queue.empty()) {
 						resp.set_fionread_count(0);
 					} else {
-						auto packet = &_queue.front();
+						auto packet = &self->_queue.front();
 						auto size = sizeof(Packet) + packet->name.size() + 1;
 						resp.set_fionread_count(size);
 					}
@@ -256,7 +254,20 @@ public:
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-			co_return;
+			co_return {};
+		}
+	};
+
+	async::result<void>
+	ioctl(Process *, uint32_t, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) override {
+		auto res = co_await dispatchRequest<
+			managarm::fs::GenericIoctlRequest
+		>(conversation, std::move(msg), HandleIoctl{}, this);
+
+		if (!res) {
+			auto [dismiss] = co_await helix_ng::exchangeMsgs(
+				conversation, helix_ng::dismiss());
+			HEL_CHECK(dismiss.error());
 		}
 	}
 

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -11,6 +11,7 @@
 #include <async/recurring-event.hpp>
 #include <bragi/helpers-std.hpp>
 
+#include <core/dispatch.hpp>
 #include "core/tty.hpp"
 #include "file.hpp"
 #include "process.hpp"
@@ -71,7 +72,7 @@ struct Channel {
 		cfsetospeed(&activeSettings, B38400);
 	}
 
-	async::result<void> commonIoctl(Process *process, uint32_t id, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation);
+	async::result<void> commonIoctl(managarm::fs::GenericIoctlRequest req, helix::BorrowedDescriptor conversation);
 
 	int ptsIndex;
 	ControllingTerminalState cts;
@@ -363,6 +364,8 @@ private:
 };
 
 struct MasterFile final : File {
+	struct HandleIoctl;
+
 public:
 	static void serve(smarter::shared_ptr<MasterFile> file) {
 		assert(!file->_passthrough);
@@ -432,6 +435,8 @@ private:
 };
 
 struct SlaveFile final : File {
+	struct HandleIoctl;
+
 public:
 	static void serve(smarter::shared_ptr<SlaveFile> file) {
 		assert(!file->_passthrough);
@@ -643,198 +648,190 @@ private:
 };
 
 async::result<void>
-Channel::commonIoctl(Process *, uint32_t id, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) {
-	if(id == managarm::fs::GenericIoctlRequest::message_id) {
-		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-		assert(req);
+Channel::commonIoctl(managarm::fs::GenericIoctlRequest req, helix::BorrowedDescriptor conversation) {
+	if(req.command() == TIOCSCTTY) {
+		auto [extractCreds] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::extractCredentials()
+		);
+		HEL_CHECK(extractCreds.error());
 
-		if(req->command() == TIOCSCTTY) {
-			auto [extractCreds] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::extractCredentials()
-			);
-			HEL_CHECK(extractCreds.error());
+		auto creds = extractCreds.credentials();
+		auto process = findProcessWithCredentials(creds);
 
-			auto creds = extractCreds.credentials();
-			auto process = findProcessWithCredentials(creds);
-
-			managarm::fs::GenericIoctlReply resp;
-			if(auto e = cts.assignSessionOf(process.get()); e == Error::illegalArguments) {
-				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
-			}else if(e == Error::insufficientPermissions) {
-				resp.set_error(managarm::fs::Errors::INSUFFICIENT_PERMISSIONS);
-			}else{
-				assert(e == Error::success);
-				cts.getSession()->setForegroundGroup(process->pgPointer().get());
-				resp.set_error(managarm::fs::Errors::SUCCESS);
-			}
-
-			auto ser = resp.SerializeAsString();
-			auto [sendResp] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::sendBuffer(ser.data(), ser.size())
-			);
-			HEL_CHECK(sendResp.error());
-		}else if(req->command() == TIOCNOTTY) {
-			managarm::fs::GenericIoctlReply resp;
-
-			auto [extractCreds] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::extractCredentials()
-			);
-			HEL_CHECK(extractCreds.error());
-
-			auto creds = extractCreds.credentials();
-			auto process = findProcessWithCredentials(creds);
-
-			if(&cts != process->pgPointer()->getSession()->getControllingTerminal()) {
-				resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
-			} else {
-				auto group = cts.getSession()->getForegroundGroup();
-				if (group && process->pgPointer()->getSession()->getSessionId() == process->pid())
-					group->issueSignalToGroup(SIGHUP, {});
-
-				cts.dropSession(process->pgPointer()->getSession());
-				resp.set_error(managarm::fs::Errors::SUCCESS);
-			}
-
-			auto [send_resp] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
-			);
-			HEL_CHECK(send_resp.error());
-		}else if(req->command() == TIOCGPGRP) {
-			managarm::fs::GenericIoctlReply resp;
-
-			auto [extractCreds] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::extractCredentials()
-			);
-			HEL_CHECK(extractCreds.error());
-
-			auto creds = extractCreds.credentials();
-			auto process = findProcessWithCredentials(creds);
-
-			if(&cts != process->pgPointer()->getSession()->getControllingTerminal()) {
-				resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
-			} else {
-				auto group = cts.getSession()->getForegroundGroup();
-				if (group) {
-					resp.set_pid(group->getHull()->getPid());
-					resp.set_error(managarm::fs::Errors::SUCCESS);
-				} else {
-					// If there is no foreground process group, tcgetpgrp() shall return
-					// a value greater than 1 that does not match the process group ID of any
-					// existing process group.
-					resp.set_pid(INT_MAX);
-					resp.set_error(managarm::fs::Errors::SUCCESS);
-				}
-			}
-
-			auto ser = resp.SerializeAsString();
-			auto [send_resp] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::sendBuffer(ser.data(), ser.size())
-			);
-			HEL_CHECK(send_resp.error());
-		}else if(req->command() == TIOCSPGRP) {
-			managarm::fs::GenericIoctlReply resp;
-
-			auto [extractCreds] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::extractCredentials()
-			);
-			HEL_CHECK(extractCreds.error());
-
-			if (req->pgid() < 0) {
-				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
-				auto [send_resp] = co_await helix_ng::exchangeMsgs(
-					conversation,
-					helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
-				);
-				HEL_CHECK(send_resp.error());
-				co_return;
-			}
-
-			auto creds = extractCreds.credentials();
-			auto process = findProcessWithCredentials(creds);
-			if (!cts.getSession()
-			    || process->pgPointer()->getSession()->getSessionId()
-			           != cts.getSession()->getSessionId()
-			    || !process->pgPointer()->getSession()->getControllingTerminal()
-			    || process->pgPointer()->getSession()->getControllingTerminal() != &cts) {
-
-				resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
-				auto [send_resp] = co_await helix_ng::exchangeMsgs(
-				    conversation, helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
-				);
-				HEL_CHECK(send_resp.error());
-				co_return;
-			}
-
-			auto group = process->pgPointer()->getSession()->getProcessGroupById(req->pgid());
-			if(!group) {
-				resp.set_error(managarm::fs::Errors::INSUFFICIENT_PERMISSIONS);
-			} else {
-				auto sigttouHandler = process->threadGroup()->signalContext()->getHandler(SIGTTOU);
-				if (process->pgPointer().get() == process->pgPointer()->getSession()->getForegroundGroup()
-				    || sigttouHandler.disposition == SignalDisposition::ignore
-				    || (process->signalMask() & (1 << (SIGTTOU - 1)))) {
-					// POSIX: If the calling thread is blocking SIGTTOU signals or the process is
-					// ignoring SIGTTOU signals, the process shall be allowed to perform
-					// the operation.
-
-					auto ret = cts.getSession()->setForegroundGroup(group.get());
-					resp.set_error(ret | protocols::fs::toFsProtoError | protocols::fs::toFsError);
-				} else if (process->pgPointer()->isOrphaned()) {
-					resp.set_error(managarm::fs::Errors::INTERNAL_ERROR);
-					auto [send_resp] = co_await helix_ng::exchangeMsgs(
-						conversation, helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
-					);
-					HEL_CHECK(send_resp.error());
-					co_return;
-				} else {
-					// TODO: if process is in a background PG, send SIGTTOU
-					// process->pgPointer()->issueSignalToGroup(SIGTTOU, {});
-				}
-			}
-
-			auto [send_resp] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
-			);
-			HEL_CHECK(send_resp.error());
-		}else if(req->command() == TIOCGSID) {
-			managarm::fs::GenericIoctlReply resp;
-
-			auto [extractCreds] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::extractCredentials()
-			);
-			HEL_CHECK(extractCreds.error());
-
-			auto creds = extractCreds.credentials();
-			auto process = findProcessWithCredentials(creds);
-
-			if(&cts != process->pgPointer()->getSession()->getControllingTerminal()) {
-				resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
-			} else {
-				resp.set_pid(cts.getSession()->getSessionId());
-				resp.set_error(managarm::fs::Errors::SUCCESS);
-			}
-
-			auto ser = resp.SerializeAsString();
-			auto [send_resp] = co_await helix_ng::exchangeMsgs(
-				conversation,
-				helix_ng::sendBuffer(ser.data(), ser.size())
-			);
-			HEL_CHECK(send_resp.error());
+		managarm::fs::GenericIoctlReply resp;
+		if(auto e = cts.assignSessionOf(process.get()); e == Error::illegalArguments) {
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+		}else if(e == Error::insufficientPermissions) {
+			resp.set_error(managarm::fs::Errors::INSUFFICIENT_PERMISSIONS);
 		}else{
-			std::cout << "\e[31m" "posix: Rejecting unknown PTS ioctl (commonIoctl) " << req->command()
-					<< "\e[39m" << std::endl;
+			assert(e == Error::success);
+			cts.getSession()->setForegroundGroup(process->pgPointer().get());
+			resp.set_error(managarm::fs::Errors::SUCCESS);
 		}
+
+		auto ser = resp.SerializeAsString();
+		auto [sendResp] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::sendBuffer(ser.data(), ser.size())
+		);
+		HEL_CHECK(sendResp.error());
+	}else if(req.command() == TIOCNOTTY) {
+		managarm::fs::GenericIoctlReply resp;
+
+		auto [extractCreds] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::extractCredentials()
+		);
+		HEL_CHECK(extractCreds.error());
+
+		auto creds = extractCreds.credentials();
+		auto process = findProcessWithCredentials(creds);
+
+		if(&cts != process->pgPointer()->getSession()->getControllingTerminal()) {
+			resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
+		} else {
+			auto group = cts.getSession()->getForegroundGroup();
+			if (group && process->pgPointer()->getSession()->getSessionId() == process->pid())
+				group->issueSignalToGroup(SIGHUP, {});
+
+			cts.dropSession(process->pgPointer()->getSession());
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+		}
+
+		auto [send_resp] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+		);
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == TIOCGPGRP) {
+		managarm::fs::GenericIoctlReply resp;
+
+		auto [extractCreds] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::extractCredentials()
+		);
+		HEL_CHECK(extractCreds.error());
+
+		auto creds = extractCreds.credentials();
+		auto process = findProcessWithCredentials(creds);
+
+		if(&cts != process->pgPointer()->getSession()->getControllingTerminal()) {
+			resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
+		} else {
+			auto group = cts.getSession()->getForegroundGroup();
+			if (group) {
+				resp.set_pid(group->getHull()->getPid());
+				resp.set_error(managarm::fs::Errors::SUCCESS);
+			} else {
+				// If there is no foreground process group, tcgetpgrp() shall return
+				// a value greater than 1 that does not match the process group ID of any
+				// existing process group.
+				resp.set_pid(INT_MAX);
+				resp.set_error(managarm::fs::Errors::SUCCESS);
+			}
+		}
+
+		auto ser = resp.SerializeAsString();
+		auto [send_resp] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::sendBuffer(ser.data(), ser.size())
+		);
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == TIOCSPGRP) {
+		managarm::fs::GenericIoctlReply resp;
+
+		auto [extractCreds] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::extractCredentials()
+		);
+		HEL_CHECK(extractCreds.error());
+
+		if (req.pgid() < 0) {
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
+			HEL_CHECK(send_resp.error());
+			co_return;
+		}
+
+		auto creds = extractCreds.credentials();
+		auto process = findProcessWithCredentials(creds);
+		if (!cts.getSession()
+				|| process->pgPointer()->getSession()->getSessionId()
+						!= cts.getSession()->getSessionId()
+				|| !process->pgPointer()->getSession()->getControllingTerminal()
+				|| process->pgPointer()->getSession()->getControllingTerminal() != &cts) {
+
+			resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation, helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
+			HEL_CHECK(send_resp.error());
+			co_return;
+		}
+
+		auto group = process->pgPointer()->getSession()->getProcessGroupById(req.pgid());
+		if(!group) {
+			resp.set_error(managarm::fs::Errors::INSUFFICIENT_PERMISSIONS);
+		} else {
+			auto sigttouHandler = process->threadGroup()->signalContext()->getHandler(SIGTTOU);
+			if (process->pgPointer().get() == process->pgPointer()->getSession()->getForegroundGroup()
+					|| sigttouHandler.disposition == SignalDisposition::ignore
+					|| (process->signalMask() & (1 << (SIGTTOU - 1)))) {
+				// POSIX: If the calling thread is blocking SIGTTOU signals or the process is
+				// ignoring SIGTTOU signals, the process shall be allowed to perform
+				// the operation.
+
+				auto ret = cts.getSession()->setForegroundGroup(group.get());
+				resp.set_error(ret | protocols::fs::toFsProtoError | protocols::fs::toFsError);
+			} else if (process->pgPointer()->isOrphaned()) {
+				resp.set_error(managarm::fs::Errors::INTERNAL_ERROR);
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation, helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+				);
+				HEL_CHECK(send_resp.error());
+				co_return;
+			} else {
+				// TODO: if process is in a background PG, send SIGTTOU
+				// process->pgPointer()->issueSignalToGroup(SIGTTOU, {});
+			}
+		}
+
+		auto [send_resp] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+		);
+		HEL_CHECK(send_resp.error());
+	}else if(req.command() == TIOCGSID) {
+		managarm::fs::GenericIoctlReply resp;
+
+		auto [extractCreds] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::extractCredentials()
+		);
+		HEL_CHECK(extractCreds.error());
+
+		auto creds = extractCreds.credentials();
+		auto process = findProcessWithCredentials(creds);
+
+		if(&cts != process->pgPointer()->getSession()->getControllingTerminal()) {
+			resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
+		} else {
+			resp.set_pid(cts.getSession()->getSessionId());
+			resp.set_error(managarm::fs::Errors::SUCCESS);
+		}
+
+		auto ser = resp.SerializeAsString();
+		auto [send_resp] = co_await helix_ng::exchangeMsgs(
+			conversation,
+			helix_ng::sendBuffer(ser.data(), ser.size())
+		);
+		HEL_CHECK(send_resp.error());
 	}else{
-		std::cout << "\e[31m" "posix: Rejecting unknown PTS ioctl message (commonIoctl) " << id
+		std::cout << "\e[31m" "posix: Rejecting unknown PTS ioctl (commonIoctl) " << req.command()
 				<< "\e[39m" << std::endl;
 	}
 }
@@ -975,18 +972,15 @@ MasterFile::pollStatus(Process *) {
 	co_return PollStatusResult{_channel->currentSeq, events};
 }
 
-async::result<void> MasterFile::ioctl(Process *process, uint32_t id, helix_ng::RecvInlineResult msg,
-		helix::UniqueLane conversation) {
-	if(id == managarm::fs::GenericIoctlRequest::message_id) {
-		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-		msg.reset();
-		assert(req);
-
-		if(req->command() == TIOCGPTN) {
+struct MasterFile::HandleIoctl {
+	async::result<std::expected<void, DispatchError>> operator()(
+			managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation,
+			bragi::preamble, MasterFile *self) {
+		if(req.command() == TIOCGPTN) {
 			managarm::fs::GenericIoctlReply resp;
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
-			resp.set_pts_index(_channel->ptsIndex);
+			resp.set_pts_index(self->_channel->ptsIndex);
 
 			auto ser = resp.SerializeAsString();
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(
@@ -994,20 +988,20 @@ async::result<void> MasterFile::ioctl(Process *process, uint32_t id, helix_ng::R
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-		}else if(req->command() == TIOCSWINSZ) {
+		}else if(req.command() == TIOCSWINSZ) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logAttrs)
 				std::cout << "posix: PTS window size is now "
-						<< req->pts_width() << "x" << req->pts_height()
+						<< req.pts_width() << "x" << req.pts_height()
 						<< " chars, "
-						<< req->pts_pixel_width() << "x" << req->pts_pixel_height()
+						<< req.pts_pixel_width() << "x" << req.pts_pixel_height()
 						<< " pixels (set by master)" << std::endl;
 
-			_channel->width = req->pts_width();
-			_channel->height = req->pts_height();
-			_channel->pixelWidth = req->pts_pixel_width();
-			_channel->pixelHeight = req->pts_pixel_height();
+			self->_channel->width = req.pts_width();
+			self->_channel->height = req.pts_height();
+			self->_channel->pixelWidth = req.pts_pixel_width();
+			self->_channel->pixelHeight = req.pts_pixel_height();
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
@@ -1020,11 +1014,11 @@ async::result<void> MasterFile::ioctl(Process *process, uint32_t id, helix_ng::R
 
 			// XXX: This should deliver SIGWINCH to the parent under certain conditions
 			UserSignal info;
-			_channel->cts.issueSignalToForegroundGroup(SIGWINCH, info);
-		}else if(req->command() == FIONREAD) {
+			self->_channel->cts.issueSignalToForegroundGroup(SIGWINCH, info);
+		}else if(req.command() == FIONREAD) {
 			managarm::fs::GenericIoctlReply resp;
 
-			size_t count = std::transform_reduce(_channel->masterQueue.begin(), _channel->masterQueue.end(), size_t{0}, std::plus<>(), [] (const Packet &p) {
+			size_t count = std::transform_reduce(self->_channel->masterQueue.begin(), self->_channel->masterQueue.end(), size_t{0}, std::plus<>(), [] (const Packet &p) {
 				return p.buffer.size() - p.offset;
 			});
 
@@ -1037,16 +1031,16 @@ async::result<void> MasterFile::ioctl(Process *process, uint32_t id, helix_ng::R
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-		}else if(req->command() == TIOCSCTTY || req->command() == TIOCGPGRP
-				|| req->command() == TIOCSPGRP || req->command() == TIOCGSID
-				|| req->command() == TIOCNOTTY) {
-			co_await _channel->commonIoctl(process, id, std::move(msg), std::move(conversation));
-		}else if(req->command() == TCGETS) {
+		}else if(req.command() == TIOCSCTTY || req.command() == TIOCGPGRP
+				|| req.command() == TIOCSPGRP || req.command() == TIOCGSID
+				|| req.command() == TIOCNOTTY) {
+			co_await self->_channel->commonIoctl(std::move(req), conversation);
+		}else if(req.command() == TCGETS) {
 			managarm::fs::GenericIoctlReply resp;
 			struct termios attrs;
 
 			memset(&attrs, 0, sizeof(struct termios));
-			ttyCopyTermios(_channel->activeSettings, attrs);
+			ttyCopyTermios(self->_channel->activeSettings, attrs);
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
@@ -1058,7 +1052,7 @@ async::result<void> MasterFile::ioctl(Process *process, uint32_t id, helix_ng::R
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_attrs.error());
-		}else if(req->command() == TCSETS) {
+		}else if(req.command() == TCSETS) {
 			struct termios attrs;
 			managarm::fs::GenericIoctlReply resp;
 
@@ -1067,7 +1061,7 @@ async::result<void> MasterFile::ioctl(Process *process, uint32_t id, helix_ng::R
 				helix_ng::recvBuffer(&attrs, sizeof(struct termios))
 			);
 			HEL_CHECK(recv_attrs.error());
-			ttyCopyTermios(attrs, _channel->activeSettings);
+			ttyCopyTermios(attrs, self->_channel->activeSettings);
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
@@ -1078,16 +1072,25 @@ async::result<void> MasterFile::ioctl(Process *process, uint32_t id, helix_ng::R
 			);
 			HEL_CHECK(send_resp.error());
 		}else{
-			std::cout << "\e[31m" "posix: Rejecting unknown PTS master ioctl " << req->command()
+			std::cout << "\e[31m" "posix: Rejecting unknown PTS master ioctl " << req.command()
 					<< "\e[39m" << std::endl;
 			auto [dismiss] = co_await helix_ng::exchangeMsgs(conversation, helix_ng::dismiss());
 			HEL_CHECK(dismiss.error());
 		}
-	}else{
-		msg.reset();
-		std::cout << "\e[31m" "posix: Rejecting unknown PTS master ioctl message " << id
-				<< "\e[39m" << std::endl;
-		auto [dismiss] = co_await helix_ng::exchangeMsgs(conversation, helix_ng::dismiss());
+
+		co_return {};
+	}
+};
+
+async::result<void> MasterFile::ioctl(Process *, uint32_t, helix_ng::RecvInlineResult msg,
+		helix::UniqueLane conversation) {
+	auto res = co_await dispatchRequest<
+		managarm::fs::GenericIoctlRequest
+	>(conversation, std::move(msg), HandleIoctl{}, this);
+
+	if (!res) {
+		auto [dismiss] = co_await helix_ng::exchangeMsgs(
+			conversation, helix_ng::dismiss());
 		HEL_CHECK(dismiss.error());
 	}
 }
@@ -1238,18 +1241,16 @@ SlaveFile::pollStatus(Process *) {
 	co_return PollStatusResult{_channel->currentSeq, events};
 }
 
-async::result<void> SlaveFile::ioctl(Process *process, uint32_t id, helix_ng::RecvInlineResult msg,
-		helix::UniqueLane conversation) {
-	if(id == managarm::fs::GenericIoctlRequest::message_id) {
-		auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-		msg.reset();
-
-		if(req->command() == TCGETS) {
+struct SlaveFile::HandleIoctl {
+	async::result<std::expected<void, DispatchError>> operator()(
+			managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation,
+			bragi::preamble, SlaveFile *self) {
+		if(req.command() == TCGETS) {
 			managarm::fs::GenericIoctlReply resp;
 			struct termios attrs;
 
 			memset(&attrs, 0, sizeof(struct termios));
-			ttyCopyTermios(_channel->activeSettings, attrs);
+			ttyCopyTermios(self->_channel->activeSettings, attrs);
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
@@ -1261,7 +1262,7 @@ async::result<void> SlaveFile::ioctl(Process *process, uint32_t id, helix_ng::Re
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_attrs.error());
-		}else if(req->command() == TCSETS) {
+		}else if(req.command() == TCSETS) {
 			struct termios attrs;
 			managarm::fs::GenericIoctlReply resp;
 
@@ -1336,7 +1337,7 @@ async::result<void> SlaveFile::ioctl(Process *process, uint32_t id, helix_ng::Re
 				std::cout << std::dec << std::endl;
 			}
 
-			ttyCopyTermios(attrs, _channel->activeSettings);
+			ttyCopyTermios(attrs, self->_channel->activeSettings);
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
@@ -1346,14 +1347,14 @@ async::result<void> SlaveFile::ioctl(Process *process, uint32_t id, helix_ng::Re
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-		}else if(req->command() == TIOCGWINSZ) {
+		}else if(req.command() == TIOCGWINSZ) {
 			managarm::fs::GenericIoctlReply resp;
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
-			resp.set_pts_width(_channel->width);
-			resp.set_pts_height(_channel->height);
-			resp.set_pts_pixel_width(_channel->pixelWidth);
-			resp.set_pts_pixel_height(_channel->pixelHeight);
+			resp.set_pts_width(self->_channel->width);
+			resp.set_pts_height(self->_channel->height);
+			resp.set_pts_pixel_width(self->_channel->pixelWidth);
+			resp.set_pts_pixel_height(self->_channel->pixelHeight);
 
 			auto ser = resp.SerializeAsString();
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(
@@ -1361,20 +1362,20 @@ async::result<void> SlaveFile::ioctl(Process *process, uint32_t id, helix_ng::Re
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-		}else if(req->command() == TIOCSWINSZ) {
+		}else if(req.command() == TIOCSWINSZ) {
 			managarm::fs::GenericIoctlReply resp;
 
 			if(logAttrs)
 				std::cout << "posix: PTS window size is now "
-						<< req->pts_width() << "x" << req->pts_height()
+						<< req.pts_width() << "x" << req.pts_height()
 						<< " chars, "
-						<< req->pts_pixel_width() << "x" << req->pts_pixel_height()
+						<< req.pts_pixel_width() << "x" << req.pts_pixel_height()
 						<< " pixels (set by slave)" << std::endl;
 
-			_channel->width = req->pts_width();
-			_channel->height = req->pts_height();
-			_channel->pixelWidth = req->pts_pixel_width();
-			_channel->pixelHeight = req->pts_pixel_height();
+			self->_channel->width = req.pts_width();
+			self->_channel->height = req.pts_height();
+			self->_channel->pixelWidth = req.pts_pixel_width();
+			self->_channel->pixelHeight = req.pts_pixel_height();
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
@@ -1387,20 +1388,20 @@ async::result<void> SlaveFile::ioctl(Process *process, uint32_t id, helix_ng::Re
 
 			// XXX: This should deliver SIGWINCH to the parent under certain conditions
 			UserSignal info;
-			_channel->cts.issueSignalToForegroundGroup(SIGWINCH, info);
-		}else if(req->command() == TIOCSCTTY || req->command() == TIOCGPGRP
-				|| req->command() == TIOCSPGRP || req->command() == TIOCGSID
-				|| req->command() == TIOCNOTTY) {
-			co_await _channel->commonIoctl(process, id, std::move(msg), std::move(conversation));
-		}else if(req->command() == TIOCINQ) {
+			self->_channel->cts.issueSignalToForegroundGroup(SIGWINCH, info);
+		}else if(req.command() == TIOCSCTTY || req.command() == TIOCGPGRP
+				|| req.command() == TIOCSPGRP || req.command() == TIOCGSID
+				|| req.command() == TIOCNOTTY) {
+			co_await self->_channel->commonIoctl(std::move(req), conversation);
+		}else if(req.command() == TIOCINQ) {
 			managarm::fs::GenericIoctlReply resp;
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 
-			if(_channel->slaveQueue.empty()) {
+			if(self->_channel->slaveQueue.empty()) {
 				resp.set_fionread_count(0);
 			}else{
-				auto packet = &_channel->slaveQueue.front();
+				auto packet = &self->_channel->slaveQueue.front();
 				resp.set_fionread_count(packet->buffer.size() - packet->offset);
 			}
 
@@ -1410,11 +1411,11 @@ async::result<void> SlaveFile::ioctl(Process *process, uint32_t id, helix_ng::Re
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-		} else if(req->command() == TIOCGPTN) {
+		} else if(req.command() == TIOCGPTN) {
 			managarm::fs::GenericIoctlReply resp;
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
-			resp.set_pts_index(_channel->ptsIndex);
+			resp.set_pts_index(self->_channel->ptsIndex);
 
 			auto ser = resp.SerializeAsString();
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(
@@ -1423,16 +1424,25 @@ async::result<void> SlaveFile::ioctl(Process *process, uint32_t id, helix_ng::Re
 			);
 			HEL_CHECK(send_resp.error());
 		}else{
-			std::cout << "\e[31m" "posix: Rejecting unknown PTS slave ioctl " << req->command()
+			std::cout << "\e[31m" "posix: Rejecting unknown PTS slave ioctl " << req.command()
 					<< "\e[39m" << std::endl;
 			auto [dismiss] = co_await helix_ng::exchangeMsgs(conversation, helix_ng::dismiss());
 			HEL_CHECK(dismiss.error());
 		}
-	}else{
-		msg.reset();
-		std::cout << "\e[31m" "posix: Rejecting unknown PTS slave ioctl message " << id
-				<< "\e[39m" << std::endl;
-		auto [dismiss] = co_await helix_ng::exchangeMsgs(conversation, helix_ng::dismiss());
+
+		co_return {};
+	}
+};
+
+async::result<void> SlaveFile::ioctl(Process *, uint32_t, helix_ng::RecvInlineResult msg,
+		helix::UniqueLane conversation) {
+	auto res = co_await dispatchRequest<
+		managarm::fs::GenericIoctlRequest
+	>(conversation, std::move(msg), HandleIoctl{}, this);
+
+	if (!res) {
+		auto [dismiss] = co_await helix_ng::exchangeMsgs(
+			conversation, helix_ng::dismiss());
 		HEL_CHECK(dismiss.error());
 	}
 }

--- a/posix/subsystem/src/timerfd.cpp
+++ b/posix/subsystem/src/timerfd.cpp
@@ -10,6 +10,7 @@
 #include <async/recurring-event.hpp>
 #include <bragi/helpers-std.hpp>
 #include <core/clock.hpp>
+#include <core/dispatch.hpp>
 #include <helix/ipc.hpp>
 #include <helix/timer.hpp>
 #include <protocols/fs/common.hpp>
@@ -158,22 +159,15 @@ public:
 		co_return;
 	}
 
-	async::result<void> ioctl(Process *, uint32_t id, helix_ng::RecvInlineResult msg,
-			helix::UniqueLane conversation) override {
-		if(id == managarm::fs::GenericIoctlRequest::message_id) {
-			auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-			if (!req) {
-				auto [dismiss] = co_await helix_ng::exchangeMsgs(
-					conversation, helix_ng::dismiss());
-				HEL_CHECK(dismiss.error());
-				co_return;
-			}
-
-			switch(req->command()) {
+	struct HandleIoctl {
+		async::result<std::expected<void, DispatchError>> operator()(
+				managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation,
+				bragi::preamble, OpenFile *self) {
+			switch(req.command()) {
 				case TFD_IOC_SET_TICKS: {
-					_expirations = req->ticks();
-					_theSeq++;
-					_seqBell.raise();
+					self->_expirations = req.ticks();
+					self->_theSeq++;
+					self->_seqBell.raise();
 
 					managarm::fs::GenericIoctlReply resp;
 					resp.set_error(managarm::fs::Errors::SUCCESS);
@@ -186,15 +180,24 @@ public:
 					break;
 				}
 				default: {
-					std::println("timerfd: unexpected ioctl request 0x{:x}", req->command());
+					std::println("timerfd: unexpected ioctl request 0x{:x}", req.command());
 					auto [dismiss] = co_await helix_ng::exchangeMsgs(
 						conversation, helix_ng::dismiss());
 					HEL_CHECK(dismiss.error());
 					break;
 				}
 			}
-		} else {
-			std::println("timerfd: unexpected ioctl message type 0x{:x}\n", id);
+			co_return {};
+		}
+	};
+
+	async::result<void> ioctl(Process *, uint32_t, helix_ng::RecvInlineResult msg,
+			helix::UniqueLane conversation) override {
+		auto res = co_await dispatchRequest<
+			managarm::fs::GenericIoctlRequest
+		>(conversation, std::move(msg), HandleIoctl{}, this);
+
+		if (!res) {
 			auto [dismiss] = co_await helix_ng::exchangeMsgs(
 				conversation, helix_ng::dismiss());
 			HEL_CHECK(dismiss.error());

--- a/posix/subsystem/src/un-socket.cpp
+++ b/posix/subsystem/src/un-socket.cpp
@@ -13,6 +13,7 @@
 #include <asm-generic/socket.h>
 #include <async/recurring-event.hpp>
 #include <core/clock.hpp>
+#include <core/dispatch.hpp>
 #include <bragi/helpers-std.hpp>
 #include <protocols/fs/common.hpp>
 #include <helix/ipc.hpp>
@@ -841,32 +842,29 @@ public:
 		co_return {};
 	}
 
-	async::result<void>
-	ioctl(Process *, uint32_t id, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) override {
-		managarm::fs::GenericIoctlReply resp;
+	struct HandleIoctl {
+		async::result<std::expected<void, DispatchError>> operator()(
+				managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation,
+				bragi::preamble, OpenFile *self) {
+			managarm::fs::GenericIoctlReply resp;
 
-		if(id == managarm::fs::GenericIoctlRequest::message_id) {
-			auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-			msg.reset();
-			assert(req);
-
-			switch(req->command()) {
+			switch(req.command()) {
 				case FIONREAD: {
 					resp.set_error(managarm::fs::Errors::SUCCESS);
 
-					if(_currentState != State::connected) {
+					if(self->_currentState != State::connected) {
 						resp.set_error(managarm::fs::Errors::NOT_CONNECTED);
-					} else if(_recvQueue.empty()) {
+					} else if(self->_recvQueue.empty()) {
 						resp.set_fionread_count(0);
 					} else {
-						auto packet = &_recvQueue.front();
+						auto packet = &self->_recvQueue.front();
 						resp.set_fionread_count(packet->buffer.size() - packet->offset);
 					}
 					break;
 				}
 				default: {
 					std::cout << "posix: invalid ioctl 0x"
-						<< std::hex << req->command() << std::dec
+						<< std::hex << req.command() << std::dec
 						<< " for un-socket" << std::endl;
 
 					auto [dismissResult] = co_await helix_ng::exchangeMsgs(
@@ -874,7 +872,7 @@ public:
 						helix_ng::dismiss()
 					);
 					HEL_CHECK(dismissResult.error());
-					co_return;
+					co_return {};
 				}
 			}
 
@@ -884,7 +882,20 @@ public:
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-			co_return;
+			co_return {};
+		}
+	};
+
+	async::result<void>
+	ioctl(Process *, uint32_t, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) override {
+		auto res = co_await dispatchRequest<
+			managarm::fs::GenericIoctlRequest
+		>(conversation, std::move(msg), HandleIoctl{}, this);
+
+		if (!res) {
+			auto [dismiss] = co_await helix_ng::exchangeMsgs(
+				conversation, helix_ng::dismiss());
+			HEL_CHECK(dismiss.error());
 		}
 	}
 

--- a/servers/netserver/src/ip/tcp4.cpp
+++ b/servers/netserver/src/ip/tcp4.cpp
@@ -17,6 +17,7 @@
 #include <netinet/ip.h>
 
 #include <bragi/helpers-std.hpp>
+#include <core/dispatch.hpp>
 
 #include "checksum.hpp"
 #include "ip4.hpp"
@@ -294,16 +295,11 @@ struct Tcp4Socket {
 		co_return sizeof(sockaddr_in);
 	}
 
-	static async::result<void> ioctl(void *object, uint32_t id, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) {
-		auto self = static_cast<Tcp4Socket *>(object);
-		managarm::fs::GenericIoctlReply resp;
+	struct HandleIoctl {
+		async::result<std::expected<void, DispatchError>> operator() (managarm::fs::GenericIoctlRequest &&req, helix::BorrowedDescriptor conversation, bragi::preamble, Tcp4Socket *self) {
+			managarm::fs::GenericIoctlReply resp;
 
-		if(id == managarm::fs::GenericIoctlRequest::message_id) {
-			auto req = bragi::parse_head_only<managarm::fs::GenericIoctlRequest>(msg);
-			msg.reset();
-			assert(req);
-
-			switch(req->command()) {
+			switch(req.command()) {
 				case FIONREAD: {
 					resp.set_error(managarm::fs::Errors::SUCCESS);
 
@@ -329,14 +325,23 @@ struct Tcp4Socket {
 				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-		}else {
-			msg.reset();
-			std::cout << "Unknown ioctl() message with ID " << id << std::endl;
+
+			co_return {};
+		}
+	};
+
+	static async::result<void> ioctl(void *object, uint32_t, helix_ng::RecvInlineResult msg, helix::UniqueLane conversation) {
+		auto self = static_cast<Tcp4Socket *>(object);
+
+		auto res = co_await dispatchRequest<
+			managarm::fs::GenericIoctlRequest
+		>(conversation, std::move(msg), HandleIoctl{}, self);
+
+		if (!res) {
 			auto [dismiss] = co_await helix_ng::exchangeMsgs(
-			conversation, helix_ng::dismiss());
+				conversation, helix_ng::dismiss());
 			HEL_CHECK(dismiss.error());
 		}
-		co_return;
 	}
 
 	static async::result<protocols::fs::Error> connect(void *object,


### PR DESCRIPTION
The first commit introduces the new `dispatchRequest()` and `dispatchTail()` functions to help with Bragi message dispatching. The remaining commits convert some of the existing server code to use `dispatchRequest()`.

A non-trivial use case of `dispatchTail()` can be found in kernletcc code. A non-trivial handler (that also does Bragi logging) can be found in the DRM code.