### PR TITLE
thor: Fix assertions that could be triggered through use of syscalls

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -97,6 +97,9 @@ Checks:
   - 'modernize-use-nullptr'
   - 'readability-enum-initial-value'
   - 'readability-redundant-smartptr-get'
+CheckOptions:
+  - key: bugprone-unused-return-value.AllowCastToVoid
+    value: true
 HeaderFileExtensions:
   - h
   - hpp

--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -623,7 +623,8 @@ VirtualSpace::synchronize(VirtualAddr address, size_t size) {
 
 			mapping = _findMapping(alignedAddress + overallProgress);
 		}
-		assert(mapping);
+		if(!mapping)
+			co_return Error::fault;
 
 		auto mappingOffset = alignedAddress + overallProgress - mapping->address;
 		auto mappingChunk = frg::min(alignedSize - overallProgress,

--- a/kernel/thor/generic/event.cpp
+++ b/kernel/thor/generic/event.cpp
@@ -7,11 +7,12 @@ namespace thor {
 // OneshotEvent implementation.
 //---------------------------------------------------------------------------------------
 
-void OneshotEvent::trigger() {
-	assert(!_triggered); // TODO: Return an error!
-
+std::expected<void, Error> OneshotEvent::trigger() {
 	auto irq_lock = frg::guard(&irqMutex());
 	auto lock = frg::guard(&_mutex);
+
+	if(_triggered)
+		return std::unexpected{Error::illegalState};
 
 	_triggered = true;
 
@@ -23,6 +24,8 @@ void OneshotEvent::trigger() {
 		if(node->cancelCb_.try_reset())
 			node->wq_->post(node->awaited_);
 	}
+
+	return {};
 }
 
 void OneshotEvent::submitAwait(AwaitEventNode<OneshotEvent> *node, uint64_t sequence) {
@@ -75,9 +78,9 @@ BitsetEvent::BitsetEvent()
 		_lastTrigger[i] = 0;
 }
 
-void BitsetEvent::trigger(uint32_t bits) {
+std::expected<void, Error> BitsetEvent::trigger(uint32_t bits) {
 	if(!bits)
-		return; // TODO: Return an error!
+		return std::unexpected{Error::illegalArgs};
 
 	auto irq_lock = frg::guard(&irqMutex());
 	auto lock = frg::guard(&_mutex);
@@ -95,6 +98,8 @@ void BitsetEvent::trigger(uint32_t bits) {
 		if(node->cancelCb_.try_reset())
 			node->wq_->post(node->awaited_);
 	}
+
+	return {};
 }
 
 void BitsetEvent::submitAwait(AwaitEventNode<BitsetEvent> *node, uint64_t sequence) {

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3334,7 +3334,9 @@ HelError helRaiseEvent(HelHandle handle) {
 
 	if(descriptor.is<OneshotEventDescriptor>()) {
 		auto event = descriptor.get<OneshotEventDescriptor>().event;
-		event->trigger();
+		auto outcome = event->trigger();
+		if(!outcome)
+			return translateError(outcome.error());
 	}else{
 		return kHelErrBadDescriptor;
 	}

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -349,16 +349,18 @@ HelError helDescriptorInfo(HelHandle handle, HelDescriptorInfo *) {
 		return kHelErrNoDescriptor;
 	switch(wrapper->tag()) {
 	default:
-		assert(!"Illegal descriptor");
+		return kHelErrOther;
 	}
 
 	return kHelErrNone;
 }
 
 HelError helGetCredentials(HelHandle handle, uint32_t flags, char *credentials) {
+	if (flags)
+		return kHelErrIllegalArgs;
+
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
-	assert(!flags);
 
 	std::array<char, 16> creds;
 	{
@@ -1368,7 +1370,6 @@ HelError doSubmitReadMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 			}
 		}
 
-		assert(error == Error::success);
 		HelSimpleResult helResult{.error = translateError(error), .reserved = {}};
 		QueueSource ipcSource{&helResult, sizeof(HelSimpleResult), nullptr};
 		co_await queue->submit(&ipcSource, context);
@@ -3638,10 +3639,13 @@ HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num
 				memory = wrapper->get<MemoryViewDescriptor>().memory;
 			}
 
-			auto window = reinterpret_cast<char *>(KernelVirtualMemory::global().allocate(0x10000));
-			assert(memory->getLength() <= 0x10000);
+			auto memorySize = memory->getLength();
+			if (memorySize > 0x10000)
+				return kHelErrIllegalArgs;
 
-			for(size_t off = 0; off < memory->getLength(); off += kPageSize) {
+			auto window = reinterpret_cast<char *>(KernelVirtualMemory::global().allocate(0x10000));
+
+			for(size_t off = 0; off < memorySize; off += kPageSize) {
 				auto range = memory->peekRange(off, fetchNone);
 				assert(range.physical != PhysicalAddr(-1));
 				PageFlags pageFlags = page_access::read;

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3342,9 +3342,13 @@ HelError helAccessIrq(int number, HelHandle *handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
+	auto pin = acpi::getGlobalSystemIrq(number);
+	if (!pin)
+		return kHelErrOutOfBounds;
+
 	auto irq = smarter::allocate_shared<GenericIrqObject>(*kernelAlloc,
 			frg::string<KernelAlloc>{*kernelAlloc, "generic-irq-object"});
-	IrqPin::attachSink(acpi::getGlobalSystemIrq(number), irq.get());
+	IrqPin::attachSink(pin, irq.get());
 
 	{
 		auto irq_lock = frg::guard(&irqMutex());

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -51,7 +51,7 @@ extern "C" int doCopyFromUser(void *dest, const void *src, size_t size);
 extern "C" int doCopyToUser(void *dest, const void *src, size_t size);
 extern "C" int doAtomicUserLoad(unsigned int *out, const unsigned int *p);
 
-bool readUserMemory(void *kernelPtr, const void *userPtr, size_t size) {
+[[nodiscard]] bool readUserMemory(void *kernelPtr, const void *userPtr, size_t size) {
 	uintptr_t limit;
 	if(__builtin_add_overflow(reinterpret_cast<uintptr_t>(userPtr), size, &limit))
 		return false;
@@ -63,7 +63,7 @@ bool readUserMemory(void *kernelPtr, const void *userPtr, size_t size) {
 	return !e;
 }
 
-bool writeUserMemory(void *userPtr, const void *kernelPtr, size_t size) {
+[[nodiscard]] bool writeUserMemory(void *userPtr, const void *kernelPtr, size_t size) {
 	uintptr_t limit;
 	if(__builtin_add_overflow(reinterpret_cast<uintptr_t>(userPtr), size, &limit))
 		return false;
@@ -76,17 +76,17 @@ bool writeUserMemory(void *userPtr, const void *kernelPtr, size_t size) {
 }
 
 template<typename T>
-bool readUserObject(const T *pointer, T &object) {
+[[nodiscard]] bool readUserObject(const T *pointer, T &object) {
 	return readUserMemory(static_cast<void *>(&object), static_cast<const void *>(pointer), sizeof(T));
 }
 
 template<typename T>
-bool writeUserObject(T *pointer, T object) {
+[[nodiscard]] bool writeUserObject(T *pointer, T object) {
 	return writeUserMemory(pointer, &object, sizeof(T));
 }
 
 template<typename T>
-bool readUserArray(const T *pointer, T *array, size_t count) {
+[[nodiscard]] bool readUserArray(const T *pointer, T *array, size_t count) {
 	size_t size;
 	if(__builtin_mul_overflow(sizeof(T), count, &size))
 		return false;
@@ -94,7 +94,7 @@ bool readUserArray(const T *pointer, T *array, size_t count) {
 }
 
 template<typename T>
-bool writeUserArray(T *pointer, const T *array, size_t count) {
+[[nodiscard]] bool writeUserArray(T *pointer, const T *array, size_t count) {
 	size_t size;
 	if(__builtin_mul_overflow(sizeof(T), count, &size))
 		return false;
@@ -2410,7 +2410,8 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 #ifdef __x86_64__
 		// FIXME: Make those registers thread-specific.
 		uint32_t *reg;
-		readUserObject(reinterpret_cast<uint32_t *const *>(image), reg);
+		if(!readUserObject(reinterpret_cast<uint32_t *const *>(image), reg))
+			return kHelErrFault;
 		breakOnWrite(reg);
 #else
 		return kHelErrUnsupportedOperation;
@@ -2742,7 +2743,8 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 				auto sglist = reinterpret_cast<HelSgItem *>(recipe->buffer);
 				for(size_t j = 0; j < recipe->length; j++) {
 					HelSgItem item;
-					readUserObject(sglist + j, item);
+					if(!readUserObject(sglist + j, item))
+						return kHelErrFault;
 					length += item.length;
 				}
 
@@ -2750,7 +2752,8 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 				size_t offset = 0;
 				for(size_t j = 0; j < recipe->length; j++) {
 					HelSgItem item;
-					readUserObject(sglist + j, item);
+					if(!readUserObject(sglist + j, item))
+						return kHelErrFault;
 					if(!readUserMemory(reinterpret_cast<char *>(buffer.data()) + offset,
 							reinterpret_cast<char *>(item.buffer), item.length))
 						return kHelErrFault;
@@ -3542,7 +3545,8 @@ HelError helAccessIo(uintptr_t *port_array, size_t num_ports,
 	auto io_space = smarter::allocate_shared<IoSpace>(*kernelAlloc);
 	for(size_t i = 0; i < num_ports; i++) {
 		uintptr_t port;
-		readUserObject<uintptr_t>(port_array + i, port);
+		if(!readUserObject<uintptr_t>(port_array + i, port))
+			return kHelErrFault;
 		io_space->addPort(port);
 	}
 

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -433,15 +433,16 @@ HelError helCreateQueue(const HelQueueParameters *paramsPtr, HelHandle *handle) 
 	if(params.flags)
 		return kHelErrIllegalArgs;
 
-	auto queue = smarter::allocate_shared<IpcQueue>(*kernelAlloc,
-			params.numChunks, params.chunkSize, params.numSqChunks);
-	queue->selfPtr = queue;
+	auto queueOutcome = IpcQueue::create(params.numChunks, params.chunkSize,
+			params.numSqChunks);
+	if(!queueOutcome)
+		return translateError(queueOutcome.error());
 	{
 		auto irq_lock = frg::guard(&irqMutex());
 		Universe::Guard universe_guard(thisUniverse->lock);
 
 		*handle = thisUniverse->attachDescriptor(universe_guard,
-				QueueDescriptor(std::move(queue)));
+				QueueDescriptor(std::move(*queueOutcome)));
 	}
 
 	return kHelErrNone;

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -1286,10 +1286,11 @@ HelError doSubmitSynchronizeSpace(HelHandle spaceHandle, smarter::shared_ptr<Ipc
 			smarter::shared_ptr<IpcQueue> queue, uintptr_t context,
 			enable_detached_coroutine) -> void {
 		auto outcome = co_await onExceptionalWq(space->synchronize((VirtualAddr)pointer, length));
-		// TODO: handle errors after propagating them through VirtualSpace::synchronize.
-		assert(outcome);
 
-		HelSimpleResult helResult{.error = kHelErrNone, .reserved = {}};
+		HelSimpleResult helResult{
+			.error = outcome ? kHelErrNone : translateError(outcome.error()),
+			.reserved = {},
+		};
 		QueueSource ipcSource{&helResult, sizeof(HelSimpleResult), nullptr};
 		co_await queue->submit(&ipcSource, context);
 	}(thisThread.lock(), std::move(space), pointer, length, std::move(queue), context,

--- a/kernel/thor/generic/ipc-queue.cpp
+++ b/kernel/thor/generic/ipc-queue.cpp
@@ -11,39 +11,44 @@ namespace thor {
 // IpcQueue
 // ----------------------------------------------------------------------------
 
-IpcQueue::IpcQueue(unsigned int numChunks, size_t chunkSize, unsigned int numSqChunks)
-: _chunkSize{chunkSize}, _chunkOffsets{*kernelAlloc},
-		_currentChunk{0}, _currentProgress{0},
-		_numCqChunks{numChunks}, _numSqChunks{numSqChunks} {
+std::expected<smarter::shared_ptr<IpcQueue>, Error>
+IpcQueue::create(unsigned int numChunks, size_t chunkSize, unsigned int numSqChunks) {
+	auto ptr = smarter::allocate_shared<IpcQueue>(*kernelAlloc,
+			numChunks, chunkSize, numSqChunks);
+	if(!ptr)
+		return std::unexpected{Error::noMemory};
+	ptr->selfPtr = ptr;
+
 	auto totalChunks = numChunks + numSqChunks;
 	auto chunksOffset = (sizeof(QueueStruct) + 63) & ~size_t(63);
 	auto reservedPerChunk = (sizeof(ChunkStruct) + chunkSize + 63) & ~size_t(63);
 	auto overallSize = chunksOffset + totalChunks * reservedPerChunk;
 
-	// Setup internal state.
-	_memory = smarter::allocate_shared<ImmediateMemory>(*kernelAlloc, overallSize);
-	_memory->selfPtr = _memory;
-	_mapping = ImmediateWindow{_memory};
-	_chunkOffsets.resize(totalChunks);
+	auto memoryOutcome = ImmediateMemory::create(overallSize);
+	if(!memoryOutcome)
+		return std::unexpected{memoryOutcome.error()};
+	ptr->_memory = std::move(*memoryOutcome);
+	ptr->_mapping = ImmediateWindow{ptr->_memory};
+	ptr->_chunkOffsets.resize(totalChunks);
 	for(unsigned int i = 0; i < totalChunks; ++i)
-		_chunkOffsets[i] = chunksOffset + i * reservedPerChunk;
+		ptr->_chunkOffsets[i] = chunksOffset + i * reservedPerChunk;
 
 	// Initialize SQ chunks if configured.
 	if(numSqChunks > 0) {
-		auto head = _mapping.access<QueueStruct>(0);
+		auto head = ptr->_mapping.access<QueueStruct>(0);
 
 		// Reset all SQ chunks.
 		for(unsigned int i = numChunks; i < totalChunks; ++i) {
-			auto chunkOffset = _chunkOffsets[i];
-			auto chunkHead = _mapping.access<ChunkStruct>(chunkOffset);
+			auto chunkOffset = ptr->_chunkOffsets[i];
+			auto chunkHead = ptr->_mapping.access<ChunkStruct>(chunkOffset);
 			chunkHead->next = 0;
 			chunkHead->progressFutex = 0;
 		}
 
 		// Link SQ chunks together.
 		for(unsigned int i = numChunks; i < totalChunks - 1; ++i) {
-			auto chunkOffset = _chunkOffsets[i];
-			auto chunkHead = _mapping.access<ChunkStruct>(chunkOffset);
+			auto chunkOffset = ptr->_chunkOffsets[i];
+			auto chunkHead = ptr->_mapping.access<ChunkStruct>(chunkOffset);
 			chunkHead->next = (i + 1) | kNextPresent;
 		}
 
@@ -51,11 +56,17 @@ IpcQueue::IpcQueue(unsigned int numChunks, size_t chunkSize, unsigned int numSqC
 		__atomic_store_n(&head->sqFirst, numChunks | kNextPresent, __ATOMIC_RELEASE);
 
 		// Initialize SQ state.
-		_sqCurrentChunk = numChunks;
-		_sqCurrentProgress = 0;
-		_sqTailChunk = totalChunks - 1;
+		ptr->_sqCurrentChunk = numChunks;
+		ptr->_sqCurrentProgress = 0;
+		ptr->_sqTailChunk = totalChunks - 1;
 	}
+	return ptr;
 }
+
+IpcQueue::IpcQueue(unsigned int numChunks, size_t chunkSize, unsigned int numSqChunks)
+: _chunkSize{chunkSize}, _chunkOffsets{*kernelAlloc},
+		_currentChunk{0}, _currentProgress{0},
+		_numCqChunks{numChunks}, _numSqChunks{numSqChunks} { }
 
 void IpcQueue::notifyError() {
 	auto head = _mapping.access<QueueStruct>(0);

--- a/kernel/thor/generic/kernlet.cpp
+++ b/kernel/thor/generic/kernlet.cpp
@@ -276,7 +276,7 @@ smarter::shared_ptr<KernletObject> processElfDso(const char *buffer,
 					infoLogger() << "__trigger_bitset on "
 							<< p << ", bits: " << bits << frg::endlog;
 				auto event = static_cast<BitsetEvent *>(p);
-				event->trigger(bits);
+				(void)event->trigger(bits);
 			};
 
 #ifdef THOR_ARCH_SUPPORTS_PIO

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -770,10 +770,13 @@ coroutine<frg::expected<Error>> AllocatedMemory::resize(size_t newSize) {
 		auto irq_lock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&_mutex);
 
-		assert(!(newSize % _chunkSize));
-		size_t num_chunks = newSize / _chunkSize;
-		assert(num_chunks >= _physicalChunks.size());
-		_physicalChunks.resize(num_chunks, PhysicalAddr(-1));
+		if (newSize % _chunkSize)
+			co_return Error::illegalArgs;
+		size_t numChunks = newSize / _chunkSize;
+		// TODO: Support shrinking of AllocatedMemory.
+		if (numChunks < _physicalChunks.size())
+			co_return Error::illegalArgs;
+		_physicalChunks.resize(numChunks, PhysicalAddr(-1));
 	}
 	co_return {};
 }
@@ -1686,8 +1689,10 @@ PhysicalRange IndirectMemory::peekRange(uintptr_t offset, FetchFlags flags) {
 		auto irqLock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&mutex_);
 
-		assert(slot < indirections_.size()); // TODO: Return Error::fault.
-		assert(indirections_[slot]); // TODO: Return Error::fault.
+		if (slot >= indirections_.size())
+			return {.physical = PhysicalAddr(-1), .size = 0, .cachingMode = CachingMode::null};
+		if (!indirections_[slot])
+			return {.physical = PhysicalAddr(-1), .size = 0, .cachingMode = CachingMode::null};
 		indirection = indirections_[slot];
 	}
 

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -532,24 +532,36 @@ smarter::shared_ptr<MemoryView> getZeroMemory() {
 // ImmediateMemory
 // --------------------------------------------------------
 
-ImmediateMemory::ImmediateMemory(size_t length)
-: _physicalPages{*kernelAlloc} {
+std::expected<smarter::shared_ptr<ImmediateMemory>, Error>
+ImmediateMemory::create(size_t length) {
+	auto ptr = smarter::allocate_shared<ImmediateMemory>(*kernelAlloc);
+	if(!ptr)
+		return std::unexpected{Error::noMemory};
+	ptr->selfPtr = ptr;
+
 	auto numPages = (length + kPageSize - 1) >> kPageShift;
-	_physicalPages.resize(numPages);
+	ptr->_physicalPages.resize(numPages, PhysicalAddr(-1));
 	for(size_t i = 0; i < numPages; ++i) {
 		auto physical = physicalAllocator->allocate(kPageSize, 64);
-		assert(physical != PhysicalAddr(-1) && "OOM when allocating ImmediateMemory");
+		if(physical == PhysicalAddr(-1))
+			return std::unexpected{Error::noMemory};
 
 		PageAccessor accessor{physical};
 		memset(accessor.get(), 0, kPageSize);
 
 		globalPfnDb().insert(physical, PfnDescriptor::otherPage());
-		_physicalPages[i] = physical;
+		ptr->_physicalPages[i] = physical;
 	}
+	return ptr;
 }
+
+ImmediateMemory::ImmediateMemory()
+: _physicalPages{*kernelAlloc} { }
 
 ImmediateMemory::~ImmediateMemory() {
 	for(size_t i = 0; i < _physicalPages.size(); ++i) {
+		if(_physicalPages[i] == PhysicalAddr(-1))
+			continue;
 		globalPfnDb().erase(_physicalPages[i]);
 		physicalAllocator->free(_physicalPages[i], kPageSize);
 	}
@@ -565,10 +577,11 @@ coroutine<frg::expected<Error>> ImmediateMemory::resize(size_t newSize) {
 		size_t currentNumPages = _physicalPages.size();
 		size_t newNumPages = (newSize + kPageSize - 1) >> kPageShift;
 		assert(newNumPages >= currentNumPages);
-		_physicalPages.resize(newNumPages);
+		_physicalPages.resize(newNumPages, PhysicalAddr(-1));
 		for(size_t i = currentNumPages; i < newNumPages; ++i) {
 			auto physical = physicalAllocator->allocate(kPageSize, 64);
-			assert(physical != PhysicalAddr(-1) && "OOM when allocating ImmediateMemory");
+			if(physical == PhysicalAddr(-1))
+				co_return Error::noMemory;
 
 			PageAccessor accessor{physical};
 			memset(accessor.get(), 0, kPageSize);

--- a/kernel/thor/generic/thor-internal/event.hpp
+++ b/kernel/thor/generic/thor-internal/event.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <expected>
+
 #include <async/cancellation.hpp>
 #include <frg/list.hpp>
 #include <thor-internal/error.hpp>
@@ -63,7 +65,7 @@ private:
 struct OneshotEvent {
 	OneshotEvent() = default;
 
-	void trigger();
+	std::expected<void, Error> trigger();
 
 	void submitAwait(AwaitEventNode<OneshotEvent> *node, uint64_t sequence);
 	void cancelAwait(AwaitEventNode<OneshotEvent> *node);
@@ -150,7 +152,7 @@ private:
 struct BitsetEvent {
 	BitsetEvent();
 
-	void trigger(uint32_t bits);
+	std::expected<void, Error> trigger(uint32_t bits);
 
 	void submitAwait(AwaitEventNode<BitsetEvent> *node, uint64_t sequence);
 	void cancelAwait(AwaitEventNode<BitsetEvent> *node);

--- a/kernel/thor/generic/thor-internal/ipc-queue.hpp
+++ b/kernel/thor/generic/thor-internal/ipc-queue.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <expected>
 #include <span>
 
 #include <async/mutex.hpp>
@@ -73,6 +74,9 @@ private:
 	using Address = uintptr_t;
 
 public:
+	static std::expected<smarter::shared_ptr<IpcQueue>, Error>
+	create(unsigned int numChunks, size_t chunkSize, unsigned int numSqChunks);
+
 	IpcQueue(unsigned int numChunks, size_t chunkSize, unsigned int numSqChunks);
 
 	IpcQueue(const IpcQueue &) = delete;

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <expected>
 
 #include <async/algorithm.hpp>
 #include <async/oneshot-event.hpp>
@@ -437,7 +438,10 @@ smarter::shared_ptr<MemoryView> getZeroMemory();
 // Memory that is allocated by the kernel and never swapped out.
 // In contrast to most other memory objects, it can be accessed synchronously.
 struct ImmediateMemory final : MemoryView {
-	ImmediateMemory(size_t length);
+	static std::expected<smarter::shared_ptr<ImmediateMemory>, Error>
+	create(size_t length);
+
+	ImmediateMemory();
 	ImmediateMemory(const ImmediateMemory &) = delete;
 	~ImmediateMemory();
 


### PR DESCRIPTION
Fix various user-triggerable code paths that could result in assertion failures in the kernel.

These issues were found by auditing the code base using Claude Code (Opus 4.7).