### PR TITLE
thor: Only send IPIs to online APs on RISC-V

### DIFF
--- a/kernel/thor/arch/riscv/ints.cpp
+++ b/kernel/thor/arch/riscv/ints.cpp
@@ -22,6 +22,9 @@ void doSendIpi(CpuData *dstData) {
 } // namespace
 
 void sendPingIpi(CpuData *dstData) {
+	if (!dstData->cpuInitialized.load(std::memory_order_acquire))
+		return;
+
 	if (raiseIpiBit(dstData, PlatformCpuData::ipiPing))
 		doSendIpi(dstData);
 }
@@ -33,6 +36,10 @@ void sendShootdownIpi() {
 	//       by tracking global counters for broadcast IPIs.
 	for (size_t i = 0; i < getCpuCount(); ++i) {
 		auto *dstData = getCpuData(i);
+
+		if (!dstData->cpuInitialized.load(std::memory_order_acquire))
+			continue;
+
 		if (raiseIpiBit(dstData, PlatformCpuData::ipiShootdown))
 			doSendIpi(dstData);
 	}


### PR DESCRIPTION
Sending the IPI SBI call targeting an offline AP can result in an error being returned which causes the cpu to panic. Prevent this by not sending IPIs to a cpu until it is initialized.