### PR TITLE
Procfs fixes

### DIFF
--- a/posix/subsystem/src/exec.cpp
+++ b/posix/subsystem/src/exec.cpp
@@ -290,7 +290,7 @@ execute(ViewPath root, ViewPath workdir,
 	// Map the stack into the new process and set it up.
 	void *stackBase = FRG_CO_TRY(co_await vmContext->mapFile(0,
 			helix::UniqueDescriptor{stackHandle}, nullptr,
-			0, stackSize, true, kHelMapProtRead | kHelMapProtWrite));
+			0, stackSize, true, kHelMapProtRead | kHelMapProtWrite, true));
 
 	// the offset at which the stack image starts.
 	size_t d = stackSize;

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -104,6 +104,7 @@ auto VmContext::splitAreaOn_(uintptr_t addr, size_t size) ->
 		if (base < addr && (base + area.areaSize) > addr) {
 			Area right;
 			right.copyOnWrite = area.copyOnWrite;
+			right.stack = area.stack;
 			right.areaSize = area.areaSize - (addr - base);
 			right.nativeFlags = area.nativeFlags;
 			right.fileView = area.fileView.dup();
@@ -129,7 +130,7 @@ auto VmContext::splitAreaOn_(uintptr_t addr, size_t size) ->
 async::result<frg::expected<Error, void *>>
 VmContext::mapFile(uintptr_t hint, helix::UniqueDescriptor memory,
 		smarter::shared_ptr<File, FileHandle> file,
-		intptr_t offset, size_t size, bool copyOnWrite, uint32_t nativeFlags) {
+		intptr_t offset, size_t size, bool copyOnWrite, uint32_t nativeFlags, bool stack) {
 	size_t alignedSize = (size + 0xFFF) & ~size_t(0xFFF);
 
 	// Perform the actual mapping.
@@ -179,6 +180,7 @@ VmContext::mapFile(uintptr_t hint, helix::UniqueDescriptor memory,
 	// Construct the new area.
 	Area area;
 	area.copyOnWrite = copyOnWrite;
+	area.stack = stack;
 	area.areaSize = alignedSize;
 	area.nativeFlags = nativeFlags;
 	area.fileView = std::move(memory);

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -45,7 +45,7 @@ struct VmContext {
 	// TODO: Pass abstract instead of hel flags to this function?
 	async::result<frg::expected<Error, void *>> mapFile(uintptr_t hint, helix::UniqueDescriptor memory,
 			smarter::shared_ptr<File, FileHandle> file,
-			intptr_t offset, size_t size, bool copyOnWrite, uint32_t nativeFlags);
+			intptr_t offset, size_t size, bool copyOnWrite, uint32_t nativeFlags, bool stack = false);
 
 	async::result<void *> remapFile(void *old_pointer, size_t old_size, size_t new_size);
 
@@ -56,6 +56,7 @@ struct VmContext {
 private:
 	struct Area {
 		bool copyOnWrite;
+		bool stack;
 		size_t areaSize;
 		uint32_t nativeFlags;
 		helix::UniqueDescriptor fileView;
@@ -89,6 +90,10 @@ public:
 
 		bool isPrivate() {
 			return _it->second.copyOnWrite;
+		}
+
+		bool isStack() {
+			return _it->second.stack;
 		}
 
 		bool isReadable() {

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -696,12 +696,23 @@ async::result<std::expected<std::string, Error>> MapNode::show(Process *) {
 			stream << std::setw(0) << fileStats.value().inodeNumber;
 			stream << "    ";
 			stream << viewPath.getPath(p->fsContext()->getRoot());
+		} else if(area.isStack()) {
+			stream << "00000000 00:00 0 ";
+
+			auto endSize = stream.tellp();
+
+			for(size_t i = endSize - startSize; i < 25 + sizeof(void *) * 6 - 1; i++) {
+				stream << " ";
+			}
+
+			stream << " [stack]";
 		} else {
 			// TODO: In the case of memfd files, show the name here.
 			stream << "00000000 00:00 0";
 		}
 		stream << "\n";
 	}
+
 	co_return stream.str();
 }
 

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -669,15 +669,18 @@ async::result<std::expected<std::string, Error>> MapNode::show(Process *) {
 
 	auto vmContext = p->vmContext();
 	std::stringstream stream;
+
 	for (auto area : *vmContext) {
-		stream << std::hex << area.baseAddress();
+		auto startSize = stream.tellp();
+
+		stream << std::hex << std::setfill('0') << std::setw(8) << area.baseAddress();
 		stream << "-";
-		stream << std::hex << area.baseAddress() + area.size();
+		stream << std::hex << std::setfill('0') << std::setw(8) << area.baseAddress() + area.size();
 		stream << " ";
 		stream << (area.isReadable() ? "r" : "-");
 		stream << (area.isWritable() ? "w" : "-");
 		stream << (area.isExecutable() ? "x" : "-");
-		stream << (area.isPrivate() ? "p" : "-");
+		stream << (area.isPrivate() ? "p" : "s");
 		stream << " ";
 		auto backingFile = area.backingFile();
 		if(backingFile && backingFile->associatedLink() && backingFile->associatedMount()) {
@@ -687,14 +690,25 @@ async::result<std::expected<std::string, Error>> MapNode::show(Process *) {
 			ViewPath viewPath = {backingFile->associatedMount(), backingFile->associatedLink()};
 			auto fileStats = co_await fsNode->getStats();
 			DeviceId deviceId{};
+			// TODO: Fill in the device id for other files too.
 			if (fsNode->getType() == VfsType::charDevice || fsNode->getType() == VfsType::blockDevice)
 				deviceId = fsNode->readDevice();
 			assert(fileStats);
 
-			stream << std::dec << std::setfill('0') << std::setw(2) << deviceId.first << ":" << deviceId.second;
+			stream << std::hex << std::setfill('0') << std::setw(2) << deviceId.first << ":"
+					<< std::setw(2) << deviceId.second;
 			stream << " ";
-			stream << std::setw(0) << fileStats.value().inodeNumber;
-			stream << "    ";
+			stream << std::dec << std::setw(0) << fileStats.value().inodeNumber;
+			stream << " ";
+
+			auto endSize = stream.tellp();
+
+			for(size_t i = endSize - startSize; i < 25 + sizeof(void *) * 6 - 1; i++) {
+				stream << " ";
+			}
+
+			stream << " ";
+
 			stream << viewPath.getPath(p->fsContext()->getRoot());
 		} else if(area.isStack()) {
 			stream << "00000000 00:00 0 ";
@@ -708,7 +722,7 @@ async::result<std::expected<std::string, Error>> MapNode::show(Process *) {
 			stream << " [stack]";
 		} else {
 			// TODO: In the case of memfd files, show the name here.
-			stream << "00000000 00:00 0";
+			stream << "00000000 00:00 0 ";
 		}
 		stream << "\n";
 	}

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -673,19 +673,16 @@ async::result<std::expected<std::string, Error>> MapNode::show(Process *) {
 	for (auto area : *vmContext) {
 		auto startSize = stream.tellp();
 
-		stream << std::hex << std::setfill('0') << std::setw(8) << area.baseAddress();
-		stream << "-";
-		stream << std::hex << std::setfill('0') << std::setw(8) << area.baseAddress() + area.size();
-		stream << " ";
-		stream << (area.isReadable() ? "r" : "-");
-		stream << (area.isWritable() ? "w" : "-");
-		stream << (area.isExecutable() ? "x" : "-");
-		stream << (area.isPrivate() ? "p" : "s");
-		stream << " ";
+		std::format_to(std::ostreambuf_iterator(stream),
+				"{:08x}-{:08x} {}{}{}{} ",
+				area.baseAddress(), area.baseAddress() + area.size(),
+				area.isReadable() ? "r" : "-",
+				area.isWritable() ? "w" : "-",
+				area.isExecutable() ? "x" : "-",
+				area.isPrivate() ? "p" : "s");
+
 		auto backingFile = area.backingFile();
 		if(backingFile && backingFile->associatedLink() && backingFile->associatedMount()) {
-			stream << std::setfill('0') << std::setw(8) << area.backingFileOffset();
-			stream << " ";
 			auto fsNode = backingFile->associatedLink()->getTarget();
 			ViewPath viewPath = {backingFile->associatedMount(), backingFile->associatedLink()};
 			auto fileStats = co_await fsNode->getStats();
@@ -695,11 +692,12 @@ async::result<std::expected<std::string, Error>> MapNode::show(Process *) {
 				deviceId = fsNode->readDevice();
 			assert(fileStats);
 
-			stream << std::hex << std::setfill('0') << std::setw(2) << deviceId.first << ":"
-					<< std::setw(2) << deviceId.second;
-			stream << " ";
-			stream << std::dec << std::setw(0) << fileStats.value().inodeNumber;
-			stream << " ";
+			std::format_to(std::ostreambuf_iterator(stream),
+					"{:08x} {:02x}:{:02x} {} ",
+					area.backingFileOffset(),
+					deviceId.first,
+					deviceId.second,
+					fileStats.value().inodeNumber);
 
 			auto endSize = stream.tellp();
 

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -90,6 +90,12 @@ RegularFile::readSome(Process *process, void *data, size_t max_length, async::ca
 
 	assert(_offset <= _buffer.size());
 	size_t chunk = std::min(_buffer.size() - _offset, max_length);
+
+	if(chunk == max_length && chunk != 0) {
+		while(chunk != 0 && _buffer[_offset + chunk - 1] != '\n')
+			chunk--;
+	}
+
 	memcpy(data, _buffer.data() + _offset, chunk);
 	_offset += chunk;
 	co_return chunk;

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -1350,7 +1350,7 @@ HandleRequest::operator()(managarm::posix::OpenAtRequest &&req,
 	smarter::shared_ptr<File, FileHandle> file;
 	std::shared_ptr<FsLink> target_link;
 
-	if(req.fd() == AT_FDCWD) {
+	if(req.fd() == AT_FDCWD || req.path().starts_with('/')) {
 		relative_to = self->fsContext()->getWorkingDirectory();
 	} else {
 		file = self->fileContext()->getFile(req.fd());


### PR DESCRIPTION
Fixes for procfs maps format/reading and ignoring dirfd in openat for absolute paths like it should.