### PR TITLE
IOMMU work, part 1: enumerate PCIe extended capabilities

### DIFF
--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -1198,6 +1198,38 @@ void findPciCaps(PciEntity *entity) {
 			offset = (ent >> 8) & 0xFC;
 		}
 	}
+
+	// PCIe devices are required to provide the 4096-byte configuration space.
+	if (io->supports4kConfigSpace() && entity->isPcie) {
+		uint16_t offset = 0x100;
+
+		while (offset) {
+			auto data = io->readConfigWord(entity->parentBus, entity->slot, entity->function, offset);
+			uint16_t extendedCapId = data;
+			uint8_t version = (data >> 16) & 0xF;
+			// The bottom 2 bits are reserved and must be masked out.
+			// This offset is relative to the start of the entire configuration space.
+			uint16_t nextOffset = (data >> 20) & 0xFFC;
+
+			if (extendedCapId == 0xFFFF && nextOffset == 0)
+				break;
+
+			// We have a valid Extended Capability
+			auto name = nameOfExtendedCapability(extendedCapId);
+			if (name) {
+				infoLogger() << frg::fmt("            {} Extended Capability (v{})", name, version)
+				             << frg::endlog;
+			} else {
+				infoLogger() << frg::fmt(
+				    "            Extended Capability 0x{:x} (v{})", extendedCapId, version
+				) << frg::endlog;
+			}
+
+			entity->extendedCaps.push({extendedCapId, offset});
+
+			offset = nextOffset;
+		}
+	}
 }
 
 template <typename EnumFunc>

--- a/kernel/thor/system/pci/thor-internal/pci/pci.hpp
+++ b/kernel/thor/system/pci/thor-internal/pci/pci.hpp
@@ -56,12 +56,18 @@ inline const char *nameOf(IrqIndex index) {
 
 inline const char *nameOfCapability(unsigned int type) {
 	switch(type) {
+	case 0x01: return "PCI Power Management Interface";
+	case 0x02: return "AGP";
+	case 0x03: return "VPD";
 	case 0x04: return "Slot-identification";
 	case 0x05: return "MSI";
 	case 0x09: return "Vendor-specific";
 	case 0x0A: return "Debug-port";
+	case 0x0C: return "PCI Hot Plug";
+	case 0x0D: return "PCI Bridge Subsystem ID";
 	case 0x10: return "PCIe";
 	case 0x11: return "MSI-X";
+	case 0x12: return "Serial ATA DATA/Index Configuration";
 	default:
 		return nullptr;
 	}

--- a/kernel/thor/system/pci/thor-internal/pci/pci.hpp
+++ b/kernel/thor/system/pci/thor-internal/pci/pci.hpp
@@ -503,6 +503,8 @@ struct PciConfigIo {
 	virtual void writeConfigWord(uint32_t seg, uint32_t bus, uint32_t slot,
 			uint32_t function, uint16_t offset, uint32_t value) = 0;
 
+	virtual bool supports4kConfigSpace() = 0;
+
 protected:
 	~PciConfigIo() = default;
 };

--- a/kernel/thor/system/pci/thor-internal/pci/pci.hpp
+++ b/kernel/thor/system/pci/thor-internal/pci/pci.hpp
@@ -73,6 +73,30 @@ inline const char *nameOfCapability(unsigned int type) {
 	}
 }
 
+inline const char *nameOfExtendedCapability(uint16_t type) {
+	switch(type) {
+	case 0x0001: return "Advanced Error Reporting";
+	case 0x0002: return "Virtual Channel";
+	case 0x0003: return "Device Serial Number";
+	case 0x0004: return "Power Budgeting";
+	case 0x0005: return "Root Complex Link Declaration";
+	case 0x0006: return "Root Complex Internal Link Control";
+	case 0x000B: return "Vendor-specific";
+	case 0x000D: return "ACS";
+	case 0x000E: return "ARI";
+	case 0x000F: return "ATS";
+	case 0x0010: return "SR-IOV";
+	case 0x0011: return "MR-IOV";
+	case 0x0013: return "Page Request";
+	case 0x0015: return "Resizable BAR";
+	case 0x0017: return "TPH Requester";
+	case 0x0018: return "LTR";
+	case 0x001B: return "PASID";
+	default:
+		return nullptr;
+	}
+}
+
 enum class RoutingModel {
 	none,
 	rootTable, // Routing table of PCI IRQ pins to global IRQs (i.e., PRT).
@@ -313,7 +337,13 @@ struct PciEntity : protected KernelBusObject {
 		size_t length;
 	};
 
+	struct ExtendedCapability {
+		uint16_t type;
+		uint16_t offset;
+	};
+
 	frg::vector<Capability, KernelAlloc> caps{*kernelAlloc};
+	frg::vector<ExtendedCapability, KernelAlloc> extendedCaps{*kernelAlloc};
 
 	PciExpansionRom expansionRom;
 

--- a/kernel/thor/system/pci/thor-internal/pci/pci_legacy.hpp
+++ b/kernel/thor/system/pci/thor-internal/pci/pci_legacy.hpp
@@ -33,6 +33,10 @@ struct LegacyPciConfigIo final : PciConfigIo {
 			uint32_t function, uint16_t offset, uint16_t value) override;
 	void writeConfigWord(uint32_t seg, uint32_t bus, uint32_t slot,
 			uint32_t function, uint16_t offset, uint32_t value) override;
+
+	bool supports4kConfigSpace() override {
+		return false;
+	}
 };
 
 } // namespace thor::pci

--- a/kernel/thor/system/pci/thor-internal/pci/pcie_brcmstb.hpp
+++ b/kernel/thor/system/pci/thor-internal/pci/pcie_brcmstb.hpp
@@ -23,6 +23,10 @@ struct BrcmStbPcie final : PciConfigIo {
 	void writeConfigWord(uint32_t seg, uint32_t bus, uint32_t slot,
 			uint32_t function, uint16_t offset, uint32_t value) override;
 
+	bool supports4kConfigSpace() override {
+		return true;
+	}
+
 private:
 	void init_();
 	void reset_();

--- a/kernel/thor/system/pci/thor-internal/pci/pcie_ecam.hpp
+++ b/kernel/thor/system/pci/thor-internal/pci/pcie_ecam.hpp
@@ -23,6 +23,10 @@ struct EcamPcieConfigIo final : PciConfigIo {
 	void writeConfigWord(uint32_t seg, uint32_t bus, uint32_t slot,
 			uint32_t function, uint16_t offset, uint32_t value) override;
 
+	bool supports4kConfigSpace() override {
+		return true;
+	}
+
 private:
 	arch::mem_space spaceForBus_(uint32_t bus);
 	uintptr_t calculateOffset_(uint32_t slot, uint32_t function,


### PR DESCRIPTION
This is useful for discovery of ACS, which might be of use for determining IOMMU domains.