### PR TITLE
thor: Fix safety bugs in thread register access code

### DIFF
--- a/kernel/thor/generic/gdbserver.cpp
+++ b/kernel/thor/generic/gdbserver.cpp
@@ -160,6 +160,15 @@ struct EmitOverlay {
 	EmitOverlay(frg::vector<uint8_t, KernelAlloc> *buf)
 	: buf_{buf} { }
 
+	// Append Enn which some commands use to indicate an error (with nn begin the error code).
+	// Since error codes are not well-defined according to the GDB protocol documentation,
+	// we simply send E01 here.
+	void appendError() {
+		buf_->push_back('E');
+		buf_->push_back('0');
+		buf_->push_back('1');
+	}
+
 	void appendString(const char *s) {
 		for(size_t n = 0; s[n]; ++n)
 			buf_->push_back(s[n]);
@@ -314,7 +323,7 @@ coroutine<frg::expected<ProtocolError>> GdbServer::handleRequest_() {
 		if(!req.fullyConsumed())
 			co_return ProtocolError::malformedPacket;
 
-		thread_->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread_->accessRegisters([&](Executor *executor) {
 #if defined(__x86_64__)
 			resp.appendLeHex64(executor->general()->rax);
 			resp.appendLeHex64(executor->general()->rbx);
@@ -358,6 +367,8 @@ coroutine<frg::expected<ProtocolError>> GdbServer::handleRequest_() {
 #	error Unknown architecture
 #endif
 		});
+		if(!accessOutcome)
+			resp.appendError();
 	}else if(req.matchString("m")) { // Read memory.
 		uint64_t address;
 		uint64_t length;

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -2082,17 +2082,17 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 		}
 	}
 
-	// TODO: Make sure that the thread is actually suspenend!
-
 	if(set == kHelRegsProgram) {
 		if(!thread) {
 			return kHelErrIllegalArgs;
 		}
 		uintptr_t regs[2];
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			regs[0] = *executor->ip();
 			regs[1] = *executor->sp();
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserArray(reinterpret_cast<uintptr_t *>(image), regs, 2))
 			return kHelErrFault;
 	}else if(set == kHelRegsGeneral) {
@@ -2101,7 +2101,7 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 		}
 #if defined(__x86_64__)
 		uintptr_t regs[15];
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			regs[0] = executor->general()->rax;
 			regs[1] = executor->general()->rbx;
 			regs[2] = executor->general()->rcx;
@@ -2118,24 +2118,30 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 			regs[13] = executor->general()->r15;
 			regs[14] = executor->general()->rbp;
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserArray(reinterpret_cast<uintptr_t *>(image), regs, 15))
 			return kHelErrFault;
 #elif defined(__aarch64__)
 		uintptr_t regs[31];
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			for (int i = 0; i < 31; i++)
 				regs[i] = executor->general()->x[i];
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserArray(reinterpret_cast<uintptr_t *>(image), regs, 31))
 			return kHelErrFault;
 #elif defined(__riscv) && __riscv_xlen == 64
 		uintptr_t regs[30];
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			regs[0] = executor->general()->x(1);
 			// Skip x(2) as it corresponds to sp.
 			for (int i = 1; i < 30; i++)
 				regs[i] = executor->general()->x(i + 2);
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserArray(reinterpret_cast<uintptr_t *>(image), regs, 30))
 			return kHelErrFault;
 #else
@@ -2147,24 +2153,30 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 		}
 #if defined(__x86_64__)
 		uintptr_t regs[2];
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			regs[0] = executor->general()->clientFs;
 			regs[1] = executor->general()->clientGs;
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserArray(reinterpret_cast<uintptr_t *>(image), regs, 2))
 			return kHelErrFault;
 #elif defined(__aarch64__)
 		uintptr_t regs[1];
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			regs[0] = executor->general()->tpidr_el0;
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserArray(reinterpret_cast<uintptr_t *>(image), regs, 1))
 			return kHelErrFault;
 #elif defined(__riscv) && __riscv_xlen == 64
 		uintptr_t regs[1];
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			regs[0] = executor->general()->tp();
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserArray(reinterpret_cast<uintptr_t *>(image), regs, 1))
 			return kHelErrFault;
 #else
@@ -2199,7 +2211,7 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 #endif
 
 		frg::unique_memory<KernelAlloc> buffer{*kernelAlloc, simdSize};
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 #if defined(__x86_64__)
 			memcpy(buffer.data(), executor->_fxState(), simdSize);
 #elif defined(__aarch64__)
@@ -2210,6 +2222,8 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 			__builtin_trap(); // Should not be reached due to return above.
 #endif
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserMemory(image, buffer.data(), simdSize))
 			return kHelErrFault;
 	}else if(set == kHelRegsSignal) {
@@ -2218,7 +2232,7 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 		}
 #if defined(__x86_64__)
 		uintptr_t regs[19];
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			regs[0] = executor->general()->r8;
 			regs[1] = executor->general()->r9;
 			regs[2] = executor->general()->r10;
@@ -2239,11 +2253,13 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 			regs[17] = *executor->rflags();
 			regs[18] = *executor->cs();
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserArray(reinterpret_cast<uintptr_t *>(image), regs, 19))
 			return kHelErrFault;
 #elif defined(__aarch64__)
 		uintptr_t regs[35];
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			regs[0] = executor->general()->far;
 			for (int i = 0; i < 31; i++)
 				regs[1 + i] = executor->general()->x[i];
@@ -2251,15 +2267,19 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 			regs[33] = executor->general()->elr;
 			regs[34] = executor->general()->spsr;
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserArray(reinterpret_cast<uintptr_t *>(image), regs, 35))
 			return kHelErrFault;
 #elif defined(__riscv) && __riscv_xlen == 64
 		uintptr_t regs[32];
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			regs[0] = executor->general()->ip;
 			for(int i = 1; i < 32; i++)
 				regs[i] = executor->general()->x(i);
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 		if(!writeUserArray(reinterpret_cast<uintptr_t *>(image), regs, 32))
 			return kHelErrFault;
 #else
@@ -2319,8 +2339,6 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 		}
 	}
 
-	// TODO: Make sure that the thread is actually suspenend!
-
 	if(set == kHelRegsProgram) {
 		if(!thread) {
 			return kHelErrIllegalArgs;
@@ -2328,10 +2346,12 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 		uintptr_t regs[2];
 		if(!readUserArray(reinterpret_cast<const uintptr_t *>(image), regs, 2))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			*executor->ip() = regs[0];
 			*executor->sp() = regs[1];
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 	}else if(set == kHelRegsGeneral) {
 		if(!thread) {
 			return kHelErrIllegalArgs;
@@ -2340,7 +2360,7 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 		uintptr_t regs[15];
 		if(!readUserArray(reinterpret_cast<const uintptr_t *>(image), regs, 15))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			executor->general()->rax = regs[0];
 			executor->general()->rbx = regs[1];
 			executor->general()->rcx = regs[2];
@@ -2357,24 +2377,30 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 			executor->general()->r15 = regs[13];
 			executor->general()->rbp = regs[14];
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 #elif defined(__aarch64__)
 		uintptr_t regs[31];
 		if(!readUserArray(reinterpret_cast<const uintptr_t *>(image), regs, 31))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			for (int i = 0; i < 31; i++)
 				executor->general()->x[i] = regs[i];
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 #elif defined(__riscv) && __riscv_xlen == 64
 		uintptr_t regs[30];
 		if(!readUserArray(reinterpret_cast<const uintptr_t *>(image), regs, 30))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			executor->general()->x(1) = regs[0];
 			// Skip x(2) as it corresponds to sp.
 			for (int i = 1; i < 30; i++)
 				executor->general()->x(i + 2) = regs[i];
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 #else
 		return kHelErrUnsupportedOperation;
 #endif
@@ -2386,24 +2412,30 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 		uintptr_t regs[2];
 		if(!readUserArray(reinterpret_cast<const uintptr_t *>(image), regs, 2))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			executor->general()->clientFs = regs[0];
 			executor->general()->clientGs = regs[1];
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 #elif defined(__aarch64__)
 		uintptr_t regs[1];
 		if(!readUserArray(reinterpret_cast<const uintptr_t *>(image), regs, 1))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			executor->general()->tpidr_el0 = regs[0];
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 #elif defined(__riscv) && __riscv_xlen == 64
 		uintptr_t regs[1];
 		if(!readUserArray(reinterpret_cast<const uintptr_t *>(image), regs, 1))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			executor->general()->tp() = regs[0];
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 #else
 		return kHelErrUnsupportedOperation;
 #endif
@@ -2447,7 +2479,7 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 		frg::unique_memory<KernelAlloc> buffer{*kernelAlloc, simdSize};
 		if(!readUserMemory(buffer.data(), image, simdSize))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 #if defined(__x86_64__)
 			memcpy(executor->_fxState(), buffer.data(), simdSize);
 #elif defined(__aarch64__)
@@ -2458,6 +2490,8 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 			__builtin_trap(); // Should not be reached due to return above.
 #endif
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 	}else if(set == kHelRegsSignal) {
 		if(!thread) {
 			return kHelErrIllegalArgs;
@@ -2466,7 +2500,7 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 		uintptr_t regs[19];
 		if(!readUserArray(reinterpret_cast<const uintptr_t *>(image), regs, 19))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			executor->general()->r8 = regs[0];
 			executor->general()->r9 = regs[1];
 			executor->general()->r10 = regs[2];
@@ -2493,11 +2527,13 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 			// Make sure that the cs is in usermode by or'ing it with 3.
 			*executor->cs() = regs[18] | 3;
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 #elif defined(__aarch64__)
 		uintptr_t regs[35];
 		if(!readUserArray(reinterpret_cast<const uintptr_t *>(image), regs, 35))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			executor->general()->far = regs[0];
 			for (int i = 0; i < 31; i++)
 				executor->general()->x[i] = regs[1 + i];
@@ -2509,15 +2545,19 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 			executor->general()->spsr &= ~allowedFlagsMask;
 			executor->general()->spsr |= regs[34] & allowedFlagsMask;
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 #elif defined(__riscv) && __riscv_xlen == 64
 		uintptr_t regs[32];
 		if(!readUserArray(reinterpret_cast<const uintptr_t *>(image), regs, 32))
 			return kHelErrFault;
-		thread->accessRegisters([&](Executor *executor) {
+		auto accessOutcome = thread->accessRegisters([&](Executor *executor) {
 			executor->general()->ip = regs[0];
 			for(int i = 1; i < 32; i++)
 				executor->general()->x(i) = regs[i];
 		});
+		if(!accessOutcome)
+			return translateError(accessOutcome.error());
 #else
 		return kHelErrUnsupportedOperation;
 #endif

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -2447,7 +2447,9 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 		return kHelErrUnsupportedOperation;
 #endif
 	}else if(set == kHelRegsDebug) {
-#ifdef __x86_64__
+#if 0 // x86_64
+		// TODO: If we want to re-enable debug registers on x86_64, we have to validate
+		//       that they only affect userspace and not the kernel.
 		// FIXME: Make those registers thread-specific.
 		uint32_t *reg;
 		if(!readUserObject(reinterpret_cast<uint32_t *const *>(image), reg))

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -2286,10 +2286,17 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 		return kHelErrUnsupportedOperation;
 #endif
 	}else if(set == kHelRegsPageFault) {
-		uintptr_t regs[2];
-		regs[0] = thread->interruptInfo.offendingAddress;
+		if(!thread)
+			return kHelErrIllegalArgs;
 
-		switch (thread->interruptInfo.pageFaultType) {
+		auto infoOutcome = thread->getInterruptInfo();
+		if (!infoOutcome)
+			return translateError(infoOutcome.error());
+
+		uintptr_t regs[2];
+		regs[0] = infoOutcome->offendingAddress;
+
+		switch (infoOutcome->pageFaultType) {
 			case thor::PageFaultType::NotMapped:
 				regs[1] = kHelPageFaultMapError;
 				break;
@@ -2300,7 +2307,7 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 				regs[1] = 0;
 				break;
 			default:
-				infoLogger() << "hel: unhandled page fault type " << frg::hex_fmt{std::to_underlying(thread->interruptInfo.pageFaultType)} << frg::endlog;
+				infoLogger() << "hel: unhandled page fault type " << frg::hex_fmt{std::to_underlying(infoOutcome->pageFaultType)} << frg::endlog;
 				regs[1] = 0;
 				break;
 		}

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -848,9 +848,11 @@ namespace posix {
 			}else if(interrupt == kIntrSuperCall + ::posix::superAnonAllocate) { // ANON_ALLOCATE.
 				// TODO: Use some always-zero memory for private anonymous mappings.
 				uintptr_t size;
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto readOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					size = *executor->arg0();
 				});
+				if(!readOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 				auto fileMemory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, size);
 				fileMemory->selfPtr = fileMemory;
 				auto cowMemory = smarter::allocate_shared<CopyOnWriteMemory>(*kernelAlloc,
@@ -867,23 +869,27 @@ namespace posix {
 				// TODO: improve error handling here.
 				assert(mapResult);
 
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto writeOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					*executor->result0() = kHelErrNone;
 					*executor->result1() = mapResult.value();
 				});
+				if(!writeOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 				if(auto e = Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(info.thread)); e != Error::success)
 					panicLogger() << "thor: Failed to resume server" << frg::endlog;
 			}else if(interrupt == kIntrSuperCall + ::posix::superAnonDeallocate) { // ANON_FREE.
 				uintptr_t address;
 				uintptr_t size;
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto readOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					address = *executor->arg0();
 					size = *executor->arg1();
 				});
+				if(!readOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 				auto space = info.thread->getAddressSpace();
 				auto unmapOutcome = co_await space->unmap(address, size);
 
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto writeOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					if(!unmapOutcome) {
 						assert(unmapOutcome.error() == Error::illegalArgs);
 						*executor->result0() = kHelErrIllegalArgs;
@@ -892,13 +898,17 @@ namespace posix {
 					}
 					*executor->result1() = 0;
 				});
+				if(!writeOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 				if(auto e = Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(info.thread)); e != Error::success)
 					panicLogger() << "thor: Failed to resume server" << frg::endlog;
 			}else if(interrupt == kIntrSuperCall + ::posix::superGetProcessData) {
 				uintptr_t dataAddr;
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto readOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					dataAddr = *executor->arg0();
 				});
+				if(!readOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 
 				::posix::ManagarmProcessData data = {
 					info.posixHandle,
@@ -910,20 +920,24 @@ namespace posix {
 
 				auto outcome = co_await info.thread->getAddressSpace()->writeSpace(
 						dataAddr, &data, sizeof(::posix::ManagarmProcessData));
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto writeOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					if(!outcome) {
 						*executor->result0() = kHelErrFault;
 					}else{
 						*executor->result0() = kHelErrNone;
 					}
 				});
+				if(!writeOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 				if(auto e = Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(info.thread)); e != Error::success)
 					panicLogger() << "thor: Failed to resume server" << frg::endlog;
 			}else if(interrupt == kIntrSuperCall + ::posix::superGetServerData) {
 				uintptr_t dataAddr;
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto readOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					dataAddr = *executor->arg0();
 				});
+				if(!readOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 
 				::posix::ManagarmServerData data = {
 					controlHandle
@@ -931,36 +945,44 @@ namespace posix {
 
 				auto outcome = co_await info.thread->getAddressSpace()->writeSpace(
 						dataAddr, &data, sizeof(::posix::ManagarmServerData));
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto writeOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					if(!outcome) {
 						*executor->result0() = kHelErrFault;
 					}else{
 						*executor->result0() = kHelErrNone;
 					}
 				});
+				if(!writeOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 				if(auto e = Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(info.thread)); e != Error::success)
 					panicLogger() << "thor: Failed to resume server" << frg::endlog;
 			}else if(interrupt == kIntrSuperCall + ::posix::superSigMask) { // sigprocmask.
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto accessOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					*executor->result0() = kHelErrNone;
 					*executor->result1() = 0;
 				});
+				if(!accessOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 				if(auto e = Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(info.thread)); e != Error::success)
 					panicLogger() << "thor: Failed to resume server" << frg::endlog;
 			}else if(interrupt == kIntrSuperCall + ::posix::superGetTid) {
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto accessOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					*executor->result0() = kHelErrNone;
 					*executor->result1() = info.tid;
 				});
+				if(!accessOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 				if(auto e = Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(info.thread)); e != Error::success)
 					panicLogger() << "thor: Failed to resume server" << frg::endlog;
 			}else if(interrupt == kIntrSuperCall + ::posix::superClone) {
 				uintptr_t argIp;
 				uintptr_t argSp;
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto readOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					argIp = *executor->arg0();
 					argSp = *executor->arg1();
 				});
+				if(!readOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 
 				AbiParameters params;
 				params.ip = argIp;
@@ -975,10 +997,12 @@ namespace posix {
 				new_thread.policy().increment();
 				new_thread.policy().increment();
 
-				info.thread->accessRegisters([&](Executor *executor) {
+				auto writeOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					*executor->result0() = kHelErrNone;
 					*executor->result1() = new_info.tid;
 				});
+				if(!writeOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 
 				LoadBalancer::singleton().connect(new_thread.get(), getCpuData());
 				Scheduler::associate(new_thread.get(), &localScheduler.get());

--- a/kernel/thor/generic/thor-internal/thread.hpp
+++ b/kernel/thor/generic/thor-internal/thread.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <expected>
 
 #include <frg/container_of.hpp>
 #include <thor-internal/arch-generic/cpu.hpp>
@@ -360,14 +361,15 @@ public:
 
 	// Access a thread's registers while the thread is interrupted.
 	// TODO: This needs to lock the thread.
-	// TODO: This needs to fail if we are not in interrupted state.
 	template<typename F>
 	requires requires(F f, Executor *executor) {
 		{ f(executor) } -> std::same_as<void>;
 	}
-	void accessRegisters(F &&f) {
-		assert(intrState_ == IntrState::inInterrupt);
+	std::expected<void, Error> accessRegisters(F &&f) {
+		if(intrState_ != IntrState::inInterrupt)
+			return std::unexpected{Error::illegalState};
 		f(&intrImage_);
+		return {};
 	}
 
 private:

--- a/kernel/thor/generic/thor-internal/thread.hpp
+++ b/kernel/thor/generic/thor-internal/thread.hpp
@@ -360,12 +360,14 @@ public:
 	InterruptInfo interruptInfo;
 
 	// Access a thread's registers while the thread is interrupted.
-	// TODO: This needs to lock the thread.
 	template<typename F>
 	requires requires(F f, Executor *executor) {
 		{ f(executor) } -> std::same_as<void>;
 	}
 	std::expected<void, Error> accessRegisters(F &&f) {
+		auto irqLock = frg::guard(&irqMutex());
+		auto lock = frg::guard(&_mutex);
+
 		if(intrState_ != IntrState::inInterrupt)
 			return std::unexpected{Error::illegalState};
 		f(&intrImage_);

--- a/kernel/thor/generic/thor-internal/thread.hpp
+++ b/kernel/thor/generic/thor-internal/thread.hpp
@@ -357,8 +357,6 @@ public:
 	// Non-virtual since syscalls/faults know that they are called from a thread.
 	void handlePreemption(FaultImageAccessor image);
 
-	InterruptInfo interruptInfo;
-
 	// Access a thread's registers while the thread is interrupted.
 	template<typename F>
 	requires requires(F f, Executor *executor) {
@@ -372,6 +370,19 @@ public:
 			return std::unexpected{Error::illegalState};
 		f(&intrImage_);
 		return {};
+	}
+
+	std::expected<InterruptInfo, Error> getInterruptInfo() {
+		InterruptInfo info;
+		{
+			auto irqLock = frg::guard(&irqMutex());
+			auto lock = frg::guard(&_mutex);
+
+			if(intrState_ != IntrState::inInterrupt)
+				return std::unexpected{Error::illegalState};
+			info = _interruptInfo;
+		}
+		return info;
 	}
 
 private:
@@ -454,6 +465,8 @@ private:
 	IntrState intrState_{IntrState::none};
 	// Only valid if intrState_ == IntrState::inInterrupt;
 	Interrupt _lastInterrupt;
+	// Only valid if intrState_ == IntrState::inInterrupt;
+	InterruptInfo _interruptInfo;
 	// Raised after intrState_ becomes IntrState::resumeFromInterrupt.
 	async::recurring_event resumeEvent_;
 

--- a/kernel/thor/generic/thread.cpp
+++ b/kernel/thor/generic/thread.cpp
@@ -218,7 +218,7 @@ void Thread::genericInterruptCurrent(Interrupt interrupt, ImageAccessor image, I
 		assert(thisThread->intrState_ == IntrState::none);
 		thisThread->intrState_ = IntrState::inInterrupt;
 		thisThread->_lastInterrupt = interrupt;
-		thisThread->interruptInfo = info;
+		thisThread->_interruptInfo = info;
 		saveExecutor(&thisThread->intrImage_, image);
 
 		queue.splice(queue.end(), thisThread->_observeQueue);


### PR DESCRIPTION
- Protect `accessRegisters()` with a lock and make it failable.
- Protect `InterruptInfo` access with a lock.
- Disallow debug register writes.