### PR TITLE
libblockfs: Add ext2 inode/block allocation locks and inode cache locks

### DIFF
--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1194,11 +1194,6 @@ async::result<std::shared_ptr<Inode>> FileSystem::createDirectory() {
 		disk_inode->flags |= EXT4_EXTENTS_FL;
 	}
 
-	// update usedDirsCount in the respective bgdt for this inode
-	auto bg_idx = (ino - 1) / inodesPerGroup;
-	bgdt[bg_idx].usedDirsCount++;
-	bdgtWriteback.raise();
-
 	updateInodeChecksum(*this, disk_inode, ino);
 
 	auto syncInode = co_await helix_ng::synchronizeSpace(

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1083,6 +1083,9 @@ auto FileSystem::accessRoot() -> std::shared_ptr<BaseInode> {
 
 auto FileSystem::accessInode(uint32_t number) -> std::shared_ptr<BaseInode> {
 	assert(number > 0);
+
+	std::lock_guard activeInodesLock{activeInodesMutex};
+
 	std::weak_ptr<Inode> &inode_slot = activeInodes[number];
 	std::shared_ptr<Inode> active_inode = inode_slot.lock();
 	if(active_inode)

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -921,6 +921,9 @@ async::detached FileSystem::handleBgdtWriteback() {
 	while(true) {
 		co_await bdgtWriteback.async_wait();
 
+		co_await allocationMutex.async_lock();
+		frg::unique_lock allocationLock{frg::adopt_lock, allocationMutex};
+
 		auto bgdt_offset = (2048 + blockSize - 1) & ~size_t(blockSize - 1);
 		co_await device->writeSectors((bgdt_offset >> blockShift) * sectorsPerBlock,
 				blockGroupDescriptorBuffer);
@@ -1109,6 +1112,8 @@ protocols::fs::FsStats FileSystem::getFsStats() {
 	stats.flags = 0;
 
 	// Sum over all block groups.
+	// TODO: Reading the BGDT technically has to take allocationMutex.
+	//       Avoid this by using atomic loads/stores when manipulating the BGDT.
 	for(uint32_t i = 0; i < numBlockGroups; i++) {
 		stats.blocksFree += bgdt[i].freeBlocksCount;
 		stats.inodesFree += bgdt[i].freeInodesCount;
@@ -1428,6 +1433,9 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 	protocols::ostrace::Timer timer;
 	std::vector<uint32_t> result;
 
+	co_await allocationMutex.async_lock();
+	frg::unique_lock allocationLock{frg::adopt_lock, allocationMutex};
+
 	if (ino) {
 		uint32_t preferred_bg = (*ino - 1) / inodesPerGroup;
 
@@ -1554,6 +1562,9 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 
 async::result<uint32_t> FileSystem::allocateInode(uint32_t parentIno, bool directory) {
 	protocols::ostrace::Timer timer;
+
+	co_await allocationMutex.async_lock();
+	frg::unique_lock allocationLock{frg::adopt_lock, allocationMutex};
 
 	auto searchBlockGroup = [&](uint32_t bg) -> async::result<std::optional<uint32_t>> {
 		helix::LockMemoryView lock_bitmap;

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -6,6 +6,7 @@
 #include <time.h>
 #include <optional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
@@ -530,6 +531,9 @@ struct FileSystem final : BaseFileSystem {
 	helix::UniqueDescriptor inodeTable;
 	helix::Mapping inodeTableMapping;
 
+	std::mutex activeInodesMutex;
+
+	// Protected by activeInodesMutex.
 	std::unordered_map<uint32_t, std::weak_ptr<Inode>> activeInodes;
 
 	arch::contiguous_pool *pool;

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -515,7 +515,19 @@ struct FileSystem final : BaseFileSystem {
 	uint32_t blocksCount;
 	uint32_t inodesCount;
 	uint8_t uuid[16];
+
+	// Mutable fields are protected by allocationMutex. These are:
+	// - freeBlocksCount
+	// - freeInodesCount
+	// - usedDirsCount
+	// - checksum
+	// - blockBitmapCsumLow
+	// - inodeBitmapCsumLow
+	// - blockBitmapCsumHigh
+	// - inodeBitmapCsumHigh
+	// All other fields are immutable.
 	arch::dma_buffer blockGroupDescriptorBuffer;
+	// View of blockGroupDescriptorBuffer; same locking as above.
 	BlockGroupDescriptorTable bgdt;
 
 	uint32_t metadataChecksumSeed;
@@ -525,13 +537,20 @@ struct FileSystem final : BaseFileSystem {
 	bool bgdtChecksum;
 
 	helix::UniqueDescriptor blockBitmap;
+	// Immutable handle. Access protected by allocationMutex.
+	// Only locked and present pages must be accessed.
 	helix::Mapping blockBitmapMapping;
 	helix::UniqueDescriptor inodeBitmap;
+	// Immutable handle. Access protected by allocationMutex.
+	// Only locked and present pages must be accessed.
 	helix::Mapping inodeBitmapMapping;
 	helix::UniqueDescriptor inodeTable;
 	helix::Mapping inodeTableMapping;
 
 	std::mutex activeInodesMutex;
+
+	// Serializes block/inode allocation and BGDT modifications.
+	async::mutex allocationMutex;
 
 	// Protected by activeInodesMutex.
 	std::unordered_map<uint32_t, std::weak_ptr<Inode>> activeInodes;


### PR DESCRIPTION
This is a first PR to add proper locking to libblockfs. We add locks for a few simple cases. Proper per-inode locks will come in a separate PR.