### PR TITLE
protocols/posix: allow passing mount options

### DIFF
--- a/protocols/posix/posix.bragi
+++ b/protocols/posix/posix.bragi
@@ -445,6 +445,7 @@ tail:
 	string path;
 	string target_path;
 	string fs_type;
+	string mount_data;
 }
 
 message SymlinkAtRequest 30 {


### PR DESCRIPTION
This adds the protocol definition for implementing mount options later.