### PR TITLE
libblockfs: Fix file type guards and SEEK_END

### DIFF
--- a/drivers/libblockfs/src/btrfs/ops.cpp
+++ b/drivers/libblockfs/src/btrfs/ops.cpp
@@ -134,11 +134,14 @@ async::result<protocols::fs::FileStats> getStats(std::shared_ptr<void> object) {
 	co_return stats;
 }
 
-async::result<std::string> readSymlink(std::shared_ptr<void> object) {
+async::result<std::expected<std::string, protocols::fs::Error>> readSymlink(std::shared_ptr<void> object) {
 	auto self = std::static_pointer_cast<btrfs::Inode>(object);
 	co_await self->readyEvent.wait();
 
-	assert(self->fileType == kTypeSymlink);
+	// readlink() is only valid on symbolic links.
+	if(self->fileType != kTypeSymlink)
+		co_return std::unexpected{protocols::fs::Error::illegalArguments};
+
 	auto fs = static_cast<btrfs::FileSystem *>(&self->fs);
 
 	BtreePtr ptr{};

--- a/drivers/libblockfs/src/common-ops.hpp
+++ b/drivers/libblockfs/src/common-ops.hpp
@@ -52,7 +52,7 @@ async::result<protocols::fs::SeekResult> doSeekEof(void *object, int64_t offset)
 	co_await inode->inodeMutex.async_lock_shared();
 	frg::shared_lock inodeLock{frg::adopt_lock, inode->inodeMutex};
 
-	self->offset += offset + inode->fileSize();
+	self->offset = offset + inode->fileSize();
 	co_return static_cast<ssize_t>(self->offset);
 }
 

--- a/drivers/libblockfs/src/common-ops.hpp
+++ b/drivers/libblockfs/src/common-ops.hpp
@@ -246,6 +246,10 @@ async::result<frg::expected<protocols::fs::Error>> doTruncate(void *object, size
 
 	co_await inode->readyEvent.wait();
 
+	// Directories cannot be truncated.
+	if (inode->fileType == FileType::kTypeDirectory)
+		co_return protocols::fs::Error::isDirectory;
+
 	co_await inode->inodeMutex.async_lock();
 	frg::unique_lock inodeLock{frg::adopt_lock, inode->inodeMutex};
 

--- a/drivers/libblockfs/src/ext2/ops.cpp
+++ b/drivers/libblockfs/src/ext2/ops.cpp
@@ -212,9 +212,13 @@ getStats(std::shared_ptr<void> object) {
 	co_return stats;
 }
 
-async::result<std::string> readSymlink(std::shared_ptr<void> object) {
+async::result<std::expected<std::string, protocols::fs::Error>> readSymlink(std::shared_ptr<void> object) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
 	co_await self->readyEvent.wait();
+
+	// readlink() is only valid on symbolic links.
+	if(self->fileType != kTypeSymlink)
+		co_return std::unexpected{protocols::fs::Error::illegalArguments};
 
 	co_await self->inodeMutex.async_lock_shared();
 	frg::shared_lock inodeLock{frg::adopt_lock, self->inodeMutex};

--- a/drivers/libblockfs/src/ext2/ops.cpp
+++ b/drivers/libblockfs/src/ext2/ops.cpp
@@ -103,8 +103,13 @@ async::result<std::expected<protocols::fs::GetLinkResult, protocols::fs::Error>>
 	co_await self->inodeMutex.async_lock();
 	frg::unique_lock inodeLock{frg::adopt_lock, self->inodeMutex};
 
-	// link() requires the target to be locked.
+	// Reject hard links to directories to guarantee an acyclic directory tree.
 	auto target = std::static_pointer_cast<ext2fs::Inode>(self->fs.accessInode(ino));
+	co_await target->readyEvent.wait();
+	if(target->fileType == kTypeDirectory)
+		co_return std::unexpected{protocols::fs::Error::insufficientPermissions};
+
+	// link() requires the target to be locked.
 	co_await target->inodeMutex.async_lock();
 	frg::unique_lock targetLock{frg::adopt_lock, target->inodeMutex};
 

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -790,7 +790,7 @@ private:
 				co_return _sb->internalizePeripheralLink(this, name, std::move(child));
 			}
 		}else{
-			co_return nullptr;
+			co_return resp.error() | toPosixError;
 		}
 	}
 

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -406,7 +406,7 @@ HandleRequest::operator()(managarm::posix::LinkAtRequest &&req,
 	assert(target->superblock() == directory->superblock()); // Hard links across mount points are not allowed, return EXDEV
 	auto result = co_await directory->link(new_resolver.nextComponent(), target);
 	if(!result) {
-		std::cout << "posix: Unexpected failure from link()" << std::endl;
+		co_await sendErrorResponse(conversation, result.error() | toPosixProtoError);
 		co_return {};
 	}
 

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -1513,7 +1513,12 @@ HandleRequest::operator()(managarm::posix::OpenAtRequest &&req,
 
 	if(req.flags() & managarm::posix::OpenFlags::OF_TRUNC) {
 		auto result = co_await file->truncate(0);
-		assert(result || result.error() == protocols::fs::Error::illegalOperationTarget);
+		// Objects that do not support truncation ignore O_TRUNC.
+		// TODO: This is better handled by forwarding O_TRUNC in semantic_flags.
+		if(!result && result.error() != protocols::fs::Error::illegalOperationTarget) {
+			co_await sendErrorResponse(conversation, result.error() | toPosixError | toPosixProtoError);
+			co_return {};
+		}
 	}
 	auto fd = self->fileContext()->attachFile(file,
 			req.flags() & managarm::posix::OpenFlags::OF_CLOEXEC);

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -248,7 +248,7 @@ struct NodeOperations {
 
 	async::result<OpenResult> (*open)(std::shared_ptr<void> object, bool write, bool read, bool append);
 
-	async::result<std::string> (*readSymlink)(std::shared_ptr<void> object);
+	async::result<std::expected<std::string, protocols::fs::Error>> (*readSymlink)(std::shared_ptr<void> object);
 
 	async::result<std::expected<MkdirResult, protocols::fs::Error>> (*mkdir)(std::shared_ptr<void> object, std::string name, uid_t uid, gid_t gid, mode_t mode);
 

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -1448,7 +1448,7 @@ struct HandleFileRequest {
 		if(result) {
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 		}else{
-			resp.set_error(managarm::fs::Errors::ILLEGAL_OPERATION_TARGET);
+			resp.set_error(result.error() | toFsError);
 		}
 
 		auto ser = resp.SerializeAsString();

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -1650,10 +1650,16 @@ struct HandleNodeRequest {
 				logBragiSerializedReply(ser);
 			}
 		} else if(req.req_type() == managarm::fs::CntReqType::NODE_READ_SYMLINK) {
-			auto link = co_await node_ops->readSymlink(node);
+			auto result = co_await node_ops->readSymlink(node);
 
 			managarm::fs::SvrResponse resp;
-			resp.set_error(managarm::fs::Errors::SUCCESS);
+			std::string link;
+			if(result) {
+				resp.set_error(managarm::fs::Errors::SUCCESS);
+				link = std::move(*result);
+			}else{
+				resp.set_error(result.error() | toFsError);
+			}
 
 			auto ser = resp.SerializeAsString();
 			auto [send_resp, send_link] = co_await helix_ng::exchangeMsgs(


### PR DESCRIPTION
Fix various smaller issues found while introducing proper locking in the previous PR.