### PR TITLE
libblockfs: Remove cached uid/gid from BaseInode

### DIFF
--- a/drivers/libblockfs/src/btrfs/btrfs.hpp
+++ b/drivers/libblockfs/src/btrfs/btrfs.hpp
@@ -46,6 +46,8 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 	HelHandle backingMemory;
 	HelHandle frontalMemory;
 
+	int uid, gid;
+
 	FileSystem &fs_;
 
 private:

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1200,10 +1200,6 @@ async::detached FileSystem::initiateInode(std::shared_ptr<Inode> inode) {
 		abort();
 	}
 
-	// TODO: support large uid / gids
-	inode->uid = disk_inode->uid;
-	inode->gid = disk_inode->gid;
-
 	// Allocate a page cache for the file.
 	auto cache_size = (inode->fileSize() + 0xFFF) & ~size_t(0xFFF);
 	HEL_CHECK(helCreateManagedMemory(cache_size, kHelManagedReadahead,

--- a/drivers/libblockfs/src/ext2/ops.cpp
+++ b/drivers/libblockfs/src/ext2/ops.cpp
@@ -156,8 +156,8 @@ getStats(std::shared_ptr<void> object) {
 	stats.linkCount = self->diskInode()->linksCount;
 	stats.fileSize = self->fileSize();
 	stats.mode = self->diskInode()->mode & 0xFFF;
-	stats.uid = self->uid;
-	stats.gid = self->gid;
+	stats.uid = self->diskInode()->uid;
+	stats.gid = self->diskInode()->gid;
 	stats.accessTime.tv_sec = self->diskInode()->atime;
 	stats.dataModifyTime.tv_sec = self->diskInode()->mtime;;
 	stats.anyChangeTime.tv_sec = self->diskInode()->ctime;

--- a/drivers/libblockfs/src/fs.hpp
+++ b/drivers/libblockfs/src/fs.hpp
@@ -31,7 +31,6 @@ struct BaseInode {
 
 	async::oneshot_event readyEvent;
 
-	int uid, gid;
 	FileType fileType;
 
 	FlockManager flockManager;


### PR DESCRIPTION
Fix #1451 by not returning stale cached values from stat().