### PR TITLE
libblockfs: Add inode metadata and rename mutexes

### DIFF
--- a/drivers/libblockfs/src/common-ops.hpp
+++ b/drivers/libblockfs/src/common-ops.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include <async/algorithm.hpp>
 #include <core/clock.hpp>
 #include <frg/scope_exit.hpp>
@@ -259,7 +261,10 @@ async::result<void> doObstructLink(std::shared_ptr<void> object, std::string nam
 
 	auto self = std::static_pointer_cast<Inode>(object);
 
-	self->obstructedLinks.insert(name);
+	{
+		std::lock_guard obstructedLinksLock{self->obstructedLinksMutex};
+		self->obstructedLinks.insert(name);
+	}
 	co_return;
 }
 
@@ -308,7 +313,13 @@ doTraverseLinks(std::shared_ptr<void> object, std::deque<std::string> components
 			nodes.push_back({self->fs.accessInode(entry->inode), entry->inode});
 
 			if (!components.empty()) {
-				if (parent->obstructedLinks.find(component) != parent->obstructedLinks.end()) {
+				bool obstructed;
+				{
+					std::lock_guard obstructedLinksLock{parent->obstructedLinksMutex};
+					obstructed = parent->obstructedLinks.find(component)
+							!= parent->obstructedLinks.end();
+				}
+				if (obstructed) {
 					break;
 				}
 

--- a/drivers/libblockfs/src/common-ops.hpp
+++ b/drivers/libblockfs/src/common-ops.hpp
@@ -49,6 +49,9 @@ async::result<protocols::fs::SeekResult> doSeekEof(void *object, int64_t offset)
 
 	co_await inode->readyEvent.wait();
 
+	co_await inode->inodeMutex.async_lock_shared();
+	frg::shared_lock inodeLock{frg::adopt_lock, inode->inodeMutex};
+
 	self->offset += offset + inode->fileSize();
 	co_return static_cast<ssize_t>(self->offset);
 }
@@ -85,6 +88,9 @@ async::result<protocols::fs::ReadResult> doReadImpl(T *inode, void *buffer, size
 
 	// TODO(geert): Pass cancellation token
 	co_await inode->readyEvent.wait();
+
+	co_await inode->inodeMutex.async_lock_shared();
+	frg::shared_lock inodeLock{frg::adopt_lock, inode->inodeMutex};
 
 	if (inode->fileType == FileType::kTypeDirectory)
 		co_return std::unexpected{protocols::fs::Error::isDirectory};
@@ -125,6 +131,9 @@ doWriteImpl(T *inode, const void *buffer, size_t length, bool append, auto &offs
 		co_return size_t{0};
 
 	co_await inode->readyEvent.wait();
+
+	co_await inode->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, inode->inodeMutex};
 
 	if (inode->fileType == FileType::kTypeDirectory)
 		co_return protocols::fs::Error::isDirectory;
@@ -237,6 +246,9 @@ async::result<frg::expected<protocols::fs::Error>> doTruncate(void *object, size
 
 	co_await inode->readyEvent.wait();
 
+	co_await inode->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, inode->inodeMutex};
+
 	FRG_CO_TRY(co_await inode->resizeFile(size));
 
 	co_return frg::success;
@@ -298,12 +310,21 @@ doTraverseLinks(std::shared_ptr<void> object, std::deque<std::string> components
 				    nodes, protocols::fs::FileType::directory, processedComponents
 				);
 
-			auto entry = FRG_CO_TRY(co_await parent->findEntry(".."));
+			std::optional<DirEntry> entry;
+			{
+				co_await parent->inodeMutex.async_lock_shared();
+				frg::shared_lock inodeLock{frg::adopt_lock, parent->inodeMutex};
+				entry = FRG_CO_TRY(co_await parent->findEntry(".."));
+			}
 			assert(entry);
 			parent = std::static_pointer_cast<Inode>(self->fs.accessInode(entry->inode));
 			nodes.pop_back();
 		} else {
-			entry = FRG_CO_TRY(co_await parent->findEntry(component));
+			{
+				co_await parent->inodeMutex.async_lock_shared();
+				frg::shared_lock inodeLock{frg::adopt_lock, parent->inodeMutex};
+				entry = FRG_CO_TRY(co_await parent->findEntry(component));
+			}
 
 			if (!entry) {
 				co_return protocols::fs::Error::fileNotFound;
@@ -369,7 +390,11 @@ doOpen(std::shared_ptr<void> object, bool write, bool read, bool append) {
 	auto [localCtrl, remoteCtrl] = helix::createStream();
 	auto [localPt, remotePt] = helix::createStream();
 
-	co_await self->updateTimes(clk::getRealtime(), std::nullopt, std::nullopt);
+	{
+		co_await self->inodeMutex.async_lock();
+		frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
+		co_await self->updateTimes(clk::getRealtime(), std::nullopt, std::nullopt);
+	}
 
 	[] (smarter::shared_ptr<File> file, BaseFileSystem &fs, helix::UniqueLane localCtrl,
 			helix::UniqueLane localPt) -> async::detached {
@@ -397,6 +422,9 @@ async::result<protocols::fs::Error> doUtimensat(std::shared_ptr<void> object,
 
 	auto self = std::static_pointer_cast<Inode>(object);
 	co_await self->readyEvent.wait();
+
+	co_await self->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
 
 	co_return co_await self->updateTimes(atime, mtime, ctime);
 }

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -230,6 +230,7 @@ Inode::insertEntry(std::string name, int64_t ino, blockfs::FileType type) {
 		HEL_CHECK(syncDir.error());
 
 		// Increment the target's link count.
+		// This is sound since the caller holds the target's inodeMutex exclusively.
 		auto target = std::static_pointer_cast<Inode>(fs.accessInode(ino));
 		co_await target->readyEvent.wait();
 		target->diskInode()->linksCount++;
@@ -375,6 +376,7 @@ async::result<frg::expected<protocols::fs::Error>> Inode::removeEntry(std::strin
 			HEL_CHECK(syncDir.error());
 
 			// Decrement the inode's link count
+			// This is sound since the caller holds the target's inodeMutex exclusively.
 			if(--target->diskInode()->linksCount == 0) {
 				// TODO: free the data blocks and set size to 0
 				target->diskInode()->dtime = clk::getRealtime().tv_sec;
@@ -506,6 +508,8 @@ async::result<frg::expected<protocols::fs::Error, bool>> Inode::isSubdirectoryOf
 	if(fileType != kTypeDirectory)
 		co_return protocols::fs::Error::notDirectory;
 
+	// Note that the caller holds BaseFileSystem::topologyMutex exclusively;
+	// hence the .. entries that we walk below cannot change.
 	auto current = number;
 	while(true) {
 		if(current == ino)
@@ -553,6 +557,10 @@ async::result<std::expected<DirEntry, protocols::fs::Error>> Inode::mkdir(std::s
 
 	auto dirNode = co_await fs.createDirectory();
 	co_await dirNode->readyEvent.wait();
+
+	// Lock the new inode immediately as it is published by insertEntry() below.
+	co_await dirNode->inodeMutex.async_lock();
+	frg::unique_lock dirNodeLock{frg::adopt_lock, dirNode->inodeMutex};
 
 	co_await fs.assignDataBlocks(dirNode.get(), 0, 1);
 
@@ -631,6 +639,10 @@ async::result<std::expected<DirEntry, protocols::fs::Error>> Inode::symlink(std:
 
 	auto newNode = co_await fs.createSymlink();
 	co_await newNode->readyEvent.wait();
+
+	// Lock the new inode immediately as it is published by insertEntry() below.
+	co_await newNode->inodeMutex.async_lock();
+	frg::unique_lock newNodeLock{frg::adopt_lock, newNode->inodeMutex};
 
 	newNode->setFileSize(target.size());
 
@@ -726,6 +738,8 @@ async::result<protocols::fs::Error> Inode::updateTimes(
 		std::optional<timespec> atime,
 		std::optional<timespec> mtime,
 		std::optional<timespec> ctime) {
+	co_await readyEvent.wait();
+
 	if(atime)
 		diskInode()->atime = atime->tv_sec;
 	if(mtime)

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -357,22 +357,33 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 	async::result<frg::expected<protocols::fs::Error, std::optional<DirEntry>>>
 	findEntry(std::string name);
 
+	// Callers must hold topologyMutex (shared or exclusive).
 	async::result<frg::expected<protocols::fs::Error, DirEntry>> insertEntry(std::string name, int64_t ino, blockfs::FileType type);
 
+	// Callers must hold topologyMutex (shared or exclusive).
 	async::result<frg::expected<protocols::fs::Error>> removeEntry(std::string name);
 
+	// Callers must hold topologyMutex (shared or exclusive).
 	async::result<std::expected<bool, protocols::fs::Error>> isDirectoryEmpty();
 
 	// Repoints the ".." entry of this directory at a new parent inode.
+	// Callers must hold topologyMutex (exclusive).
 	async::result<frg::expected<protocols::fs::Error>> updateDotDot(uint32_t parent);
 
 	// Returns whether this directory is `ino` itself or one of its descendants,
 	// found by walking the ".." chain up to the filesystem root.
+	// Callers must hold topologyMutex (exclusive).
 	async::result<frg::expected<protocols::fs::Error, bool>> isSubdirectoryOf(uint32_t ino);
 
+	// Callers must hold topologyMutex (shared or exclusive).
 	async::result<std::expected<DirEntry, protocols::fs::Error>> link(std::string name, int64_t ino, blockfs::FileType type);
+
+	// Callers must hold topologyMutex (shared or exclusive).
 	async::result<std::expected<DirEntry, protocols::fs::Error>> mkdir(std::string name, uid_t uid, gid_t gid, mode_t mode);
+
+	// Callers must hold topologyMutex (shared or exclusive).
 	async::result<std::expected<DirEntry, protocols::fs::Error>> symlink(std::string name, std::string target);
+
 	async::result<protocols::fs::Error> chmod(int mode);
 	async::result<protocols::fs::Error> chown(std::optional<uid_t> uid, std::optional<gid_t> gid);
 	async::result<protocols::fs::Error> updateTimes(

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -348,26 +348,33 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 	DiskInode *diskInode();
 
 	// Returns the size of the file in bytes.
+	// Callers must hold inodeMutex (shared).
 	uint64_t fileSize() {
 		return diskInode()->size;
 	}
 
+	// Callers must hold inodeMutex (exclusive).
 	void setFileSize(uint64_t size);
 
+	// Callers must hold inodeMutex (shared).
 	async::result<frg::expected<protocols::fs::Error, std::optional<DirEntry>>>
 	findEntry(std::string name);
 
 	// Callers must hold topologyMutex (shared or exclusive).
+	// Callers must hold inodeMutex (exclusive), plus the target inode's inodeMutex (exclusive).
 	async::result<frg::expected<protocols::fs::Error, DirEntry>> insertEntry(std::string name, int64_t ino, blockfs::FileType type);
 
 	// Callers must hold topologyMutex (shared or exclusive).
+	// Callers must hold inodeMutex (exclusive), plus the target inode's inodeMutex (exclusive).
 	async::result<frg::expected<protocols::fs::Error>> removeEntry(std::string name);
 
 	// Callers must hold topologyMutex (shared or exclusive).
+	// Callers must hold inodeMutex (shared).
 	async::result<std::expected<bool, protocols::fs::Error>> isDirectoryEmpty();
 
 	// Repoints the ".." entry of this directory at a new parent inode.
 	// Callers must hold topologyMutex (exclusive).
+	// Callers must hold inodeMutex (exclusive).
 	async::result<frg::expected<protocols::fs::Error>> updateDotDot(uint32_t parent);
 
 	// Returns whether this directory is `ino` itself or one of its descendants,
@@ -376,16 +383,24 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 	async::result<frg::expected<protocols::fs::Error, bool>> isSubdirectoryOf(uint32_t ino);
 
 	// Callers must hold topologyMutex (shared or exclusive).
+	// Callers must hold inodeMutex (exclusive), plus the target inode's inodeMutex (exclusive).
 	async::result<std::expected<DirEntry, protocols::fs::Error>> link(std::string name, int64_t ino, blockfs::FileType type);
 
 	// Callers must hold topologyMutex (shared or exclusive).
+	// Callers must hold inodeMutex (exclusive).
 	async::result<std::expected<DirEntry, protocols::fs::Error>> mkdir(std::string name, uid_t uid, gid_t gid, mode_t mode);
 
 	// Callers must hold topologyMutex (shared or exclusive).
+	// Callers must hold inodeMutex (exclusive).
 	async::result<std::expected<DirEntry, protocols::fs::Error>> symlink(std::string name, std::string target);
 
+	// Callers must hold inodeMutex (exclusive).
 	async::result<protocols::fs::Error> chmod(int mode);
+
+	// Callers must hold inodeMutex (exclusive).
 	async::result<protocols::fs::Error> chown(std::optional<uid_t> uid, std::optional<gid_t> gid);
+
+	// Callers must hold inodeMutex (exclusive).
 	async::result<protocols::fs::Error> updateTimes(
 		std::optional<timespec> atime,
 		std::optional<timespec> mtime,
@@ -404,9 +419,11 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 		return helix::BorrowedDescriptor{frontalMemory};
 	}
 
+	// Callers must hold inodeMutex (exclusive).
 	async::result<frg::expected<protocols::fs::Error>>
 	ensureBackingBlocks(size_t offset, size_t length);
 
+	// Callers must hold inodeMutex (exclusive).
 	async::result<frg::expected<protocols::fs::Error>>
 	resizeFile(size_t newSize);
 
@@ -577,6 +594,8 @@ struct OpenFile final : BaseFile {
 	OpenFile(std::shared_ptr<Inode> inode, bool write, bool read, bool append)
 	: BaseFile{inode, write, read, append} { }
 
+	// Callers must hold BaseFile::mutex.
+	// Callers must hold the inode's inodeMutex (shared).
 	async::result<std::expected<protocols::fs::ReadEntriesResult, managarm::fs::Errors>> readEntries();
 };
 

--- a/drivers/libblockfs/src/ext2/ops.cpp
+++ b/drivers/libblockfs/src/ext2/ops.cpp
@@ -21,6 +21,12 @@ readEntries(void *object) {
 		ostEvtReadDir
 	);
 
+	co_await self->mutex.async_lock();
+	frg::unique_lock fileLock{frg::adopt_lock, self->mutex};
+
+	co_await self->inode->inodeMutex.async_lock_shared();
+	frg::shared_lock inodeLock{frg::adopt_lock, self->inode->inodeMutex};
+
 	co_return co_await self->readEntries();
 }
 
@@ -59,6 +65,10 @@ getLink(std::shared_ptr<void> object,
 
 
 	assert(!name.empty() && name != "." && name != "..");
+
+	co_await self->inodeMutex.async_lock_shared();
+	frg::shared_lock inodeLock{frg::adopt_lock, self->inodeMutex};
+
 	auto entry = FRG_CO_TRY(co_await self->findEntry(name));
 	if(!entry)
 		co_return protocols::fs::GetLinkResult{nullptr, -1,
@@ -90,6 +100,14 @@ async::result<std::expected<protocols::fs::GetLinkResult, protocols::fs::Error>>
 	co_await self->fs.topologyMutex.async_lock_shared();
 	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
 
+	co_await self->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
+
+	// link() requires the target to be locked.
+	auto target = std::static_pointer_cast<ext2fs::Inode>(self->fs.accessInode(ino));
+	co_await target->inodeMutex.async_lock();
+	frg::unique_lock targetLock{frg::adopt_lock, target->inodeMutex};
+
 	auto entry = co_await self->link(std::move(name), ino, kTypeRegular);
 	if(!entry)
 		co_return std::unexpected{entry.error()};
@@ -119,6 +137,9 @@ async::result<std::expected<void, protocols::fs::Error>> unlink(std::shared_ptr<
 	co_await self->fs.topologyMutex.async_lock_shared();
 	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
 
+	co_await self->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
+
 	auto entry = co_await self->findEntry(name);
 	if(!entry)
 		co_return std::unexpected{entry.error()};
@@ -126,6 +147,11 @@ async::result<std::expected<void, protocols::fs::Error>> unlink(std::shared_ptr<
 		co_return std::unexpected{protocols::fs::Error::fileNotFound};
 	if(entry.value()->fileType == kTypeDirectory)
 		co_return std::unexpected{protocols::fs::Error::isDirectory};
+
+	// removeEntry() requires the target to be locked.
+	auto target = std::static_pointer_cast<ext2fs::Inode>(self->fs.accessInode(entry.value()->inode));
+	co_await target->inodeMutex.async_lock();
+	frg::unique_lock targetLock{frg::adopt_lock, target->inodeMutex};
 
 	auto result = co_await self->removeEntry(std::move(name));
 	if (!result)
@@ -139,6 +165,9 @@ async::result<std::expected<void, protocols::fs::Error>> rmdir(std::shared_ptr<v
 	co_await self->fs.topologyMutex.async_lock_shared();
 	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
 
+	co_await self->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
+
 	auto entry = co_await self->findEntry(name);
 	if(!entry)
 		co_return std::unexpected{entry.error()};
@@ -147,8 +176,11 @@ async::result<std::expected<void, protocols::fs::Error>> rmdir(std::shared_ptr<v
 	if(entry.value()->fileType != kTypeDirectory)
 		co_return std::unexpected{protocols::fs::Error::notDirectory};
 
-	// Check that the directory is empty.
+	// isDirectoryEmpty() and removeEntry() require the target to be locked.
 	auto target = std::static_pointer_cast<ext2fs::Inode>(self->fs.accessInode(entry.value()->inode));
+	co_await target->inodeMutex.async_lock();
+	frg::unique_lock targetLock{frg::adopt_lock, target->inodeMutex};
+
 	auto isEmpty = FRG_CO_TRY(co_await target->isDirectoryEmpty());
 	if(!isEmpty)
 		co_return std::unexpected{protocols::fs::Error::directoryNotEmpty};
@@ -163,6 +195,9 @@ async::result<protocols::fs::FileStats>
 getStats(std::shared_ptr<void> object) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
 	co_await self->readyEvent.wait();
+
+	co_await self->inodeMutex.async_lock_shared();
+	frg::shared_lock inodeLock{frg::adopt_lock, self->inodeMutex};
 
 	protocols::fs::FileStats stats;
 	stats.linkCount = self->diskInode()->linksCount;
@@ -180,6 +215,9 @@ getStats(std::shared_ptr<void> object) {
 async::result<std::string> readSymlink(std::shared_ptr<void> object) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
 	co_await self->readyEvent.wait();
+
+	co_await self->inodeMutex.async_lock_shared();
+	frg::shared_lock inodeLock{frg::adopt_lock, self->inodeMutex};
 
 	if(self->fileSize() <= 60) {
 		co_return std::string{self->diskInode()->data.embedded,
@@ -201,6 +239,9 @@ mkdir(std::shared_ptr<void> object, std::string name, uid_t uid, gid_t gid, mode
 	co_await self->fs.topologyMutex.async_lock_shared();
 	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
 
+	co_await self->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
+
 	auto entry = co_await self->mkdir(std::move(name), uid, gid, mode);
 
 	if(!entry)
@@ -217,6 +258,9 @@ symlink(std::shared_ptr<void> object, std::string name, std::string target) {
 	co_await self->fs.topologyMutex.async_lock_shared();
 	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
 
+	co_await self->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
+
 	auto entry = co_await self->symlink(std::move(name), std::move(target));
 
 	if(!entry)
@@ -228,6 +272,10 @@ symlink(std::shared_ptr<void> object, std::string name, std::string target) {
 
 async::result<protocols::fs::Error> chmod(std::shared_ptr<void> object, int mode) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
+
+	co_await self->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
+
 	auto result = co_await self->chmod(mode);
 
 	co_return result;
@@ -235,6 +283,10 @@ async::result<protocols::fs::Error> chmod(std::shared_ptr<void> object, int mode
 
 async::result<protocols::fs::Error> chown(std::shared_ptr<void> object, std::optional<uid_t> uid, std::optional<gid_t> gid) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
+
+	co_await self->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
+
 	auto result = co_await self->chown(uid, gid);
 
 	co_return result;
@@ -247,6 +299,9 @@ getLinkOrCreate(std::shared_ptr<void> object, std::string name, mode_t mode, boo
 
 	co_await self->fs.topologyMutex.async_lock_shared();
 	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
+
+	co_await self->inodeMutex.async_lock();
+	frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
 
 	auto findResult = co_await self->findEntry(name);
 
@@ -279,6 +334,11 @@ getLinkOrCreate(std::shared_ptr<void> object, std::string name, mode_t mode, boo
 
 	auto baseInode = co_await self->fs.createRegular(uid, gid, self->number);
 	auto inode = std::static_pointer_cast<ext2fs::Inode>(baseInode);
+
+	// Lock the new inode immediately as it is published by link() below.
+	co_await inode->inodeMutex.async_lock();
+	frg::unique_lock newInodeLock{frg::adopt_lock, inode->inodeMutex};
+
 	auto chmodResult = co_await inode->chmod(mode);
 	if (chmodResult != protocols::fs::Error::none)
 		co_return std::unexpected{chmodResult};

--- a/drivers/libblockfs/src/ext2/ops.cpp
+++ b/drivers/libblockfs/src/ext2/ops.cpp
@@ -86,6 +86,10 @@ getLink(std::shared_ptr<void> object,
 async::result<std::expected<protocols::fs::GetLinkResult, protocols::fs::Error>> link(std::shared_ptr<void> object,
 		std::string name, int64_t ino) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
+
+	co_await self->fs.topologyMutex.async_lock_shared();
+	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
+
 	auto entry = co_await self->link(std::move(name), ino, kTypeRegular);
 	if(!entry)
 		co_return std::unexpected{entry.error()};
@@ -111,6 +115,10 @@ async::result<std::expected<protocols::fs::GetLinkResult, protocols::fs::Error>>
 
 async::result<std::expected<void, protocols::fs::Error>> unlink(std::shared_ptr<void> object, std::string name) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
+
+	co_await self->fs.topologyMutex.async_lock_shared();
+	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
+
 	auto entry = co_await self->findEntry(name);
 	if(!entry)
 		co_return std::unexpected{entry.error()};
@@ -127,6 +135,10 @@ async::result<std::expected<void, protocols::fs::Error>> unlink(std::shared_ptr<
 
 async::result<std::expected<void, protocols::fs::Error>> rmdir(std::shared_ptr<void> object, std::string name) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
+
+	co_await self->fs.topologyMutex.async_lock_shared();
+	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
+
 	auto entry = co_await self->findEntry(name);
 	if(!entry)
 		co_return std::unexpected{entry.error()};
@@ -185,6 +197,10 @@ async::result<std::string> readSymlink(std::shared_ptr<void> object) {
 async::result<std::expected<protocols::fs::MkdirResult, protocols::fs::Error>>
 mkdir(std::shared_ptr<void> object, std::string name, uid_t uid, gid_t gid, mode_t mode) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
+
+	co_await self->fs.topologyMutex.async_lock_shared();
+	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
+
 	auto entry = co_await self->mkdir(std::move(name), uid, gid, mode);
 
 	if(!entry)
@@ -197,6 +213,10 @@ mkdir(std::shared_ptr<void> object, std::string name, uid_t uid, gid_t gid, mode
 async::result<std::expected<protocols::fs::SymlinkResult, protocols::fs::Error>>
 symlink(std::shared_ptr<void> object, std::string name, std::string target) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
+
+	co_await self->fs.topologyMutex.async_lock_shared();
+	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
+
 	auto entry = co_await self->symlink(std::move(name), std::move(target));
 
 	if(!entry)
@@ -224,6 +244,10 @@ async::result<std::expected<protocols::fs::GetLinkResult, protocols::fs::Error>>
 getLinkOrCreate(std::shared_ptr<void> object, std::string name, mode_t mode, bool exclusive,
 		uid_t uid, gid_t gid) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
+
+	co_await self->fs.topologyMutex.async_lock_shared();
+	frg::shared_lock topologyLock{frg::adopt_lock, self->fs.topologyMutex};
+
 	auto findResult = co_await self->findEntry(name);
 
 	if (!findResult)

--- a/drivers/libblockfs/src/fs.hpp
+++ b/drivers/libblockfs/src/fs.hpp
@@ -34,6 +34,16 @@ struct BaseInode {
 
 	std::mutex obstructedLinksMutex;
 
+	// Serializes operations on this inode's metadata and directory entries.
+	// inodeMutex MUST be taken for all operations that access these data.
+	// inodeMutex may be taken in shared mode for read-only accesses.
+	// It must be taken in exclusive mode for modifications.
+	// Ordered after BaseFile::mutex -> BaseFileSystem::topologyMutex.
+	// When locking multiple inodeMutex at the same time:
+	// - Descendents (in the directory hierarchy) are ordered after ancestors.
+	// - If there is no ancestry relation, the order is lower inode number first.
+	async::shared_mutex inodeMutex;
+
 	FileType fileType;
 
 	FlockManager flockManager;
@@ -78,7 +88,7 @@ struct BaseFileSystem {
 	// Serializes operations that change the directory hierarchy.
 	// topologyMutex MUST be taken for all operations that modify directory entries.
 	// For operations that operate on a single directory entry only (i.e., link/unlink/mkdir/rmdir/symlink)
-	// taking it in shared mode is enough (assuming that the directory entry is protected by different means).
+	// taking it in shared mode is enough (assuming that the directory entry is protected by inodeMutex).
 	// Taking it in exclusive mode allows an operation that operates on multiple directory entries
 	// (i.e., rename()) to exclude all other directory-entry-modifying operations.
 	// Ordered after BaseFile::mutex.

--- a/drivers/libblockfs/src/fs.hpp
+++ b/drivers/libblockfs/src/fs.hpp
@@ -2,6 +2,7 @@
 
 #include "common.hpp"
 #include <memory>
+#include <mutex>
 #include <unordered_set>
 
 #include <async/mutex.hpp>
@@ -31,9 +32,13 @@ struct BaseInode {
 
 	async::oneshot_event readyEvent;
 
+	std::mutex obstructedLinksMutex;
+
 	FileType fileType;
 
 	FlockManager flockManager;
+
+	// Protected by obstructedLinksMutex.
 	std::unordered_set<std::string> obstructedLinks;
 };
 

--- a/drivers/libblockfs/src/fs.hpp
+++ b/drivers/libblockfs/src/fs.hpp
@@ -73,7 +73,16 @@ struct BaseFileSystem {
 	virtual async::result<std::shared_ptr<BaseInode>> createRegular(int uid, int gid, uint32_t parentIno) = 0;
 	virtual protocols::fs::FsStats getFsStats() = 0;
 
-	constexpr BaseFileSystem() = default;
+	BaseFileSystem() = default;
+
+	// Serializes operations that change the directory hierarchy.
+	// topologyMutex MUST be taken for all operations that modify directory entries.
+	// For operations that operate on a single directory entry only (i.e., link/unlink/mkdir/rmdir/symlink)
+	// taking it in shared mode is enough (assuming that the directory entry is protected by different means).
+	// Taking it in exclusive mode allows an operation that operates on multiple directory entries
+	// (i.e., rename()) to exclude all other directory-entry-modifying operations.
+	// Ordered after BaseFile::mutex.
+	async::shared_mutex topologyMutex;
 
 	BaseFileSystem(const BaseFileSystem &) = delete;
 	BaseFileSystem(BaseFileSystem &&) = delete;

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -182,6 +182,40 @@ struct HandlePartition {
 		co_await fs->topologyMutex.async_lock();
 		frg::unique_lock topologyLock{frg::adopt_lock, fs->topologyMutex};
 
+		// Lock the two parent directories in inodeMutex order.
+		std::optional<frg::unique_lock<async::shared_mutex>> firstLock;
+		std::optional<frg::unique_lock<async::shared_mutex>> secondLock;
+		if (oldInode.get() == newInode.get()) {
+			co_await oldInode->inodeMutex.async_lock();
+			firstLock.emplace(frg::adopt_lock, oldInode->inodeMutex);
+		} else {
+			auto oldIsSubdir = co_await oldInode->isSubdirectoryOf(newInode->number);
+			auto newIsSubdir = co_await newInode->isSubdirectoryOf(oldInode->number);
+			// TODO: Handle errors gracefully here.
+			assert(oldIsSubdir); // isSubdirectoryOf() should not fail.
+			assert(newIsSubdir); // isSubdirectoryOf() should not fail.
+
+			bool oldBeforeNew;
+			if (oldIsSubdir.value()) {
+				oldBeforeNew = false;
+			} else if (newIsSubdir.value()) {
+				oldBeforeNew = true;
+			} else {
+				oldBeforeNew = oldInode->number < newInode->number;
+			}
+
+			ext2fs::Inode *firstInode = oldInode.get();
+			ext2fs::Inode *secondInode = newInode.get();
+			if (!oldBeforeNew)
+				std::swap(firstInode, secondInode);
+
+			co_await firstInode->inodeMutex.async_lock();
+			firstLock.emplace(frg::adopt_lock, firstInode->inodeMutex);
+
+			co_await secondInode->inodeMutex.async_lock();
+			secondLock.emplace(frg::adopt_lock, secondInode->inodeMutex);
+		}
+
 		auto old_result = co_await oldInode->findEntry(req.old_name());
 		if(!old_result) {
 			managarm::fs::SvrResponse resp;
@@ -197,6 +231,12 @@ struct HandlePartition {
 
 		auto old_file = old_result.value();
 		managarm::fs::SvrResponse resp;
+
+		// Keep the moved and victim inodes alive.
+		std::shared_ptr<ext2fs::Inode> movedInode, victimInode;
+		// These locks are taken below for the moved and victim inodes.
+		std::optional<frg::unique_lock<async::shared_mutex>> thirdLock, fourthLock;
+
 		if(old_file) {
 			// Reject moving a directory into itself or one of its own
 			// descendants, which would detach the subtree from the tree.
@@ -271,10 +311,45 @@ struct HandlePartition {
 					co_return {};
 				}
 			}
+
+			// Lock the moved inode and victim inode in inodeMutex order.
+			movedInode = std::static_pointer_cast<ext2fs::Inode>(
+				fs->accessInode(old_file.value().inode)
+			);
+			if(new_entry.value()) {
+				victimInode = std::static_pointer_cast<ext2fs::Inode>(
+					fs->accessInode(new_entry.value()->inode)
+				);
+			}
+
+			auto stillUnlocked = [&] (ext2fs::Inode *inode) {
+				return inode != oldInode.get() && inode != newInode.get();
+			};
+			if(!victimInode) {
+				if (stillUnlocked(movedInode.get())) {
+					co_await movedInode->inodeMutex.async_lock();
+					thirdLock.emplace(frg::adopt_lock, movedInode->inodeMutex);
+				}
+			} else {
+				bool movedBeforeVictim = movedInode->number < victimInode->number;
+
+				ext2fs::Inode *thirdInode = movedInode.get();
+				ext2fs::Inode *fourthInode = victimInode.get();
+				if (!movedBeforeVictim)
+					std::swap(thirdInode, fourthInode);
+
+				if (stillUnlocked(thirdInode)) {
+					co_await thirdInode->inodeMutex.async_lock();
+					thirdLock.emplace(frg::adopt_lock, thirdInode->inodeMutex);
+				}
+				if (stillUnlocked(fourthInode)) {
+					co_await fourthInode->inodeMutex.async_lock();
+					fourthLock.emplace(frg::adopt_lock, fourthInode->inodeMutex);
+				}
+			}
+
 			if(new_entry.value() && new_entry.value()->fileType == kTypeDirectory) {
-				auto target_inode = std::static_pointer_cast<ext2fs::Inode>(
-						fs->accessInode(new_entry.value()->inode));
-				auto isEmpty = co_await target_inode->isDirectoryEmpty();
+				auto isEmpty = co_await victimInode->isDirectoryEmpty();
 				if(!isEmpty) {
 					std::cout << "libblockfs: rename: isDirectoryEmpty failed: "
 						<< (int)isEmpty.error() << std::endl;
@@ -325,8 +400,6 @@ struct HandlePartition {
 			// subdirectory link between the two parents.
 			if(old_file.value().fileType == kTypeDirectory
 					&& oldInode->number != newInode->number) {
-				auto movedInode = std::static_pointer_cast<ext2fs::Inode>(
-						fs->accessInode(old_file.value().inode));
 				auto reparent = co_await movedInode->updateDotDot(newInode->number);
 				if(!reparent) {
 					resp.set_error(reparent.error() | protocols::fs::toFsError);

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -177,6 +177,11 @@ struct HandlePartition {
 		auto oldInode = std::static_pointer_cast<ext2fs::Inode>(oldInodeRaw);
 		auto newInode = std::static_pointer_cast<ext2fs::Inode>(newInodeRaw);
 
+		// Take topologyMutex exclusively for the whole rename.
+		// This ensures that the ancestry checks below see a consistent state.
+		co_await fs->topologyMutex.async_lock();
+		frg::unique_lock topologyLock{frg::adopt_lock, fs->topologyMutex};
+
 		auto old_result = co_await oldInode->findEntry(req.old_name());
 		if(!old_result) {
 			managarm::fs::SvrResponse resp;


### PR DESCRIPTION
This ensures that all inode metadata and directory entry manipulation is safe regardless of concurrency and suspension point ordering.