### PR TITLE
thor: Fix AP cache enable and BSP discovery on x86

### DIFF
--- a/kernel/thor/arch/x86/trampoline.S
+++ b/kernel/thor/arch/x86/trampoline.S
@@ -19,6 +19,9 @@
 .global trampoline
 trampoline:
 	cli
+	# APs boot with CR0.CD = 1 and CR0.NW = 1 (caching disabled).
+	# Immediately writeback + invalidate stale cache lines. This matches Linux.
+	wbinvd
 
 	# We assume that the APIC SIPI loads IP with 0.
 	mov %cs, %bx
@@ -26,6 +29,11 @@ trampoline:
 
 	# Load our base address into EBX. We need it once we enter a linear address space.
 	shl $4, %ebx
+
+	# Enable caching by clearing CR0.CD and CR0.NW together.
+	mov %cr0, %eax
+	and $0x9FFFFFFF, %eax
+	mov %eax, %cr0
 
 	# Inform the BSP that we're awake.
 	movl $1, statusTargetStage

--- a/kernel/thor/system/acpi/madt.cpp
+++ b/kernel/thor/system/acpi/madt.cpp
@@ -153,6 +153,9 @@ void bootOtherProcessors() {
 
 	infoLogger() << "thor: Booting APs." << frg::endlog;
 
+	// The BSP is already running and occupies CPU index 0; skip its MADT entry.
+	auto bspApicId = getLocalApicId();
+
 	size_t apCpuIndex = 1;
 	size_t offset = sizeof(acpi_sdt_hdr) + sizeof(MadtHeader);
 	while (offset < madt->length) {
@@ -161,8 +164,7 @@ void bootOtherProcessors() {
 			case ACPI_MADT_ENTRY_TYPE_LAPIC: {
 				auto entry = (MadtLocalEntry *)generic;
 
-				// TODO: Support BSPs with APIC ID != 0.
-				if ((entry->flags & local_flags::enabled) && entry->localApicId != 0) {
+				if ((entry->flags & local_flags::enabled) && entry->localApicId != bspApicId) {
 					if (apCpuIndex < cpuConfigNote->effectiveCpus)
 						bootSecondary(entry->localApicId, apCpuIndex);
 					apCpuIndex++;
@@ -171,8 +173,7 @@ void bootOtherProcessors() {
 			case ACPI_MADT_ENTRY_TYPE_LOCAL_X2APIC: {
 				auto entry = (MadtLocalX2Entry *)generic;
 
-				// TODO: Support BSPs with APIC ID != 0.
-				if ((entry->flags & local_flags::enabled) && entry->localX2ApicId != 0) {
+				if ((entry->flags & local_flags::enabled) && entry->localX2ApicId != bspApicId) {
 					if (apCpuIndex < cpuConfigNote->effectiveCpus)
 						bootSecondary(entry->localX2ApicId, apCpuIndex);
 					apCpuIndex++;


### PR DESCRIPTION
This fixes two bugs in the x86 AP startup code.