### PR TITLE
thor: Move allocations out of IRQ disabled regions and spinlocks

### DIFF
--- a/kernel/thor/arch/arm/paging.cpp
+++ b/kernel/thor/arch/arm/paging.cpp
@@ -99,12 +99,14 @@ KernelPageSpace &KernelPageSpace::global() {
 }
 
 void initializeAsidContext(CpuData *cpuData) {
-	auto irqLock = frg::guard(&irqMutex());
-
 	// TODO(qookie): Check the max number of ASIDs. 256 is safe, but it could also be 65536.
 	asidData.get(cpuData).initialize(256);
 	asidData.get(cpuData)->globalBinding.initialize(globalBindingId);
-	asidData.get(cpuData)->globalBinding.initialBind(*kernelSpacePtr);
+
+	{
+		auto irqLock = frg::guard(&irqMutex());
+		asidData.get(cpuData)->globalBinding.initialBind(*kernelSpacePtr);
+	}
 }
 
 

--- a/kernel/thor/arch/riscv/paging.cpp
+++ b/kernel/thor/arch/riscv/paging.cpp
@@ -44,11 +44,13 @@ void invalidatePage(int asid, const void *address) {
 }
 
 void initializeAsidContext(CpuData *cpuData) {
-	auto irqLock = frg::guard(&irqMutex());
-
 	asidData.get(cpuData).initialize(1);
 	asidData.get(cpuData)->globalBinding.initialize(globalBindingId);
-	asidData.get(cpuData)->globalBinding.initialBind(*kernelSpacePtr);
+
+	{
+		auto irqLock = frg::guard(&irqMutex());
+		asidData.get(cpuData)->globalBinding.initialBind(*kernelSpacePtr);
+	}
 }
 
 // --------------------------------------------------------

--- a/kernel/thor/arch/x86/paging.cpp
+++ b/kernel/thor/arch/x86/paging.cpp
@@ -103,14 +103,16 @@ KernelPageSpace &KernelPageSpace::global() {
 static constexpr int maxPcidCount = 8;
 
 void initializeAsidContext(CpuData *cpuData) {
-	auto irqLock = frg::guard(&irqMutex());
-
 	// If PCIDs are not supported, create only one binding.
 	auto pcidCount = getCpuData()->havePcids ? maxPcidCount : 1;
 
 	asidData.get(cpuData).initialize(pcidCount);
 	asidData.get(cpuData)->globalBinding.initialize(globalBindingId);
-	asidData.get(cpuData)->globalBinding.initialBind(*kernelSpacePtr);
+
+	{
+		auto irqLock = frg::guard(&irqMutex());
+		asidData.get(cpuData)->globalBinding.initialBind(*kernelSpacePtr);
+	}
 }
 
 

--- a/kernel/thor/arch/x86/pic.cpp
+++ b/kernel/thor/arch/x86/pic.cpp
@@ -442,11 +442,25 @@ void sendGlobalNmi() {
 // MSI management
 // --------------------------------------------------------
 
-// TODO: Replace this by proper IRQ allocation.
 extern frg::manual_box<IrqSlot> globalIrqSlots[64];
-extern IrqSpinlock globalIrqSlotsLock;
 
 namespace {
+	IrqSpinlock irqAllocationLock;
+	static bool irqSlotAllocated[64]{};
+
+	std::optional<int> allocateIrqSlot() {
+		auto guard = frg::guard(&irqAllocationLock);
+
+		for(int i = 0; i < 64; i++) {
+			if(irqSlotAllocated[i])
+				continue;
+			irqSlotAllocated[i] = true;
+			return i;
+		}
+
+		return std::nullopt;
+	}
+
 	struct ApicMsiPin final : MsiPin {
 		ApicMsiPin(frg::string<KernelAlloc> name, unsigned int vector)
 		: MsiPin{std::move(name)}, vector_{vector} { }
@@ -482,17 +496,10 @@ namespace {
 }
 
 MsiPin *allocateApicMsi(frg::string<KernelAlloc> name) {
-	auto guard = frg::guard(&globalIrqSlotsLock);
-
-	int slotIndex = -1;
-	for(int i = 0; i < 64; i++) {
-		if(!globalIrqSlots[i]->isAvailable())
-			continue;
-		slotIndex = i;
-		break;
-	}
-	if(slotIndex == -1)
+	auto maybeSlotIndex = allocateIrqSlot();
+	if (!maybeSlotIndex)
 		return nullptr;
+	auto slotIndex = *maybeSlotIndex;
 
 	// Create an IRQ pin for the MSI.
 	auto pin = frg::construct<ApicMsiPin>(*kernelAlloc,
@@ -652,21 +659,14 @@ namespace {
 
 		// Allocate an IRQ vector for the I/O APIC pin.
 		if(_vector == -1) {
-			auto guard = frg::guard(&globalIrqSlotsLock);
-
-			for(int i = 0; i < 64; i++) {
-				if(!globalIrqSlots[i]->isAvailable())
-					continue;
-				infoLogger() << "thor: Allocating IRQ slot " << i
-						<< " to " << name() << frg::endlog;
-				globalIrqSlots[i]->link(this);
-				_vector = 64 + i;
-				break;
-			}
+			auto maybeSlotIndex = allocateIrqSlot();
+			if (!maybeSlotIndex)
+				panicLogger() << "thor: Could not allocate interrupt vector for "
+						<< name() << frg::endlog;
+			auto slotIndex = *maybeSlotIndex;
+			globalIrqSlots[slotIndex]->link(this);
+			_vector = 64 + slotIndex;
 		}
-		if(_vector == -1)
-			panicLogger() << "thor: Could not allocate interrupt vector for "
-					<< name() << frg::endlog;
 
 		{
 			auto irqLock = frg::guard(&irqMutex());

--- a/kernel/thor/generic/executor-context.cpp
+++ b/kernel/thor/generic/executor-context.cpp
@@ -1,0 +1,17 @@
+#include <thor-internal/executor-context.hpp>
+#include <thor-internal/rcu.hpp>
+
+namespace thor {
+
+ExecutorContext *ExecutorContext::create() {
+	return frg::construct<ExecutorContext>(*kernelAlloc);
+}
+
+void ExecutorContext::retire(ExecutorContext *ctx) {
+	submitRcu(ctx, [] (RcuCallable *base) {
+		auto derived = static_cast<ExecutorContext *>(base);
+		frg::destruct(*kernelAlloc, derived);
+	});
+}
+
+} // namespace thor

--- a/kernel/thor/generic/fiber.cpp
+++ b/kernel/thor/generic/fiber.cpp
@@ -31,7 +31,7 @@ void KernelFiber::blockCurrent(FiberBlocker *blocker) {
 
 		assert(!this_fiber->_blocked);
 		this_fiber->_blocked = true;
-		this_fiber->_executorContext.active.store(false, std::memory_order_relaxed);
+		this_fiber->_executorContext->active.store(false, std::memory_order_relaxed);
 		getCpuData()->executorContext = nullptr;
 		getCpuData()->activeFiber = nullptr;
 		localScheduler.get().update();
@@ -97,14 +97,18 @@ KernelFiber *KernelFiber::post(UniqueKernelStack stack,
 KernelFiber::KernelFiber(UniqueKernelStack stack, AbiParameters abi)
 : _blocked{false}, _fiberContext{std::move(stack)}, _executor{&_fiberContext, abi} {
 	_associatedWorkQueue = smarter::allocate_shared<AssociatedWorkQueue>(*kernelAlloc, this);
-	_executorContext.exceptionalWq = _associatedWorkQueue.get();
+	_executorContext->exceptionalWq = _associatedWorkQueue.get();
+}
+
+KernelFiber::~KernelFiber() {
+	ExecutorContext::retire(_executorContext);
 }
 
 void KernelFiber::invoke() {
 	assert(!intsAreEnabled());
 
-	_executorContext.active.store(true, std::memory_order_relaxed);
-	getCpuData()->executorContext = &_executorContext;
+	_executorContext->active.store(true, std::memory_order_relaxed);
+	getCpuData()->executorContext = _executorContext;
 	getCpuData()->activeFiber = this;
 	restoreExecutor(&_executor);
 }
@@ -119,7 +123,7 @@ void KernelFiber::handlePreemption() {
 	if(scheduler->maybeReschedule()) {
 		auto lock = frg::guard(&_mutex);
 
-		_executorContext.active.store(false, std::memory_order_relaxed);
+		_executorContext->active.store(false, std::memory_order_relaxed);
 		getCpuData()->executorContext = nullptr;
 		getCpuData()->activeFiber = nullptr;
 
@@ -147,7 +151,7 @@ void KernelFiber::handlePreemption(IrqImageAccessor image) {
 		auto lock = frg::guard(&_mutex);
 
 		saveExecutor(&_executor, image);
-		_executorContext.active.store(false, std::memory_order_relaxed);
+		_executorContext->active.store(false, std::memory_order_relaxed);
 		getCpuData()->executorContext = nullptr;
 		getCpuData()->activeFiber = nullptr;
 

--- a/kernel/thor/generic/fiber.cpp
+++ b/kernel/thor/generic/fiber.cpp
@@ -14,7 +14,9 @@ void KernelFiber::blockCurrent(FiberBlocker *blocker) {
 	auto this_fiber = thisFiber();
 	while(true) {
 		// Run the WQ outside of the locks.
-		this_fiber->_associatedWorkQueue->run();
+		auto ipl = currentIpl();
+		if (ipl < ipl::exceptionalWork)
+			this_fiber->_associatedWorkQueue->run();
 
 		StatelessIrqLock irq_lock;
 		auto lock = frg::guard(&this_fiber->_mutex);
@@ -22,8 +24,10 @@ void KernelFiber::blockCurrent(FiberBlocker *blocker) {
 		// Those are the important tests; they are protected by the fiber's mutex.
 		if(blocker->_done)
 			break;
-		if(this_fiber->_associatedWorkQueue->check())
-			continue;
+		if (ipl < ipl::exceptionalWork) {
+			if(this_fiber->_associatedWorkQueue->check())
+				continue;
+		}
 
 		assert(!this_fiber->_blocked);
 		this_fiber->_blocked = true;
@@ -156,6 +160,9 @@ void KernelFiber::handlePreemption(IrqImageAccessor image) {
 void KernelFiber::AssociatedWorkQueue::wakeup() {
 	auto irq_lock = frg::guard(&irqMutex());
 	auto lock = frg::guard(&fiber_->_mutex);
+
+	// TODO: As for threads, we should suppress wakeups if the IPL at which the fiber is saved
+	//       does not allow the work queue to run.
 
 	if(!fiber_->_blocked)
 		return;

--- a/kernel/thor/generic/fiber.cpp
+++ b/kernel/thor/generic/fiber.cpp
@@ -31,6 +31,7 @@ void KernelFiber::blockCurrent(FiberBlocker *blocker) {
 
 		assert(!this_fiber->_blocked);
 		this_fiber->_blocked = true;
+		this_fiber->_executorContext.active.store(false, std::memory_order_relaxed);
 		getCpuData()->executorContext = nullptr;
 		getCpuData()->activeFiber = nullptr;
 		localScheduler.get().update();
@@ -102,6 +103,7 @@ KernelFiber::KernelFiber(UniqueKernelStack stack, AbiParameters abi)
 void KernelFiber::invoke() {
 	assert(!intsAreEnabled());
 
+	_executorContext.active.store(true, std::memory_order_relaxed);
 	getCpuData()->executorContext = &_executorContext;
 	getCpuData()->activeFiber = this;
 	restoreExecutor(&_executor);
@@ -117,6 +119,7 @@ void KernelFiber::handlePreemption() {
 	if(scheduler->maybeReschedule()) {
 		auto lock = frg::guard(&_mutex);
 
+		_executorContext.active.store(false, std::memory_order_relaxed);
 		getCpuData()->executorContext = nullptr;
 		getCpuData()->activeFiber = nullptr;
 
@@ -144,6 +147,7 @@ void KernelFiber::handlePreemption(IrqImageAccessor image) {
 		auto lock = frg::guard(&_mutex);
 
 		saveExecutor(&_executor, image);
+		_executorContext.active.store(false, std::memory_order_relaxed);
 		getCpuData()->executorContext = nullptr;
 		getCpuData()->activeFiber = nullptr;
 

--- a/kernel/thor/generic/ipl.cpp
+++ b/kernel/thor/generic/ipl.cpp
@@ -55,7 +55,7 @@ void handleIplDeferred(Ipl current, Ipl ceiling) {
 		// Note: during this switch, the currentIpl() is not necessarily l.
 		// If handlers rely on running at a certain IPL, they need to raise it.
 		switch (l) {
-			case ipl::schedule: {
+			case ipl::noPreemption: {
 				StatelessIrqLock irqLock;
 				localScheduler.get().checkPreemption();
 				break;

--- a/kernel/thor/generic/kernel-mutexes.cpp
+++ b/kernel/thor/generic/kernel-mutexes.cpp
@@ -1,0 +1,65 @@
+#include <thor-internal/block-on.hpp>
+#include <thor-internal/executor-context.hpp>
+#include <thor-internal/kernel-mutexes.hpp>
+
+namespace thor {
+
+void AdaptiveMutex::lock_() {
+	assert(currentIpl() == ipl::noPreemption);
+
+	if (asyncMutex_.try_lock()) [[likely]] {
+		ownerCtx_.store(currentExecutorContext(), std::memory_order_relaxed);
+		return;
+	}
+	[[unlikely]] lockSlow_();
+}
+
+[[gnu::noinline]] void AdaptiveMutex::lockSlow_() {
+	// TTAS in a loop.
+	while (true) {
+		if (asyncMutex_.test()) {
+			if (asyncMutex_.try_lock()) {
+				ownerCtx_.store(currentExecutorContext(), std::memory_order_relaxed);
+				return;
+			}
+		} else {
+			// If the owner blocks, we also block.
+			// Note that this check is not perfectly reliable since reading ownerCtx_
+			// and active is not atomic (e.g., the thread may have unlocked and became inactive).
+			auto ownerCtx = ownerCtx_.load(std::memory_order_relaxed);
+			if (ownerCtx) {
+				if (!ownerCtx->active.load(std::memory_order_relaxed))
+					break;
+			}
+			frg::detail::loophint();
+		}
+	}
+
+	// A nullptr ownerCtx_ may be caused by the owner releasing the lock.
+	// Hence, do another try_lock() to avoid blockOn() if the lock has just been released.
+	if (asyncMutex_.try_lock()) {
+		ownerCtx_.store(currentExecutorContext(), std::memory_order_relaxed);
+		return;
+	}
+
+	// Snapshot currentExecutorContext() since the lambda below runs in a different context.
+	auto thisCtx = currentExecutorContext();
+	blockOn(
+		// async::transform() ensures that ownerCtx_ is stored *before* unblocking the thread.
+		// This is necessary to avoid deadlocks: other threads may try to take the mutex (with
+		// preemption disabled) after the previous owner has been unblocked but before it is scheduled.
+		async::transform(
+			asyncMutex_.async_lock(),
+			[&] { ownerCtx_.store(thisCtx, std::memory_order_relaxed); }
+		)
+	);
+}
+
+void AdaptiveMutex::unlock_() {
+	assert(currentIpl() == ipl::noPreemption);
+
+	ownerCtx_.store(nullptr, std::memory_order_relaxed);
+	asyncMutex_.unlock();
+}
+
+} // namespace thor

--- a/kernel/thor/generic/load-balancing.cpp
+++ b/kernel/thor/generic/load-balancing.cpp
@@ -81,6 +81,14 @@ coroutine<void> LoadBalancer::run_(CpuData *cpu) {
 
 		// On this CPU, estimate the load.
 		uint64_t load = 0;
+		frg::intrusive_list<
+			LbControlBlock,
+			frg::locate_member<
+				LbControlBlock,
+				frg::default_list_hook<LbControlBlock>,
+				&LbControlBlock::hook_
+			>
+		> staleCbs;
 		{
 			auto irqLock = frg::guard(&irqMutex());
 			auto lock = frg::guard(&thisNode->mutex);
@@ -96,7 +104,7 @@ coroutine<void> LoadBalancer::run_(CpuData *cpu) {
 				auto thread = cb->thread_.lock();
 				if (!thread) {
 					thisNode->tasks.erase(currentIt);
-					frg::destruct(*kernelAlloc, cb);
+					staleCbs.push_back(cb);
 					continue;
 				}
 
@@ -110,6 +118,10 @@ coroutine<void> LoadBalancer::run_(CpuData *cpu) {
 
 		thisNode->totalLoad = load;
 		thisNode->currentLoad = load;
+
+		// Destroy stale CBs outside of locks.
+		while(!staleCbs.empty())
+			frg::destruct(*kernelAlloc, staleCbs.pop_front());
 
 		if (debugLb)
 			infoLogger() << "CPU #" << cpu->cpuIndex << " has load " << load << frg::endlog;

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -41,7 +41,6 @@ bool debugToSerial = false;
 bool debugToBochs = false;
 
 frg::manual_box<IrqSlot> globalIrqSlots[numIrqSlots];
-IrqSpinlock globalIrqSlotsLock;
 
 MfsDirectory *mfsRoot;
 frg::manual_box<frg::string<KernelAlloc>> kernelCommandLine;

--- a/kernel/thor/generic/thor-internal/block-on.hpp
+++ b/kernel/thor/generic/thor-internal/block-on.hpp
@@ -1,0 +1,21 @@
+#include <thor-internal/debug.hpp>
+#include <thor-internal/fiber.hpp>
+#include <thor-internal/thread.hpp>
+
+namespace thor {
+
+// Block on a sender without specifying a work queue.
+// Because no WQ is specified, this only supports senders that do not need to schedule work.
+// For example, coroutines are *not* supported.
+template<typename S>
+typename S::value_type blockOn(S sender) {
+	if (getCurrentThread()) {
+		Thread::asyncBlockCurrent(std::move(sender), nullptr);
+	} else if(thisFiber()) {
+		KernelFiber::asyncBlockCurrent(std::move(sender), nullptr);
+	} else {
+		panicLogger() << "thor: Trying to block outside of thread-like context" << frg::endlog;
+	}
+}
+
+} // namespace thor

--- a/kernel/thor/generic/thor-internal/cpu-data.hpp
+++ b/kernel/thor/generic/thor-internal/cpu-data.hpp
@@ -47,16 +47,18 @@ inline constexpr Ipl exceptional = 2;
 // Level that work queues which can be entered from currentIpl() <= ipl::exceptional run at.
 // Threads can only block on such work queues while running at currentIpl <= ipl::exceptional.
 inline constexpr Ipl exceptionalWork = 3;
-// Blocking is only allowed at currentIpl() < ipl::schedule.
-// Threads may only be scheduled out if Executor::iplState()->current < ipl::schedule.
-inline constexpr Ipl schedule = 4;
+// Preemption is only allowed at currentIpl() < ipl::noPreemption.
+inline constexpr Ipl noPreemption = 4;
+// Blocking is only allowed at currentIpl() < ipl::noSchedule,
+// i.e., threads may only be scheduled out if Executor::iplState()->current < ipl::noSchedule.
+inline constexpr Ipl noSchedule = 5;
 // Level that interrupts run at.
 // Also, level that the scheduler itself runs at.
-inline constexpr Ipl interrupt = 5;
+inline constexpr Ipl interrupt = 6;
 // Level that exceptions and NMIs run at.
 // This is the only level that can be entered multiple times
 // (i.e., ipl::maximal -> ipl::maximal entries are allowed).
-inline constexpr Ipl maximal = 6;
+inline constexpr Ipl maximal = 7;
 } // namespace ipl
 
 struct IplState {

--- a/kernel/thor/generic/thor-internal/executor-context.hpp
+++ b/kernel/thor/generic/thor-internal/executor-context.hpp
@@ -12,6 +12,8 @@ struct ExecutorContext {
 
 	ExecutorContext &operator= (const ExecutorContext &) = delete;
 
+	// Used by AdaptiveMutex to test if the context is still active (i.e., running on any CPU).
+	std::atomic<bool> active{false};
 	WorkQueue *exceptionalWq{nullptr};
 };
 

--- a/kernel/thor/generic/thor-internal/executor-context.hpp
+++ b/kernel/thor/generic/thor-internal/executor-context.hpp
@@ -1,11 +1,20 @@
 #pragma once
 
+#include <thor-internal/rcu-base.hpp>
+
 namespace thor {
 
 struct WorkQueue;
 
 // This class uniquely identifies a thread or fiber.
-struct ExecutorContext {
+// RCU protected such that we can reference this from mutex implementations,
+// WorkQueue or similar with worrying about lifetimes.
+struct ExecutorContext : RcuCallable {
+	static ExecutorContext *create();
+
+	// Destroy this ExecutorContext after RCU grace period.
+	static void retire(ExecutorContext *ctx);
+
 	ExecutorContext();
 
 	ExecutorContext(const ExecutorContext &) = delete;

--- a/kernel/thor/generic/thor-internal/fiber.hpp
+++ b/kernel/thor/generic/thor-internal/fiber.hpp
@@ -31,7 +31,7 @@ struct KernelFiber final : ScheduleEntity {
 private:
 	struct AssociatedWorkQueue final : WorkQueue {
 		AssociatedWorkQueue(KernelFiber *fiber)
-		: WorkQueue{&fiber->_executorContext, ipl::exceptionalWork}, fiber_{fiber} { }
+		: WorkQueue{fiber->_executorContext, ipl::exceptionalWork}, fiber_{fiber} { }
 
 		void wakeup() override;
 
@@ -168,6 +168,7 @@ public:
 	static KernelFiber *post(UniqueKernelStack stack, void (*function)(void *), void *argument, Scheduler* = &localScheduler.get());
 
 	explicit KernelFiber(UniqueKernelStack stack, AbiParameters abi);
+	~KernelFiber();
 
 	[[ noreturn ]] void invoke() override;
 
@@ -182,9 +183,11 @@ private:
 	frg::ticket_spinlock _mutex;
 	bool _blocked;
 
+	// Used by the AssociatedWorkQueue below so must be initialized before.
+	ExecutorContext *_executorContext{ExecutorContext::create()};
+
 	smarter::shared_ptr<AssociatedWorkQueue> _associatedWorkQueue;
 	FiberContext _fiberContext;
-	ExecutorContext _executorContext;
 	Executor _executor;
 };
 

--- a/kernel/thor/generic/thor-internal/fiber.hpp
+++ b/kernel/thor/generic/thor-internal/fiber.hpp
@@ -43,14 +43,23 @@ public:
 	static void blockCurrent(FiberBlocker *blocker);
 
 	template<typename Sender>
+	static auto asyncBlockCurrent(Sender s) {
+		return asyncBlockCurrent(std::move(s), thisFiber()->associatedWorkQueue().get());
+	}
+
+	template<typename Sender>
 	requires std::is_same_v<typename Sender::value_type, void>
-	static void asyncBlockCurrent(Sender s) {
-		assert(currentIpl() < ipl::exceptionalWork);
+	static void asyncBlockCurrent(Sender s, WorkQueue *wq) {
+		if (wq) {
+			assert(currentIpl() < wq->wqIpl());
+		} else {
+			assert(currentIpl() < ipl::noSchedule);
+		}
 
 		struct Closure {
 			FiberBlocker blocker;
 			WorkQueue *wq;
-		} closure{.wq = thisFiber()->associatedWorkQueue().get()};
+		} closure{.wq = wq};
 
 		struct Env {
 			WorkQueue *get_work_queue() {

--- a/kernel/thor/generic/thor-internal/ipl.hpp
+++ b/kernel/thor/generic/thor-internal/ipl.hpp
@@ -143,6 +143,9 @@ private:
 	Ipl previous_{ipl::bad};
 };
 
+using PreemptionGuard = IplGuard<ipl::noPreemption>;
+using ScheduleGuard = IplGuard<ipl::noSchedule>;
+
 struct IrqMutex {
 	IrqMutex() = default;
 

--- a/kernel/thor/generic/thor-internal/kernel-heap.hpp
+++ b/kernel/thor/generic/thor-internal/kernel-heap.hpp
@@ -98,7 +98,7 @@ using CoreAllocator = frg::slab_allocator<CoreSlabPolicy, IrqSpinlock>;
 CoreAllocator &getCoreAllocator();
 
 struct Allocator {
-	struct Guard : IplGuard<ipl::schedule> {
+	struct Guard : IplGuard<ipl::noPreemption> {
 		Guard() {
 			auto cpu = getCpuData();
 			assert(!inSlabPool.get(cpu).load(std::memory_order_relaxed));

--- a/kernel/thor/generic/thor-internal/kernel-mutexes.hpp
+++ b/kernel/thor/generic/thor-internal/kernel-mutexes.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <async/mutex.hpp>
+#include <thor-internal/ipl.hpp>
+
+namespace thor {
+
+struct ExecutorContext;
+
+// Mutex intended for very short critical sections.
+// Requires preemption to be disabled but may block.
+// This should be used instead of a spinlock if blocking is required.
+struct AdaptiveMutex {
+public:
+	struct Guard {
+		Guard(AdaptiveMutex &mutex)
+		: mutex_{&mutex} {
+			mutex_->lock_();
+		}
+
+		~Guard() {
+			mutex_->unlock_();
+		}
+
+		Guard(const Guard &) = delete;
+
+		Guard &operator= (const Guard &) = delete;
+
+	private:
+		AdaptiveMutex *mutex_;
+	};
+
+private:
+	void lock_();
+	void lockSlow_();
+	void unlock_();
+
+	async::mutex asyncMutex_;
+	std::atomic<ExecutorContext *> ownerCtx_;
+};
+
+} // namespace thor

--- a/kernel/thor/generic/thor-internal/pfn-db.hpp
+++ b/kernel/thor/generic/thor-internal/pfn-db.hpp
@@ -83,7 +83,7 @@ struct PfnDb {
 		assert(!(pa & (kPageSize - 1)));
 		auto pfn = pa >> kPageShift;
 
-		IplGuard<ipl::schedule> guard;
+		IplGuard<ipl::noSchedule> guard;
 
 		auto it = tree_.find(pfn);
 		if(!it)

--- a/kernel/thor/generic/thor-internal/rcu-base.hpp
+++ b/kernel/thor/generic/thor-internal/rcu-base.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <frg/list.hpp>
+
+namespace thor {
+
+struct RcuCallable {
+	friend struct RcuDispatcher;
+
+private:
+	void (*call_)(RcuCallable *);
+	frg::default_list_hook<RcuCallable> hook_;
+};
+
+} // namespace thor

--- a/kernel/thor/generic/thor-internal/rcu.hpp
+++ b/kernel/thor/generic/thor-internal/rcu.hpp
@@ -9,6 +9,7 @@
 #include <smarter.hpp>
 #include <thor-internal/coroutine.hpp>
 #include <thor-internal/cpu-data.hpp>
+#include <thor-internal/rcu-base.hpp>
 
 namespace thor {
 
@@ -125,14 +126,6 @@ private:
 
 	std::atomic<CriticalSection> cs_;
 	async::recurring_event gpEvent_;
-};
-
-struct RcuCallable {
-	friend struct RcuDispatcher;
-
-private:
-	void (*call_)(RcuCallable *);
-	frg::default_list_hook<RcuCallable> hook_;
 };
 
 void setRcuOnline(CpuData *cpu);

--- a/kernel/thor/generic/thor-internal/schedule.hpp
+++ b/kernel/thor/generic/thor-internal/schedule.hpp
@@ -14,9 +14,9 @@ namespace thor {
 
 template<typename ImageAccessor>
 inline bool deferPreemption(ImageAccessor image) {
-	if (image.iplState()->current < ipl::schedule)
+	if (image.iplState()->current < ipl::noPreemption)
 		return false;
-	deferToIplLowerThan(ipl::schedule);
+	deferToIplLowerThan(ipl::noPreemption);
 	return true;
 }
 
@@ -73,10 +73,10 @@ public:
 
 	// Precondition: Preemption must be safe at the call site.
 	//               In particular, before the caller disables interrupts,
-	//               it should be on a code path with currentIpl() < ipl::schedule.
+	//               it should be on a code path with currentIpl() < ipl::noPreemption.
 	// Precondition: !intsAreEnabled().
 	virtual void handlePreemption() = 0;
-	// Must only be called if the image's IPL < ipl::schedule.
+	// Must only be called if the image's IPL < ipl::noPreemption.
 	// Precondition: !intsAreEnabled().
 	virtual void handlePreemption(IrqImageAccessor image) = 0;
 

--- a/kernel/thor/generic/thor-internal/thread.hpp
+++ b/kernel/thor/generic/thor-internal/thread.hpp
@@ -73,7 +73,7 @@ struct Thread final : ScheduleEntity, Credentials {
 private:
 	struct AssociatedWorkQueue final : WorkQueue {
 		AssociatedWorkQueue(Thread *thread, Ipl wqIpl)
-		: WorkQueue{&thread->_executorContext, wqIpl}, _thread{thread} { }
+		: WorkQueue{thread->_executorContext, wqIpl}, _thread{thread} { }
 
 		void wakeup() override;
 
@@ -134,7 +134,7 @@ public:
 		auto thread = smarter::allocate_shared<Thread>(*kernelAlloc,
 				std::move(universe), std::move(address_space), abi);
 		thread->self = thread;
-		thread->_executorContext.exceptionalWq = &thread->_pagingWorkQueue;
+		thread->_executorContext->exceptionalWq = &thread->_pagingWorkQueue;
 
 		// The kernel owns one reference to the thread until the thread finishes execution.
 		thread.policy().increment();
@@ -451,6 +451,9 @@ private:
 		resumeFromInterrupt,
 	};
 
+	// Used by the AssociatedWorkQueues below so must be initialized before.
+	ExecutorContext *_executorContext{ExecutorContext::create()};
+
 	AssociatedWorkQueue _mainWorkQueue;
 	AssociatedWorkQueue _pagingWorkQueue;
 
@@ -490,7 +493,6 @@ private:
 	std::atomic<int> _runCount;
 
 	UserContext _userContext;
-	ExecutorContext _executorContext;
 	// Depends on _userContext, MUST come after it in the struct due to initialization order.
 	Executor _executor;
 	// Register image that is saved/restored by the interrupt state.

--- a/kernel/thor/generic/thor-internal/thread.hpp
+++ b/kernel/thor/generic/thor-internal/thread.hpp
@@ -167,7 +167,11 @@ public:
 		using ValueType = std::invoke_result_t<SenderFactory, async::cancellation_token>::value_type;
 
 		auto ipl = currentIpl();
-		assert(ipl < wq->wqIpl());
+		if (wq) {
+			assert(ipl < wq->wqIpl());
+		} else {
+			assert(currentIpl() < ipl::noSchedule);
+		}
 		assert(!(maskedCancelConditions & ~cancelConditions));
 		(void)tag;
 		auto thisThread = getCurrentThread();

--- a/kernel/thor/generic/thread.cpp
+++ b/kernel/thor/generic/thread.cpp
@@ -27,7 +27,7 @@ namespace {
 // --------------------------------------------------------
 
 void Thread::migrateCurrent() {
-	assert(currentIpl() < ipl::schedule);
+	assert(currentIpl() < ipl::noSchedule);
 
 	auto this_thread = getCurrentThread().get();
 	auto maskSize = LbControlBlock::affinityMaskSize();
@@ -78,7 +78,7 @@ void Thread::migrateCurrent() {
 }
 
 void Thread::blockCurrent(Condition checkedConditions) {
-	assert(currentIpl() < ipl::schedule);
+	assert(currentIpl() < ipl::noSchedule);
 
 	auto thisThread = getCurrentThread();
 
@@ -126,7 +126,7 @@ void Thread::blockCurrent(Condition checkedConditions) {
 }
 
 void Thread::deferCurrent() {
-	assert(currentIpl() < ipl::schedule);
+	assert(currentIpl() < ipl::noSchedule);
 
 	auto thisThread = getCurrentThread();
 	StatelessIrqLock irq_lock;
@@ -153,7 +153,7 @@ void Thread::deferCurrent() {
 }
 
 void Thread::deferCurrent(IrqImageAccessor image) {
-	assert(image.iplState()->current < ipl::schedule);
+	assert(image.iplState()->current < ipl::noPreemption);
 
 	auto this_thread = getCurrentThread();
 	StatelessIrqLock irq_lock;
@@ -179,7 +179,7 @@ void Thread::deferCurrent(IrqImageAccessor image) {
 }
 
 void Thread::suspendCurrent(IrqImageAccessor image) {
-	assert(image.iplState()->current < ipl::schedule);
+	assert(image.iplState()->current < ipl::noPreemption);
 
 	auto this_thread = getCurrentThread();
 	StatelessIrqLock irq_lock;
@@ -206,7 +206,7 @@ void Thread::suspendCurrent(IrqImageAccessor image) {
 
 template<typename ImageAccessor>
 void Thread::genericInterruptCurrent(Interrupt interrupt, ImageAccessor image, InterruptInfo info) {
-	assert(image.iplState()->current < ipl::schedule);
+	assert(image.iplState()->current < ipl::noPreemption);
 	auto thisThread = getCurrentThread();
 
 	// We must never save kernel state into intrImage_.
@@ -387,7 +387,7 @@ void Thread::terminateCurrent_() {
 
 template<typename ImageAccessor>
 void Thread::genericHandleConditions(ImageAccessor image) {
-	assert(image.iplState()->current < ipl::schedule);
+	assert(image.iplState()->current < ipl::noPreemption);
 	auto thisThread = getCurrentThread();
 
 	auto clearPending = [&] (Condition c) {
@@ -437,7 +437,7 @@ void Thread::handleConditions(IrqImageAccessor image) {
 }
 
 void Thread::raiseSignals(SyscallImageAccessor image) {
-	assert(image.iplState()->current < ipl::schedule);
+	assert(image.iplState()->current < ipl::noPreemption);
 	auto this_thread = getCurrentThread();
 
 	if(auto assignedCpu = this_thread->_lbCb->getAssignedCpu(); assignedCpu != getCpuData()) {
@@ -709,7 +709,7 @@ template<typename ImageAccessor>
 void Thread::genericHandlePreemption(ImageAccessor image) {
 	assert(!intsAreEnabled());
 	assert(getCurrentThread().get() == this);
-	assert(image.iplState()->current < ipl::schedule);
+	assert(image.iplState()->current < ipl::noPreemption);
 
 	auto *scheduler = &localScheduler.get();
 

--- a/kernel/thor/generic/thread.cpp
+++ b/kernel/thor/generic/thread.cpp
@@ -588,6 +588,7 @@ Thread::~Thread() {
 		infoLogger() << "thor: Thread is destructed" << frg::endlog;
 	assert(_runState == kRunTerminated);
 	assert(_observeQueue.empty());
+	ExecutorContext::retire(_executorContext);
 }
 
 // This function has to initiate the thread's shutdown.
@@ -661,8 +662,8 @@ void Thread::invoke() {
 
 	_userContext.migrate(cpuData);
 	AddressSpace::activate(_addressSpace);
-	_executorContext.active.store(true, std::memory_order_relaxed);
-	cpuData->executorContext = &_executorContext;
+	_executorContext->active.store(true, std::memory_order_relaxed);
+	cpuData->executorContext = _executorContext;
 	cpuData->activeThread = self;
 	restoreExecutor(&_executor);
 }
@@ -757,7 +758,7 @@ void Thread::_uninvoke() {
 	UserContext::deactivate();
 
 	auto cpuData = getCpuData();
-	_executorContext.active.store(false, std::memory_order_relaxed);
+	_executorContext->active.store(false, std::memory_order_relaxed);
 	cpuData->executorContext = nullptr;
 	cpuData->activeThread = {};
 }

--- a/kernel/thor/generic/thread.cpp
+++ b/kernel/thor/generic/thread.cpp
@@ -661,6 +661,7 @@ void Thread::invoke() {
 
 	_userContext.migrate(cpuData);
 	AddressSpace::activate(_addressSpace);
+	_executorContext.active.store(true, std::memory_order_relaxed);
 	cpuData->executorContext = &_executorContext;
 	cpuData->activeThread = self;
 	restoreExecutor(&_executor);
@@ -756,6 +757,7 @@ void Thread::_uninvoke() {
 	UserContext::deactivate();
 
 	auto cpuData = getCpuData();
+	_executorContext.active.store(false, std::memory_order_relaxed);
 	cpuData->executorContext = nullptr;
 	cpuData->activeThread = {};
 }

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -57,6 +57,7 @@ src = files(
 	'generic/kernel-heap.cpp',
 	'generic/kernel-io.cpp',
 	'generic/kernel-log.cpp',
+	'generic/kernel-mutexes.cpp',
 	'generic/kernel-stack.cpp',
 	'generic/load-balancing.cpp',
 	'generic/main.cpp',

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -43,6 +43,7 @@ src = files(
 	'generic/credentials.cpp',
 	'generic/debug.cpp',
 	'generic/event.cpp',
+	'generic/executor-context.cpp',
 	'generic/fiber.cpp',
 	'generic/gdbserver.cpp',
 	'generic/hel.cpp',


### PR DESCRIPTION
This is a first step towards avoiding panics on OOM. We move allocations out of code paths that have IRQs disabled such that we can retry critical allocation in the future. For cases where it's impossible to move allocations out of locks, we introduce an `AdaptiveMutex` class that is similar to a spinlock but that allows blocking while the lock is taken (which will cause waiters on the lock to also block).

Circularly dependent on https://github.com/managarm/libasync/pull/44