### PR TITLE
libblockfs: Fix various rename() failure modes

### DIFF
--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -443,6 +443,47 @@ async::result<std::expected<bool, protocols::fs::Error>> Inode::isDirectoryEmpty
 	co_return true;
 }
 
+async::result<frg::expected<protocols::fs::Error>> Inode::updateDotDot(uint32_t parent) {
+	co_await readyEvent.wait();
+
+	if(fileType != kTypeDirectory)
+		co_return protocols::fs::Error::notDirectory;
+
+	helix::LockMemoryView lock_memory;
+	auto map_size = (fileSize() + 0xFFF) & ~size_t(0xFFF);
+	auto &&submit = helix::submitLockMemoryView(helix::BorrowedDescriptor(frontalMemory),
+			&lock_memory,
+			0, map_size, helix::Dispatcher::global());
+	co_await submit.async_wait();
+	HEL_CHECK(lock_memory.error());
+
+	uintptr_t offset = 0;
+	while(offset < fileSize()) {
+		assert(!(offset & 3));
+		assert(offset + sizeof(DiskDirEntry) <= fileSize());
+		auto disk_entry = reinterpret_cast<DiskDirEntry *>(
+				reinterpret_cast<char *>(fileMapping.get()) + offset);
+		assert(disk_entry->recordLength);
+
+		if(disk_entry->inode
+				&& disk_entry->nameLength == 2
+				&& disk_entry->name[0] == '.'
+				&& disk_entry->name[1] == '.') {
+			disk_entry->inode = parent;
+
+			auto syncDir = co_await helix_ng::synchronizeSpace(
+					helix::BorrowedDescriptor{kHelNullHandle}, fileMapping.get(), fileSize());
+			HEL_CHECK(syncDir.error());
+
+			co_return {};
+		}
+
+		offset += disk_entry->recordLength;
+	}
+
+	co_return protocols::fs::Error::fileNotFound;
+}
+
 async::result<std::expected<DirEntry, protocols::fs::Error>>
 Inode::link(std::string name, int64_t ino, blockfs::FileType type) {
 	// Check if an entry with this name already exists.

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -500,6 +500,30 @@ async::result<frg::expected<protocols::fs::Error>> Inode::updateDotDot(uint32_t 
 	co_return protocols::fs::Error::fileNotFound;
 }
 
+async::result<frg::expected<protocols::fs::Error, bool>> Inode::isSubdirectoryOf(uint32_t ino) {
+	co_await readyEvent.wait();
+
+	if(fileType != kTypeDirectory)
+		co_return protocols::fs::Error::notDirectory;
+
+	auto current = number;
+	while(true) {
+		if(current == ino)
+			co_return true;
+		if(current == EXT2_ROOT_INO)
+			co_return false;
+
+		auto dir = std::static_pointer_cast<Inode>(fs.accessInode(current));
+		auto parent = co_await dir->findEntry("..");
+		if(!parent)
+			co_return parent.error();
+		// A directory whose ".." is missing or points at itself ends the walk.
+		if(!parent.value() || parent.value()->inode == current)
+			co_return false;
+		current = parent.value()->inode;
+	}
+}
+
 async::result<std::expected<DirEntry, protocols::fs::Error>>
 Inode::link(std::string name, int64_t ino, blockfs::FileType type) {
 	// Check if an entry with this name already exists.

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -259,6 +259,10 @@ Inode::insertEntry(std::string name, int64_t ino, blockfs::FileType type) {
 	auto time = clk::getRealtime();
 	diskInode()->mtime = time.tv_sec;
 
+	// A new subdirectory adds a ".." backlink to this directory.
+	if(type == kTypeDirectory)
+		diskInode()->linksCount++;
+
 	updateInodeChecksum(fs, diskInode(), number);
 
 	auto syncInode = co_await helix_ng::synchronizeSpace(
@@ -382,6 +386,18 @@ async::result<frg::expected<protocols::fs::Error>> Inode::removeEntry(std::strin
 					helix::BorrowedDescriptor{kHelNullHandle},
 					target->diskInode(), fs.inodeSize);
 			HEL_CHECK(syncInode.error());
+
+			// A removed subdirectory drops its ".." backlink to this directory.
+			if(target->fileType == kTypeDirectory) {
+				diskInode()->linksCount--;
+
+				updateInodeChecksum(fs, diskInode(), number);
+
+				auto syncParent = co_await helix_ng::synchronizeSpace(
+						helix::BorrowedDescriptor{kHelNullHandle},
+						diskInode(), fs.inodeSize);
+				HEL_CHECK(syncParent.error());
+			}
 
 			co_return {};
 		}
@@ -551,20 +567,11 @@ async::result<std::expected<DirEntry, protocols::fs::Error>> Inode::mkdir(std::s
 	auto dotDotEntry = reinterpret_cast<DiskDirEntry *>(
 			reinterpret_cast<char *>(dirNode->fileMapping.get()) + offset);
 
-	diskInode()->linksCount++;
 	dotDotEntry->inode = number;
 	dotDotEntry->recordLength = dirNode->fileSize() - offset;
 	dotDotEntry->nameLength = 2;
 	dotDotEntry->fileType = EXT2_FT_DIR;
 	memcpy(dotDotEntry->name, "..", 3);
-
-	updateInodeChecksum(fs, diskInode(), number);
-
-	// Synchronize this inode to update the linksCount
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			diskInode(), fs.inodeSize);
-	HEL_CHECK(syncInode.error());
 
 	updateInodeChecksum(fs, dirNode->diskInode(), dirNode->number);
 

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -362,6 +362,9 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 
 	async::result<std::expected<bool, protocols::fs::Error>> isDirectoryEmpty();
 
+	// Repoints the ".." entry of this directory at a new parent inode.
+	async::result<frg::expected<protocols::fs::Error>> updateDotDot(uint32_t parent);
+
 	async::result<std::expected<DirEntry, protocols::fs::Error>> link(std::string name, int64_t ino, blockfs::FileType type);
 	async::result<std::expected<DirEntry, protocols::fs::Error>> mkdir(std::string name, uid_t uid, gid_t gid, mode_t mode);
 	async::result<std::expected<DirEntry, protocols::fs::Error>> symlink(std::string name, std::string target);

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -365,6 +365,10 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 	// Repoints the ".." entry of this directory at a new parent inode.
 	async::result<frg::expected<protocols::fs::Error>> updateDotDot(uint32_t parent);
 
+	// Returns whether this directory is `ino` itself or one of its descendants,
+	// found by walking the ".." chain up to the filesystem root.
+	async::result<frg::expected<protocols::fs::Error, bool>> isSubdirectoryOf(uint32_t ino);
+
 	async::result<std::expected<DirEntry, protocols::fs::Error>> link(std::string name, int64_t ino, blockfs::FileType type);
 	async::result<std::expected<DirEntry, protocols::fs::Error>> mkdir(std::string name, uid_t uid, gid_t gid, mode_t mode);
 	async::result<std::expected<DirEntry, protocols::fs::Error>> symlink(std::string name, std::string target);

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -232,31 +232,16 @@ struct HandlePartition {
 				}
 			}
 
+			// A missing destination is the common case and not an error.
 			auto result = co_await newInode->removeEntry(req.new_name());
-			if(!result) {
-				if(result.error() == protocols::fs::Error::fileNotFound) {
-					// Ignored
-				} else if(result.error() == protocols::fs::Error::directoryNotEmpty) {
-					resp.set_error(managarm::fs::Errors::DIRECTORY_NOT_EMPTY);
+			if(!result && result.error() != protocols::fs::Error::fileNotFound) {
+				resp.set_error(result.error() | protocols::fs::toFsError);
 
-					auto ser = resp.SerializeAsString();
-					auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
-						helix_ng::sendBuffer(ser.data(), ser.size()));
-					HEL_CHECK(send_resp.error());
-					co_return {};
-				} else if(result.error() == protocols::fs::Error::notDirectory) {
-					resp.set_error(managarm::fs::Errors::NOT_DIRECTORY);
-
-					auto ser = resp.SerializeAsString();
-					auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
-						helix_ng::sendBuffer(ser.data(), ser.size()));
-					HEL_CHECK(send_resp.error());
-					co_return {};
-				} else {
-					// Handle error
-					std::cout << "libblockfs: rename: unhandled error: " << (int)result.error() << std::endl;
-					assert(result.error() == protocols::fs::Error::fileNotFound || result.error() == protocols::fs::Error::directoryNotEmpty || result.error() == protocols::fs::Error::notDirectory);
-				}
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size()));
+				HEL_CHECK(send_resp.error());
+				co_return {};
 			}
 			auto link_result = co_await newInode->link(req.new_name(),
 					old_file.value().inode, old_file.value().fileType);
@@ -281,8 +266,7 @@ struct HandlePartition {
 
 		auto result = co_await oldInode->removeEntry(req.old_name());
 		if(!result) {
-			assert(result.error() == protocols::fs::Error::fileNotFound);
-			resp.set_error(managarm::fs::Errors::FILE_NOT_FOUND);
+			resp.set_error(result.error() | protocols::fs::toFsError);
 
 			auto ser = resp.SerializeAsString();
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <sys/epoll.h>
 #include <linux/cdrom.h>
 #include <linux/fs.h>
@@ -155,13 +156,27 @@ struct HandlePartition {
 		}
 
 		auto &fs = *fsPtr;
+
+		auto isInvalidName = [](std::string_view name) {
+			return name.empty() || name == "." || name == "..";
+		};
+		if(isInvalidName(req.old_name()) || isInvalidName(req.new_name())) {
+			managarm::fs::SvrResponse resp;
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+
+			auto ser = resp.SerializeAsString();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+				helix_ng::sendBuffer(ser.data(), ser.size()));
+			HEL_CHECK(send_resp.error());
+			co_return {};
+		}
+
 		auto oldInodeRaw = fs->accessInode(req.inode_source());
 		auto newInodeRaw = fs->accessInode(req.inode_target());
 
 		auto oldInode = std::static_pointer_cast<ext2fs::Inode>(oldInodeRaw);
 		auto newInode = std::static_pointer_cast<ext2fs::Inode>(newInodeRaw);
 
-		assert(!req.old_name().empty() && req.old_name() != "." && req.old_name() != "..");
 		auto old_result = co_await oldInode->findEntry(req.old_name());
 		if(!old_result) {
 			managarm::fs::SvrResponse resp;

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -193,6 +193,30 @@ struct HandlePartition {
 		auto old_file = old_result.value();
 		managarm::fs::SvrResponse resp;
 		if(old_file) {
+			// Reject moving a directory into itself or one of its own
+			// descendants, which would detach the subtree from the tree.
+			if(old_file.value().fileType == kTypeDirectory) {
+				auto loop = co_await newInode->isSubdirectoryOf(old_file.value().inode);
+				if(!loop) {
+					resp.set_error(loop.error() | protocols::fs::toFsError);
+
+					auto ser = resp.SerializeAsString();
+					auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+						helix_ng::sendBuffer(ser.data(), ser.size()));
+					HEL_CHECK(send_resp.error());
+					co_return {};
+				}
+				if(loop.value()) {
+					resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+
+					auto ser = resp.SerializeAsString();
+					auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+						helix_ng::sendBuffer(ser.data(), ser.size()));
+					HEL_CHECK(send_resp.error());
+					co_return {};
+				}
+			}
+
 			// If new_name names an existing directory, refuse to overwrite
 			// a non-empty one rather than corrupting it via removeEntry.
 			auto new_entry = co_await newInode->findEntry(req.new_name());

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -193,6 +193,45 @@ struct HandlePartition {
 		auto old_file = old_result.value();
 		managarm::fs::SvrResponse resp;
 		if(old_file) {
+			// If new_name names an existing directory, refuse to overwrite
+			// a non-empty one rather than corrupting it via removeEntry.
+			auto new_entry = co_await newInode->findEntry(req.new_name());
+			if(!new_entry) {
+				assert(new_entry.error() == protocols::fs::Error::notDirectory);
+				resp.set_error(managarm::fs::Errors::NOT_DIRECTORY);
+
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size()));
+				HEL_CHECK(send_resp.error());
+				co_return {};
+			}
+			if(new_entry.value() && new_entry.value()->fileType == kTypeDirectory) {
+				auto target_inode = std::static_pointer_cast<ext2fs::Inode>(
+						fs->accessInode(new_entry.value()->inode));
+				auto isEmpty = co_await target_inode->isDirectoryEmpty();
+				if(!isEmpty) {
+					std::cout << "libblockfs: rename: isDirectoryEmpty failed: "
+						<< (int)isEmpty.error() << std::endl;
+					resp.set_error(managarm::fs::Errors::INTERNAL_ERROR);
+
+					auto ser = resp.SerializeAsString();
+					auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+						helix_ng::sendBuffer(ser.data(), ser.size()));
+					HEL_CHECK(send_resp.error());
+					co_return {};
+				}
+				if(!isEmpty.value()) {
+					resp.set_error(managarm::fs::Errors::DIRECTORY_NOT_EMPTY);
+
+					auto ser = resp.SerializeAsString();
+					auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+						helix_ng::sendBuffer(ser.data(), ser.size()));
+					HEL_CHECK(send_resp.error());
+					co_return {};
+				}
+			}
+
 			auto result = co_await newInode->removeEntry(req.new_name());
 			if(!result) {
 				if(result.error() == protocols::fs::Error::fileNotFound) {

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -219,7 +219,17 @@ struct HandlePartition {
 					assert(result.error() == protocols::fs::Error::fileNotFound || result.error() == protocols::fs::Error::directoryNotEmpty || result.error() == protocols::fs::Error::notDirectory);
 				}
 			}
-			co_await newInode->link(req.new_name(), old_file.value().inode, old_file.value().fileType);
+			auto link_result = co_await newInode->link(req.new_name(),
+					old_file.value().inode, old_file.value().fileType);
+			if(!link_result) {
+				resp.set_error(link_result.error() | protocols::fs::toFsError);
+
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size()));
+				HEL_CHECK(send_resp.error());
+				co_return {};
+			}
 		} else {
 			resp.set_error(managarm::fs::Errors::FILE_NOT_FOUND);
 

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -206,6 +206,30 @@ struct HandlePartition {
 				HEL_CHECK(send_resp.error());
 				co_return {};
 			}
+			if(new_entry.value()) {
+				// POSIX only allows replacing a directory with a directory and a
+				// non-directory with a non-directory.
+				auto sourceIsDir = old_file.value().fileType == kTypeDirectory;
+				auto targetIsDir = new_entry.value()->fileType == kTypeDirectory;
+				if(sourceIsDir && !targetIsDir) {
+					resp.set_error(managarm::fs::Errors::NOT_DIRECTORY);
+
+					auto ser = resp.SerializeAsString();
+					auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+						helix_ng::sendBuffer(ser.data(), ser.size()));
+					HEL_CHECK(send_resp.error());
+					co_return {};
+				}
+				if(!sourceIsDir && targetIsDir) {
+					resp.set_error(managarm::fs::Errors::IS_DIRECTORY);
+
+					auto ser = resp.SerializeAsString();
+					auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+						helix_ng::sendBuffer(ser.data(), ser.size()));
+					HEL_CHECK(send_resp.error());
+					co_return {};
+				}
+			}
 			if(new_entry.value() && new_entry.value()->fileType == kTypeDirectory) {
 				auto target_inode = std::static_pointer_cast<ext2fs::Inode>(
 						fs->accessInode(new_entry.value()->inode));

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -207,6 +207,18 @@ struct HandlePartition {
 				co_return {};
 			}
 			if(new_entry.value()) {
+				// If old_name and new_name resolve to the same inode, rename is a
+				// no-op; the removeEntry/link below would otherwise drop the file's
+				// last link.
+				if(old_file.value().inode == new_entry.value()->inode) {
+					resp.set_error(managarm::fs::Errors::SUCCESS);
+
+					auto ser = resp.SerializeAsString();
+					auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+						helix_ng::sendBuffer(ser.data(), ser.size()));
+					HEL_CHECK(send_resp.error());
+					co_return {};
+				}
 				// POSIX only allows replacing a directory with a directory and a
 				// non-directory with a non-directory.
 				auto sourceIsDir = old_file.value().fileType == kTypeDirectory;

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -278,6 +278,25 @@ struct HandlePartition {
 				HEL_CHECK(send_resp.error());
 				co_return {};
 			}
+
+			// Moving a directory to a different parent must repoint its ".."
+			// entry. The link() and removeEntry() above already shifted the
+			// subdirectory link between the two parents.
+			if(old_file.value().fileType == kTypeDirectory
+					&& oldInode->number != newInode->number) {
+				auto movedInode = std::static_pointer_cast<ext2fs::Inode>(
+						fs->accessInode(old_file.value().inode));
+				auto reparent = co_await movedInode->updateDotDot(newInode->number);
+				if(!reparent) {
+					resp.set_error(reparent.error() | protocols::fs::toFsError);
+
+					auto ser = resp.SerializeAsString();
+					auto [send_resp] = co_await helix_ng::exchangeMsgs(conversation,
+						helix_ng::sendBuffer(ser.data(), ser.size()));
+					HEL_CHECK(send_resp.error());
+					co_return {};
+				}
+			}
 		} else {
 			resp.set_error(managarm::fs::Errors::FILE_NOT_FOUND);
 

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -973,11 +973,9 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
 	managarm::fs::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 	recv_resp.reset();
-	if(resp.error() == managarm::fs::Errors::SUCCESS) {
+	if(resp.error() == managarm::fs::Errors::SUCCESS)
 		co_return internalizePeripheralLink(target_node, name, shared_node);
-	}else{
-		co_return nullptr;
-	}
+	co_return resp.error() | toPosixError;
 }
 
 std::shared_ptr<Node> Superblock::internalizeStructural(uint64_t id, helix::UniqueLane lane) {

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -681,8 +681,7 @@ HandleRequest::operator()(managarm::posix::RenameAtRequest &&req,
 	auto result = co_await superblock->rename(resolver.currentLink().get(),
 			directory.get(), new_resolver.nextComponent());
 	if(!result) {
-		assert(result.error() == Error::alreadyExists);
-		co_await sendErrorResponse(conversation, managarm::posix::Errors::ALREADY_EXISTS);
+		co_await sendErrorResponse(conversation, result.error() | toPosixProtoError);
 		co_return {};
 	}
 

--- a/testsuites/posix-tests/meson.build
+++ b/testsuites/posix-tests/meson.build
@@ -22,6 +22,7 @@ src = [
 	'src/pty.cpp',
 	'src/procfs.cpp',
 	'src/path-resolution.cpp',
+	'src/rename.cpp',
 	'src/pthread-fork-wait.cpp',
 	'src/thread.cpp',
 	'src/poll.cpp',

--- a/testsuites/posix-tests/src/rename.cpp
+++ b/testsuites/posix-tests/src/rename.cpp
@@ -1,0 +1,407 @@
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <frg/scope_exit.hpp>
+
+#include "testsuite.hpp"
+
+namespace {
+
+// Create a fresh per-test scratch directory on the ext2 root filesystem
+// (so the libblockfs rename handler is actually on the path; /tmp is tmpfs
+// and would bypass the code under test).
+std::string make_scratch() {
+	std::string tmpl = "/posix-tests-rename-XXXXXX";
+	std::string path(tmpl);
+	if(!mkdtemp(path.data()))
+		assert(!"mkdtemp() failed");
+	return path;
+}
+
+void create_file(const std::string &path, const char *data = nullptr) {
+	int fd = creat(path.c_str(), 0644);
+	assert(fd >= 0);
+	if(data) {
+		auto len = strlen(data);
+		auto written = write(fd, data, len);
+		assert(static_cast<size_t>(written) == len);
+	}
+	close(fd);
+}
+
+bool path_exists(const std::string &path) {
+	struct stat st;
+	return stat(path.c_str(), &st) == 0;
+}
+
+} // namespace
+
+// rename(missing, *) must fail with ENOENT.
+DEFINE_TEST(rename_missing_source, ([] {
+	auto dir = make_scratch();
+	frg::scope_exit cleanup{[&] { rmdir(dir.c_str()); }};
+
+	auto src = dir + "/missing";
+	auto dst = dir + "/dst";
+
+	errno = 0;
+	int e = rename(src.c_str(), dst.c_str());
+	assert(e == -1);
+	assert(errno == ENOENT);
+	assert(!path_exists(dst));
+}))
+
+// Basic rename of a regular file to a new name in the same directory.
+DEFINE_TEST(rename_file_basic, ([] {
+	auto dir = make_scratch();
+	auto src = dir + "/a";
+	auto dst = dir + "/b";
+	frg::scope_exit cleanup{[&] {
+		unlink(src.c_str());
+		unlink(dst.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	create_file(src, "hello");
+
+	int e = rename(src.c_str(), dst.c_str());
+	assert(e == 0);
+	assert(!path_exists(src));
+	assert(path_exists(dst));
+
+	struct stat st;
+	assert(stat(dst.c_str(), &st) == 0);
+	assert(st.st_size == 5);
+}))
+
+// Rename onto an existing regular file replaces the destination.
+DEFINE_TEST(rename_file_over_file, ([] {
+	auto dir = make_scratch();
+	auto src = dir + "/a";
+	auto dst = dir + "/b";
+	frg::scope_exit cleanup{[&] {
+		unlink(src.c_str());
+		unlink(dst.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	create_file(src, "from-src");
+	create_file(dst, "from-dst");
+
+	int e = rename(src.c_str(), dst.c_str());
+	assert(e == 0);
+	assert(!path_exists(src));
+
+	int fd = open(dst.c_str(), O_RDONLY);
+	assert(fd >= 0);
+	char buf[16] = {};
+	auto n = read(fd, buf, sizeof(buf) - 1);
+	close(fd);
+	assert(n == 8);
+	assert(std::string(buf) == "from-src");
+}))
+
+// Rename of an empty directory to a new name.
+DEFINE_TEST(rename_dir_basic, ([] {
+	auto dir = make_scratch();
+	auto src = dir + "/srcdir";
+	auto dst = dir + "/dstdir";
+	frg::scope_exit cleanup{[&] {
+		rmdir(src.c_str());
+		rmdir(dst.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	int e = mkdir(src.c_str(), 0755);
+	assert(e == 0);
+
+	e = rename(src.c_str(), dst.c_str());
+	assert(e == 0);
+	assert(!path_exists(src));
+
+	struct stat st;
+	assert(stat(dst.c_str(), &st) == 0);
+	assert(S_ISDIR(st.st_mode));
+}))
+
+// Rename onto an existing non-empty directory must fail with ENOTEMPTY.
+DEFINE_TEST(rename_onto_nonempty_dir, ([] {
+	auto dir = make_scratch();
+	auto src = dir + "/srcdir";
+	auto dst = dir + "/dstdir";
+	auto dst_child = dst + "/child";
+	frg::scope_exit cleanup{[&] {
+		unlink(dst_child.c_str());
+		rmdir(src.c_str());
+		rmdir(dst.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	int e = mkdir(src.c_str(), 0755);
+	assert(e == 0);
+	e = mkdir(dst.c_str(), 0755);
+	assert(e == 0);
+	create_file(dst_child);
+
+	errno = 0;
+	e = rename(src.c_str(), dst.c_str());
+	assert(e == -1);
+	assert(errno == ENOTEMPTY || errno == EEXIST);
+
+	// Both directories must still exist with their original contents.
+	struct stat st;
+	assert(stat(src.c_str(), &st) == 0 && S_ISDIR(st.st_mode));
+	assert(stat(dst.c_str(), &st) == 0 && S_ISDIR(st.st_mode));
+	assert(path_exists(dst_child));
+}))
+
+// Rename within the same directory removes the source name.
+DEFINE_TEST(rename_in_same_directory, ([] {
+	auto dir = make_scratch();
+	auto src = dir + "/a";
+	auto dst = dir + "/b";
+	frg::scope_exit cleanup{[&] {
+		unlink(src.c_str());
+		unlink(dst.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	create_file(src);
+	int e = rename(src.c_str(), dst.c_str());
+	assert(e == 0);
+	assert(!path_exists(src));
+	assert(path_exists(dst));
+}))
+
+// Renaming a non-directory onto an existing directory must fail with EISDIR.
+DEFINE_TEST(rename_file_onto_dir_fails, ([] {
+	auto dir = make_scratch();
+	auto src = dir + "/file";
+	auto dst = dir + "/dir";
+	frg::scope_exit cleanup{[&] {
+		unlink(src.c_str());
+		rmdir(dst.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	create_file(src);
+	assert(mkdir(dst.c_str(), 0755) == 0);
+
+	errno = 0;
+	int e = rename(src.c_str(), dst.c_str());
+	assert(e == -1);
+	assert(errno == EISDIR);
+	assert(path_exists(src));
+	assert(path_exists(dst));
+}))
+
+// Renaming a directory onto an existing non-directory must fail with ENOTDIR.
+DEFINE_TEST(rename_dir_onto_file_fails, ([] {
+	auto dir = make_scratch();
+	auto src = dir + "/dir";
+	auto dst = dir + "/file";
+	frg::scope_exit cleanup{[&] {
+		rmdir(src.c_str());
+		unlink(dst.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	assert(mkdir(src.c_str(), 0755) == 0);
+	create_file(dst);
+
+	errno = 0;
+	int e = rename(src.c_str(), dst.c_str());
+	assert(e == -1);
+	assert(errno == ENOTDIR);
+	assert(path_exists(src));
+	assert(path_exists(dst));
+}))
+
+// Moving a directory to a new parent repoints its ".." and shifts the
+// subdirectory link from the old to the new parent.
+DEFINE_TEST(rename_dir_to_new_parent, ([] {
+	auto dir = make_scratch();
+	auto p1 = dir + "/p1";
+	auto p2 = dir + "/p2";
+	auto src = p1 + "/d";
+	auto dst = p2 + "/d";
+	frg::scope_exit cleanup{[&] {
+		rmdir(src.c_str());
+		rmdir(dst.c_str());
+		rmdir(p1.c_str());
+		rmdir(p2.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	assert(mkdir(p1.c_str(), 0755) == 0);
+	assert(mkdir(p2.c_str(), 0755) == 0);
+	assert(mkdir(src.c_str(), 0755) == 0);
+
+	struct stat p1_before, p2_before;
+	assert(stat(p1.c_str(), &p1_before) == 0);
+	assert(stat(p2.c_str(), &p2_before) == 0);
+
+	assert(rename(src.c_str(), dst.c_str()) == 0);
+	assert(!path_exists(src));
+	assert(path_exists(dst));
+
+	// ".." of the moved directory now resolves to the new parent.
+	struct stat dotdot, p2_stat;
+	assert(stat((dst + "/..").c_str(), &dotdot) == 0);
+	assert(stat(p2.c_str(), &p2_stat) == 0);
+	assert(dotdot.st_ino == p2_stat.st_ino);
+
+	// The old parent loses a link, the new parent gains one.
+	struct stat p1_after, p2_after;
+	assert(stat(p1.c_str(), &p1_after) == 0);
+	assert(stat(p2.c_str(), &p2_after) == 0);
+	assert(p1_after.st_nlink == p1_before.st_nlink - 1);
+	assert(p2_after.st_nlink == p2_before.st_nlink + 1);
+}))
+
+// Replacing an empty directory in another parent repoints ".." but leaves the
+// new parent's link count unchanged, since the replaced directory already
+// contributed it.
+DEFINE_TEST(rename_dir_onto_empty_dir_in_new_parent, ([] {
+	auto dir = make_scratch();
+	auto p1 = dir + "/p1";
+	auto p2 = dir + "/p2";
+	auto src = p1 + "/d";
+	auto dst = p2 + "/d";
+	frg::scope_exit cleanup{[&] {
+		rmdir(src.c_str());
+		rmdir(dst.c_str());
+		rmdir(p1.c_str());
+		rmdir(p2.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	assert(mkdir(p1.c_str(), 0755) == 0);
+	assert(mkdir(p2.c_str(), 0755) == 0);
+	assert(mkdir(src.c_str(), 0755) == 0);
+	assert(mkdir(dst.c_str(), 0755) == 0);
+
+	struct stat p1_before, p2_before;
+	assert(stat(p1.c_str(), &p1_before) == 0);
+	assert(stat(p2.c_str(), &p2_before) == 0);
+
+	assert(rename(src.c_str(), dst.c_str()) == 0);
+	assert(!path_exists(src));
+	assert(path_exists(dst));
+
+	struct stat dotdot, p2_stat;
+	assert(stat((dst + "/..").c_str(), &dotdot) == 0);
+	assert(stat(p2.c_str(), &p2_stat) == 0);
+	assert(dotdot.st_ino == p2_stat.st_ino);
+
+	struct stat p1_after, p2_after;
+	assert(stat(p1.c_str(), &p1_after) == 0);
+	assert(stat(p2.c_str(), &p2_after) == 0);
+	assert(p1_after.st_nlink == p1_before.st_nlink - 1);
+	assert(p2_after.st_nlink == p2_before.st_nlink);
+}))
+
+// Renaming a file onto itself is a no-op and must not destroy it.
+DEFINE_TEST(rename_same_path_file, ([] {
+	auto dir = make_scratch();
+	auto src = dir + "/file";
+	frg::scope_exit cleanup{[&] {
+		unlink(src.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	create_file(src, "payload");
+
+	assert(rename(src.c_str(), src.c_str()) == 0);
+	assert(path_exists(src));
+
+	char buf[8] = {};
+	int fd = open(src.c_str(), O_RDONLY);
+	assert(fd >= 0);
+	assert(read(fd, buf, sizeof(buf) - 1) == 7);
+	close(fd);
+	assert(!strcmp(buf, "payload"));
+}))
+
+// Renaming a (non-empty) directory onto itself is a no-op and must not destroy
+// it or its contents.
+DEFINE_TEST(rename_same_path_dir, ([] {
+	auto dir = make_scratch();
+	auto sub = dir + "/sub";
+	auto child = sub + "/child";
+	frg::scope_exit cleanup{[&] {
+		unlink(child.c_str());
+		rmdir(sub.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	assert(mkdir(sub.c_str(), 0755) == 0);
+	create_file(child);
+
+	assert(rename(sub.c_str(), sub.c_str()) == 0);
+	assert(path_exists(sub));
+	assert(path_exists(child));
+}))
+
+// Renaming one hard link onto another link of the same file is a no-op: both
+// names must survive.
+DEFINE_TEST(rename_hardlink_same_inode, ([] {
+	auto dir = make_scratch();
+	auto a = dir + "/a";
+	auto b = dir + "/b";
+	frg::scope_exit cleanup{[&] {
+		unlink(a.c_str());
+		unlink(b.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	create_file(a);
+	assert(link(a.c_str(), b.c_str()) == 0);
+
+	assert(rename(a.c_str(), b.c_str()) == 0);
+	assert(path_exists(a));
+	assert(path_exists(b));
+
+	struct stat sa, sb;
+	assert(stat(a.c_str(), &sa) == 0);
+	assert(stat(b.c_str(), &sb) == 0);
+	assert(sa.st_ino == sb.st_ino);
+	assert(sa.st_nlink == 2);
+}))
+
+// Renaming a directory into itself or one of its own descendants must fail
+// with EINVAL rather than detaching the subtree.
+DEFINE_TEST(rename_dir_into_descendant, ([] {
+	auto dir = make_scratch();
+	auto a = dir + "/a";
+	auto b = a + "/b";
+	frg::scope_exit cleanup{[&] {
+		rmdir(b.c_str());
+		rmdir(a.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	assert(mkdir(a.c_str(), 0755) == 0);
+	assert(mkdir(b.c_str(), 0755) == 0);
+
+	// Moving "a" directly into itself.
+	errno = 0;
+	assert(rename(a.c_str(), (a + "/x").c_str()) == -1);
+	assert(errno == EINVAL);
+
+	// Moving "a" into its descendant "a/b".
+	errno = 0;
+	assert(rename(a.c_str(), (b + "/x").c_str()) == -1);
+	assert(errno == EINVAL);
+
+	// The tree is left untouched.
+	assert(path_exists(a));
+	assert(path_exists(b));
+}))


### PR DESCRIPTION
This PR fixes various issues with rename() on ext2, mostly in failure cases.

Fix #704.