### PR TITLE
eir, thor: Inital ACPI support for aarch64

### DIFF
--- a/kernel/eir/arch/arm/platform/raspi4/raspi4.cpp
+++ b/kernel/eir/arch/arm/platform/raspi4/raspi4.cpp
@@ -252,6 +252,9 @@ static initgraph::Task setupFramebuffer{
     initgraph::Requires{getCmdlineAvailableStage()},
     initgraph::Entails{getFramebufferAvailableStage()},
     [] {
+	    if (!eirDtbPtr)
+		    return;
+
 	    DeviceTree dt{physToVirt<void>(eirDtbPtr)};
 	    auto rootNode = dt.rootNode();
 

--- a/kernel/eir/boot/limine/entry.cpp
+++ b/kernel/eir/boot/limine/entry.cpp
@@ -146,8 +146,6 @@ extern "C" void eirLimineMain(void) {
 	if (dtb_request.response) {
 		eir::infoLogger() << "DTB accessible at " << dtb_request.response->dtb_ptr << frg::endlog;
 		eirDtbPtr = virtToPhys(dtb_request.response->dtb_ptr);
-	} else {
-		eir::infoLogger() << "Limine did not pass a DTB" << frg::endlog;
 	}
 
 	assert(executable_file_request.response);
@@ -161,7 +159,7 @@ extern "C" void eirLimineMain(void) {
 	kernel_physical = executable_address_request.response->physical_base;
 
 	// Enter a stack that is part of Eir's image.
-	// This ensures that we can still access the stack when paging in enabled.
+	// This ensures that we can still access the stack when paging is enabled.
 	runOnStack([] { eirMain(); }, eirStackTop);
 }
 

--- a/kernel/eir/system/acpi/acpi.cpp
+++ b/kernel/eir/system/acpi/acpi.cpp
@@ -1,11 +1,13 @@
 #include <eir-internal/acpi/acpi.hpp>
 #include <eir-internal/main.hpp>
+#include <uacpi/context.h>
 #include <uacpi/uacpi.h>
 
 namespace eir::acpi {
 
 namespace {
 
+[[gnu::aligned(alignof(uintptr_t))]]
 constinit std::array<uint8_t, 4096> earlyTableBuffer{};
 constinit bool haveTablesFlag{false};
 

--- a/kernel/eir/system/acpi/console.cpp
+++ b/kernel/eir/system/acpi/console.cpp
@@ -56,7 +56,10 @@ initgraph::Task parseSpcrDbg2{
 
 		    if (!std::holds_alternative<std::monostate>(acpiUart)) {
 			    acpiUartLogHandler.initialize(&acpiUart);
-			    enableLogHandler(acpiUartLogHandler.get());
+
+			    // If we can't access physical memory directly, we need to skip the logger.
+			    if (!physOffset)
+				    enableLogHandler(acpiUartLogHandler.get());
 			    uart::setBootUart(&acpiUart);
 			    return;
 		    }

--- a/kernel/eir/system/acpi/cpu-count.cpp
+++ b/kernel/eir/system/acpi/cpu-count.cpp
@@ -4,6 +4,7 @@
 #include <eir-internal/generic.hpp>
 #include <eir-internal/main.hpp>
 #include <frg/cmdline.hpp>
+#include <frg/scope_exit.hpp>
 #include <uacpi/acpi.h>
 #include <uacpi/tables.h>
 
@@ -30,6 +31,7 @@ initgraph::Task detectCpusFromMadt{
 		    infoLogger() << "eir: No MADT found" << frg::endlog;
 		    return;
 	    }
+	    frg::scope_exit finish{[&] { uacpi_table_unref(&madtTbl); }};
 	    auto *madt = madtTbl.hdr;
 
 	    size_t cpuCount = 0;
@@ -51,6 +53,14 @@ initgraph::Task detectCpusFromMadt{
 				    acpi_madt_x2apic entry;
 				    memcpy(&entry, genericPtr, sizeof(entry));
 				    if (entry.flags & ACPI_PIC_ENABLED)
+					    ++cpuCount;
+			    } break;
+#endif
+#ifdef __aarch64__
+			    case ACPI_MADT_ENTRY_TYPE_GICC: {
+				    acpi_madt_gicc entry;
+				    memcpy(&entry, genericPtr, sizeof(entry));
+				    if (entry.flags & ACPI_GICC_ENABLED)
 					    ++cpuCount;
 			    } break;
 #endif

--- a/kernel/thor/arch/arm/cpu.cpp
+++ b/kernel/thor/arch/arm/cpu.cpp
@@ -12,6 +12,10 @@ namespace thor {
 extern "C" void saveFpSimdRegisters(FpRegisters *frame);
 extern "C" void restoreFpSimdRegisters(FpRegisters *frame);
 
+uint32_t affinityFromMpidr(uint64_t mpidr) {
+	return (mpidr & 0xFFFFFF) | ((mpidr >> 32) & 0xFF) << 24;
+}
+
 bool FaultImageAccessor::allowUserPages() {
 	return true;
 }
@@ -251,7 +255,7 @@ void initializeThisProcessor() {
 
 	uint64_t mpidr;
 	asm volatile("mrs %0, mpidr_el1" : "=r"(mpidr));
-	cpu_data->affinity = (mpidr & 0xFFFFFF) | (mpidr >> 32 & 0xFF) << 24;
+	cpu_data->affinity = affinityFromMpidr(mpidr);
 
 	cpu_data->detachedStack = UniqueKernelStack::make();
 	cpu_data->idleStack = UniqueKernelStack::make();

--- a/kernel/thor/arch/arm/gic.cpp
+++ b/kernel/thor/arch/arm/gic.cpp
@@ -1,3 +1,7 @@
+#include <frg/optional.hpp>
+#include <frg/scope_exit.hpp>
+#include <frg/vector.hpp>
+#include <thor-internal/acpi/acpi.hpp>
 #include <thor-internal/arch/gic.hpp>
 #include <thor-internal/arch/gic_v2.hpp>
 #include <thor-internal/arch/gic_v3.hpp>
@@ -8,19 +12,140 @@
 #include <thor-internal/schedule.hpp>
 #include <thor-internal/thread.hpp>
 #include <thor-internal/traps.hpp>
+#include <uacpi/acpi.h>
+#include <uacpi/tables.h>
 
 namespace thor {
+
+namespace {
+
+void installAcpiGsiPins() {
+	std::visit(
+	    frg::overloaded{
+	        [](Gic *gic) {
+		        for (uint32_t irq = 32; irq < gic->irqCount(); ++irq) {
+			        auto pin = gic->getPin(irq);
+			        if (pin)
+				        acpi::setGlobalSystemIrq(irq, pin);
+		        }
+	        },
+	        [](std::monostate) {}
+	    },
+	    externalIrq
+	);
+}
+
+struct AcpiGicInfo {
+	uint32_t bspAffinity;
+	frg::optional<acpi_madt_gicd> gicd;
+	uintptr_t cpuInterface{0};
+	frg::vector<GicRedistributorRange, KernelAlloc> gicrRanges{*kernelAlloc};
+	frg::vector<GicRedistributorRange, KernelAlloc> giccRedistRanges{*kernelAlloc};
+};
+
+uacpi_iteration_decision handleMadtGicEntry(uacpi_handle opaque, acpi_entry_hdr *genericPtr) {
+	auto *info = static_cast<AcpiGicInfo *>(opaque);
+
+	switch (genericPtr->type) {
+		case ACPI_MADT_ENTRY_TYPE_GICD: {
+			acpi_madt_gicd entry;
+			memcpy(&entry, genericPtr, sizeof(entry));
+			info->gicd = entry;
+		} break;
+		case ACPI_MADT_ENTRY_TYPE_GICC: {
+			acpi_madt_gicc entry;
+			memcpy(&entry, genericPtr, sizeof(entry));
+			if (!(entry.flags & ACPI_GICC_ENABLED))
+				break;
+
+			if (affinityFromMpidr(entry.mpidr) == info->bspAffinity)
+				info->cpuInterface = entry.address;
+			if (entry.gicr_base_address)
+				info->giccRedistRanges.push({entry.gicr_base_address, 0x20000});
+		} break;
+		case ACPI_MADT_ENTRY_TYPE_GICR: {
+			acpi_madt_gicr entry;
+			memcpy(&entry, genericPtr, sizeof(entry));
+			info->gicrRanges.push({entry.address, entry.length});
+		} break;
+		default:
+			break;
+	}
+
+	return UACPI_ITERATION_DECISION_CONTINUE;
+}
+
+bool initGicFromAcpi() {
+	uacpi_table madtTbl;
+	if (uacpi_table_find_by_signature("APIC", &madtTbl) != UACPI_STATUS_OK)
+		return false;
+	frg::scope_exit finish{[&] { uacpi_table_unref(&madtTbl); }};
+
+	AcpiGicInfo info{.bspAffinity = getCpuData()->affinity};
+	if (uacpi_for_each_subtable(madtTbl.hdr, sizeof(acpi_madt), handleMadtGicEntry, &info)
+	    != UACPI_STATUS_OK) {
+		warningLogger() << "thor: Failed to parse the ACPI MADT" << frg::endlog;
+		return false;
+	}
+
+	auto &gicd = info.gicd;
+	auto &gicrRanges = info.gicrRanges;
+	auto &giccRedistRanges = info.giccRedistRanges;
+
+	if (!gicd) {
+		warningLogger() << "thor: ACPI MADT has no GIC distributor" << frg::endlog;
+		return false;
+	}
+
+	auto version = gicd->gic_version;
+	if (!version)
+		version = (gicrRanges.size() || giccRedistRanges.size()) ? 3 : 2;
+
+	if (version >= 3) {
+		if (gicrRanges.size())
+			return initGicV3FromAcpi(
+			    gicd->address,
+			    0x10000,
+			    frg::span<const GicRedistributorRange>{gicrRanges.data(), gicrRanges.size()}
+			);
+		return initGicV3FromAcpi(
+		    gicd->address,
+		    0x10000,
+		    frg::span<const GicRedistributorRange>{giccRedistRanges.data(), giccRedistRanges.size()}
+		);
+	}
+
+	if (!info.cpuInterface) {
+		warningLogger() << "thor: ACPI MADT has no BSP GICC CPU interface" << frg::endlog;
+		return false;
+	}
+
+	return initGicV2FromAcpi(gicd->address, info.cpuInterface, 0x2000);
+}
+
+} // namespace
 
 static initgraph::Task initGic{
     &globalInitEngine,
     "arm.init-gic",
-    initgraph::Requires{getDeviceTreeParsedStage(), getBootProcessorReadyStage()},
+    initgraph::Requires{
+        acpi::getTablesDiscoveredStage(), getDeviceTreeParsedStage(), getBootProcessorReadyStage()
+    },
     initgraph::Entails{getIrqControllerReadyStage()},
     // Initialize the GIC.
     [] {
-	    if (initGicV2() || initGicV3()) {
+	    // Take either the ACPI or the device tree code path, never both.
+	    if (acpiRsdpNote->rsdp) {
+		    if (!initGicFromAcpi())
+			    panicLogger() << "thor: Failed to initialize the GIC from ACPI" << frg::endlog;
+
 		    initGicOnThisCpu();
+		    installAcpiGsiPins();
+		    return;
 	    }
+
+	    if (initGicV2() || initGicV3())
+		    initGicOnThisCpu();
     }
 };
 

--- a/kernel/thor/arch/arm/gic_v2.cpp
+++ b/kernel/thor/arch/arm/gic_v2.cpp
@@ -154,8 +154,12 @@ auto GicDistributorV2::setupIrq(uint32_t irq, TriggerMode trigger) -> Pin * {
 	return pin;
 }
 
-IrqStrategy GicDistributorV2::Pin::program(TriggerMode mode, Polarity polarity) {
-	bool success = setMode(mode, polarity);
+uint32_t GicDistributorV2::irqCount() const {
+	return irqPins_.size();
+}
+
+IrqStrategy GicDistributorV2::Pin::program(TriggerMode mode, Polarity) {
+	bool success = setMode(mode);
 	assert(success);
 
 	if (irq_ >= 32)
@@ -217,14 +221,11 @@ void GicDistributorV2::Pin::setPriority_(uint8_t prio) {
 			dist_reg::irqPriorityBase + regOff, v);
 }
 
-bool GicDistributorV2::Pin::setMode(TriggerMode trigger, Polarity polarity) {
+bool GicDistributorV2::Pin::setMode(TriggerMode trigger) {
 	uintptr_t i = irq_ / 16;
 	uintptr_t j = (irq_ % 16) * 2;
 
 	if (irq_ < 16)
-		return false;
-
-	if (polarity == Polarity::low)
 		return false;
 
 	auto v = arch::scalar_load_relaxed<uint32_t>(parent_->space_,
@@ -376,8 +377,12 @@ static uintptr_t cpuInterfaceAddr;
 static uintptr_t cpuInterfaceSize;
 
 bool initGicV2() {
+	auto root = getDeviceTreeRoot();
+	if (!root)
+		return false;
+
 	DeviceTreeNode *gicNode = nullptr;
-	getDeviceTreeRoot()->forEach([&](DeviceTreeNode *node) -> bool {
+	root->forEach([&](DeviceTreeNode *node) -> bool {
 		if (node->isCompatible(dtGicV2Compatible)) {
 			gicNode = node;
 			return true;
@@ -405,6 +410,21 @@ bool initGicV2() {
 	return true;
 }
 
+bool initGicV2FromAcpi(uintptr_t distributor, uintptr_t cpuInterface, size_t interfaceSize) {
+	infoLogger() << "thor: found ACPI GICv2 distributor at " << frg::hex_fmt{distributor}
+	             << frg::endlog;
+
+	dist.initialize(distributor);
+	dist->init();
+
+	cpuInterfaceAddr = cpuInterface;
+	cpuInterfaceSize = interfaceSize;
+
+	externalIrq = &gicV2;
+
+	return true;
+}
+
 void initGicOnThisCpuV2() {
 	auto cpuData = getCpuData();
 
@@ -420,6 +440,10 @@ void initGicOnThisCpuV2() {
 
 void GicV2::sendIpi(int cpuId, uint8_t id) {
 	dist->sendIpi(getCpuData(cpuId)->gicCpuInterfaceV2->interfaceNumber(), id);
+}
+
+void GicV2::sendIpiToInterface(uint8_t ifaceNo, uint8_t id) {
+	dist->sendIpi(ifaceNo, id);
 }
 
 void GicV2::sendIpiToOthers(uint8_t id) {
@@ -450,5 +474,8 @@ Gic::Pin *GicV2::getPin(uint32_t irq) {
 	return dist->getPin(irq);
 }
 
+uint32_t GicV2::irqCount() {
+	return dist->irqCount();
+}
 
 } // namespace thor

--- a/kernel/thor/arch/arm/gic_v3.cpp
+++ b/kernel/thor/arch/arm/gic_v3.cpp
@@ -30,6 +30,7 @@ static constexpr uint8_t defaultPrio = 0xA0;
 namespace dist_reg {
 	static constexpr arch::bit_register<uint32_t> control{0x0};
 	static constexpr arch::bit_register<uint32_t> type{0x4};
+	static constexpr arch::bit_register<uint32_t> pidr2{0xffe8};
 
 	static constexpr uintptr_t irqGroupBase = 0x80;
 	static constexpr uintptr_t irqConfigBase = 0xC00;
@@ -54,6 +55,12 @@ namespace dist_type {
 	static constexpr arch::field<uint32_t, bool> securityExtensions{10, 1};
 }
 
+namespace dist_pidr2 {
+	static constexpr arch::field<uint32_t, uint8_t> arch{4, 4};
+	static constexpr uint8_t arch_gicv3 = 3;
+	static constexpr uint8_t arch_gicv4 = 4;
+}
+
 namespace dist_router {
 	static constexpr arch::field<uint64_t, uint8_t> aff0{0, 8};
 	static constexpr arch::field<uint64_t, uint8_t> aff1{8, 8};
@@ -64,7 +71,10 @@ namespace dist_router {
 namespace redist_reg {
 	static constexpr arch::bit_register<uint64_t> type{0x8};
 	static constexpr arch::bit_register<uint32_t> waker{0x14};
+	static constexpr arch::bit_register<uint32_t> pidr2{dist_reg::pidr2};
 }
+
+namespace redist_pidr2 = dist_pidr2;
 
 namespace redist_waker {
 	static constexpr arch::field<uint32_t, bool> processorSleep{1, 1};
@@ -72,6 +82,7 @@ namespace redist_waker {
 }
 
 namespace redist_type {
+	static constexpr arch::field<uint64_t, bool> vlpis{1, 1};
 	static constexpr arch::field<uint64_t, bool> last{4, 1};
 	static constexpr arch::field<uint64_t, uint32_t> affinity{32, 32};
 }
@@ -153,11 +164,8 @@ bool GicRedistributorV3::ownedBy(uint32_t affinity) const {
 	return (space_.load_relaxed(redist_reg::type) & redist_type::affinity) == affinity;
 }
 
-bool GicPinV3::setMode(TriggerMode trigger, Polarity polarity) {
+bool GicPinV3::setMode(TriggerMode trigger) {
 	if(irq_ < 16)
-		return false;
-
-	if(polarity == Polarity::low)
 		return false;
 
 	auto bitOffset = irq_ % 16 * 2;
@@ -186,8 +194,8 @@ bool GicPinV3::setMode(TriggerMode trigger, Polarity polarity) {
 	return true;
 }
 
-IrqStrategy GicPinV3::program(TriggerMode mode, Polarity polarity) {
-	bool success = setMode(mode, polarity);
+IrqStrategy GicPinV3::program(TriggerMode mode, Polarity) {
+	bool success = setMode(mode);
 	assert(success);
 
 	if(irq_ >= 32)
@@ -250,9 +258,61 @@ void GicPinV3::setPriority_(uint8_t priority) {
 	arch::scalar_store_relaxed(space, dist_reg::irqPriorityBase + offset, value);
 }
 
+void addRedistRange(uintptr_t address, size_t size) {
+	auto redistPtr = KernelVirtualMemory::global().allocate(size);
+	for(size_t i = 0; i < size; i += kPageSize) {
+		KernelPageSpace::global().mapSingle4k(VirtualAddr(redistPtr) + i, address + i,
+				page_access::write, CachingMode::mmio);
+	}
+
+	auto redistCount = size / 0x20000;
+	size_t offset = 0;
+
+	for(size_t i = 0; i < redistCount; ++i) {
+		arch::mem_space space{(void *)(VirtualAddr(redistPtr) + offset)};
+
+		// Check if we have a redistributor.
+		auto pidr2 = space.load_relaxed(redist_reg::pidr2);
+		uint8_t arch = pidr2 & redist_pidr2::arch;
+		if(arch != redist_pidr2::arch_gicv3 && arch != redist_pidr2::arch_gicv4) {
+			warningLogger() << "No redistributor present" << frg::endlog;
+			break;
+		}
+
+		auto type = space.load_relaxed(redist_reg::type);
+		uint32_t redistAff = type & redist_type::affinity;
+		bool vlpis = type & redist_type::vlpis;
+		bool last = type & redist_type::last;
+
+		infoLogger() << "thor: GIC redistributor at " << frg::hex_fmt{address + offset}
+		             << " affinity " << frg::hex_fmt{redistAff}
+		             << (vlpis ? " vlpi" : "")
+		             << (last ? " last" : "") << frg::endlog;
+
+		redists->emplace_back(space);
+
+		if(last)
+			break;
+
+		// Skip RD_base and SGI_base.
+		offset += 0x20000;
+
+		// If VLPIS is present, skip the VLPI_base and reserved space.
+		if(vlpis)
+			offset += 0x20000;
+
+		if(offset >= size)
+			break;
+	}
+}
+
 bool initGicV3() {
+	auto root = getDeviceTreeRoot();
+	if (!root)
+		return false;
+
 	DeviceTreeNode *gicNode = nullptr;
-	getDeviceTreeRoot()->forEach([&](DeviceTreeNode *node) -> bool {
+	root->forEach([&](DeviceTreeNode *node) -> bool {
 		if(node->isCompatible(dtGicV3Compatible)) {
 			gicNode = node;
 			return true;
@@ -270,33 +330,43 @@ bool initGicV3() {
 	auto reg = gicNode->reg();
 	dist.initialize(reg[0].addr, reg[0].size);
 
-
-	auto redistPtr = KernelVirtualMemory::global().allocate(reg[1].size);
-	for(size_t i = 0; i < reg[1].size; i += kPageSize) {
-		KernelPageSpace::global().mapSingle4k(VirtualAddr(redistPtr) + i, reg[1].addr + i,
-				page_access::write, CachingMode::mmio);
-	}
-
-	auto redistCount = reg[1].size / 0x20000;
 	redists.initialize(*kernelAlloc);
+	addRedistRange(reg[1].addr, reg[1].size);
 
-	for(size_t i = 0; i < redistCount; ++i) {
-		arch::mem_space space{(void *)(VirtualAddr(redistPtr) + i * 0x20000)};
-		redists->emplace_back(space);
+	dist->init();
 
-		if(space.load_relaxed(redist_reg::type) & redist_type::last)
-			break;
+	gicV3.initialize();
+
+	externalIrq = gicV3.get();
+
+	gicNode->associateIrqController(gicV3.get());
+
+	return true;
+}
+
+bool initGicV3FromAcpi(
+    uintptr_t distributor,
+    size_t distributorSize,
+    frg::span<const GicRedistributorRange> redistributorRanges
+) {
+	infoLogger() << "thor: found ACPI GICv3 distributor at " << frg::hex_fmt{distributor}
+	             << frg::endlog;
+
+	dist.initialize(distributor, distributorSize);
+
+	redists.initialize(*kernelAlloc);
+	for (auto range : redistributorRanges)
+		addRedistRange(range.address, range.size);
+
+	if (!redists->size()) {
+		warningLogger() << "thor: ACPI GICv3 has no redistributor ranges" << frg::endlog;
+		return false;
 	}
 
 	dist->init();
 
 	gicV3.initialize();
-	
 	externalIrq = gicV3.get();
-
-	initGicOnThisCpuV3();
-
-	gicNode->associateIrqController(gicV3.get());
 
 	return true;
 }
@@ -425,6 +495,10 @@ Gic::Pin *GicV3::getPin(uint32_t irq) {
 		return nullptr;
 
 	return irqPins_[irq];
+}
+
+uint32_t GicV3::irqCount() {
+	return irqPins_.size();
 }
 
 }

--- a/kernel/thor/arch/arm/meson.build
+++ b/kernel/thor/arch/arm/meson.build
@@ -50,3 +50,4 @@ link_args += [ '-z', 'max-page-size=0x1000' ]
 args += [ '-mgeneral-regs-only', '-mno-red-zone' ]
 
 want_dtb = true
+want_acpi = true

--- a/kernel/thor/arch/arm/smp.cpp
+++ b/kernel/thor/arch/arm/smp.cpp
@@ -1,4 +1,11 @@
+#include <frg/scope_exit.hpp>
+#include <frg/utility.hpp>
+#include <stddef.h>
+#include <thor-internal/acpi/acpi.hpp>
+#include <thor-internal/arch/cpu.hpp>
 #include <thor-internal/arch/gic.hpp>
+#include <thor-internal/arch/gic_v2.hpp>
+#include <thor-internal/arch/gic_v3.hpp>
 #include <thor-internal/arch/timer.hpp>
 #include <thor-internal/arch/trap.hpp>
 #include <thor-internal/dtb/dtb.hpp>
@@ -11,6 +18,8 @@
 #include <thor-internal/fiber.hpp>
 #include <thor-internal/load-balancing.hpp>
 #include <thor-internal/rcu.hpp>
+#include <uacpi/acpi.h>
+#include <uacpi/tables.h>
 
 namespace thor {
 
@@ -29,7 +38,29 @@ namespace {
 		CpuData *cpuContext;
 	};
 
+	enum class EnableMethod {
+		unknown,
+		spinTable,
+		parkingProtocol,
+		psci
+	};
+
+	constexpr size_t parkingMailboxCpuId = 0;
+	constexpr size_t parkingMailboxEntryPoint = 8;
+
+	constexpr uint32_t parkingMailboxInvalidCpuId = 0xFFFFFFFF;
+
+	struct EnableInfo {
+		EnableMethod method{EnableMethod::unknown};
+		uint64_t releaseAddress{0};
+		uint32_t cpuInterfaceNumber{0};
+	};
+
+	constexpr uint32_t psciIdCpuOn64 = 0xC4000003;
+
 	struct Psci {
+		Psci(bool usesHvc) : cpuOn_{psciIdCpuOn64}, usesHvc_{usesHvc} {}
+
 		Psci(DeviceTreeNode *node) {
 			auto methodProp = node->dtNode().findProperty("method");
 			if (!methodProp)
@@ -42,7 +73,7 @@ namespace {
 
 			auto onProp = node->dtNode().findProperty("cpu-on");
 			if (!onProp) {
-				cpuOn_ = 0xC4000003;
+				cpuOn_ = psciIdCpuOn64;
 			} else {
 				auto it = onProp->access();
 				if (!it.readCells(cpuOn_, 1))
@@ -71,6 +102,36 @@ namespace {
 	};
 
 	frg::manual_box<Psci> psci_;
+
+	bool hasAcpiField(size_t length, size_t offset, size_t size) {
+		return offset <= length && size <= length - offset;
+	}
+
+	template <typename T>
+	bool copyAcpiEntry(T *entry, const void *ptr, size_t length, size_t requiredLength) {
+		memset(entry, 0, sizeof(T));
+		if (length < requiredLength)
+			return false;
+
+		memcpy(entry, ptr, frg::min(sizeof(T), length));
+		return true;
+	}
+
+	void sendParkingWakeupIpi(size_t cpuIndex, uint32_t cpuInterfaceNumber) {
+		std::visit(
+		    frg::overloaded{
+		        [&](GicV2 *gic) {
+			        gic->sendIpiToInterface(static_cast<uint8_t>(cpuInterfaceNumber), 0);
+		        },
+		        [&](GicV3 *gic) { gic->sendIpi(static_cast<int>(cpuIndex), 0); },
+		        [](std::monostate) {
+			        panicLogger() << "thor: Cannot wake up parked CPUs without a GIC"
+			                      << frg::endlog;
+		        }
+		    },
+		    externalIrq
+		);
+	}
 
 	void secondaryMain(StatusBlock *statusBlock) {
 		initializeIrqVectors();
@@ -102,41 +163,15 @@ namespace {
 	}
 }
 
-bool bootSecondary(DeviceTreeNode *node, size_t cpuIndex) {
-	infoLogger() << "thor: Starting CPU \"" << node->path() << "\"" << frg::endlog;
-	uint64_t id = node->reg()[0].addr;
-
-	auto methodProp = node->dtNode().findProperty("enable-method");
-	if (!methodProp)
-		panicLogger() << node->path() << " has no enable-method" << frg::endlog;
-
-	enum class EnableMethod {
-		unknown,
-		spinTable,
-		psci
-	} method = EnableMethod::unknown;
-
-	size_t i = 0;
-	while (i < methodProp->size()) {
-		frg::string_view sv{reinterpret_cast<const char *>(methodProp->data()) + i};
-		i += sv.size() + 1;
-
-		if (sv == "psci")
-			method = EnableMethod::psci;
-		else if (sv == "spin-table")
-			method = EnableMethod::spinTable;
-	}
-
-	if (method == EnableMethod::unknown) {
-		infoLogger() << "thor: We don't know how to start this CPU" << frg::endlog;
-		return false;
-	}
+bool bootSecondary(uint64_t id, size_t cpuIndex, EnableInfo enable) {
+	infoLogger() << "thor: Starting CPU with MPIDR " << frg::hex_fmt{id} << frg::endlog;
 
 	// Allocate a stack for the initialization code.
 	constexpr size_t stackSize = 0x10000;
 	void *stackPtr = kernelAlloc->allocate(stackSize);
 
 	auto *context = getCpuData(cpuIndex);
+	context->affinity = affinityFromMpidr(id);
 
 	// Participate in global TLB invalidation *before* paging is used by the target CPU.
 	initializeAsidContext(context);
@@ -170,26 +205,15 @@ bool bootSecondary(DeviceTreeNode *node, size_t cpuIndex) {
 	statusBlock->stack = (uintptr_t)stackPtr + stackSize;
 	statusBlock->main = &secondaryMain;
 	statusBlock->cpuContext = context;
-	statusBlock->cpuId = id;
+	statusBlock->cpuId = static_cast<int>(cpuIndex);
 
 	bool dontWait = false;
 
-	switch(method) {
+	switch(enable.method) {
 		case EnableMethod::spinTable: {
 			infoLogger() << "thor: This CPU uses a spin-table" << frg::endlog;
 
-
-			auto addrProp = node->dtNode().findProperty("cpu-release-addr");
-			if (!addrProp)
-				panicLogger() << node->path() << " has no cpu-release-addr" << frg::endlog;
-
-			uint64_t ptr;
-			auto it = addrProp->access();
-			if(!it.readCells(ptr, 2)) {
-				if(!it.readCells(ptr, 1)) {
-					panicLogger() << node->path() << " has an empty cpu-release-addr" << frg::endlog;
-				}
-			}
+			uint64_t ptr = enable.releaseAddress;
 
 			infoLogger() << "thor: Release address is " << frg::hex_fmt{ptr} << frg::endlog;
 
@@ -210,6 +234,48 @@ bool bootSecondary(DeviceTreeNode *node, size_t cpuIndex) {
 			KernelPageSpace::global().unmapSingle4k(VirtualAddr(virtPtr));
 
 			KernelVirtualMemory::global().deallocate(virtPtr, kPageSize);
+
+			break;
+		}
+
+		case EnableMethod::parkingProtocol: {
+			infoLogger() << "thor: This CPU uses the ACPI parking protocol" << frg::endlog;
+
+			uint64_t ptr = enable.releaseAddress;
+
+			infoLogger() << "thor: Mailbox address is " << frg::hex_fmt{ptr} << frg::endlog;
+
+			auto page = ptr & ~(kPageSize - 1);
+			auto offset = ptr & (kPageSize - 1);
+			assert(offset + parkingMailboxEntryPoint + sizeof(uint64_t) <= kPageSize);
+
+			auto virtPtr = KernelVirtualMemory::global().allocate(kPageSize);
+
+			KernelPageSpace::global().mapSingle4k(VirtualAddr(virtPtr), page,
+					page_access::write, CachingMode::uncached);
+
+			auto space = arch::mem_space{virtPtr};
+
+			// The firmware sets the CPU ID to all ones until the mailbox is ready.
+			auto parkedCpuId = arch::scalar_load<uint32_t>(space, offset + parkingMailboxCpuId);
+			if (parkedCpuId != parkingMailboxInvalidCpuId) {
+				infoLogger() << "thor: Parking protocol mailbox is not ready" << frg::endlog;
+				dontWait = true;
+			} else {
+				// Hand the entry point to the AP and wake it up by storing its ID.
+				arch::scalar_store<uint64_t>(space, offset + parkingMailboxEntryPoint,
+						codePhysPtr);
+				arch::scalar_store<uint32_t>(space, offset + parkingMailboxCpuId,
+						enable.cpuInterfaceNumber);
+			}
+
+			KernelPageSpace::global().unmapSingle4k(VirtualAddr(virtPtr));
+
+			KernelVirtualMemory::global().deallocate(virtPtr, kPageSize);
+
+			// The AP waits in WFI, hence it needs an interrupt to leave the parked state.
+			if (!dontWait)
+				sendParkingWakeupIpi(cpuIndex, enable.cpuInterfaceNumber);
 
 			break;
 		}
@@ -271,20 +337,180 @@ bool bootSecondary(DeviceTreeNode *node, size_t cpuIndex) {
 	return !dontWait;
 }
 
+bool bootSecondaryFromDt(DeviceTreeNode *node, size_t cpuIndex) {
+	infoLogger() << "thor: Starting CPU \"" << node->path() << "\"" << frg::endlog;
+
+	auto methodProp = node->dtNode().findProperty("enable-method");
+	if (!methodProp)
+		panicLogger() << node->path() << " has no enable-method" << frg::endlog;
+
+	EnableInfo enable;
+	size_t i = 0;
+	while (i < methodProp->size()) {
+		frg::string_view sv{reinterpret_cast<const char *>(methodProp->data()) + i};
+		i += sv.size() + 1;
+
+		if (sv == "psci")
+			enable.method = EnableMethod::psci;
+		else if (sv == "spin-table")
+			enable.method = EnableMethod::spinTable;
+	}
+
+	if (enable.method == EnableMethod::unknown) {
+		infoLogger() << "thor: We don't know how to start this CPU" << frg::endlog;
+		return false;
+	}
+
+	if (enable.method == EnableMethod::spinTable) {
+		auto addrProp = node->dtNode().findProperty("cpu-release-addr");
+		if (!addrProp)
+			panicLogger() << node->path() << " has no cpu-release-addr" << frg::endlog;
+
+		uint64_t ptr;
+		auto it = addrProp->access();
+		if(!it.readCells(ptr, 2)) {
+			if(!it.readCells(ptr, 1)) {
+				panicLogger() << node->path() << " has an empty cpu-release-addr" << frg::endlog;
+			}
+		}
+		enable.releaseAddress = ptr;
+	}
+
+	return bootSecondary(node->reg()[0].addr, cpuIndex, enable);
+}
+
+bool initPsciFromAcpi() {
+	acpi_fadt *fadt;
+	if (uacpi_table_fadt(&fadt) != UACPI_STATUS_OK) {
+		infoLogger() << "thor: ACPI FADT not found, trying GICC parking protocol"
+		             << frg::endlog;
+		return false;
+	}
+
+	constexpr size_t requiredFadtLength = offsetof(acpi_fadt, arm_boot_arch)
+	                                      + sizeof(fadt->arm_boot_arch);
+	if (fadt->hdr.length < requiredFadtLength) {
+		infoLogger() << "thor: FADT is too small for ARM boot architecture flags" << frg::endlog;
+		return false;
+	}
+
+	if (!(fadt->arm_boot_arch & ACPI_ARM_PSCI_COMPLIANT)) {
+		infoLogger() << "thor: ACPI FADT does not advertise PSCI" << frg::endlog;
+		return false;
+	}
+
+	psci_.initialize(fadt->arm_boot_arch & ACPI_ARM_PSCI_USE_HVC);
+	return true;
+}
+
+struct AcpiApBootInfo {
+	bool havePsci;
+	uint32_t bspAffinity;
+	size_t apCpuIndex{1};
+	size_t enabledCpuCount{0};
+};
+
+uacpi_iteration_decision bootApFromMadtEntry(uacpi_handle opaque, acpi_entry_hdr *genericPtr) {
+	auto *info = static_cast<AcpiApBootInfo *>(opaque);
+
+	if (genericPtr->type != ACPI_MADT_ENTRY_TYPE_GICC)
+		return UACPI_ITERATION_DECISION_CONTINUE;
+
+	auto length = genericPtr->length;
+
+	acpi_madt_gicc entry;
+	constexpr size_t requiredGiccLength = offsetof(acpi_madt_gicc, flags) + sizeof(entry.flags);
+	if (!copyAcpiEntry(&entry, genericPtr, length, requiredGiccLength)) {
+		warningLogger() << "thor: Ignoring truncated MADT GICC entry" << frg::endlog;
+		return UACPI_ITERATION_DECISION_CONTINUE;
+	}
+
+	if (!(entry.flags & ACPI_GICC_ENABLED))
+		return UACPI_ITERATION_DECISION_CONTINUE;
+
+	++info->enabledCpuCount;
+	if (!hasAcpiField(length, offsetof(acpi_madt_gicc, mpidr), sizeof(entry.mpidr)))
+		panicLogger() << "thor: Enabled MADT GICC entry has no MPIDR" << frg::endlog;
+
+	auto affinity = affinityFromMpidr(entry.mpidr);
+	if (affinity == info->bspAffinity)
+		return UACPI_ITERATION_DECISION_CONTINUE;
+
+	if (static_cast<uint64_t>(info->apCpuIndex) >= cpuConfigNote->totalCpus) {
+		panicLogger() << "thor: CPU index " << info->apCpuIndex
+		              << " exceeds expected number of CPUs " << cpuConfigNote->totalCpus
+		              << frg::endlog;
+	}
+
+	if (info->apCpuIndex < cpuConfigNote->effectiveCpus) {
+		EnableInfo enable;
+		if (info->havePsci) {
+			enable.method = EnableMethod::psci;
+		} else if (hasAcpiField(length, offsetof(acpi_madt_gicc, parking_protocol_version),
+		               sizeof(entry.parking_protocol_version))
+		           && hasAcpiField(length, offsetof(acpi_madt_gicc, parked_address),
+		               sizeof(entry.parked_address))
+		           && entry.parking_protocol_version && entry.parked_address) {
+			enable.method = EnableMethod::parkingProtocol;
+			enable.releaseAddress = entry.parked_address;
+			enable.cpuInterfaceNumber = entry.interface_number;
+		} else {
+			panicLogger() << "thor: Enabled MADT GICC entry for MPIDR "
+			              << frg::hex_fmt{entry.mpidr}
+			              << " has neither PSCI nor parking protocol" << frg::endlog;
+		}
+
+		bootSecondary(entry.mpidr, info->apCpuIndex, enable);
+	}
+	++info->apCpuIndex;
+
+	return UACPI_ITERATION_DECISION_CONTINUE;
+}
+
+bool bootApsFromAcpi() {
+	uacpi_table madtTbl;
+	if (uacpi_table_find_by_signature("APIC", &madtTbl) != UACPI_STATUS_OK)
+		panicLogger() << "thor: Unable to initialize APs, no MADT found" << frg::endlog;
+	frg::scope_exit finish{[&] { uacpi_table_unref(&madtTbl); }};
+
+	AcpiApBootInfo info{
+	    .havePsci = initPsciFromAcpi(),
+	    .bspAffinity = getCpuData()->affinity
+	};
+	if (uacpi_for_each_subtable(madtTbl.hdr, sizeof(acpi_madt), bootApFromMadtEntry, &info)
+	    != UACPI_STATUS_OK)
+		panicLogger() << "thor: Failed to parse the ACPI MADT" << frg::endlog;
+
+	if (info.enabledCpuCount != cpuConfigNote->totalCpus)
+		panicLogger() << "thor: Found " << info.enabledCpuCount << " CPUs but Eir detected "
+		              << cpuConfigNote->totalCpus << frg::endlog;
+
+	return true;
+}
+
 static initgraph::Task initAPs{&globalInitEngine, "arm.init-aps",
-	initgraph::Requires{getDeviceTreeParsedStage(), getTaskingAvailableStage()},
+	initgraph::Requires{
+	    acpi::getTablesDiscoveredStage(),
+	    getDeviceTreeParsedStage(),
+	    getBootProcessorReadyStage(),
+	    getTaskingAvailableStage()
+	},
 	[] {
-		getDeviceTreeRoot()->forEach([&](DeviceTreeNode *node) -> bool {
+		if (acpiRsdpNote->rsdp) {
+			bootApsFromAcpi();
+			return;
+		}
+		auto root = getDeviceTreeRoot();
+		if (!root)
+			return;
+		root->forEach([&](DeviceTreeNode *node) -> bool {
 			if (node->isCompatible<2>({"arm,psci", "arm,psci-1.0"})) {
 				psci_.initialize(node);
 				return true;
 			}
-
 			return false;
 		});
-
 		auto bspAffinity = getCpuData()->affinity;
-
 		size_t apCpuIndex = 1;
 		auto bootApFromDt = [&](DeviceTreeNode *node) {
 			auto affinity = node->reg()[0].addr;
@@ -297,12 +523,9 @@ static initgraph::Task initAPs{&globalInitEngine, "arm.init-aps",
 						<< frg::endlog;
 			}
 			if (apCpuIndex < cpuConfigNote->effectiveCpus)
-				bootSecondary(node, apCpuIndex);
+				bootSecondaryFromDt(node, apCpuIndex);
 			++apCpuIndex;
 		};
-
-		auto root = getDeviceTreeRoot();
-
 		if (auto it = root->children().find("cpus"); it != root->children().end()) {
 			auto cpus = it->get<1>();
 			cpus->forEach([&](DeviceTreeNode *node) {

--- a/kernel/thor/arch/arm/stubs.S
+++ b/kernel/thor/arch/arm/stubs.S
@@ -254,7 +254,11 @@ forkExecutorRegisters:
 	str x4, [x0, THOR_FRAME_SP]
 
 	// Set new PSTATE
-	mov x4, #5
+	mrs x4, currentel
+	lsr x4, x4, #2
+	lsl x4, x4, #2
+	// Select the SP of the target EL
+	orr x4, x4, #1
 	mrs x5, daif
 	orr x4, x4, x5
 	str x4, [x0, THOR_FRAME_SPSR]

--- a/kernel/thor/arch/arm/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/cpu.hpp
@@ -2,7 +2,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <utility>
 
 #include <frg/tuple.hpp>
 #include <frg/vector.hpp>
@@ -308,5 +307,7 @@ initgraph::Stage *getBootProcessorReadyStage();
 
 struct CpuData;
 void prepareCpuDataFor(CpuData *context, int cpu);
+
+uint32_t affinityFromMpidr(uint64_t mpidr);
 
 } // namespace thor

--- a/kernel/thor/arch/arm/thor-internal/arch/gic.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic.hpp
@@ -28,12 +28,12 @@ struct Gic : dt::IrqController {
 
 		virtual bool setMode(TriggerMode trigger, Polarity polarity) = 0;
 
-		virtual IrqStrategy program(TriggerMode mode, Polarity polarity) override = 0;
+		IrqStrategy program(TriggerMode mode, Polarity polarity) override = 0;
 
-		virtual void mask() override = 0;
-		virtual void unmask() override = 0;
+		void mask() override = 0;
+		void unmask() override = 0;
 
-		virtual void endOfInterrupt() override = 0;
+		void endOfInterrupt() override = 0;
 	};
 
 	virtual Pin *setupIrq(uint32_t irq, TriggerMode trigger) = 0;

--- a/kernel/thor/arch/arm/thor-internal/arch/gic.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <arch/mem_space.hpp>
 #include <initgraph.hpp>
 #include <thor-internal/arch-generic/cpu.hpp>
 #include <thor-internal/dtb/irq.hpp>
 #include <thor-internal/irq.hpp>
-#include <arch/mem_space.hpp>
 
 namespace thor {
 
@@ -23,10 +23,9 @@ struct Gic : dt::IrqController {
 	struct Pin : public IrqPin {
 		virtual ~Pin() = default;
 
-		Pin(frg::string<KernelAlloc> name)
-		: IrqPin{std::move(name)} {}
+		Pin(frg::string<KernelAlloc> name) : IrqPin{std::move(name)} {}
 
-		virtual bool setMode(TriggerMode trigger, Polarity polarity) = 0;
+		virtual bool setMode(TriggerMode trigger) = 0;
 
 		IrqStrategy program(TriggerMode mode, Polarity polarity) override = 0;
 
@@ -38,6 +37,7 @@ struct Gic : dt::IrqController {
 
 	virtual Pin *setupIrq(uint32_t irq, TriggerMode trigger) = 0;
 	virtual Pin *getPin(uint32_t irq) = 0;
+	virtual uint32_t irqCount() = 0;
 
 	IrqPin *resolveDtIrq(dtb::Cells irqSpecifier) override {
 		if (irqSpecifier.numCells() != 3 && irqSpecifier.numCells() != 4)
@@ -80,10 +80,8 @@ struct Gic : dt::IrqController {
 				trigger = TriggerMode::level;
 				break;
 			default:
-				infoLogger()
-					<< "thor: Illegal IRQ flags " << (flags & 0xF)
-					<< " found when parsing GIC interrupt"
-					<< frg::endlog;
+				infoLogger() << "thor: Illegal IRQ flags " << (flags & 0xF)
+				             << " found when parsing GIC interrupt" << frg::endlog;
 				polarity = Polarity::null;
 				trigger = TriggerMode::null;
 		}
@@ -101,4 +99,4 @@ struct Gic : dt::IrqController {
 
 void initGicOnThisCpu();
 
-}
+} // namespace thor

--- a/kernel/thor/arch/arm/thor-internal/arch/gic_v2.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic_v2.hpp
@@ -37,7 +37,7 @@ struct GicDistributorV2 {
 		void activate();
 		void deactivate();
 
-		bool setMode(TriggerMode trigger, Polarity polarity) override;
+		bool setMode(TriggerMode trigger) override;
 
 	private:
 		void setAffinity_(uint8_t ifaceNo);
@@ -49,6 +49,7 @@ struct GicDistributorV2 {
 
 	Pin *setupIrq(uint32_t irq, TriggerMode mode);
 	Pin *getPin(uint32_t irq);
+	uint32_t irqCount() const;
 
 private:
 	uint8_t getCurrentCpuIfaceNo_();
@@ -89,14 +90,19 @@ struct GicV2 : public Gic {
 	void sendIpi(int cpuId, uint8_t id) override;
 	void sendIpiToOthers(uint8_t id) override;
 
+	// Sends an IPI to a CPU that did not set up its CPU interface yet.
+	void sendIpiToInterface(uint8_t ifaceNo, uint8_t id);
+
 	CpuIrq getIrq() override;
 	void eoi(uint32_t cpuId, uint32_t id) override;
 
 	Pin *setupIrq(uint32_t irq, TriggerMode trigger) override;
 	Pin *getPin(uint32_t irq) override;
+	uint32_t irqCount() override;
 };
 
 bool initGicV2();
+bool initGicV2FromAcpi(uintptr_t distributor, uintptr_t cpuInterface, size_t cpuInterfaceSize);
 void initGicOnThisCpuV2();
 
 }

--- a/kernel/thor/arch/arm/thor-internal/arch/gic_v3.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic_v3.hpp
@@ -2,8 +2,14 @@
 
 #include <thor-internal/arch/gic.hpp>
 #include <frg/manual_box.hpp>
+#include <frg/span.hpp>
 
 namespace thor {
+
+struct GicRedistributorRange {
+	uintptr_t address;
+	size_t size;
+};
 
 struct GicDistributorV3;
 
@@ -41,7 +47,7 @@ struct GicPinV3 : public Gic::Pin {
 	GicPinV3(GicDistributorV3 *dist, uint32_t irq)
 		: Gic::Pin {dist->buildPinName(irq)}, irq_ {irq} {}
 
-	bool setMode(TriggerMode trigger, Polarity polarity) override;
+	bool setMode(TriggerMode trigger) override;
 
 	IrqStrategy program(TriggerMode mode, Polarity polarity) override;
 
@@ -71,12 +77,18 @@ struct GicV3 : public Gic {
 
 	Pin *setupIrq(uint32_t irq, TriggerMode trigger) override;
 	Pin *getPin(uint32_t irq) override;
+	uint32_t irqCount() override;
 
 private:
 	frg::vector<GicPinV3 *, KernelAlloc> irqPins_;
 };
 
 bool initGicV3();
+bool initGicV3FromAcpi(
+    uintptr_t distributor,
+    size_t distributorSize,
+    frg::span<const GicRedistributorRange> redistributorRanges
+);
 void initGicOnThisCpuV3();
 
 }

--- a/kernel/thor/arch/arm/timer.cpp
+++ b/kernel/thor/arch/arm/timer.cpp
@@ -1,3 +1,5 @@
+#include <frg/scope_exit.hpp>
+#include <thor-internal/acpi/acpi.hpp>
 #include <thor-internal/arch/timer.hpp>
 #include <thor-internal/arch/trap.hpp>
 #include <thor-internal/arch-generic/cpu.hpp>
@@ -8,8 +10,12 @@
 #include <initgraph.hpp>
 #include <thor-internal/main.hpp>
 #include <thor-internal/arch/gic.hpp>
+#include <thor-internal/arch/gic_v2.hpp>
+#include <thor-internal/arch/gic_v3.hpp>
 #include <thor-internal/dtb/dtb.hpp>
 #include <thor-internal/util.hpp>
+#include <uacpi/acpi.h>
+#include <uacpi/tables.h>
 
 namespace thor {
 
@@ -72,11 +78,85 @@ static DeviceTreeNode *timerNode = nullptr;
 static dt::IrqController *timerIrqParent = nullptr;
 static frg::manual_box<dtb::Cells> timerIrq;
 
+enum class TimerIrqSource {
+	none,
+	dt,
+	acpi
+};
+
+static TimerIrqSource timerIrqSource = TimerIrqSource::none;
+static GlobalIrqInfo acpiTimerIrq;
+
+IrqPin *setupAcpiTimerIrq() {
+	return std::visit(
+	    frg::overloaded{
+	        [](GicV2 *gic) -> IrqPin * {
+		        auto pin = gic->getPin(acpiTimerIrq.gsi);
+		        if (!pin)
+			        panicLogger() << "thor: GTDT timer GSI " << acpiTimerIrq.gsi
+			                      << " has no GIC pin" << frg::endlog;
+		        pin->configure(acpiTimerIrq.configuration);
+		        return pin;
+	        },
+	        [](GicV3 *gic) -> IrqPin * {
+		        auto pin = gic->getPin(acpiTimerIrq.gsi);
+		        if (!pin)
+			        panicLogger() << "thor: GTDT timer GSI " << acpiTimerIrq.gsi
+			                      << " has no GIC pin" << frg::endlog;
+		        pin->configure(acpiTimerIrq.configuration);
+		        return pin;
+	        },
+	        [](auto &&) -> IrqPin * {
+		        panicLogger() << "thor: GTDT timer requires a GIC" << frg::endlog;
+		        __builtin_unreachable();
+	        }
+	    },
+	    externalIrq
+	);
+}
+
+bool initTimerIrqFromAcpi() {
+	if (!acpiRsdpNote->rsdp)
+		return false;
+
+	uacpi_table gtdtTbl;
+	if (uacpi_table_find_by_signature("GTDT", &gtdtTbl) != UACPI_STATUS_OK)
+		return false;
+	frg::scope_exit finish{[&] { uacpi_table_unref(&gtdtTbl); }};
+
+	if (gtdtTbl.hdr->length < sizeof(acpi_gtdt))
+		panicLogger() << "thor: GTDT is too small" << frg::endlog;
+
+	auto *gtdt = reinterpret_cast<acpi_gtdt *>(gtdtTbl.ptr);
+	auto flags = gtdt->el1_virtual_flags;
+
+	acpiTimerIrq.gsi = gtdt->el1_virtual_gsiv;
+	acpiTimerIrq.configuration.trigger =
+	    (flags & ACPI_GTDT_TRIGGERING) ? TriggerMode::edge : TriggerMode::level;
+	acpiTimerIrq.configuration.polarity =
+	    (flags & ACPI_GTDT_POLARITY) ? Polarity::low : Polarity::high;
+	timerIrqSource = TimerIrqSource::acpi;
+
+	infoLogger() << "thor: Found GTDT EL1 virtual timer at GSI " << acpiTimerIrq.gsi
+	             << frg::endlog;
+	return true;
+}
+
 static initgraph::Task initTimerIrq{&globalInitEngine, "arm.init-timer-irq",
 	initgraph::Requires{getIrqControllerReadyStage()},
 	initgraph::Entails{getTaskingAvailableStage()},
 	[] {
-		getDeviceTreeRoot()->forEach([&](DeviceTreeNode *node) -> bool {
+		if (initTimerIrqFromAcpi()) {
+			initTimerOnThisCpu();
+			timersFound = true;
+			return;
+		}
+
+		auto root = getDeviceTreeRoot();
+		if (!root)
+			panicLogger() << "thor: Failed to find timer" << frg::endlog;
+
+		root->forEach([&](DeviceTreeNode *node) -> bool {
 			if (node->isCompatible<1>({"arm,armv8-timer"})) {
 				timerNode = node;
 				return true;
@@ -100,6 +180,7 @@ static initgraph::Task initTimerIrq{&globalInitEngine, "arm.init-timer-irq",
 				if (idx == 2) {
 					timerIrqParent = parentNode->getAssociatedIrqController();
 					timerIrq.initialize(irqCells);
+					timerIrqSource = TimerIrqSource::dt;
 				}
 
 				idx++;
@@ -120,7 +201,17 @@ bool haveTimer() {
 // Sets up the proper interrupt trigger and polarity for the PPI
 void initTimerOnThisCpu() {
 	auto sink = frg::construct<GenericTimerSink>(*kernelAlloc);
-	auto pin = timerIrqParent->resolveDtIrq(*timerIrq);
+	IrqPin *pin = nullptr;
+	switch (timerIrqSource) {
+		case TimerIrqSource::dt:
+			pin = timerIrqParent->resolveDtIrq(*timerIrq);
+			break;
+		case TimerIrqSource::acpi:
+			pin = setupAcpiTimerIrq();
+			break;
+		case TimerIrqSource::none:
+			panicLogger() << "thor: Timer IRQ was not initialized" << frg::endlog;
+	}
 	IrqPin::attachSink(pin, sink);
 }
 

--- a/kernel/thor/system/acpi/glue.cpp
+++ b/kernel/thor/system/acpi/glue.cpp
@@ -90,7 +90,7 @@ uacpi_status uacpi_kernel_raw_io_read(uacpi_io_addr address, T *out_value) {
 }
 #else
 template <typename T>
-uacpi_status uacpi_kernel_raw_io_read(uacpi_io_addr address, T *out_value) {
+uacpi_status uacpi_kernel_raw_io_read(uacpi_io_addr, T) {
 	return UACPI_STATUS_UNIMPLEMENTED;
 }
 

--- a/kernel/thor/system/acpi/madt.cpp
+++ b/kernel/thor/system/acpi/madt.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <uacpi/acpi.h>
+#include <uacpi/context.h>
 #include <uacpi/event.h>
 #include <uacpi/sleep.h>
 #include <uacpi/tables.h>
@@ -297,6 +298,40 @@ void dumpMadt() {
 				infoLogger() << "    PLIC " << entry.id << ", GSI Base at "
 				             << frg::hex_fmt{entry.gsi_base} << frg::endlog;
 			} break;
+			case ACPI_MADT_ENTRY_TYPE_GICC: {
+				acpi_madt_gicc entry;
+				memcpy(&entry, genericPtr, sizeof(entry));
+				infoLogger() << "    GICC " << entry.interface_number << ", MPIDR "
+				             << frg::hex_fmt{entry.mpidr}
+				             << ((entry.flags & ACPI_GICC_ENABLED) ? "" : " (disabled)")
+				             << frg::endlog;
+			} break;
+			case ACPI_MADT_ENTRY_TYPE_GICD: {
+				acpi_madt_gicd entry;
+				memcpy(&entry, genericPtr, sizeof(entry));
+				infoLogger() << "    GICD " << entry.id << ", address "
+				             << frg::hex_fmt{entry.address} << ", version "
+				             << static_cast<int>(entry.gic_version) << frg::endlog;
+			} break;
+			case ACPI_MADT_ENTRY_TYPE_GICR: {
+				acpi_madt_gicr entry;
+				memcpy(&entry, genericPtr, sizeof(entry));
+				infoLogger() << "    GICR address " << frg::hex_fmt{entry.address} << ", length "
+				             << entry.length << frg::endlog;
+			} break;
+			case ACPI_MADT_ENTRY_TYPE_GIC_MSI_FRAME: {
+				acpi_madt_gic_msi_frame entry;
+				memcpy(&entry, genericPtr, sizeof(entry));
+				infoLogger() << "    GIC MSI frame " << entry.id << ", address "
+				             << frg::hex_fmt{entry.address} << ", SPIs " << entry.spi_base << ".."
+				             << entry.spi_base + entry.spi_count << frg::endlog;
+			} break;
+			case ACPI_MADT_ENTRY_TYPE_GIC_ITS: {
+				acpi_madt_gic_its entry;
+				memcpy(&entry, genericPtr, sizeof(entry));
+				infoLogger() << "    GIC ITS " << entry.id << ", address "
+				             << frg::hex_fmt{entry.address} << frg::endlog;
+			} break;
 			default: {
 				infoLogger() << "    Unexpected MADT entry of type " << generic.type << frg::endlog;
 			}
@@ -457,7 +492,13 @@ static initgraph::Task loadAcpiNamespaceTask{
 	    ret = uacpi_namespace_load();
 	    assert(ret == UACPI_STATUS_OK);
 
+#if defined(__aarch64__)
+	    ret = uacpi_set_interrupt_model(UACPI_INTERRUPT_MODEL_GIC);
+#elif defined(__riscv)
+	    ret = uacpi_set_interrupt_model(UACPI_INTERRUPT_MODEL_RINTC);
+#else
 	    ret = uacpi_set_interrupt_model(UACPI_INTERRUPT_MODEL_IOAPIC);
+#endif
 	    assert(ret == UACPI_STATUS_OK);
 
 	    initEc();

--- a/kernel/thor/system/pci/pci_quirks_rpi4.cpp
+++ b/kernel/thor/system/pci/pci_quirks_rpi4.cpp
@@ -126,8 +126,11 @@ void uploadRaspberryPi4Vl805Firmware(PciDevice *dev) {
 	// Not a VL805.
 	if (dev->deviceId != 0x3483) return;
 
+	auto root = getDeviceTreeRoot();
+	if (!root) return;
+
 	DeviceTreeNode *rpiFwResetNode = nullptr;
-	getDeviceTreeRoot()->forEach([&](DeviceTreeNode *node) -> bool {
+	root->forEach([&](DeviceTreeNode *node) -> bool {
 		if (node->isCompatible<1>({"raspberrypi,firmware-reset"})) {
 			rpiFwResetNode = node;
 			return true;
@@ -140,7 +143,7 @@ void uploadRaspberryPi4Vl805Firmware(PciDevice *dev) {
 	if (!rpiFwResetNode) return;
 
 	DeviceTreeNode *rpiMboxNode = nullptr;
-	getDeviceTreeRoot()->forEach([&](DeviceTreeNode *node) -> bool {
+	root->forEach([&](DeviceTreeNode *node) -> bool {
 		if (node->isCompatible<1>({"brcm,bcm2835-mbox"})) {
 			rpiMboxNode = node;
 			return true;


### PR DESCRIPTION
Boots on QEMU with eir-limine and eir-uefi. Also disables logging (for eir-limine) when it's not possible to directly access device memory.