### PR TITLE
eir: Fix missing initgraph edges and inconsistencies

### DIFF
--- a/kernel/eir/arch/arm/arch.cpp
+++ b/kernel/eir/arch/arm/arch.cpp
@@ -2,6 +2,7 @@
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
+#include <eir-internal/main.hpp>
 #include <eir-internal/memory-layout.hpp>
 
 extern "C" void eirExcVectors();
@@ -323,6 +324,13 @@ void initProcessorEarly() {
 		asm volatile("msr vbar_el2, %0" : : "r"(vbar) : "memory");
 	}
 }
+
+static initgraph::Task earlyProcessorInit{
+    &globalInitEngine,
+    "arm.early-processor-init",
+    initgraph::Entails{getMemoryLayoutReservedStage()},
+    [] { initProcessorEarly(); }
+};
 
 void initProcessorPaging() {
 	setupPaging();

--- a/kernel/eir/arch/riscv/cpu.cpp
+++ b/kernel/eir/arch/riscv/cpu.cpp
@@ -270,4 +270,11 @@ void initProcessorEarly() {
 	riscv::writeCsr<riscv::Csr::stvec>(reinterpret_cast<uint64_t>(&handleException));
 }
 
+static initgraph::Task earlyProcessorInit{
+    &globalInitEngine,
+    "riscv.early-processor-init",
+    initgraph::Entails{getMemoryLayoutReservedStage()},
+    [] { initProcessorEarly(); }
+};
+
 } // namespace eir

--- a/kernel/eir/arch/riscv/cpu.cpp
+++ b/kernel/eir/arch/riscv/cpu.cpp
@@ -4,6 +4,7 @@
 #include <eir-internal/arch.hpp>
 #include <eir-internal/arch/riscv.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/dtb/dtb.hpp>
 #include <eir-internal/main.hpp>
 #include <eir-internal/memory-layout.hpp>
 #include <riscv/csr.hpp>
@@ -201,7 +202,7 @@ static initgraph::Task earlyInitAcpi{
 static initgraph::Task earlyInit{
     &globalInitEngine,
     "riscv.early-init",
-    initgraph::Requires{getReservedRegionsKnownStage()},
+    initgraph::Requires{getReservedRegionsKnownStage(), getDtbAvailableStage()},
     initgraph::Entails{getMemoryLayoutReservedStage()},
     [] {
 	    if (!eirDtbPtr)

--- a/kernel/eir/arch/riscv/cpu.cpp
+++ b/kernel/eir/arch/riscv/cpu.cpp
@@ -140,6 +140,11 @@ static initgraph::Task earlyInitAcpi{
     [] {
 	    if (!eirRsdpAddr)
 		    return;
+	    if (riscvConfig.numPtLevels) {
+		    infoLogger() << "eir: Skipping ACPI MMU discovery (page table levels already known)"
+		                 << frg::endlog;
+		    return;
+	    }
 
 	    uacpi_table rhct_table;
 	    if (uacpi_table_find_by_signature("RHCT", &rhct_table) != UACPI_STATUS_OK)
@@ -207,6 +212,11 @@ static initgraph::Task earlyInit{
     [] {
 	    if (!eirDtbPtr)
 		    return;
+	    if (riscvConfig.numPtLevels) {
+		    infoLogger() << "eir: Skipping DT MMU discovery (page table levels already known)"
+		                 << frg::endlog;
+		    return;
+	    }
 	    DeviceTree dt{physToVirt<void>(eirDtbPtr)};
 
 	    // Get the first "/cpus/cpu@..."

--- a/kernel/eir/arch/x86/arch.cpp
+++ b/kernel/eir/arch/x86/arch.cpp
@@ -2,6 +2,7 @@
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
+#include <eir-internal/main.hpp>
 #include <eir-internal/memory-layout.hpp>
 #include <x86/gdt.hpp>
 #include <x86/machine.hpp>
@@ -215,6 +216,13 @@ void initProcessorEarly() {
 	uint64_t pat = 0x00'00'01'00'00'00'04'06;
 	common::x86::wrmsr(0x277, pat);
 }
+
+static initgraph::Task earlyProcessorInit{
+    &globalInitEngine,
+    "x86.early-processor-init",
+    initgraph::Entails{getMemoryLayoutReservedStage()},
+    [] { initProcessorEarly(); }
+};
 
 int getKernelVirtualBits() { return 48; }
 

--- a/kernel/eir/boot/limine/entry.cpp
+++ b/kernel/eir/boot/limine/entry.cpp
@@ -5,6 +5,7 @@
 #include <eir-internal/arch.hpp>
 #include <eir-internal/cmdline.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/dtb/dtb.hpp>
 #include <eir-internal/framebuffer.hpp>
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
@@ -48,7 +49,9 @@ LIMINE_REQUEST(smbios_request, LIMINE_SMBIOS_REQUEST_ID, 0);
 initgraph::Task obtainFirmwareTables{
     &globalInitEngine,
     "limine.obtain-firmware-tables",
-    initgraph::Entails{getKernelLoadableStage(), acpi::getRsdpAvailableStage()},
+    initgraph::Entails{
+        getKernelLoadableStage(), acpi::getRsdpAvailableStage(), getDtbAvailableStage()
+    },
     [] {
 	    if (rsdp_request.response) {
 		    eirRsdpAddr = virtToPhys(rsdp_request.response->address);

--- a/kernel/eir/boot/uefi/entry.cpp
+++ b/kernel/eir/boot/uefi/entry.cpp
@@ -175,7 +175,10 @@ uint32_t convertIp(frg::string_view ip) {
 }
 
 initgraph::Task preparePxe{
-    &globalInitEngine, "uefi.pxe-setup", initgraph::Entails{getBootservicesDoneStage()}, [] {
+    &globalInitEngine,
+    "uefi.pxe-setup",
+    initgraph::Entails{getBootservicesDoneStage(), getInitrdAvailableStage()},
+    [] {
 	    efi_guid pxe_guid = EFI_PXE_BASE_CODE_PROTOCOL_GUID;
 	    efi_pxe_base_code_protocol *pxe = nullptr;
 
@@ -396,7 +399,7 @@ initgraph::Task readInitrd{
     &globalInitEngine,
     "uefi.read-initrd",
     initgraph::Requires{&preparePxe},
-    initgraph::Entails{getBootservicesDoneStage()},
+    initgraph::Entails{getBootservicesDoneStage(), getInitrdAvailableStage()},
     [] {
 	    if (initrd)
 		    return;
@@ -419,7 +422,10 @@ initgraph::Task readInitrd{
 };
 
 initgraph::Task setupGop{
-    &globalInitEngine, "uefi.setup-gop", initgraph::Entails{getBootservicesDoneStage()}, [] {
+    &globalInitEngine,
+    "uefi.setup-gop",
+    initgraph::Entails{getBootservicesDoneStage(), getFramebufferAvailableStage()},
+    [] {
 	    // Get the frame buffer.
 	    efi_guid gop_protocol = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
 	    efi_status status =

--- a/kernel/eir/boot/uefi/entry.cpp
+++ b/kernel/eir/boot/uefi/entry.cpp
@@ -10,6 +10,7 @@
 #include <eir-internal/arch.hpp>
 #include <eir-internal/cmdline.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/dtb/dtb.hpp>
 #include <eir-internal/error.hpp>
 #include <eir-internal/framebuffer.hpp>
 #include <eir-internal/generic.hpp>
@@ -143,7 +144,10 @@ initgraph::Task obtainFirmwareTables{
     &globalInitEngine,
     "uefi.obtain-firmware-tables",
     initgraph::Entails{
-        getBootservicesDoneStage(), getKernelLoadableStage(), acpi::getRsdpAvailableStage()
+        getBootservicesDoneStage(),
+        getKernelLoadableStage(),
+        acpi::getRsdpAvailableStage(),
+        getDtbAvailableStage()
     },
     [] {
 	    eirDtbPtr = findConfigurationTable(EFI_DTB_TABLE_GUID).value_or(0);

--- a/kernel/eir/generic/eir-internal/arch.hpp
+++ b/kernel/eir/generic/eir-internal/arch.hpp
@@ -40,7 +40,6 @@ void mapSingle4kPage(
 address_t getSingle4kPage(address_t address);
 
 void initPlatform();
-void initProcessorEarly();
 void initProcessorPaging();
 
 // Patches an arch-specific ELF note in thor.

--- a/kernel/eir/generic/eir-internal/main.hpp
+++ b/kernel/eir/generic/eir-internal/main.hpp
@@ -43,7 +43,7 @@ initgraph::Stage *getKernelMappableStage();
 
 // Before this stage, everything needed to fill out ELF notes but be available.
 // After this stage, the kernel image is loaded and the boot information is finalized.
-// Ordered after getkernelMappableStage().
+// Ordered after getKernelMappableStage().
 initgraph::Stage *getKernelLoadableStage();
 
 extern void *initrd;

--- a/kernel/eir/generic/main-function.cpp
+++ b/kernel/eir/generic/main-function.cpp
@@ -81,14 +81,6 @@ static initgraph::Task parseInitrdInfo{
     }
 };
 
-static initgraph::Task earlyProcessorInit{
-    &globalInitEngine,
-    "generic.early-processor-init",
-    initgraph::Requires{getReservedRegionsKnownStage()},
-    initgraph::Entails{getMemoryLayoutReservedStage()},
-    [] { initProcessorEarly(); }
-};
-
 static initgraph::Task setupRegions{
     &globalInitEngine,
     "generic.setup-regions",

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -659,34 +659,6 @@ void generateInfo() {
 		j++;
 	}
 
-	// Parse the kernel command line.
-	bool serial{false};
-	bool kernelProfile{false};
-	frg::string_view ubsan;
-	frg::array options = {
-	    frg::option{"serial", frg::store_true(serial)},
-	    frg::option{"kernel-profile", frg::store_true(kernelProfile)},
-	    frg::option{"thor-ubsan", frg::as_string_view(ubsan)},
-	};
-	parseCmdline(options);
-
-	if (serial)
-		debugOptions.flags |= eirDebugSerial;
-	if (logE9)
-		debugOptions.flags |= eirDebugBochs;
-	if (kernelProfile)
-		debugOptions.flags |= eirDebugKernelProfile;
-
-	if (ubsan.size()) {
-		if (ubsan == "ignore") {
-			debugOptions.ubsanAbort = false;
-		} else if (ubsan == "abort") {
-			debugOptions.ubsanAbort = true;
-		} else {
-			infoLogger() << "eir: Unknown value for 'ubsan' command line: " << ubsan << frg::endlog;
-		}
-	}
-
 	// Pass the command line to Thor.
 	auto cmdlineChunks = getCmdline();
 
@@ -733,6 +705,42 @@ void generateInfo() {
 		info_ptr->frameBuffer.fbEarlyWindow = getKernelFrameBuffer();
 	}
 }
+
+static initgraph::Task parseCmdlineTask{
+    &globalInitEngine,
+    "generic.parse-cmdline",
+    initgraph::Requires{getCmdlineAvailableStage()},
+    initgraph::Entails{getKernelLoadableStage()},
+    [] {
+	    bool serial{false};
+	    bool kernelProfile{false};
+	    frg::string_view ubsan;
+	    frg::array options = {
+	        frg::option{"serial", frg::store_true(serial)},
+	        frg::option{"kernel-profile", frg::store_true(kernelProfile)},
+	        frg::option{"thor-ubsan", frg::as_string_view(ubsan)},
+	    };
+	    parseCmdline(options);
+
+	    if (serial)
+		    debugOptions.flags |= eirDebugSerial;
+	    if (logE9)
+		    debugOptions.flags |= eirDebugBochs;
+	    if (kernelProfile)
+		    debugOptions.flags |= eirDebugKernelProfile;
+
+	    if (ubsan.size()) {
+		    if (ubsan == "ignore") {
+			    debugOptions.ubsanAbort = false;
+		    } else if (ubsan == "abort") {
+			    debugOptions.ubsanAbort = true;
+		    } else {
+			    infoLogger() << "eir: Unknown value for 'ubsan' command line: " << ubsan
+			                 << frg::endlog;
+		    }
+	    }
+    }
+};
 
 static initgraph::Task generateInfoStruct{
     &globalInitEngine,

--- a/kernel/eir/system/acpi/console.cpp
+++ b/kernel/eir/system/acpi/console.cpp
@@ -20,6 +20,11 @@ initgraph::Task parseSpcrDbg2{
     [] {
 	    if (!haveTables())
 		    return;
+	    if (uart::hasBootUart()) {
+		    infoLogger() << "eir: Skipping ACPI UART discovery (boot UART already known)"
+		                 << frg::endlog;
+		    return;
+	    }
 
 	    uacpi_table spcrTbl;
 	    uacpi_table dbg2Tbl;

--- a/kernel/eir/system/acpi/cpu-count.cpp
+++ b/kernel/eir/system/acpi/cpu-count.cpp
@@ -19,6 +19,11 @@ initgraph::Task detectCpusFromMadt{
     [] {
 	    if (!haveTables())
 		    return;
+	    if (cpuConfig.totalCpus) {
+		    infoLogger() << "eir: Skipping MADT CPU discovery (CPU count already known)"
+		                 << frg::endlog;
+		    return;
+	    }
 
 	    uacpi_table madtTbl;
 	    if (uacpi_table_find_by_signature("APIC", &madtTbl) != UACPI_STATUS_OK) {

--- a/kernel/eir/system/dtb/cpu-count.cpp
+++ b/kernel/eir/system/dtb/cpu-count.cpp
@@ -17,6 +17,11 @@ initgraph::Task detectCpusFromDtb{
     [] {
 	    if (!eirDtbPtr)
 		    return;
+	    if (cpuConfig.totalCpus) {
+		    infoLogger() << "eir: Skipping DT CPU discovery (CPU count already known)"
+		                 << frg::endlog;
+		    return;
+	    }
 
 	    DeviceTree dt{physToVirt<void>(eirDtbPtr)};
 	    size_t cpuCount = 0;

--- a/kernel/eir/system/dtb/cpu-count.cpp
+++ b/kernel/eir/system/dtb/cpu-count.cpp
@@ -1,6 +1,7 @@
 #include <dtb.hpp>
 #include <eir-internal/cmdline.hpp>
 #include <eir-internal/debug.hpp>
+#include <eir-internal/dtb/dtb.hpp>
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
 
@@ -9,7 +10,11 @@ namespace eir {
 namespace {
 
 initgraph::Task detectCpusFromDtb{
-    &globalInitEngine, "dt.detect-cpu-count", initgraph::Entails{getKernelLoadableStage()}, [] {
+    &globalInitEngine,
+    "dt.detect-cpu-count",
+    initgraph::Requires{getDtbAvailableStage()},
+    initgraph::Entails{getKernelLoadableStage()},
+    [] {
 	    if (!eirDtbPtr)
 		    return;
 

--- a/kernel/eir/system/dtb/discovery.cpp
+++ b/kernel/eir/system/dtb/discovery.cpp
@@ -8,6 +8,7 @@
 #include <eir-internal/cmdline.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/dtb/discovery.hpp>
+#include <eir-internal/dtb/dtb.hpp>
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
 #include <eir-internal/uart/uart.hpp>
@@ -15,6 +16,11 @@
 #include <frg/small_vector.hpp>
 
 namespace eir {
+
+initgraph::Stage *getDtbAvailableStage() {
+	static initgraph::Stage s{&globalInitEngine, "dt.dtb-available"};
+	return &s;
+}
 
 size_t findAddressCells(DeviceTreeNode parent) {
 	auto maybeProperty = parent.findProperty("#address-cells");
@@ -249,6 +255,7 @@ constinit frg::manual_box<uart::UartLogHandler> dtbUartLogHandler;
 static initgraph::Task discoverOutput{
     &globalInitEngine,
     "dt.discover-stdout",
+    initgraph::Requires{getDtbAvailableStage()},
     initgraph::Entails{uart::getBootUartDeterminedStage()},
     [] {
 	    if (!eirDtbPtr)

--- a/kernel/eir/system/dtb/discovery.cpp
+++ b/kernel/eir/system/dtb/discovery.cpp
@@ -260,6 +260,11 @@ static initgraph::Task discoverOutput{
     [] {
 	    if (!eirDtbPtr)
 		    return;
+	    if (uart::hasBootUart()) {
+		    infoLogger() << "eir: Skipping DT UART discovery (boot UART already known)"
+		                 << frg::endlog;
+		    return;
+	    }
 	    DeviceTree dt{physToVirt<void>(eirDtbPtr)};
 
 	    auto chosen = dt.findNode("/chosen");

--- a/kernel/eir/system/dtb/eir-internal/dtb/dtb.hpp
+++ b/kernel/eir/system/dtb/eir-internal/dtb/dtb.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <initgraph.hpp>
+
+namespace eir {
+
+// eirDtbPtr is available at this stage.
+initgraph::Stage *getDtbAvailableStage();
+
+} // namespace eir

--- a/kernel/eir/system/uart/eir-internal/uart/uart.hpp
+++ b/kernel/eir/system/uart/eir-internal/uart/uart.hpp
@@ -27,6 +27,8 @@ extern BootUartConfig bootUartConfig;
 
 void setBootUart(common::uart::AnyUart *uartPtr);
 
+bool hasBootUart();
+
 // Initialize a UART from the DBG2 or SPCR tables.
 // For DBG2, the type (not subtype) must be serial (= 0x8000).
 // The subtype that is passed to this function is also defined by DBG2.

--- a/kernel/eir/system/uart/uart.cpp
+++ b/kernel/eir/system/uart/uart.cpp
@@ -121,6 +121,8 @@ void UartLogHandler::emit(frg::string_view line) {
 
 void setBootUart(common::uart::AnyUart *uartPtr) { bootUartPtr = uartPtr; }
 
+bool hasBootUart() { return bootUartPtr != nullptr; }
+
 void initFromAcpi(common::uart::AnyUart &uart, unsigned int subtype, const acpi_gas &base) {
 	switch (subtype) {
 		case ACPI_DBG2_SUBTYPE_SERIAL_NS16550:


### PR DESCRIPTION
Fix initgraph tasks that are either not strictly enough or too strictly ordered. Also take into account that some systems can expose both a DT and ACPI tables.