### PR TITLE
thor: Support page mappings with no access bits

### DIFF
--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -503,7 +503,8 @@ VirtualSpace::map(smarter::borrowed_ptr<MemorySlice> slice,
 			if((actualMappingFlags & MappingFlags::permissionMask) & MappingFlags::protRead)
 				pageFlags |= page_access::read;
 
-			{
+			// PROT_NONE mappings have no accessible pages to populate.
+			if(pageFlags) {
 				LocalRcuEngine::Guard revokeGuard{mapping->revokeRcu};
 
 				auto mapOutcome = _ops->mapPresentPages(mapping->address, mapping->view.get(),
@@ -582,10 +583,18 @@ VirtualSpace::protect(VirtualAddr address, size_t length, uint32_t flags) {
 		{
 			LocalRcuEngine::Guard revokeGuard{mapping->revokeRcu};
 
-			auto restrictOutcome = _ops->restrictPages(mapping->address,
-					mapping->length, pageFlags, caching);
-			assert(restrictOutcome);
-			anyRevoked = restrictOutcome.value().anyRevoked;
+			// A present page is always readable, so dropping all access requires unmapping.
+			if(pageFlags) {
+				auto restrictOutcome = _ops->restrictPages(mapping->address,
+						mapping->length, pageFlags, caching);
+				assert(restrictOutcome);
+				anyRevoked = restrictOutcome.value().anyRevoked;
+			}else{
+				auto unmapOutcome = _ops->unmapPages(mapping->address, mapping->length);
+				assert(unmapOutcome);
+				notifyRss_(unmapOutcome.value());
+				anyRevoked = unmapOutcome.value().anyRevoked;
+			}
 
 			if(anyRevoked)
 				co_await _ops->shootdown(mapping->address, mapping->length);
@@ -681,6 +690,9 @@ VirtualSpace::handleFault(VirtualAddr address, uint32_t faultFlags) {
 			if (!(flags & MappingFlags::protExecute))
 				co_return Error::badPermissions;
 		}
+		// A mapping without any permission (PROT_NONE) faults on every access.
+		if(!(flags & MappingFlags::permissionMask))
+			co_return Error::badPermissions;
 
 		// TODO: Aligning should not be necessary here.
 		auto offset = (address - mapping->address) & ~(kPageSize - 1);
@@ -707,6 +719,10 @@ VirtualSpace::handleFault(VirtualAddr address, uint32_t faultFlags) {
 			if (mapping->state.load(std::memory_order_relaxed) != MappingState::active)
 				continue;
 			auto flags = mapping->flags.load(std::memory_order_relaxed);
+			// Re-check under the RCU guard: a concurrent protect() may have dropped all
+			// access and unmapped the range, so the page must not be made present again.
+			if(!(flags & MappingFlags::permissionMask))
+				co_return Error::badPermissions;
 
 			{
 				LocalRcuEngine::Guard revokeGuard{mapping->revokeRcu};

--- a/kernel/thor/generic/thor-internal/address-space.hpp
+++ b/kernel/thor/generic/thor-internal/address-space.hpp
@@ -71,6 +71,8 @@ frg::expected<Error, PagesAffected> mapPresentPagesByCursor(PageSpace *ps, Virtu
 	assert(!(va & (kPageSize - 1)));
 	assert(!(offset & (kPageSize - 1)));
 	assert(!(size & (kPageSize - 1)));
+	// At least one access bit is always set; see VirtualOperations.
+	assert(flags & (page_access::read | page_access::write | page_access::execute));
 
 	PagesAffected affected{};
 	Cursor c{ps, va, policy};
@@ -118,6 +120,8 @@ frg::expected<Error, PagesAffected> restrictPagesByCursor(PageSpace *ps, Virtual
 		typename Cursor::PolicyType policy) {
 	assert(!(va & (kPageSize - 1)));
 	assert(!(size & (kPageSize - 1)));
+	// At least one access bit is always set; see VirtualOperations.
+	assert(flags & (page_access::read | page_access::write | page_access::execute));
 
 	PagesAffected affected{};
 	Cursor c{ps, va, policy};
@@ -147,6 +151,8 @@ frg::expected<Error, PagesAffected> faultPageByCursor(PageSpace *ps, VirtualAddr
 		typename Cursor::PolicyType policy) {
 	assert(!(va & (kPageSize - 1)));
 	assert(!(offset & (kPageSize - 1)));
+	// At least one access bit is always set; see VirtualOperations.
+	assert(flags & (page_access::read | page_access::write | page_access::execute));
 
 	PagesAffected affected{};
 	Cursor c{ps, va, policy};
@@ -275,12 +281,15 @@ struct VirtualOperations {
 
 	virtual bool submitShootdown(ShootNode *node) = 0;
 
+	// Precondition: flags has at least one access bit (read/write/execute) set.
 	virtual frg::expected<Error, PagesAffected> mapPresentPages(VirtualAddr va, MemoryView *view,
 			uintptr_t offset, size_t size, PageFlags flags, CachingMode mode) = 0;
 
+	// Precondition: flags has at least one access bit (read/write/execute) set.
 	virtual frg::expected<Error, PagesAffected> restrictPages(VirtualAddr va,
 			size_t size, PageFlags flags, CachingMode mode) = 0;
 
+	// Precondition: flags has at least one access bit (read/write/execute) set.
 	virtual frg::expected<Error, PagesAffected> faultPage(VirtualAddr va, MemoryView *view,
 			uintptr_t offset, FetchFlags fetchFlags, PageFlags flags, CachingMode mode) = 0;
 

--- a/testsuites/kernel-tests/meson.build
+++ b/testsuites/kernel-tests/meson.build
@@ -4,6 +4,7 @@ executable('kernel-tests',
 		'src/faults.cpp',
 		'src/mapping.cpp',
 		'src/memory.cpp',
+		'src/protect.cpp',
 	],
 	dependencies: [ helix_dep ],
 	install : true

--- a/testsuites/kernel-tests/src/protect.cpp
+++ b/testsuites/kernel-tests/src/protect.cpp
@@ -1,0 +1,68 @@
+#include <cassert>
+#include <cstddef>
+
+#include <async/result.hpp>
+#include <helix/ipc.hpp>
+
+#include <hel.h>
+#include <hel-syscalls.h>
+
+#include "testsuite.hpp"
+
+namespace {
+
+// helLog() reads user memory through the kernel and reports kHelErrFault on inaccessible
+// pages, letting us probe access without faulting the test itself.
+
+async::result<void> testProtectProtNone() {
+	HelHandle handle;
+	HEL_CHECK(helAllocateMemory(0x1000, 0, nullptr, &handle));
+	void *window;
+	HEL_CHECK(helMapMemory(handle, kHelNullHandle, nullptr, 0, 0x1000,
+			kHelMapProtRead | kHelMapProtWrite, &window));
+
+	// Touch the page so that it is actually present before we drop access.
+	auto p = reinterpret_cast<volatile std::byte *>(window);
+	p[0] = static_cast<std::byte>(42);
+	assert(p[0] == static_cast<std::byte>(42));
+
+	// Drop all access; the previously present page must become inaccessible.
+	helix::ProtectMemory dropProtect;
+	auto &&dropSubmit = helix::submitProtectMemory(helix::BorrowedDescriptor{kHelNullHandle},
+			&dropProtect, window, 0x1000, 0, helix::Dispatcher::global());
+	co_await dropSubmit.async_wait();
+	HEL_CHECK(dropProtect.error());
+
+	assert(helLog(kHelLogSeverityInfo, static_cast<char *>(window), 0x1000) == kHelErrFault);
+
+	// Restoring access faults the page back in on demand.
+	helix::ProtectMemory restoreProtect;
+	auto &&restoreSubmit = helix::submitProtectMemory(helix::BorrowedDescriptor{kHelNullHandle},
+			&restoreProtect, window, 0x1000, kHelMapProtRead | kHelMapProtWrite,
+			helix::Dispatcher::global());
+	co_await restoreSubmit.async_wait();
+	HEL_CHECK(restoreProtect.error());
+
+	p[0] = static_cast<std::byte>(43);
+	assert(p[0] == static_cast<std::byte>(43));
+
+	HEL_CHECK(helUnmapMemory(kHelNullHandle, window, 0x1000));
+}
+
+} // anonymous namespace
+
+DEFINE_TEST(mapProtNone, ([] {
+	HelHandle handle;
+	HEL_CHECK(helAllocateMemory(0x1000, 0, nullptr, &handle));
+	void *window;
+	HEL_CHECK(helMapMemory(handle, kHelNullHandle, nullptr, 0, 0x1000, 0, &window));
+
+	// A mapping without any access permits no access at all.
+	assert(helLog(kHelLogSeverityInfo, static_cast<char *>(window), 0x1000) == kHelErrFault);
+
+	HEL_CHECK(helUnmapMemory(kHelNullHandle, window, 0x1000));
+}))
+
+DEFINE_TEST(protectProtNone, ([] {
+	async::run(testProtectProtNone(), helix::currentDispatcher);
+}))

--- a/testsuites/posix-tests/src/mmap.cpp
+++ b/testsuites/posix-tests/src/mmap.cpp
@@ -406,3 +406,44 @@ DEFINE_TEST(mprotect_check_whether_three_way_split_mappings_are_handled_correctl
 		assert(ensureNotWritable(offsetBy(mem, pageSize * 2)));
 	});
 }))
+
+DEFINE_TEST(mmap_prot_none, ([] {
+	void *mem = mmap(nullptr, pageSize, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	assert_errno("mmap", mem != MAP_FAILED);
+
+	runChecks([&] {
+		assert(ensureNotReadable(mem));
+		assert(ensureNotWritable(mem));
+	});
+
+	int ret = munmap(mem, pageSize);
+	assert_errno("munmap", ret != -1);
+}))
+
+DEFINE_TEST(mprotect_prot_none, ([] {
+	void *mem = mmap(nullptr, pageSize, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	assert_errno("mmap", mem != MAP_FAILED);
+
+	// Touch the page so that it is actually present before we drop access.
+	*reinterpret_cast<volatile uint8_t *>(mem) = 42;
+
+	int ret = mprotect(mem, pageSize, PROT_NONE);
+	assert_errno("mprotect", ret != -1);
+
+	runChecks([&] {
+		assert(ensureNotReadable(mem));
+		assert(ensureNotWritable(mem));
+	});
+
+	// Restoring access must fault the page back in on demand.
+	ret = mprotect(mem, pageSize, PROT_READ | PROT_WRITE);
+	assert_errno("mprotect", ret != -1);
+
+	runChecks([&] {
+		assert(ensureReadable(mem));
+		assert(ensureWritable(mem));
+	});
+
+	ret = munmap(mem, pageSize);
+	assert_errno("munmap", ret != -1);
+}))


### PR DESCRIPTION
This implements the equivalent of `PROT_NONE`. No POSIX changes are needed since posix-subsystem already passed the flags correctly.