### PR TITLE
posix: Make findProcessWithCredentials() fallible

### DIFF
--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -330,19 +330,24 @@ async::result<void> serveServerLane(helix::UniqueDescriptor lane) {
 			HEL_CHECK(recv_handle.error());
 
 			auto creds = helix_ng::CredentialsView{req.passthrough_credentials()};
-			auto process = findProcessWithCredentials(creds);
+			auto maybeProcess = findProcessWithCredentials(creds);
 
 			auto handle = helix::UniqueLane(recv_handle.descriptor());
 			auto dev_file = smarter::make_shared<PassthroughFile>(std::move(handle));
 			dev_file->setupWeakFile(dev_file);
 			auto file = File::constructHandle(std::move(dev_file));
 
-			auto fd = process->fileContext()->attachFile(file);
-			if (fd) {
-				resp.set_error(managarm::posix::Errors::SUCCESS);
-				resp.set_fd(fd.value());
+			if(!maybeProcess) {
+				std::cout << "posix: FD_SERVE with unknown process credentials" << std::endl;
+				resp.set_error(Error::badProcessCredentials | toPosixProtoError);
 			} else {
-				resp.set_error(fd.error() | toPosixProtoError);
+				auto fd = (*maybeProcess)->fileContext()->attachFile(file);
+				if (fd) {
+					resp.set_error(managarm::posix::Errors::SUCCESS);
+					resp.set_fd(fd.value());
+				} else {
+					resp.set_error(fd.error() | toPosixProtoError);
+				}
 			}
 
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,

--- a/posix/subsystem/src/devices/ttyn.cpp
+++ b/posix/subsystem/src/devices/ttyn.cpp
@@ -188,8 +188,18 @@ private:
 			HEL_CHECK(extractCreds.error());
 
 			auto creds = extractCreds.credentials();
-			auto process = findProcessWithCredentials(creds);
-			self->_controllingProcess = process;
+			auto maybeProcess = findProcessWithCredentials(creds);
+			if(!maybeProcess) {
+				std::cout << "posix: VT_SETMODE with unknown process credentials" << std::endl;
+				managarm::fs::VtSetModeResponse resp;
+				resp.set_error(Error::badProcessCredentials | protocols::fs::toFsProtoError | protocols::fs::toFsError);
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+						helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+				);
+				HEL_CHECK(send_resp.error());
+				co_return {};
+			}
+			self->_controllingProcess = *maybeProcess;
 
 			if(logVTRequests) {
 				std::println("posix: VT_SETMODE: \tmode: {}, waitv: {}, relsig: {}, acqsig: {}, frsig: {}",

--- a/posix/subsystem/src/file.cpp
+++ b/posix/subsystem/src/file.cpp
@@ -54,32 +54,48 @@ async::result<protocols::fs::ReadResult>
 File::ptRead(void *object, helix_ng::CredentialsView credentials,
 		void *buffer, size_t length, async::cancellation_token ce) {
 	auto self = static_cast<File *>(object);
-	auto process = findProcessWithCredentials(credentials);
-	co_return (co_await self->readSome(process.get(), buffer, length, ce))
+	auto maybeProcess = findProcessWithCredentials(credentials);
+	if(!maybeProcess) {
+		std::cout << "posix: ptRead with unknown process credentials" << std::endl;
+		co_return std::unexpected{Error::badProcessCredentials | protocols::fs::toFsProtoError};
+	}
+	co_return (co_await self->readSome(maybeProcess->get(), buffer, length, ce))
 		.transform_error(protocols::fs::toFsProtoError);
 }
 
 async::result<protocols::fs::ReadResult>
 File::ptPread(void *object, int64_t offset, helix_ng::CredentialsView credentials, void *buffer, size_t length) {
 	auto self = static_cast<File *>(object);
-	auto process = findProcessWithCredentials(credentials);
-	co_return (co_await self->pread(process.get(), offset, buffer, length))
+	auto maybeProcess = findProcessWithCredentials(credentials);
+	if(!maybeProcess) {
+		std::cout << "posix: ptPread with unknown process credentials" << std::endl;
+		co_return std::unexpected{Error::badProcessCredentials | protocols::fs::toFsProtoError};
+	}
+	co_return (co_await self->pread(maybeProcess->get(), offset, buffer, length))
 		.transform_error(protocols::fs::toFsProtoError);
 }
 
 async::result<frg::expected<protocols::fs::Error, size_t>> File::ptWrite(void *object, helix_ng::CredentialsView credentials,
 		const void *buffer, size_t length) {
 	auto self = static_cast<File *>(object);
-	auto process = findProcessWithCredentials(credentials);
-	co_return (co_await self->writeAll(process.get(), buffer, length))
+	auto maybeProcess = findProcessWithCredentials(credentials);
+	if(!maybeProcess) {
+		std::cout << "posix: ptWrite with unknown process credentials" << std::endl;
+		co_return Error::badProcessCredentials | protocols::fs::toFsProtoError;
+	}
+	co_return (co_await self->writeAll(maybeProcess->get(), buffer, length))
 		.map_error(protocols::fs::toFsProtoError);
 }
 
 async::result<frg::expected<protocols::fs::Error, size_t>> File::ptPwrite(void *object, int64_t offset, helix_ng::CredentialsView credentials,
 			const void *buffer, size_t length) {
 	auto self = static_cast<File *>(object);
-	auto process = findProcessWithCredentials(credentials);
-	auto result = co_await self->pwrite(process.get(), offset, buffer, length);
+	auto maybeProcess = findProcessWithCredentials(credentials);
+	if(!maybeProcess) {
+		std::cout << "posix: ptPwrite with unknown process credentials" << std::endl;
+		co_return Error::badProcessCredentials | protocols::fs::toFsProtoError;
+	}
+	auto result = co_await self->pwrite(maybeProcess->get(), offset, buffer, length);
 	if(!result) {
 		switch(result.error()) {
 		case Error::noSpaceLeft:
@@ -113,8 +129,12 @@ async::result<protocols::fs::Error> File::ptBind(void *object,
 		helix_ng::CredentialsView credentials,
 		const void *addr_ptr, size_t addr_length) {
 	auto self = static_cast<File *>(object);
-	auto process = findProcessWithCredentials(credentials);
-	return self->bind(process.get(), addr_ptr, addr_length);
+	auto maybeProcess = findProcessWithCredentials(credentials);
+	if(!maybeProcess) {
+		std::cout << "posix: ptBind with unknown process credentials" << std::endl;
+		co_return Error::badProcessCredentials | protocols::fs::toFsProtoError;
+	}
+	co_return co_await self->bind(maybeProcess->get(), addr_ptr, addr_length);
 }
 
 async::result<protocols::fs::Error> File::ptListen(void *object) {
@@ -125,8 +145,12 @@ async::result<protocols::fs::Error> File::ptListen(void *object) {
 async::result<protocols::fs::Error> File::ptConnect(void *object,
 		helix_ng::CredentialsView credentials, const void *addr, size_t addr_len) {
 	auto self = static_cast<File *>(object);
-	auto process = findProcessWithCredentials(credentials);
-	return self->connect(process.get(), addr, addr_len);
+	auto maybeProcess = findProcessWithCredentials(credentials);
+	if(!maybeProcess) {
+		std::cout << "posix: ptConnect with unknown process credentials" << std::endl;
+		co_return Error::badProcessCredentials | protocols::fs::toFsProtoError;
+	}
+	co_return co_await self->connect(maybeProcess->get(), addr, addr_len);
 }
 
 async::result<size_t> File::ptSockname(void *object, void *addr_ptr, size_t max_addr_length) {
@@ -171,8 +195,12 @@ File::ptRecvMsg(void *object, helix_ng::CredentialsView creds, uint32_t flags,
 		void *addr, size_t addr_len,
 		size_t max_ctrl_len) {
 	auto self = static_cast<File *>(object);
-	auto process = findProcessWithCredentials(creds);
-	return self->recvMsg(process.get(), flags,
+	auto maybeProcess = findProcessWithCredentials(creds);
+	if(!maybeProcess) {
+		std::cout << "posix: ptRecvMsg with unknown process credentials" << std::endl;
+		co_return Error::badProcessCredentials | protocols::fs::toFsProtoError;
+	}
+	co_return co_await self->recvMsg(maybeProcess->get(), flags,
 			data, len,
 			addr, addr_len,
 			max_ctrl_len);
@@ -184,7 +212,11 @@ File::ptSendMsg(void *object, helix_ng::CredentialsView creds, uint32_t flags,
 		void *addr, size_t addr_len,
 		std::vector<uint32_t> fds, struct ucred ucreds) {
 	auto self = static_cast<File *>(object);
-	auto process = findProcessWithCredentials(creds);
+	auto maybeProcess = findProcessWithCredentials(creds);
+	if(!maybeProcess) {
+		std::cout << "posix: ptSendMsg with unknown process credentials" << std::endl;
+		co_return Error::badProcessCredentials | protocols::fs::toFsProtoError;
+	}
 
 	if(flags & ~(MSG_DONTWAIT | MSG_CMSG_CLOEXEC | MSG_NOSIGNAL)) {
 		std::cout << "\e[31mposix: Unknown SENDMSG flags: 0x" << std::hex << flags
@@ -194,12 +226,12 @@ File::ptSendMsg(void *object, helix_ng::CredentialsView creds, uint32_t flags,
 
 	std::vector<smarter::shared_ptr<File, FileHandle>> files;
 	for(auto fd : fds) {
-		auto file = process->fileContext()->getFile(fd);
+		auto file = (*maybeProcess)->fileContext()->getFile(fd);
 		assert(file && "Illegal FD for SENDMSG cmsg");
 		files.push_back(std::move(file));
 	}
 
-	return self->sendMsg(process.get(), flags,
+	co_return co_await self->sendMsg(maybeProcess->get(), flags,
 			data, len,
 			addr, addr_len,
 			std::move(files), ucreds);
@@ -220,8 +252,12 @@ async::result<frg::expected<protocols::fs::Error>> File::ptSetSocketOption(void 
 async::result<frg::expected<protocols::fs::Error>> File::ptGetSocketOption(void *object,
 	helix_ng::CredentialsView creds, int layer, int number, std::vector<char> &optbuf) {
 	auto self = static_cast<File *>(object);
-	auto process = findProcessWithCredentials(creds);
-	co_return co_await self->getSocketOption(process.get(), layer, number, optbuf);
+	auto maybeProcess = findProcessWithCredentials(creds);
+	if(!maybeProcess) {
+		std::cout << "posix: ptGetSocketOption with unknown process credentials" << std::endl;
+		co_return Error::badProcessCredentials | protocols::fs::toFsProtoError;
+	}
+	co_return co_await self->getSocketOption(maybeProcess->get(), layer, number, optbuf);
 }
 
 async::result<protocols::fs::Error> File::ptShutdown(void *object, int how) {

--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -109,6 +109,10 @@ enum class Error {
 
 	// Corresponds with EBADF
 	badFileDescriptor,
+
+	// Credentials passed in a request did not match any known process.
+	// Maps to EIO.
+	badProcessCredentials,
 };
 
 inline protocols::fs::Error operator|(Error e, protocols::fs::ToFsProtoError) {
@@ -143,6 +147,7 @@ inline protocols::fs::Error operator|(Error e, protocols::fs::ToFsProtoError) {
 		case Error::noFileDescriptorsAvailable: return protocols::fs::Error::noFileDescriptorsAvailable;
 		case Error::notSupported: return protocols::fs::Error::notSupported;
 		case Error::badFileDescriptor: return protocols::fs::Error::badFileDescriptor;
+		case Error::badProcessCredentials: return protocols::fs::Error::internalError;
 		default:
 			std::cout << std::format("posix: unmapped Error {}", static_cast<int>(e)) << std::endl;
 			return protocols::fs::Error::internalError;
@@ -181,6 +186,7 @@ inline managarm::posix::Errors operator|(Error e, ToPosixProtoError) {
 		case Error::noSuchProcess: return managarm::posix::Errors::NO_SUCH_RESOURCE;
 		case Error::noFileDescriptorsAvailable: return managarm::posix::Errors::NO_FILE_DESCRIPTORS_AVAILABLE;
 		case Error::notSupported: return managarm::posix::Errors::NOT_SUPPORTED;
+		case Error::badProcessCredentials: return managarm::posix::Errors::INTERNAL_ERROR;
 		case Error::fileClosed:
 		case Error::badExecutable:
 		case Error::seekOnPipe:

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -48,10 +48,13 @@ std::map<
 	Process *
 > globalCredentialsMap;
 
-std::shared_ptr<Process> findProcessWithCredentials(helix_ng::CredentialsView credentials) {
+std::optional<std::shared_ptr<Process>> findProcessWithCredentials(helix_ng::CredentialsView credentials) {
 	std::array<char, 16> creds;
 	memcpy(creds.data(), credentials.data(), 16);
-	return globalCredentialsMap.at(creds)->shared_from_this();
+	auto it = globalCredentialsMap.find(creds);
+	if(it == globalCredentialsMap.end())
+		return std::nullopt;
+	return it->second->shared_from_this();
 }
 
 async::result<void> serveSignals(std::shared_ptr<Process> self,

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -734,7 +734,7 @@ private:
 	std::array<char, 16> credentials_{};
 };
 
-std::shared_ptr<Process> findProcessWithCredentials(helix_ng::CredentialsView);
+std::optional<std::shared_ptr<Process>> findProcessWithCredentials(helix_ng::CredentialsView);
 
 struct ThreadGroup : std::enable_shared_from_this<ThreadGroup> {
 	friend struct Process;

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -652,7 +652,20 @@ Channel::commonIoctl(managarm::fs::GenericIoctlRequest req, helix::BorrowedDescr
 		HEL_CHECK(extractCreds.error());
 
 		auto creds = extractCreds.credentials();
-		auto process = findProcessWithCredentials(creds);
+		auto maybeProcess = findProcessWithCredentials(creds);
+		if(!maybeProcess) {
+			std::cout << "posix: TIOCSCTTY with unknown process credentials" << std::endl;
+			managarm::fs::GenericIoctlReply resp;
+			resp.set_error(Error::badProcessCredentials | protocols::fs::toFsProtoError | protocols::fs::toFsError);
+			auto ser = resp.SerializeAsString();
+			auto [sendResp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBuffer(ser.data(), ser.size())
+			);
+			HEL_CHECK(sendResp.error());
+			co_return;
+		}
+		auto process = *maybeProcess;
 
 		managarm::fs::GenericIoctlReply resp;
 		if(auto e = cts.assignSessionOf(process.get()); e == Error::illegalArguments) {
@@ -681,7 +694,18 @@ Channel::commonIoctl(managarm::fs::GenericIoctlRequest req, helix::BorrowedDescr
 		HEL_CHECK(extractCreds.error());
 
 		auto creds = extractCreds.credentials();
-		auto process = findProcessWithCredentials(creds);
+		auto maybeProcess = findProcessWithCredentials(creds);
+		if(!maybeProcess) {
+			std::cout << "posix: TIOCNOTTY with unknown process credentials" << std::endl;
+			resp.set_error(Error::badProcessCredentials | protocols::fs::toFsProtoError | protocols::fs::toFsError);
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
+			HEL_CHECK(send_resp.error());
+			co_return;
+		}
+		auto process = *maybeProcess;
 
 		if(&cts != process->pgPointer()->getSession()->getControllingTerminal()) {
 			resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
@@ -709,7 +733,19 @@ Channel::commonIoctl(managarm::fs::GenericIoctlRequest req, helix::BorrowedDescr
 		HEL_CHECK(extractCreds.error());
 
 		auto creds = extractCreds.credentials();
-		auto process = findProcessWithCredentials(creds);
+		auto maybeProcess = findProcessWithCredentials(creds);
+		if(!maybeProcess) {
+			std::cout << "posix: TIOCGPGRP with unknown process credentials" << std::endl;
+			resp.set_error(Error::badProcessCredentials | protocols::fs::toFsProtoError | protocols::fs::toFsError);
+			auto ser = resp.SerializeAsString();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBuffer(ser.data(), ser.size())
+			);
+			HEL_CHECK(send_resp.error());
+			co_return;
+		}
+		auto process = *maybeProcess;
 
 		if(&cts != process->pgPointer()->getSession()->getControllingTerminal()) {
 			resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);
@@ -753,7 +789,17 @@ Channel::commonIoctl(managarm::fs::GenericIoctlRequest req, helix::BorrowedDescr
 		}
 
 		auto creds = extractCreds.credentials();
-		auto process = findProcessWithCredentials(creds);
+		auto maybeProcess = findProcessWithCredentials(creds);
+		if(!maybeProcess) {
+			std::cout << "posix: TIOCSPGRP with unknown process credentials" << std::endl;
+			resp.set_error(Error::badProcessCredentials | protocols::fs::toFsProtoError | protocols::fs::toFsError);
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation, helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{})
+			);
+			HEL_CHECK(send_resp.error());
+			co_return;
+		}
+		auto process = *maybeProcess;
 		if (!cts.getSession()
 				|| process->pgPointer()->getSession()->getSessionId()
 						!= cts.getSession()->getSessionId()
@@ -810,7 +856,19 @@ Channel::commonIoctl(managarm::fs::GenericIoctlRequest req, helix::BorrowedDescr
 		HEL_CHECK(extractCreds.error());
 
 		auto creds = extractCreds.credentials();
-		auto process = findProcessWithCredentials(creds);
+		auto maybeProcess = findProcessWithCredentials(creds);
+		if(!maybeProcess) {
+			std::cout << "posix: TIOCGSID with unknown process credentials" << std::endl;
+			resp.set_error(Error::badProcessCredentials | protocols::fs::toFsProtoError | protocols::fs::toFsError);
+			auto ser = resp.SerializeAsString();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBuffer(ser.data(), ser.size())
+			);
+			HEL_CHECK(send_resp.error());
+			co_return;
+		}
+		auto process = *maybeProcess;
 
 		if(&cts != process->pgPointer()->getSession()->getControllingTerminal()) {
 			resp.set_error(managarm::fs::Errors::NOT_A_TERMINAL);

--- a/posix/subsystem/src/util.cpp
+++ b/posix/subsystem/src/util.cpp
@@ -35,6 +35,7 @@ std::ostream& operator<<(std::ostream& os, const Error& err) {
 		case Error::noFileDescriptorsAvailable: err_string = "noFileDescriptorsAvailable"; break;
 		case Error::notSupported: err_string = "notSupported"; break;
 		case Error::badFileDescriptor: err_string = "badFileDescriptor"; break;
+		case Error::badProcessCredentials: err_string = "badProcessCredentials"; break;
 	}
 
 	return os << err_string;


### PR DESCRIPTION
Fixes posix-subsystem crashes in case a process w/o credentials is able to do a POSIX request. This was reported by @Qwinci .