### PR TITLE
thor: Do not mask PLIC interrupts that are currently in service

### DIFF
--- a/kernel/thor/arch/riscv/plic.cpp
+++ b/kernel/thor/arch/riscv/plic.cpp
@@ -54,7 +54,11 @@ struct Plic : dt::IrqController {
 
 		IrqStrategy program(TriggerMode mode, Polarity polarity) override {
 			unmask();
-			return irq_strategy::maskable | irq_strategy::endOfService;
+			// A claimed source is not re-raised until completed, and masking it while in service
+			// would only drop the completion (ignored for a disabled source); rely on
+			// claim/complete instead.
+			return irq_strategy::maskable | irq_strategy::endOfService
+			       | irq_strategy::suppressMaskInService;
 		}
 
 		void mask() override { plic_->mask(plic_->bspCtx_, idx_); }

--- a/kernel/thor/generic/irq.cpp
+++ b/kernel/thor/generic/irq.cpp
@@ -173,6 +173,9 @@ void IrqPin::configure(IrqConfiguration desired) {
 				<< " to trigger mode: " << static_cast<int>(desired.trigger)
 				<< ", polarity: " << static_cast<int>(desired.polarity) << frg::endlog;
 		_strategy = program(desired.trigger, desired.polarity);
+		// suppressMaskInService and maskInService are contradictory.
+		assert(!((_strategy & irq_strategy::maskInService)
+				&& (_strategy & irq_strategy::suppressMaskInService)));
 
 		_activeCfg = desired;
 		_inService = false;
@@ -193,7 +196,7 @@ void IrqPin::raise() {
 	}
 
 	// If the IRQ is already masked, we're encountering a hardware race.
-	if(_maskState) {
+	if(_hwMaskRequested()) {
 		++_maskedRaiseCtr;
 		// At least on x86, the IRQ controller may buffer up to one edge-triggered IRQ.
 		// If an IRQ is already buffered while we mask it, it will inevitably be raised again.
@@ -374,6 +377,13 @@ void IrqPin::_doService() {
 	assert(!_inService);
 	assert(!_raiseBuffered);
 
+	// suppressMaskInService lines run unmasked while in service. A masked line cannot have been
+	// claimed, so _maskState is clear here; unmask defensively in case it was masked externally.
+	if(_strategy & irq_strategy::suppressMaskInService) {
+		assert(!_maskState);
+		unmask();
+	}
+
 	if(logService)
 		infoLogger() << "thor: IRQ pin "
 				<< _name << " enters service" << frg::endlog;
@@ -449,9 +459,18 @@ void IrqPin::_doService() {
 	_dueSinks = numAsynchronous;
 }
 
+bool IrqPin::_hwMaskRequested() {
+	// suppressMaskInService controllers must not be masked while in service (completing a masked
+	// source is dropped); they suppress the in-service IRQ themselves. Out of service _maskState
+	// drives the hardware mask normally.
+	if((_strategy & irq_strategy::suppressMaskInService) && _inService)
+		return false;
+	return _maskState;
+}
+
 void IrqPin::_updateMask() {
 	// TODO: Avoid the virtual calls if the state does not change?
-	if(!_maskState) {
+	if(!_hwMaskRequested()) {
 		_maskedRaiseCtr = 0;
 		unmask();
 	}else{

--- a/kernel/thor/generic/thor-internal/irq.hpp
+++ b/kernel/thor/generic/thor-internal/irq.hpp
@@ -160,9 +160,16 @@ using IrqStrategy = uint32_t;
 
 namespace irq_strategy {
 
+// The line can be masked in hardware: mask()/unmask() are implemented. Guards every mask() call
+// and gates the buffer/nack-stall machinery (a line that cannot be held off must not be stalled).
 constexpr IrqStrategy maskable = IrqStrategy{1} << 0;
 // Mask the interrupt while its being serviced.
 constexpr IrqStrategy maskInService = IrqStrategy{1} << 1;
+// Do not drive the hardware mask while the line is in service: the controller suppresses the
+// in-service IRQ itself (e.g. the PLIC does not re-raise a claimed source until it is completed),
+// and masking a claimed source would drop its completion. Out of service _maskState drives the
+// mask normally, so unlike !maskable the line can still be masked (e.g. manually).
+constexpr IrqStrategy suppressMaskInService = IrqStrategy{1} << 2;
 // Whether endOfInterrupt() should be called.
 constexpr IrqStrategy endOfInterrupt = IrqStrategy{1} << 8;
 // Whether endOfService() should be called.
@@ -230,6 +237,8 @@ protected:
 private:
 	void _doService();
 	void _updateMask();
+	// Whether the line should be masked in hardware (may differ from _maskState while in service).
+	bool _hwMaskRequested();
 
 	frg::string<KernelAlloc> _name;
 	// Hash of the IRQ name. Mostly useful when extracting entropy from IRQs.


### PR DESCRIPTION
The PLIC uses a claim/complete scheme but specifies:
> If the completion ID does not match an interrupt source that is currently enabled for the target, the completion is silently ignored.

Hence, we must not mask interrupts that are currently being serviced, otherwise the PLIC will not process the completion.

Fix #1450.