### PR TITLE
eir, thor: Remove EirInfo struct in favor of ELF notes

### DIFF
--- a/kernel/eir/arch/riscv/cpu.cpp
+++ b/kernel/eir/arch/riscv/cpu.cpp
@@ -274,7 +274,10 @@ static initgraph::Task earlyProcessorInit{
     &globalInitEngine,
     "riscv.early-processor-init",
     initgraph::Entails{getMemoryLayoutReservedStage()},
-    [] { initProcessorEarly(); }
+    [] {
+	    initProcessorEarly();
+	    riscvConfig.bspHartId = eirBootHartId;
+    }
 };
 
 } // namespace eir

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -16,6 +16,7 @@ extern frg::span<uint8_t> initrd_image;
 
 extern CpuConfig cpuConfig;
 extern AcpiData acpiDataNote;
+extern DtData dtDataNote;
 
 enum class RegionType { null, unconstructed, allocatable };
 

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -17,6 +17,7 @@ extern frg::span<uint8_t> initrd_image;
 extern CpuConfig cpuConfig;
 extern AcpiData acpiDataNote;
 extern DtData dtDataNote;
+extern EirFramebuffer framebufferNote;
 
 enum class RegionType { null, unconstructed, allocatable };
 

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -18,6 +18,7 @@ extern CpuConfig cpuConfig;
 extern AcpiData acpiDataNote;
 extern DtData dtDataNote;
 extern EirFramebuffer framebufferNote;
+extern Initrd initrdNote;
 
 enum class RegionType { null, unconstructed, allocatable };
 

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -15,6 +15,7 @@ extern address_t kernel_physical;
 extern frg::span<uint8_t> initrd_image;
 
 extern CpuConfig cpuConfig;
+extern AcpiData acpiDataNote;
 
 enum class RegionType { null, unconstructed, allocatable };
 

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -20,6 +20,7 @@ extern DtData dtDataNote;
 extern EirFramebuffer framebufferNote;
 extern Initrd initrdNote;
 extern PhysicalMemory physicalMemoryNote;
+extern CommandLine commandLineNote;
 
 enum class RegionType { null, unconstructed, allocatable };
 

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -19,6 +19,7 @@ extern AcpiData acpiDataNote;
 extern DtData dtDataNote;
 extern EirFramebuffer framebufferNote;
 extern Initrd initrdNote;
+extern PhysicalMemory physicalMemoryNote;
 
 enum class RegionType { null, unconstructed, allocatable };
 

--- a/kernel/eir/generic/main-function.cpp
+++ b/kernel/eir/generic/main-function.cpp
@@ -170,6 +170,9 @@ static initgraph::Task prepareFramebufferForThor{
 			    );
 		    mapKasanShadow(getKernelFrameBuffer(), fb->fbPitch * fb->fbHeight);
 		    unpoisonKasanShadow(getKernelFrameBuffer(), fb->fbPitch * fb->fbHeight);
+
+		    framebufferNote = *fb;
+		    framebufferNote.fbEarlyWindow = getKernelFrameBuffer();
 	    }
     }
 };

--- a/kernel/eir/generic/main-function.cpp
+++ b/kernel/eir/generic/main-function.cpp
@@ -115,11 +115,35 @@ static initgraph::Task setupPageTables{
 };
 
 static initgraph::Task mapRegions{
-    &globalInitEngine, "generic.map-regions", initgraph::Requires{getKernelMappableStage()}, [] {
+    &globalInitEngine,
+    "generic.map-regions",
+    initgraph::Requires{getKernelMappableStage()},
+    initgraph::Entails{getKernelLoadableStage()},
+    [] {
 	    mapRegionsAndStructs();
 #ifdef KERNEL_LOG_ALLOCATIONS
 	    allocLogRingBuffer();
 #endif
+
+	    int n = 0;
+	    for (size_t i = 0; i < eirMaxMemoryRegions; ++i) {
+		    if (regions[i].regionType == RegionType::allocatable)
+			    n++;
+	    }
+	    auto regionInfos = bootAlloc<EirRegion>(n);
+	    int j = 0;
+	    for (size_t i = 0; i < eirMaxMemoryRegions; ++i) {
+		    if (regions[i].regionType != RegionType::allocatable)
+			    continue;
+		    regionInfos[j].address = regions[i].address;
+		    regionInfos[j].length = regions[i].size;
+		    regionInfos[j].order = regions[i].order;
+		    regionInfos[j].numRoots = regions[i].numRoots;
+		    regionInfos[j].buddyTree = regions[i].buddyMap;
+		    j++;
+	    }
+	    physicalMemoryNote.numRegions = n;
+	    physicalMemoryNote.regionInfo = mapBootstrapData(regionInfos);
     }
 };
 

--- a/kernel/eir/generic/main-function.cpp
+++ b/kernel/eir/generic/main-function.cpp
@@ -74,10 +74,12 @@ static initgraph::Task parseInitrdInfo{
     &globalInitEngine,
     "generic.parse-initrd",
     initgraph::Requires{getInitrdAvailableStage()},
-    initgraph::Entails{getReservedRegionsKnownStage()},
+    initgraph::Entails{getReservedRegionsKnownStage(), getKernelLoadableStage()},
     [] {
 	    assert(initrd);
 	    parseInitrd(initrd);
+	    initrdNote.physicalBase = virtToPhys(initrd);
+	    initrdNote.length = initrd_image.size();
     }
 };
 

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -377,7 +377,7 @@ address_t bootstrapDataPointer = 0;
 
 address_t mapBootstrapData(void *p) {
 	if (!bootstrapDataPointer)
-		bootstrapDataPointer = getMemoryLayout().eirInfo;
+		bootstrapDataPointer = getMemoryLayout().bootstrapData;
 
 	auto pointer = bootstrapDataPointer;
 	bootstrapDataPointer += pageSize;
@@ -650,15 +650,6 @@ void loadKernelImage(void *imagePtr) {
 
 namespace {
 
-void generateInfo() {
-	// Setup the eir interface struct.
-	auto info_ptr = bootAlloc<EirInfo>();
-	memset(info_ptr, 0, sizeof(EirInfo));
-	auto info_vaddr = mapBootstrapData(info_ptr);
-	assert(info_vaddr == getMemoryLayout().eirInfo);
-	info_ptr->signature = eirSignatureValue;
-}
-
 static initgraph::Task parseCmdlineTask{
     &globalInitEngine,
     "generic.parse-cmdline",
@@ -727,15 +718,6 @@ static initgraph::Task composeCommandLine{
 
 	    commandLineNote.ptr = mapBootstrapData(cmdlineBuffer);
     }
-};
-
-static initgraph::Task generateInfoStruct{
-    &globalInitEngine,
-    "generic.generate-thor-info-struct",
-    initgraph::Requires{
-        getInitrdAvailableStage(), getCmdlineAvailableStage(), getKernelLoadableStage()
-    },
-    [] { generateInfo(); }
 };
 
 } // namespace

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -37,6 +37,7 @@ DebugCapabilities eirDebugCapabilities{};
 CpuConfig cpuConfig{0};
 DebugOptions debugOptions{};
 AcpiData acpiDataNote{};
+constinit DtData dtDataNote{};
 
 // ----------------------------------------------------------------------------
 // Memory region management.
@@ -515,6 +516,11 @@ bool patchGenericManagarmElfNote(unsigned int type, frg::span<char> desc) {
 			panicLogger() << "AcpiData size does not match ELF note" << frg::endlog;
 		memcpy(desc.data(), &acpiDataNote, sizeof(AcpiData));
 		return true;
+	} else if (type == elf_note_type::dtData) {
+		if (desc.size() != sizeof(DtData))
+			panicLogger() << "DtData size does not match ELF note" << frg::endlog;
+		memcpy(desc.data(), &dtDataNote, sizeof(DtData));
+		return true;
 	}
 	return false;
 }
@@ -627,13 +633,6 @@ void generateInfo() {
 	auto info_vaddr = mapBootstrapData(info_ptr);
 	assert(info_vaddr == getMemoryLayout().eirInfo);
 	info_ptr->signature = eirSignatureValue;
-
-	// Pass firmware tables.
-	if (eirDtbPtr) {
-		DeviceTree dt{physToVirt<void>(eirDtbPtr)};
-		info_ptr->dtbPtr = eirDtbPtr;
-		info_ptr->dtbSize = dt.size();
-	}
 
 	// Pass all memory regions to thor.
 	int n = 0;

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -40,6 +40,7 @@ AcpiData acpiDataNote{};
 constinit DtData dtDataNote{};
 EirFramebuffer framebufferNote{};
 Initrd initrdNote{};
+PhysicalMemory physicalMemoryNote{};
 
 // ----------------------------------------------------------------------------
 // Memory region management.
@@ -533,6 +534,11 @@ bool patchGenericManagarmElfNote(unsigned int type, frg::span<char> desc) {
 			panicLogger() << "Initrd size does not match ELF note" << frg::endlog;
 		memcpy(desc.data(), &initrdNote, sizeof(Initrd));
 		return true;
+	} else if (type == elf_note_type::physicalMemory) {
+		if (desc.size() != sizeof(PhysicalMemory))
+			panicLogger() << "PhysicalMemory size does not match ELF note" << frg::endlog;
+		memcpy(desc.data(), &physicalMemoryNote, sizeof(PhysicalMemory));
+		return true;
 	}
 	return false;
 }
@@ -645,29 +651,6 @@ void generateInfo() {
 	auto info_vaddr = mapBootstrapData(info_ptr);
 	assert(info_vaddr == getMemoryLayout().eirInfo);
 	info_ptr->signature = eirSignatureValue;
-
-	// Pass all memory regions to thor.
-	int n = 0;
-	for (size_t i = 0; i < eirMaxMemoryRegions; ++i) {
-		if (regions[i].regionType == RegionType::allocatable)
-			n++;
-	}
-
-	auto regionInfos = bootAlloc<EirRegion>(n);
-	info_ptr->numRegions = n;
-	info_ptr->regionInfo = mapBootstrapData(regionInfos);
-	int j = 0;
-	for (size_t i = 0; i < eirMaxMemoryRegions; ++i) {
-		if (regions[i].regionType != RegionType::allocatable)
-			continue;
-
-		regionInfos[j].address = regions[i].address;
-		regionInfos[j].length = regions[i].size;
-		regionInfos[j].order = regions[i].order;
-		regionInfos[j].numRoots = regions[i].numRoots;
-		regionInfos[j].buddyTree = regions[i].buddyMap;
-		j++;
-	}
 
 	// Pass the command line to Thor.
 	auto cmdlineChunks = getCmdline();

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -38,6 +38,7 @@ CpuConfig cpuConfig{0};
 DebugOptions debugOptions{};
 AcpiData acpiDataNote{};
 constinit DtData dtDataNote{};
+EirFramebuffer framebufferNote{};
 
 // ----------------------------------------------------------------------------
 // Memory region management.
@@ -521,6 +522,11 @@ bool patchGenericManagarmElfNote(unsigned int type, frg::span<char> desc) {
 			panicLogger() << "DtData size does not match ELF note" << frg::endlog;
 		memcpy(desc.data(), &dtDataNote, sizeof(DtData));
 		return true;
+	} else if (type == elf_note_type::framebuffer) {
+		if (desc.size() != sizeof(EirFramebuffer))
+			panicLogger() << "EirFramebuffer size does not match ELF note" << frg::endlog;
+		memcpy(desc.data(), &framebufferNote, sizeof(EirFramebuffer));
+		return true;
 	}
 	return false;
 }
@@ -695,13 +701,6 @@ void generateInfo() {
 	initrd_module->nameLength = name_length;
 
 	info_ptr->moduleInfo = mapBootstrapData(initrd_module);
-
-	// Pass the framebuffer to thor.
-	auto *fb = getFramebuffer();
-	if (fb) {
-		info_ptr->frameBuffer = *fb;
-		info_ptr->frameBuffer.fbEarlyWindow = getKernelFrameBuffer();
-	}
 }
 
 static initgraph::Task parseCmdlineTask{

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -41,6 +41,7 @@ constinit DtData dtDataNote{};
 EirFramebuffer framebufferNote{};
 Initrd initrdNote{};
 PhysicalMemory physicalMemoryNote{};
+CommandLine commandLineNote{};
 
 // ----------------------------------------------------------------------------
 // Memory region management.
@@ -534,6 +535,11 @@ bool patchGenericManagarmElfNote(unsigned int type, frg::span<char> desc) {
 			panicLogger() << "Initrd size does not match ELF note" << frg::endlog;
 		memcpy(desc.data(), &initrdNote, sizeof(Initrd));
 		return true;
+	} else if (type == elf_note_type::commandLine) {
+		if (desc.size() != sizeof(CommandLine))
+			panicLogger() << "CommandLine size does not match ELF note" << frg::endlog;
+		memcpy(desc.data(), &commandLineNote, sizeof(CommandLine));
+		return true;
 	} else if (type == elf_note_type::physicalMemory) {
 		if (desc.size() != sizeof(PhysicalMemory))
 			panicLogger() << "PhysicalMemory size does not match ELF note" << frg::endlog;
@@ -651,33 +657,6 @@ void generateInfo() {
 	auto info_vaddr = mapBootstrapData(info_ptr);
 	assert(info_vaddr == getMemoryLayout().eirInfo);
 	info_ptr->signature = eirSignatureValue;
-
-	// Pass the command line to Thor.
-	auto cmdlineChunks = getCmdline();
-
-	// For each chunk: we either have a trailing space or null terminator.
-	auto cmdlineLength = cmdlineChunks.size();
-	for (auto chunk : cmdlineChunks)
-		cmdlineLength += chunk.size();
-
-	if (cmdlineLength > pageSize)
-		panicLogger() << "eir: Command line exceeds page size" << frg::endlog;
-	auto cmdlineBuffer = bootAlloc<char>(cmdlineLength);
-
-	char *cmdlinePtr = cmdlineBuffer;
-	for (auto chunk : cmdlineChunks) {
-		if (!chunk.size())
-			continue;
-		if (cmdlinePtr != cmdlineBuffer)
-			*(cmdlinePtr++) = ' ';
-		memcpy(cmdlinePtr, chunk.data(), chunk.size());
-		cmdlinePtr += chunk.size();
-	}
-	*cmdlinePtr = '\0';
-
-	infoLogger() << "eir: Kernel command line: '" << cmdlineBuffer << "'" << frg::endlog;
-
-	info_ptr->commandLine = mapBootstrapData(cmdlineBuffer);
 }
 
 static initgraph::Task parseCmdlineTask{
@@ -713,6 +692,40 @@ static initgraph::Task parseCmdlineTask{
 			                 << frg::endlog;
 		    }
 	    }
+    }
+};
+
+static initgraph::Task composeCommandLine{
+    &globalInitEngine,
+    "generic.compose-cmdline",
+    initgraph::Requires{getCmdlineAvailableStage(), getKernelMappableStage()},
+    initgraph::Entails{getKernelLoadableStage()},
+    [] {
+	    auto cmdlineChunks = getCmdline();
+
+	    // For each chunk: we either have a trailing space or null terminator.
+	    auto cmdlineLength = cmdlineChunks.size();
+	    for (auto chunk : cmdlineChunks)
+		    cmdlineLength += chunk.size();
+
+	    if (cmdlineLength > pageSize)
+		    panicLogger() << "eir: Command line exceeds page size" << frg::endlog;
+	    auto cmdlineBuffer = bootAlloc<char>(cmdlineLength);
+
+	    char *cmdlinePtr = cmdlineBuffer;
+	    for (auto chunk : cmdlineChunks) {
+		    if (!chunk.size())
+			    continue;
+		    if (cmdlinePtr != cmdlineBuffer)
+			    *(cmdlinePtr++) = ' ';
+		    memcpy(cmdlinePtr, chunk.data(), chunk.size());
+		    cmdlinePtr += chunk.size();
+	    }
+	    *cmdlinePtr = '\0';
+
+	    infoLogger() << "eir: Kernel command line: '" << cmdlineBuffer << "'" << frg::endlog;
+
+	    commandLineNote.ptr = mapBootstrapData(cmdlineBuffer);
     }
 };
 

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -632,10 +632,6 @@ void generateInfo() {
 		info_ptr->dtbSize = dt.size();
 	}
 
-#ifdef __riscv
-	info_ptr->hartId = eirBootHartId;
-#endif
-
 	// Pass all memory regions to thor.
 	int n = 0;
 	for (size_t i = 0; i < eirMaxMemoryRegions; ++i) {

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -36,6 +36,7 @@ DebugCapabilities eirDebugCapabilities{};
 
 CpuConfig cpuConfig{0};
 DebugOptions debugOptions{};
+AcpiData acpiDataNote{};
 
 // ----------------------------------------------------------------------------
 // Memory region management.
@@ -509,6 +510,11 @@ bool patchGenericManagarmElfNote(unsigned int type, frg::span<char> desc) {
 			panicLogger() << "DebugOptions size does not match ELF note" << frg::endlog;
 		memcpy(desc.data(), &debugOptions, sizeof(DebugOptions));
 		return true;
+	} else if (type == elf_note_type::acpiData) {
+		if (desc.size() != sizeof(AcpiData))
+			panicLogger() << "AcpiData size does not match ELF note" << frg::endlog;
+		memcpy(desc.data(), &acpiDataNote, sizeof(AcpiData));
+		return true;
 	}
 	return false;
 }
@@ -623,9 +629,6 @@ void generateInfo() {
 	info_ptr->signature = eirSignatureValue;
 
 	// Pass firmware tables.
-	if (eirRsdpAddr) {
-		info_ptr->acpiRsdp = eirRsdpAddr;
-	}
 	if (eirDtbPtr) {
 		DeviceTree dt{physToVirt<void>(eirDtbPtr)};
 		info_ptr->dtbPtr = eirDtbPtr;

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -39,6 +39,7 @@ DebugOptions debugOptions{};
 AcpiData acpiDataNote{};
 constinit DtData dtDataNote{};
 EirFramebuffer framebufferNote{};
+Initrd initrdNote{};
 
 // ----------------------------------------------------------------------------
 // Memory region management.
@@ -527,6 +528,11 @@ bool patchGenericManagarmElfNote(unsigned int type, frg::span<char> desc) {
 			panicLogger() << "EirFramebuffer size does not match ELF note" << frg::endlog;
 		memcpy(desc.data(), &framebufferNote, sizeof(EirFramebuffer));
 		return true;
+	} else if (type == elf_note_type::initrd) {
+		if (desc.size() != sizeof(Initrd))
+			panicLogger() << "Initrd size does not match ELF note" << frg::endlog;
+		memcpy(desc.data(), &initrdNote, sizeof(Initrd));
+		return true;
 	}
 	return false;
 }
@@ -689,18 +695,6 @@ void generateInfo() {
 	infoLogger() << "eir: Kernel command line: '" << cmdlineBuffer << "'" << frg::endlog;
 
 	info_ptr->commandLine = mapBootstrapData(cmdlineBuffer);
-
-	auto initrd_module = bootAlloc<EirModule>(1);
-	initrd_module->physicalBase = virtToPhys(initrd);
-	initrd_module->length = initrd_image.size();
-	const char *initrd_mod_name = "initrd.cpio";
-	size_t name_length = strlen(initrd_mod_name);
-	char *name_ptr = bootAlloc<char>(name_length);
-	memcpy(name_ptr, initrd_mod_name, name_length);
-	initrd_module->namePtr = mapBootstrapData(name_ptr);
-	initrd_module->nameLength = name_length;
-
-	info_ptr->moduleInfo = mapBootstrapData(initrd_module);
 }
 
 static initgraph::Task parseCmdlineTask{

--- a/kernel/eir/generic/memory-layout.cpp
+++ b/kernel/eir/generic/memory-layout.cpp
@@ -58,7 +58,7 @@ void doDetermineMemoryLayout() {
 	ml.directPhysical = assignLayout(UINT64_C(1) << (s - 2));
 	ml.kernelVirtual = assignLayout(ml.kernelVirtualSize);
 	ml.allocLog = assignLayout(ml.allocLogSize);
-	ml.eirInfo = assignLayout(0x200000);           // 2 MiB should be enough.
+	ml.bootstrapData = assignLayout(0x200000);     // 2 MiB should be enough.
 	kernelFrameBuffer = assignLayout(0x4000'0000); // 1 GiB.
 	kernelStack = assignLayout(kernelStackSize);
 	if (earlyMmioSize)
@@ -68,7 +68,7 @@ void doDetermineMemoryLayout() {
 	infoLogger() << "    Direct physical : 0x" << frg::hex_fmt{ml.directPhysical} << frg::endlog;
 	infoLogger() << "    Kernel virtual  : 0x" << frg::hex_fmt{ml.kernelVirtual} << frg::endlog;
 	infoLogger() << "    Allocation ring : 0x" << frg::hex_fmt{ml.allocLog} << frg::endlog;
-	infoLogger() << "    EirInfo         : 0x" << frg::hex_fmt{ml.eirInfo} << frg::endlog;
+	infoLogger() << "    Bootstrap data  : 0x" << frg::hex_fmt{ml.bootstrapData} << frg::endlog;
 	infoLogger() << "    Kernel FB       : 0x" << frg::hex_fmt{kernelFrameBuffer} << frg::endlog;
 	infoLogger() << "    Kernel stack    : 0x" << frg::hex_fmt{kernelStack} << frg::endlog;
 	if (earlyMmioSize)

--- a/kernel/eir/system/acpi/acpi.cpp
+++ b/kernel/eir/system/acpi/acpi.cpp
@@ -13,7 +13,7 @@ initgraph::Task setupTables{
     &globalInitEngine,
     "acpi.setup-tables",
     initgraph::Requires{getRsdpAvailableStage()},
-    initgraph::Entails{getTablesAvailableStage()},
+    initgraph::Entails{getTablesAvailableStage(), getKernelLoadableStage()},
     [] {
 	    if (!eirRsdpAddr) {
 		    infoLogger() << "eir: No RSDP available, skipping ACPI table setup" << frg::endlog;
@@ -25,6 +25,7 @@ initgraph::Task setupTables{
 	    );
 
 	    haveTablesFlag = true;
+	    acpiDataNote.rsdp = eirRsdpAddr;
     }
 };
 

--- a/kernel/eir/system/dtb/discovery.cpp
+++ b/kernel/eir/system/dtb/discovery.cpp
@@ -249,6 +249,20 @@ static initgraph::Task discoverMemory{
 
 #endif
 
+static initgraph::Task passDtbTask{
+    &globalInitEngine,
+    "dt.pass-dtb",
+    initgraph::Requires{getDtbAvailableStage()},
+    initgraph::Entails{getKernelLoadableStage()},
+    [] {
+	    if (!eirDtbPtr)
+		    return;
+	    DeviceTree dt{physToVirt<void>(eirDtbPtr)};
+	    dtDataNote.address = eirDtbPtr;
+	    dtDataNote.size = dt.size();
+    }
+};
+
 constinit common::uart::AnyUart dtbUart;
 constinit frg::manual_box<uart::UartLogHandler> dtbUartLogHandler;
 

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -4,8 +4,6 @@
 #include <frg/string.hpp>
 #include <stdint.h>
 
-static const uint64_t eirSignatureValue = 0x68692C2074686F72;
-
 static const uint32_t eirDebugSerial = 1;
 static const uint32_t eirDebugBochs = 2;
 static const uint32_t eirDebugKernelProfile = 16;
@@ -31,10 +29,6 @@ struct EirFramebuffer {
 	EirSize fbHeight;
 	EirSize fbBpp;
 	EirSize fbType;
-};
-
-struct EirInfo {
-	uint64_t signature;
 };
 
 // Please keep this sorted.
@@ -179,8 +173,10 @@ struct MemoryLayout {
 	// Address and size of the allocation log ring buffer.
 	uint64_t allocLog;
 	uint64_t allocLogSize;
-	// Address of the EirInfo struct.
-	uint64_t eirInfo;
+	// Base address of the bootstrap data area: a region of Thor's virtual address
+	// space into which Eir maps variable-length boot information (e.g., the kernel
+	// command line and the physical memory map) before handing off to Thor.
+	uint64_t bootstrapData;
 };
 
 struct RiscvConfig {

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -48,9 +48,6 @@ struct EirInfo {
 	EirPtr regionInfo;
 	EirPtr moduleInfo;
 
-	EirPtr dtbPtr;
-	EirSize dtbSize;
-
 	EirFramebuffer frameBuffer;
 };
 
@@ -150,6 +147,7 @@ constexpr unsigned int smbiosData = 0x1000'0002;
 constexpr unsigned int bootUartConfig = 0x1000'0003;
 constexpr unsigned int debugOptions = 0x1000'0004;
 constexpr unsigned int acpiData = 0x1000'0005;
+constexpr unsigned int dtData = 0x1000'0006;
 // 0x11xx'xxxx range reserved for arch-specific configuration notes in Thor (write-only by Eir).
 // 0x1100'0xxx range reserved for x86.
 // 0x1100'1xxx range reserved for aarch64.
@@ -256,4 +254,9 @@ struct DebugCapabilities {
 
 struct AcpiData {
 	uint64_t rsdp = 0;
+};
+
+struct DtData {
+	uint64_t address = 0;
+	uint64_t size = 0;
 };

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -36,9 +36,6 @@ struct EirFramebuffer {
 struct EirInfo {
 	uint64_t signature;
 	EirPtr commandLine;
-
-	EirSize numRegions;
-	EirPtr regionInfo;
 };
 
 // Please keep this sorted.
@@ -140,6 +137,7 @@ constexpr unsigned int acpiData = 0x1000'0005;
 constexpr unsigned int dtData = 0x1000'0006;
 constexpr unsigned int framebuffer = 0x1000'0007;
 constexpr unsigned int initrd = 0x1000'0008;
+constexpr unsigned int physicalMemory = 0x1000'0009;
 // 0x11xx'xxxx range reserved for arch-specific configuration notes in Thor (write-only by Eir).
 // 0x1100'0xxx range reserved for x86.
 // 0x1100'1xxx range reserved for aarch64.
@@ -256,4 +254,11 @@ struct DtData {
 struct Initrd {
 	uint64_t physicalBase = 0;
 	uint64_t length = 0;
+};
+
+struct PhysicalMemory {
+	// Number of regions in the array pointed to by regionInfo.
+	uint64_t numRegions = 0;
+	// Virtual address of an EirRegion[numRegions] array in the bootstrap data area.
+	uint64_t regionInfo = 0;
 };

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -47,8 +47,6 @@ struct EirInfo {
 	EirSize numRegions;
 	EirPtr regionInfo;
 	EirPtr moduleInfo;
-
-	EirFramebuffer frameBuffer;
 };
 
 // Please keep this sorted.
@@ -148,6 +146,7 @@ constexpr unsigned int bootUartConfig = 0x1000'0003;
 constexpr unsigned int debugOptions = 0x1000'0004;
 constexpr unsigned int acpiData = 0x1000'0005;
 constexpr unsigned int dtData = 0x1000'0006;
+constexpr unsigned int framebuffer = 0x1000'0007;
 // 0x11xx'xxxx range reserved for arch-specific configuration notes in Thor (write-only by Eir).
 // 0x1100'0xxx range reserved for x86.
 // 0x1100'1xxx range reserved for aarch64.

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -44,8 +44,6 @@ struct EirInfo {
 	uint64_t signature;
 	EirPtr commandLine;
 
-	uint64_t hartId;
-
 	EirSize numRegions;
 	EirPtr regionInfo;
 	EirPtr moduleInfo;
@@ -203,7 +201,9 @@ struct RiscvConfig {
 	// 3 for Sv39,
 	// 4 for Sv48,
 	// 5 for Sv57.
-	int numPtLevels{0};
+	int32_t numPtLevels{0};
+	uint32_t pad{0};
+	uint64_t bspHartId{0};
 };
 
 struct RiscvHartCaps {

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -23,13 +23,6 @@ struct EirRegion {
 	EirPtr buddyTree;
 };
 
-struct EirModule {
-	EirPtr physicalBase;
-	EirSize length;
-	EirPtr namePtr;
-	EirSize nameLength;
-};
-
 struct EirFramebuffer {
 	EirPtr fbAddress;
 	EirPtr fbEarlyWindow;
@@ -46,7 +39,6 @@ struct EirInfo {
 
 	EirSize numRegions;
 	EirPtr regionInfo;
-	EirPtr moduleInfo;
 };
 
 // Please keep this sorted.
@@ -147,6 +139,7 @@ constexpr unsigned int debugOptions = 0x1000'0004;
 constexpr unsigned int acpiData = 0x1000'0005;
 constexpr unsigned int dtData = 0x1000'0006;
 constexpr unsigned int framebuffer = 0x1000'0007;
+constexpr unsigned int initrd = 0x1000'0008;
 // 0x11xx'xxxx range reserved for arch-specific configuration notes in Thor (write-only by Eir).
 // 0x1100'0xxx range reserved for x86.
 // 0x1100'1xxx range reserved for aarch64.
@@ -258,4 +251,9 @@ struct AcpiData {
 struct DtData {
 	uint64_t address = 0;
 	uint64_t size = 0;
+};
+
+struct Initrd {
+	uint64_t physicalBase = 0;
+	uint64_t length = 0;
 };

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -35,7 +35,6 @@ struct EirFramebuffer {
 
 struct EirInfo {
 	uint64_t signature;
-	EirPtr commandLine;
 };
 
 // Please keep this sorted.
@@ -138,6 +137,7 @@ constexpr unsigned int dtData = 0x1000'0006;
 constexpr unsigned int framebuffer = 0x1000'0007;
 constexpr unsigned int initrd = 0x1000'0008;
 constexpr unsigned int physicalMemory = 0x1000'0009;
+constexpr unsigned int commandLine = 0x1000'000a;
 // 0x11xx'xxxx range reserved for arch-specific configuration notes in Thor (write-only by Eir).
 // 0x1100'0xxx range reserved for x86.
 // 0x1100'1xxx range reserved for aarch64.
@@ -261,4 +261,9 @@ struct PhysicalMemory {
 	uint64_t numRegions = 0;
 	// Virtual address of an EirRegion[numRegions] array in the bootstrap data area.
 	uint64_t regionInfo = 0;
+};
+
+struct CommandLine {
+	// Virtual address of a null-terminated string in the bootstrap data area.
+	uint64_t ptr = 0;
 };

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -52,8 +52,6 @@ struct EirInfo {
 	EirSize dtbSize;
 
 	EirFramebuffer frameBuffer;
-
-	uint64_t acpiRsdp;
 };
 
 // Please keep this sorted.
@@ -151,6 +149,7 @@ constexpr unsigned int cpuConfig = 0x1000'0001;
 constexpr unsigned int smbiosData = 0x1000'0002;
 constexpr unsigned int bootUartConfig = 0x1000'0003;
 constexpr unsigned int debugOptions = 0x1000'0004;
+constexpr unsigned int acpiData = 0x1000'0005;
 // 0x11xx'xxxx range reserved for arch-specific configuration notes in Thor (write-only by Eir).
 // 0x1100'0xxx range reserved for x86.
 // 0x1100'1xxx range reserved for aarch64.
@@ -253,4 +252,8 @@ struct DebugOptions {
 
 struct DebugCapabilities {
 	bool kasan = false;
+};
+
+struct AcpiData {
+	uint64_t rsdp = 0;
 };

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -230,7 +230,7 @@ void setupBootCpuContext() {
 	auto context = getCpuData(0);
 	writeToTp(context);
 
-	context->hartId = getEirInfo()->hartId;
+	context->hartId = riscvConfigNote->bspHartId;
 }
 
 static initgraph::Task probeSbiFeatures{

--- a/kernel/thor/arch/riscv/plic.cpp
+++ b/kernel/thor/arch/riscv/plic.cpp
@@ -285,7 +285,7 @@ initgraph::Task initPlicAcpi{
     initgraph::Requires{acpi::getTablesDiscoveredStage()},
     initgraph::Entails{getTaskingAvailableStage()},
     [] {
-	    auto rsdp = getEirInfo()->acpiRsdp;
+	    auto rsdp = acpiRsdpNote->rsdp;
 	    if (!rsdp)
 		    return;
 

--- a/kernel/thor/arch/riscv/smp.cpp
+++ b/kernel/thor/arch/riscv/smp.cpp
@@ -136,7 +136,7 @@ initgraph::Task initAPsAcpi{
     "riscv.init-aps-acpi",
     initgraph::Requires{acpi::getTablesDiscoveredStage(), getTaskingAvailableStage()},
     [] {
-	    if (!getEirInfo()->acpiRsdp)
+	    if (!acpiRsdpNote->rsdp)
 		    return;
 
 	    setUpTrampoline();

--- a/kernel/thor/arch/riscv/timer.cpp
+++ b/kernel/thor/arch/riscv/timer.cpp
@@ -27,7 +27,7 @@ initgraph::Task initTimerAcpi{
     initgraph::Requires{acpi::getTablesDiscoveredStage()},
     initgraph::Entails{getTaskingAvailableStage()},
     [] {
-	    if (!getEirInfo()->acpiRsdp)
+	    if (!acpiRsdpNote->rsdp)
 		    return;
 
 	    uint32_t freqSeconds;

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -52,10 +52,6 @@ extern "C" void frg_panic(const char *cstring) {
 	panicLogger() << "frg: Panic! " << cstring << frg::endlog;
 }
 
-EirInfo *getEirInfo() {
-	return reinterpret_cast<EirInfo *>(memoryLayoutNote->eirInfo);
-}
-
 extern ManagarmElfNote<Initrd> initrdNote;
 THOR_DEFINE_ELF_NOTE(initrdNote){elf_note_type::initrd, {}};
 
@@ -87,12 +83,6 @@ extern "C" void thorInitialize() {
 			reinterpret_cast<void *>(framebufferNote->fbEarlyWindow));
 
 	infoLogger() << "Starting Thor" << frg::endlog;
-
-	if(getEirInfo()->signature == eirSignatureValue) {
-		infoLogger() << "thor: Bootstrap information signature matches" << frg::endlog;
-	}else{
-		panicLogger() << "thor: Bootstrap information signature mismatch!" << frg::endlog;
-	}
 
 #ifdef THOR_KASAN
 	infoLogger() << "thor: Using KASAN" << frg::endlog;

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -59,6 +59,9 @@ EirInfo *getEirInfo() {
 extern ManagarmElfNote<Initrd> initrdNote;
 THOR_DEFINE_ELF_NOTE(initrdNote){elf_note_type::initrd, {}};
 
+extern ManagarmElfNote<CommandLine> commandLineNote;
+THOR_DEFINE_ELF_NOTE(commandLineNote){elf_note_type::commandLine, {}};
+
 frg::string_view getKernelCmdline() {
 	return *kernelCommandLine;
 }
@@ -190,7 +193,7 @@ extern "C" void thorMain() {
 	infoLogger() << "thor: Entering main function" << frg::endlog;
 
 	kernelCommandLine.initialize(*kernelAlloc,
-			reinterpret_cast<const char *>(getEirInfo()->commandLine));
+			reinterpret_cast<const char *>(commandLineNote->ptr));
 
 	for(int i = 0; i < numIrqSlots; i++)
 		globalIrqSlots[i].initialize();

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -74,10 +74,10 @@ extern "C" void thorInitialize() {
 		debugToBochs = true;
 	setupDebugging();
 
-	initializeBootFb(getEirInfo()->frameBuffer.fbAddress, getEirInfo()->frameBuffer.fbPitch,
-			getEirInfo()->frameBuffer.fbWidth, getEirInfo()->frameBuffer.fbHeight,
-			getEirInfo()->frameBuffer.fbBpp, getEirInfo()->frameBuffer.fbType,
-			reinterpret_cast<void *>(getEirInfo()->frameBuffer.fbEarlyWindow));
+	initializeBootFb(framebufferNote->fbAddress, framebufferNote->fbPitch,
+			framebufferNote->fbWidth, framebufferNote->fbHeight,
+			framebufferNote->fbBpp, framebufferNote->fbType,
+			reinterpret_cast<void *>(framebufferNote->fbEarlyWindow));
 
 	infoLogger() << "Starting Thor" << frg::endlog;
 

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -98,8 +98,8 @@ extern "C" void thorInitialize() {
 	KernelPageSpace::initialize();
 
 	physicalAllocator.initialize();
-	auto region = reinterpret_cast<EirRegion *>(getEirInfo()->regionInfo);
-	for(size_t i = 0; i < getEirInfo()->numRegions; i++)
+	auto region = reinterpret_cast<EirRegion *>(physicalMemoryNote->regionInfo);
+	for(size_t i = 0; i < physicalMemoryNote->numRegions; i++)
 		physicalAllocator->bootstrapRegion(region[i].address, region[i].order,
 				region[i].numRoots, reinterpret_cast<int8_t *>(region[i].buddyTree));
 	infoLogger() << "thor: Number of available pages: "

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -9,6 +9,7 @@
 #include <thor-internal/arch/system.hpp>
 #include <thor-internal/debug.hpp>
 #include <thor-internal/dtb/dtb.hpp>
+#include <thor-internal/elf-notes.hpp>
 #include <thor-internal/fiber.hpp>
 #include <thor-internal/framebuffer/fb.hpp>
 #include <thor-internal/irq.hpp>
@@ -54,6 +55,9 @@ extern "C" void frg_panic(const char *cstring) {
 EirInfo *getEirInfo() {
 	return reinterpret_cast<EirInfo *>(memoryLayoutNote->eirInfo);
 }
+
+extern ManagarmElfNote<Initrd> initrdNote;
+THOR_DEFINE_ELF_NOTE(initrdNote){elf_note_type::initrd, {}};
 
 frg::string_view getKernelCmdline() {
 	return *kernelCommandLine;
@@ -223,12 +227,10 @@ extern "C" void thorMain() {
 		smbios::publish();
 
 		// Parse the initrd image.
-		auto modules = reinterpret_cast<EirModule *>(getEirInfo()->moduleInfo);
-
 		mfsRoot = frg::construct<MfsDirectory>(*kernelAlloc);
 		{
-			auto initrdBase = modules[0].physicalBase;
-			auto initrdLength = modules[0].length;
+			auto initrdBase = initrdNote->physicalBase;
+			auto initrdLength = initrdNote->length;
 
 			auto initrdMisalign = initrdBase & (kPageSize - 1);
 			initrdBase &= ~(kPageSize - 1);
@@ -284,7 +286,7 @@ extern "C" void thorMain() {
 			};
 
 			auto p = base;
-			auto limit = base + modules[0].length;
+			auto limit = base + initrdNote->length;
 			while(true) {
 				Header header;
 				assert(p + sizeof(Header) <= limit);

--- a/kernel/thor/generic/physical.cpp
+++ b/kernel/thor/generic/physical.cpp
@@ -9,6 +9,7 @@ namespace thor {
 static bool logPhysicalAllocs = false;
 
 THOR_DEFINE_ELF_NOTE(memoryLayoutNote){elf_note_type::memoryLayout, {}};
+THOR_DEFINE_ELF_NOTE(physicalMemoryNote){elf_note_type::physicalMemory, {}};
 
 void poisonPhysicalAccess(PhysicalAddr physical) {
 	auto address = directPhysicalOffset() + physical;

--- a/kernel/thor/generic/thor-internal/main.hpp
+++ b/kernel/thor/generic/thor-internal/main.hpp
@@ -5,7 +5,6 @@
 
 namespace thor {
 
-EirInfo *getEirInfo();
 frg::string_view getKernelCmdline();
 
 struct GlobalInitEngine : public initgraph::Engine {

--- a/kernel/thor/generic/thor-internal/physical.hpp
+++ b/kernel/thor/generic/thor-internal/physical.hpp
@@ -13,6 +13,7 @@
 namespace thor {
 
 extern ManagarmElfNote<MemoryLayout> memoryLayoutNote;
+extern ManagarmElfNote<PhysicalMemory> physicalMemoryNote;
 
 inline uintptr_t directPhysicalOffset() {
 	return memoryLayoutNote->directPhysical;

--- a/kernel/thor/system/acpi/glue.cpp
+++ b/kernel/thor/system/acpi/glue.cpp
@@ -11,6 +11,7 @@
 #include <thor-internal/acpi/acpi.hpp>
 #include <thor-internal/arch-generic/paging.hpp>
 #include <thor-internal/cpu-data.hpp>
+#include <thor-internal/elf-notes.hpp>
 #include <thor-internal/fiber.hpp>
 #include <thor-internal/irq.hpp>
 #include <thor-internal/kernel-heap.hpp>
@@ -600,6 +601,12 @@ void uacpi_kernel_unlock_spinlock(uacpi_handle opaque, uacpi_cpu_flags) {
 }
 
 uacpi_status uacpi_kernel_get_rsdp(uacpi_phys_addr *out_rsdp_address) {
-	*out_rsdp_address = getEirInfo()->acpiRsdp;
+	*out_rsdp_address = thor::acpiRsdpNote->rsdp;
 	return UACPI_STATUS_OK;
 }
+
+namespace thor {
+
+THOR_DEFINE_ELF_NOTE(acpiRsdpNote){elf_note_type::acpiData, {}};
+
+} // namespace thor

--- a/kernel/thor/system/acpi/madt.cpp
+++ b/kernel/thor/system/acpi/madt.cpp
@@ -331,7 +331,7 @@ constinit std::array<char, 4096> earlyTableBuffer{};
 
 static initgraph::Task initTablesTask{
     &globalInitEngine, "acpi.init-tables", initgraph::Entails{getTablesDiscoveredStage()}, [] {
-	    if (!getEirInfo()->acpiRsdp)
+	    if (!acpiRsdpNote->rsdp)
 		    return;
 
 	    auto ret = uacpi_setup_early_table_access(earlyTableBuffer.data(), earlyTableBuffer.size());
@@ -347,7 +347,7 @@ static initgraph::Task discoverIoApicsTask{
     initgraph::Requires{getTablesDiscoveredStage(), getFibersAvailableStage()},
     initgraph::Entails{getTaskingAvailableStage()},
     [] {
-	    if (!getEirInfo()->acpiRsdp)
+	    if (!acpiRsdpNote->rsdp)
 		    return;
 
 	    dumpMadt();
@@ -440,7 +440,7 @@ static initgraph::Task loadAcpiNamespaceTask{
     initgraph::Requires{getTaskingAvailableStage(), pci::getBus0AvailableStage()},
     initgraph::Entails{getNsAvailableStage()},
     [] {
-	    if (!getEirInfo()->acpiRsdp)
+	    if (!acpiRsdpNote->rsdp)
 		    return;
 
 	    initGlue();
@@ -476,7 +476,7 @@ static initgraph::Task loadAcpiNamespaceTask{
 
 static initgraph::Task bootApsTask{
     &globalInitEngine, "acpi.boot-aps", initgraph::Requires{&loadAcpiNamespaceTask}, [] {
-	    if (!getEirInfo()->acpiRsdp)
+	    if (!acpiRsdpNote->rsdp)
 		    return;
 
 	    bootOtherProcessors();
@@ -485,7 +485,7 @@ static initgraph::Task bootApsTask{
 
 static initgraph::Task initPmInterfaceTask{
     &globalInitEngine, "acpi.init-pm-interface", initgraph::Requires{&loadAcpiNamespaceTask}, [] {
-	    if (!getEirInfo()->acpiRsdp)
+	    if (!acpiRsdpNote->rsdp)
 		    return;
 
 	    initializePmInterface();

--- a/kernel/thor/system/acpi/ps2.cpp
+++ b/kernel/thor/system/acpi/ps2.cpp
@@ -113,7 +113,7 @@ static initgraph::Task initPS2Task{
     "acpi.init-ps2",
     initgraph::Requires{getNsAvailableStage(), getAcpiFiberAvailableStage()},
     [] {
-	    if (!getEirInfo()->acpiRsdp)
+	    if (!acpiRsdpNote->rsdp)
 		    return;
 
 	    initializePS2();

--- a/kernel/thor/system/acpi/thor-internal/acpi/acpi.hpp
+++ b/kernel/thor/system/acpi/thor-internal/acpi/acpi.hpp
@@ -2,8 +2,10 @@
 
 #include <async/oneshot-event.hpp>
 #include <async/queue.hpp>
+#include <eir/interface.hpp>
 #include <initgraph.hpp>
 #include <smarter.hpp>
+#include <thor-internal/elf-notes.hpp>
 #include <thor-internal/irq.hpp>
 #include <thor-internal/mbus.hpp>
 #include <thor-internal/stream.hpp>
@@ -11,6 +13,8 @@
 #include <uacpi/utilities.h>
 
 namespace thor {
+
+extern ManagarmElfNote<AcpiData> acpiRsdpNote;
 
 // Stores the global IRQ information (GSI, trigger mode, polarity)
 // (in constrast to bus-specific information, e.g., for IRQs on the ISA bus).

--- a/kernel/thor/system/dtb/dtb.cpp
+++ b/kernel/thor/system/dtb/dtb.cpp
@@ -1,5 +1,6 @@
 #include <thor-internal/dtb/dtb.hpp>
 #include <thor-internal/debug.hpp>
+#include <thor-internal/elf-notes.hpp>
 #include <thor-internal/main.hpp>
 #include <thor-internal/arch-generic/paging.hpp>
 #include <frg/manual_box.hpp>
@@ -8,6 +9,8 @@
 #include <dtb.hpp>
 
 namespace thor {
+
+THOR_DEFINE_ELF_NOTE(dtDataNote){elf_note_type::dtData, {}};
 
 static inline constexpr bool logNodeInfo = false;
 
@@ -329,15 +332,15 @@ DeviceTreeNode *getDeviceTreeRoot() {
 static initgraph::Task initTablesTask{&globalInitEngine, "dtb.parse-dtb",
 	initgraph::Entails{getDeviceTreeParsedStage()},
 	[] {
-		if (!getEirInfo()->dtbPtr)
+		if (!dtDataNote->address)
 			return;
 
-		size_t dtbPageOff = getEirInfo()->dtbPtr & (kPageSize - 1);
-		size_t dtbSize = (getEirInfo()->dtbSize + dtbPageOff + kPageSize - 1) & ~(kPageSize - 1);
+		size_t dtbPageOff = dtDataNote->address & (kPageSize - 1);
+		size_t dtbSize = (dtDataNote->size + dtbPageOff + kPageSize - 1) & ~(kPageSize - 1);
 
 		auto ptr = KernelVirtualMemory::global().allocate(dtbSize);
 		uintptr_t va = reinterpret_cast<uintptr_t>(ptr);
-		uintptr_t pa = getEirInfo()->dtbPtr & ~(kPageSize - 1);
+		uintptr_t pa = dtDataNote->address & ~(kPageSize - 1);
 
 		for (size_t i = 0; i < dtbSize; i += kPageSize) {
 			KernelPageSpace::global().mapSingle4k(va, pa,

--- a/kernel/thor/system/dtb/thor-internal/dtb/dtb.hpp
+++ b/kernel/thor/system/dtb/thor-internal/dtb/dtb.hpp
@@ -15,6 +15,8 @@
 
 namespace thor {
 
+extern ManagarmElfNote<DtData> dtDataNote;
+
 namespace dt {
 struct IrqController;
 struct MbusNode;

--- a/kernel/thor/system/framebuffer/fb.cpp
+++ b/kernel/thor/system/framebuffer/fb.cpp
@@ -16,6 +16,8 @@
 
 namespace thor {
 
+THOR_DEFINE_ELF_NOTE(framebufferNote){elf_note_type::framebuffer, {}};
+
 void publishFreestandingFb(FbInfo *associatedFrameBuffer, BootScreen *associatedScreen);
 
 // ------------------------------------------------------------------------

--- a/kernel/thor/system/framebuffer/thor-internal/framebuffer/fb.hpp
+++ b/kernel/thor/system/framebuffer/thor-internal/framebuffer/fb.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <eir/interface.hpp>
 #include <thor-internal/address-space.hpp>
+#include <thor-internal/elf-notes.hpp>
 
 namespace thor {
 
@@ -11,9 +13,11 @@ struct FbInfo {
 	uint64_t height;
 	uint64_t bpp;
 	uint64_t type;
-	
+
 	smarter::shared_ptr<MemoryView> memory;
 };
+
+extern ManagarmElfNote<EirFramebuffer> framebufferNote;
 
 void initializeBootFb(uint64_t address, uint64_t pitch, uint64_t width,
 		uint64_t height, uint64_t bpp, uint64_t type, void *early_window);

--- a/kernel/thor/system/pci/pci_acpi.cpp
+++ b/kernel/thor/system/pci/pci_acpi.cpp
@@ -193,7 +193,7 @@ static initgraph::Task discoverConfigIoSpaces{&globalInitEngine, "pci.discover-a
 	initgraph::Requires{acpi::getTablesDiscoveredStage()},
 	initgraph::Entails{getBus0AvailableStage()},
 	[] {
-		if (!getEirInfo()->acpiRsdp)
+		if (!acpiRsdpNote->rsdp)
 			return;
 
 		uacpi_table mcfgTbl;
@@ -236,7 +236,7 @@ static initgraph::Task discoverAcpiRootBuses{&globalInitEngine, "pci.discover-ac
 	initgraph::Requires{getTaskingAvailableStage(), acpi::getNsAvailableStage()},
 	initgraph::Entails{getRootsDiscoveredStage()},
 	[] {
-		if (!getEirInfo()->acpiRsdp)
+		if (!acpiRsdpNote->rsdp)
 			return;
 
 		static const char *pciRootIds[] = {


### PR DESCRIPTION
This PR completes the transition from a fixed data structure to separate ELF notes.