### PR TITLE
eir: Load GDT using inline assembly

### DIFF
--- a/kernel/eir/arch/x86/i386.cpp
+++ b/kernel/eir/arch/x86/i386.cpp
@@ -4,9 +4,6 @@
 
 namespace arch = common::x86;
 
-// TODO: eirLoadGdt could be written using inline assembly.
-extern "C" void eirLoadGdt(uint32_t *pointer, uint32_t size);
-
 uint32_t gdtEntries[4 * 2];
 
 namespace eir {
@@ -17,7 +14,19 @@ void initArchCpu() {
 	arch::makeGdtFlatData32SystemSegment(gdtEntries, 2);
 	arch::makeGdtCode64SystemSegment(gdtEntries, 3);
 
-	eirLoadGdt(gdtEntries, 4 * 8 - 1);
+	arch::Gdtr gdtr = {4 * 8 - 1, gdtEntries};
+
+	asm volatile("lgdt %0;"
+	             "ljmp %1, $1f;"
+	             "1:;"
+	             "mov %2, %%ds;"
+	             "mov %2, %%es;"
+	             "mov %2, %%ss;"
+	             "mov %3, %%fs;"
+	             "mov %3, %%gs;"
+	             :
+	             : "m"(gdtr), "i"(0x08), "r"(0x10), "r"(0x00)
+	             : "memory");
 }
 
 } // namespace eir

--- a/kernel/eir/arch/x86/load32.S
+++ b/kernel/eir/arch/x86/load32.S
@@ -1,44 +1,12 @@
 .set kEferLme, 0x100
 .set kEferNx, 0x800
 
-.section .data
-gdtr:
-	.short 0
-	.int 0
-
 .section .bss
 	.align 16
 eirStackBottom:
 	.skip 0x100000 # reserve 1 MiB for the stack
 	.global eirStackTop
 eirStackTop:
-
-.section .text
-
-.global eirLoadGdt
-eirLoadGdt:
-
-	mov 4(%esp), %eax
-	mov 8(%esp), %ecx
-	
-	# construct gdtr and load it
-	mov %cx, (gdtr)
-	mov %eax, (gdtr + 2)
-	lgdt (gdtr)
-
-	# reload code segment
-	ljmp $0x8, $.Lgdt_reload
-
-.Lgdt_reload:
-	# reload data segments
-	mov $0x10, %ax
-	mov %ax, %ds
-	mov %ax, %es
-	mov %ax, %ss
-	mov $0, %ax
-	mov %ax, %fs
-	mov %ax, %gs
-	ret
 
 .section .trampoline
 .global eirEnterKernel


### PR DESCRIPTION
Resolves the to-do in [kernel/eir/arch/x86/i386.cpp](https://github.com/managarm/managarm/blob/master/kernel/eir/arch/x86/i386.cpp#L7).