### PR TITLE
drivers: Make addressBits mandatory for contiguous_pool

### DIFF
--- a/core/arch/include/arch/os/dma_pool.hpp
+++ b/core/arch/include/arch/os/dma_pool.hpp
@@ -10,7 +10,7 @@
 namespace arch {
 
 struct contiguous_pool_options {
-	size_t addressBits{32};
+	size_t addressBits{};
 	// Gap in bytes between the base addresses of two allocations.
 	// When doing non-coherent DMA, this is needed to ensure that different allocations
 	// end up on different cache lines (such that writes to an allocation cannot cause

--- a/core/arch/src/dma_pool.cpp
+++ b/core/arch/src/dma_pool.cpp
@@ -12,7 +12,9 @@ namespace {
 } // namespace
 
 contiguous_pool::contiguous_pool(contiguous_pool_options options)
-: options_{options} { }
+: options_{options} {
+	assert(options.addressBits != 0 && "options.addressBits must be provided");
+}
 
 dma_ptr contiguous_pool::allocate(size_t size, size_t count, size_t align) {
 	auto b = shift_of_(size, count, align);

--- a/drivers/block/ahci/src/port.hpp
+++ b/drivers/block/ahci/src/port.hpp
@@ -43,7 +43,7 @@ private:
 	// Mapping is owned by Controller
 	arch::mem_space regs_;
 
-	arch::contiguous_pool dmaPool_;
+	arch::contiguous_pool dmaPool_{{.addressBits = 32}};
 	arch::dma_object<commandList> commandList_;
 	arch::dma_array<commandTable> commandTables_;
 	arch::dma_object<receivedFis> receivedFis_;

--- a/drivers/gfx/intel-lil/src/gfx.hpp
+++ b/drivers/gfx/intel-lil/src/gfx.hpp
@@ -25,7 +25,7 @@ private:
 	LilGpu *_gpu;
 	uint16_t _pchDevId;
 	helix::UniqueDescriptor apertureHandle_;
-	arch::contiguous_pool _pool = {};
+	arch::contiguous_pool _pool{{.addressBits = 64}};
 
 	arch::dma_buffer gttScratch_;
 

--- a/drivers/nic/bcmgenet/src/main.hpp
+++ b/drivers/nic/bcmgenet/src/main.hpp
@@ -88,7 +88,7 @@ private:
 	std::vector<arch::dma_buffer> txBufs_;
 	std::vector<arch::dma_buffer> rxBufs_;
 	arch::mem_space space_;
-	arch::contiguous_pool dmaPool_;
+	arch::contiguous_pool dmaPool_{{.addressBits = 64}};
 	nic::PhyMode phyMode_;
 
 	async::recurring_event rxEvent_;

--- a/drivers/nic/freebsd-e1000/include/nic/freebsd-e1000/common.hpp
+++ b/drivers/nic/freebsd-e1000/include/nic/freebsd-e1000/common.hpp
@@ -65,7 +65,7 @@ private:
 	helix::Mapping _mmio_mapping;
 	arch::mem_space _mmio;
 
-	arch::contiguous_pool _dmaPool;
+	arch::contiguous_pool _dmaPool{{.addressBits = 64}};
 	protocols::hw::Device _device;
 
 	helix::UniqueDescriptor _irq;

--- a/drivers/nic/rtl8168/include/nic/rtl8168/common.hpp
+++ b/drivers/nic/rtl8168/include/nic/rtl8168/common.hpp
@@ -218,7 +218,7 @@ private:
 	helix::Mapping _mmio_mapping;
 	arch::mem_space _mmio;
 
-	arch::contiguous_pool _dmaPool;
+	arch::contiguous_pool _dmaPool{{.addressBits = 64}};
 	protocols::hw::Device _device;
 
 	helix::UniqueDescriptor _irq;

--- a/drivers/nic/usb_net/src/usb-net.hpp
+++ b/drivers/nic/usb_net/src/usb-net.hpp
@@ -14,7 +14,7 @@ struct UsbNic : nic::Link {
 protected:
 	virtual async::detached listenForNotifications() = 0;
 
-	arch::contiguous_pool dmaPool_;
+	arch::contiguous_pool dmaPool_{{.addressBits = 64}};
 	protocols::usb::Device device_;
 
 	/* the control interface */

--- a/drivers/nic/virtio/src/virtio.cpp
+++ b/drivers/nic/virtio/src/virtio.cpp
@@ -48,7 +48,7 @@ struct VirtioNic : nic::Link {
 private:
 	mbus_ng::EntityId entity_;
 	std::unique_ptr<virtio_core::Transport> transport_;
-	arch::contiguous_pool dmaPool_;
+	arch::contiguous_pool dmaPool_{{.addressBits = 64}};
 	virtio_core::Queue *receiveVq_;
 	virtio_core::Queue *transmitVq_;
 	size_t headerSize_;

--- a/drivers/tty/virtio-console/src/console.hpp
+++ b/drivers/tty/virtio-console/src/console.hpp
@@ -29,7 +29,7 @@ struct Device {
 	async::detached runDevice();
 
 private:
-	arch::contiguous_pool dmaPool_;
+	arch::contiguous_pool dmaPool_{{.addressBits = 64}};
 	std::unique_ptr<virtio_core::Transport> transport_;
 	virtio_core::Queue *rxQueue_;
 	virtio_core::Queue *txQueue_;

--- a/drivers/usb/devices/serial/src/controller.hpp
+++ b/drivers/usb/devices/serial/src/controller.hpp
@@ -49,7 +49,7 @@ struct Controller {
 	struct termios activeSettings = {};
 	bool nonBlock_;
 	protocols::usb::Device hw_;
-	arch::contiguous_pool pool_;
+	arch::contiguous_pool pool_{{.addressBits = 64}};
 };
 
 struct WriteRequest {

--- a/drivers/usb/devices/serial/src/main.cpp
+++ b/drivers/usb/devices/serial/src/main.cpp
@@ -45,7 +45,7 @@ using WriteQueue = frg::intrusive_list<
 
 std::vector<smarter::shared_ptr<Controller>> controllers;
 
-arch::contiguous_pool pool;
+arch::contiguous_pool pool{{.addressBits = 64}};
 
 WriteQueue sendRequests;
 

--- a/drivers/usb/hcds/ehci/src/main.cpp
+++ b/drivers/usb/hcds/ehci/src/main.cpp
@@ -38,7 +38,7 @@ std::vector<std::shared_ptr<Controller>> globalControllers;
 // ----------------------------------------------------------------------------
 
 namespace {
-	arch::contiguous_pool schedulePool;
+	arch::contiguous_pool schedulePool{{.addressBits = 32}};
 }
 
 // ----------------------------------------------------------------------------

--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -170,7 +170,9 @@ void Controller::initialize() {
 
 	// Setup the frame list.
 	HelHandle list_handle;
-	HEL_CHECK(helAllocateMemory(4096, 0, nullptr, &list_handle));
+	HelAllocRestrictions restrictions{};
+	restrictions.addressBits = 32;
+	HEL_CHECK(helAllocateMemory(4096, 0, &restrictions, &list_handle));
 	void *list_mapping;
 	HEL_CHECK(helMapMemory(list_handle, kHelNullHandle,
 			nullptr, 0, 4096, kHelMapProtRead | kHelMapProtWrite, &list_mapping));

--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -35,7 +35,7 @@ std::vector<std::shared_ptr<Controller>> globalControllers;
 // ----------------------------------------------------------------------------
 
 namespace {
-	arch::contiguous_pool schedulePool;
+	arch::contiguous_pool schedulePool{{.addressBits = 32}};
 }
 
 // ----------------------------------------------------------------------------

--- a/drivers/usb/hcds/xhci/src/main.cpp
+++ b/drivers/usb/hcds/xhci/src/main.cpp
@@ -39,7 +39,15 @@ Controller::Controller(protocols::hw::Device hw_device, mbus_ng::Entity entity, 
 		helix::UniqueDescriptor mmio, helix::UniqueIrq irq, std::string name)
 : _hw_device{std::move(hw_device)}, _mapping{std::move(mapping)},
 		_mmio{std::move(mmio)}, _irq{std::move(irq)},
-		_space{_mapping.get()}, _name{name}, _memoryPool{},
+		_space{_mapping.get()}, _name{name},
+#ifdef __aarch64__
+// TODO: When we have a way to query the platform this could be restricted to RPI4 only.
+		_memoryPool{{.addressBits = 31}},
+#else
+// TODO: It is theoretically possible that there could be controllers that don't support 64-bit
+// addresses, to support those this would have to be conditional.
+		_memoryPool{{.addressBits = 64}},
+#endif
 		_dcbaa{&_memoryPool, 256}, _cmdRing{this},
 		_eventRing{this},
 		_enumerator{this}, _largeCtx{false},


### PR DESCRIPTION
Make providing address bits to `arch::dma_pool` mandatory and make all existing drivers use supported values for them.