### PR TITLE
libblockfs: Add mutex to protect the association of file offsets -> ext2 blocks

### DIFF
--- a/drivers/libblockfs/meson.build
+++ b/drivers/libblockfs/meson.build
@@ -1,5 +1,6 @@
 src = [
 	'src/libblockfs.cpp',
+	'src/metadata-cache.cpp',
 	'src/gpt.cpp',
 	'src/raw.cpp',
 	'src/scsi.cpp',

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -2124,7 +2124,7 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 				auto idx = block_offset + prg - i_range;
 
 				size_t range = 0;
-				for(size_t i = idx; i < per_single; i++) {
+				for(size_t i = idx; i < per_indirect; i++) {
 					if(prg + range >= num_blocks)
 						break;
 
@@ -2202,7 +2202,7 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 					memset(window, 0, size_t{1} << blockPagesShift);
 
 				size_t range = 0;
-				for(size_t i = indirect_index; i < per_double; i++) {
+				for(size_t i = indirect_index; i < per_indirect; i++) {
 					if(prg + range >= num_blocks)
 						break;
 

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -306,7 +306,13 @@ Inode::insertEntry(std::string name, int64_t ino, blockfs::FileType type) {
 	auto newSize = offset + fs.blockSize;
 	auto newMappingSize = (newSize + 0xFFF) & ~size_t(0xFFF);
 	setFileSize(newSize);
-	co_await fs.assignDataBlocks(this, blockOffset, 1);
+
+	{
+		co_await blockMapMutex.async_lock();
+		frg::unique_lock blockMapLock{frg::adopt_lock, blockMapMutex};
+		co_await fs.assignDataBlocks(this, blockOffset, 1);
+	}
+
 	auto resizeResult = co_await helix_ng::resizeMemory(
 			helix::BorrowedDescriptor{backingMemory}, newMappingSize);
 	HEL_CHECK(resizeResult.error());
@@ -562,7 +568,11 @@ async::result<std::expected<DirEntry, protocols::fs::Error>> Inode::mkdir(std::s
 	co_await dirNode->inodeMutex.async_lock();
 	frg::unique_lock dirNodeLock{frg::adopt_lock, dirNode->inodeMutex};
 
-	co_await fs.assignDataBlocks(dirNode.get(), 0, 1);
+	{
+		co_await dirNode->blockMapMutex.async_lock();
+		frg::unique_lock dirNodeBlockMapLock{frg::adopt_lock, dirNode->blockMapMutex};
+		co_await fs.assignDataBlocks(dirNode.get(), 0, 1);
+	}
 
 	dirNode->setFileSize(fs.blockSize);
 	auto resizeResult = co_await helix_ng::resizeMemory(
@@ -652,7 +662,11 @@ async::result<std::expected<DirEntry, protocols::fs::Error>> Inode::symlink(std:
 	} else {
 		// slow symlink: store target in data blocks.
 		auto numBlocks = (target.size() + fs.blockSize - 1) / fs.blockSize;
-		co_await fs.assignDataBlocks(newNode.get(), 0, numBlocks);
+		{
+			co_await newNode->blockMapMutex.async_lock();
+			frg::unique_lock newNodeBlockMapLock{frg::adopt_lock, newNode->blockMapMutex};
+			co_await fs.assignDataBlocks(newNode.get(), 0, numBlocks);
+		}
 
 		auto newSize = (target.size() + 0xFFF) & ~size_t(0xFFF);
 		auto resizeResult = co_await helix_ng::resizeMemory(
@@ -763,7 +777,12 @@ Inode::ensureBackingBlocks(size_t offset, size_t length) {
 	auto [alignedOffset, alignedSize] = core::alignExtend({offset, length}, fs.blockSize);
 	size_t blockOffset = alignedOffset / fs.blockSize;
 	size_t blockCount = alignedSize / fs.blockSize;
-	co_await fs.assignDataBlocks(this, blockOffset, blockCount);
+
+	{
+		co_await blockMapMutex.async_lock();
+		frg::unique_lock blockMapLock{frg::adopt_lock, blockMapMutex};
+		co_await fs.assignDataBlocks(this, blockOffset, blockCount);
+	}
 
 	co_return frg::success;
 }
@@ -1329,9 +1348,13 @@ async::detached FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 			assert(!(manage.offset() % inode->fs.blockSize));
 			size_t backed_size = std::min(manage.length(), inode->fileSize() - manage.offset());
 			size_t num_blocks = (backed_size + (inode->fs.blockSize - 1)) / inode->fs.blockSize;
-
 			assert(num_blocks * inode->fs.blockSize <= manage.length());
-			co_await inode->fs.readDataBlocks(inode, manage.offset() / inode->fs.blockSize, fileView);
+
+			{
+				co_await inode->blockMapMutex.async_lock();
+				frg::unique_lock blockMapLock{frg::adopt_lock, inode->blockMapMutex};
+				co_await inode->fs.readDataBlocks(inode, manage.offset() / inode->fs.blockSize, fileView);
+			}
 
 			HEL_CHECK(helUpdateMemory(inode->backingMemory, kHelManageInitialize,
 					manage.offset(), manage.length()));
@@ -1345,8 +1368,12 @@ async::detached FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 
 			assert(numBlocks * inode->fs.blockSize <= manage.length());
 
-			co_await inode->fs.assignDataBlocks(inode.get(), blockOffset, numBlocks);
-			co_await inode->fs.writeDataBlocks(inode, blockOffset, fileView);
+			{
+				co_await inode->blockMapMutex.async_lock();
+				frg::unique_lock blockMapLock{frg::adopt_lock, inode->blockMapMutex};
+				co_await inode->fs.assignDataBlocks(inode.get(), blockOffset, numBlocks);
+				co_await inode->fs.writeDataBlocks(inode, blockOffset, fileView);
+			}
 
 			HEL_CHECK(helUpdateMemory(inode->backingMemory, kHelManageWriteback,
 					manage.offset(), manage.length()));

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -883,6 +883,8 @@ async::result<void> FileSystem::init() {
 	assert(blockSize >= device->sectorSize);
 	assert(blockSize % device->sectorSize == 0);
 
+	metadataCache.emplace(device, blocksCount, blockSize);
+
 	blockGroupDescriptorBuffer = arch::dma_buffer{
 	    pool,
 	    (numBlockGroups * blockGroupDescriptorSize + device->sectorSize - 1)
@@ -1301,21 +1303,8 @@ async::detached FileSystem::initiateInode(std::shared_ptr<Inode> inode) {
 				kHelMapProtRead | kHelMapProtWrite | kHelMapDontRequireBacking};
 	}
 
-	if(disk_inode->flags & EXT4_EXTENTS_FL) {
+	if(disk_inode->flags & EXT4_EXTENTS_FL)
 		inode->usesExtents = true;
-	}else {
-		HelHandle frontalOrder1, frontalOrder2;
-		HelHandle backingOrder1, backingOrder2;
-		HEL_CHECK(helCreateManagedMemory(3 << blockPagesShift,
-				0, &backingOrder1, &frontalOrder1));
-		HEL_CHECK(helCreateManagedMemory((blockSize / 4) << blockPagesShift,
-				0, &backingOrder2, &frontalOrder2));
-		inode->indirectOrder1 = helix::UniqueDescriptor{frontalOrder1};
-		inode->indirectOrder2 = helix::UniqueDescriptor{frontalOrder2};
-
-		manageIndirect(inode, 1, helix::UniqueDescriptor{backingOrder1});
-		manageIndirect(inode, 2, helix::UniqueDescriptor{backingOrder2});
-	}
 
 	manageFileData(inode);
 
@@ -1367,75 +1356,6 @@ async::detached FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 			ostEvtExt2ManageFile,
 			ostAttrTime(timer.elapsed())
 		);
-	}
-}
-
-async::detached FileSystem::manageIndirect(std::shared_ptr<Inode> inode,
-		int order, helix::UniqueDescriptor memory) {
-	while(true) {
-		helix::ManageMemory manage;
-		auto &&submit_manage = helix::submitManageMemory(memory,
-				&manage, helix::Dispatcher::global());
-		co_await submit_manage.async_wait();
-		HEL_CHECK(manage.error());
-
-		auto view = pool->importMemory(memory, manage.offset(), manage.length());
-
-		// TODO(qookie): This can probably implemented in a more optimal manner.
-		for (size_t progress = 0; progress < manage.length(); progress += blockSize) {
-			auto offset = manage.offset() + progress;
-			uint32_t element = offset >> blockPagesShift;
-
-			uint32_t block;
-			if(order == 1) {
-				auto disk_inode = inode->diskInode();
-
-				switch(element) {
-					case 0: block = disk_inode->data.blocks.singleIndirect; break;
-					case 1: block = disk_inode->data.blocks.doubleIndirect; break;
-					case 2: block = disk_inode->data.blocks.tripleIndirect; break;
-					default:
-						assert(!"unexpected offset");
-						abort();
-				}
-			}else{
-				assert(order == 2);
-
-				auto indirect_frame = element >> (blockShift - 2);
-				auto indirect_index = element & ((1 << (blockShift - 2)) - 1);
-
-				helix::LockMemoryView lock_indirect;
-				auto &&submit_indirect = helix::submitLockMemoryView(inode->indirectOrder1,
-						&lock_indirect,
-						(1 + indirect_frame) << blockPagesShift, 1 << blockPagesShift,
-						helix::Dispatcher::global());
-				co_await submit_indirect.async_wait();
-				HEL_CHECK(lock_indirect.error());
-
-				helix::Mapping indirect_map{inode->indirectOrder1,
-					(1 + indirect_frame) << blockPagesShift, size_t{1} << blockPagesShift,
-					kHelMapProtRead | kHelMapDontRequireBacking};
-				block = reinterpret_cast<uint32_t *>(indirect_map.get())[indirect_index];
-			}
-
-			auto subview = view.view().subview(progress, 1 << blockPagesShift);
-
-			if (manage.type() == kHelManageInitialize) {
-				co_await device->readSectors(block * sectorsPerBlock, subview);
-			} else {
-				assert(manage.type() == kHelManageWriteback);
-				co_await device->writeSectors(block * sectorsPerBlock, subview);
-			}
-		}
-
-		if (manage.type() == kHelManageInitialize) {
-			HEL_CHECK(helUpdateMemory(memory.getHandle(), kHelManageInitialize,
-							manage.offset(), manage.length()));
-		} else {
-			assert(manage.type() == kHelManageWriteback);
-			HEL_CHECK(helUpdateMemory(memory.getHandle(), kHelManageWriteback,
-							manage.offset(), manage.length()));
-		}
 	}
 }
 
@@ -2104,20 +2024,12 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 				needsReset = true;
 			}
 
-			helix::LockMemoryView lock_indirect;
-			auto &&submit = helix::submitLockMemoryView(inode->indirectOrder1,
-					&lock_indirect, 0, 1 << blockPagesShift,
-					helix::Dispatcher::global());
-			co_await submit.async_wait();
-			HEL_CHECK(lock_indirect.error());
-
-			helix::Mapping indirect_map{inode->indirectOrder1,
-					0, size_t{1} << blockPagesShift,
-					kHelMapProtRead | kHelMapProtWrite | kHelMapDontRequireBacking};
-			auto window = reinterpret_cast<uint32_t *>(indirect_map.get());
+			auto indirectWindow = co_await metadataCache->access(
+					disk_inode->data.blocks.singleIndirect, true);
+			auto window = reinterpret_cast<uint32_t *>(indirectWindow.get());
 
 			if(needsReset)
-				memset(window, 0, size_t{1} << blockPagesShift);
+				memset(window, 0, blockSize);
 
 			while(prg < num_blocks
 					&& block_offset + prg < s_range) {
@@ -2156,20 +2068,12 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 				doubleNeedsReset = true;
 			}
 
-			helix::LockMemoryView lock_double_indirect;
-			auto &&submit = helix::submitLockMemoryView(inode->indirectOrder1,
-					&lock_double_indirect, 1 << blockPagesShift, 1 << blockPagesShift,
-					helix::Dispatcher::global());
-			co_await submit.async_wait();
-			HEL_CHECK(lock_double_indirect.error());
-
-			helix::Mapping double_indirect_map{inode->indirectOrder1,
-					1 << blockPagesShift, size_t{1} << blockPagesShift,
-					kHelMapProtRead | kHelMapProtWrite | kHelMapDontRequireBacking};
-			auto double_window = reinterpret_cast<uint32_t *>(double_indirect_map.get());
+			auto doubleIndirectWindow = co_await metadataCache->access(
+					disk_inode->data.blocks.doubleIndirect, true);
+			auto double_window = reinterpret_cast<uint32_t *>(doubleIndirectWindow.get());
 
 			if(doubleNeedsReset)
-				memset(double_window, 0, size_t{1} << blockPagesShift);
+				memset(double_window, 0, blockSize);
 
 			while(prg < num_blocks
 					&& block_offset + prg < d_range) {
@@ -2186,20 +2090,12 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 					needsReset = true;
 				}
 
-				helix::LockMemoryView lock_indirect;
-				auto &&submit = helix::submitLockMemoryView(inode->indirectOrder2,
-						&lock_indirect, indirect_frame << blockPagesShift, 1 << blockPagesShift,
-						helix::Dispatcher::global());
-				co_await submit.async_wait();
-				HEL_CHECK(lock_indirect.error());
-
-				helix::Mapping indirect_map{inode->indirectOrder2,
-						indirect_frame << blockPagesShift, size_t{1} << blockPagesShift,
-						kHelMapProtRead | kHelMapProtWrite | kHelMapDontRequireBacking};
-				auto window = reinterpret_cast<uint32_t *>(indirect_map.get());
+				auto indirectWindow = co_await metadataCache->access(
+						double_window[indirect_frame], true);
+				auto window = reinterpret_cast<uint32_t *>(indirectWindow.get());
 
 				if(needsReset)
-					memset(window, 0, size_t{1} << blockPagesShift);
+					memset(window, 0, blockSize);
 
 				size_t range = 0;
 				for(size_t i = indirect_index; i < per_indirect; i++) {
@@ -2298,56 +2194,48 @@ async::result<void> FileSystem::readDataBlocks(std::shared_ptr<Inode> inode,
 			int64_t indirect_frame = (index - s_range) >> (blockShift - 2);
 			int64_t indirect_index = (index - s_range) & ((1 << (blockShift - 2)) - 1);
 
-			if (remaining > indirectBufferSize) {
-				helix::LockMemoryView lock_indirect;
-				auto &&submit = helix::submitLockMemoryView(inode->indirectOrder2, &lock_indirect,
-						indirect_frame << blockPagesShift, 1 << blockPagesShift,
-						helix::Dispatcher::global());
-				co_await submit.async_wait();
-				HEL_CHECK(lock_indirect.error());
+			auto disk_inode = inode->diskInode();
+			uint32_t indirect_block = 0;
+			if(disk_inode->data.blocks.doubleIndirect)
+				co_await metadataCache->read(disk_inode->data.blocks.doubleIndirect,
+						indirect_frame * 4, 4, &indirect_block);
 
-				helix::Mapping indirect_map{inode->indirectOrder2,
-						indirect_frame << blockPagesShift, size_t{1} << blockPagesShift,
-						kHelMapProtRead | kHelMapDontRequireBacking};
+			if(!indirect_block) {
+				issue = {0, std::min<size_t>(remaining, per_indirect - indirect_index)};
+			} else if (remaining > indirectBufferSize) {
+				auto indirectWindow = co_await metadataCache->access(indirect_block, false);
 
 				issue = fuse(remaining,
-						reinterpret_cast<uint32_t *>(indirect_map.get()) + indirect_index,
+						reinterpret_cast<uint32_t *>(indirectWindow.get()) + indirect_index,
 						per_indirect - indirect_index);
 			} else {
-				auto readMemory = co_await helix_ng::readMemory(
-						helix::BorrowedDescriptor{inode->indirectOrder2},
-						(indirect_frame << blockPagesShift) + indirect_index * 4,
-						remaining * 4, indirectBuffer.data());
-				HEL_CHECK(readMemory.error());
+				auto chunk = std::min<size_t>(remaining, per_indirect - indirect_index);
+				co_await metadataCache->read(indirect_block,
+						indirect_index * 4, chunk * 4, indirectBuffer.data());
 
-				issue = fuse(remaining, indirectBuffer.data(), remaining);
+				issue = fuse(chunk, indirectBuffer.data(), chunk);
 			}
 		}else if(index >= i_range) { // Use the single indirect block.
 			auto remaining = num_blocks - progress;
 			auto indirect_index = index - i_range;
 
-			if (remaining > indirectBufferSize) {
-				helix::LockMemoryView lock_indirect;
-				auto &&submit = helix::submitLockMemoryView(inode->indirectOrder1,
-						&lock_indirect, 0, 1 << blockPagesShift,
-						helix::Dispatcher::global());
-				co_await submit.async_wait();
-				HEL_CHECK(lock_indirect.error());
+			auto disk_inode = inode->diskInode();
+			auto indirect_block = disk_inode->data.blocks.singleIndirect;
 
-				helix::Mapping indirect_map{inode->indirectOrder1,
-						0, size_t{1} << blockPagesShift,
-						kHelMapProtRead | kHelMapDontRequireBacking};
+			if(!indirect_block) {
+				issue = {0, std::min<size_t>(remaining, per_single - indirect_index)};
+			} else if (remaining > indirectBufferSize) {
+				auto indirectWindow = co_await metadataCache->access(indirect_block, false);
 
 				issue = fuse(remaining,
-						reinterpret_cast<uint32_t *>(indirect_map.get()) + indirect_index,
+						reinterpret_cast<uint32_t *>(indirectWindow.get()) + indirect_index,
 						per_indirect - indirect_index);
 			} else {
-				auto readMemory = co_await helix_ng::readMemory(
-						helix::BorrowedDescriptor{inode->indirectOrder1},
-						indirect_index * 4, remaining * 4, indirectBuffer.data());
-				HEL_CHECK(readMemory.error());
+				auto chunk = std::min<size_t>(remaining, per_single - indirect_index);
+				co_await metadataCache->read(indirect_block,
+						indirect_index * 4, chunk * 4, indirectBuffer.data());
 
-				issue = fuse(remaining, indirectBuffer.data(), remaining);
+				issue = fuse(chunk, indirectBuffer.data(), chunk);
 			}
 		}else{
 			auto disk_inode = inode->diskInode();
@@ -2421,32 +2309,26 @@ async::result<void> FileSystem::writeDataBlocks(std::shared_ptr<Inode> inode,
 			int64_t indirect_frame = (index - s_range) >> (blockShift - 2);
 			int64_t indirect_index = (index - s_range) & ((1 << (blockShift - 2)) - 1);
 
-			helix::LockMemoryView lock_indirect;
-			auto &&submit = helix::submitLockMemoryView(inode->indirectOrder2, &lock_indirect,
-					indirect_frame << blockPagesShift, 1 << blockPagesShift,
-					helix::Dispatcher::global());
-			co_await submit.async_wait();
-			HEL_CHECK(lock_indirect.error());
+			auto disk_inode = inode->diskInode();
+			assert(disk_inode->data.blocks.doubleIndirect);
+			uint32_t indirect_block;
+			co_await metadataCache->read(disk_inode->data.blocks.doubleIndirect,
+					indirect_frame * 4, 4, &indirect_block);
+			assert(indirect_block);
 
-			helix::Mapping indirect_map{inode->indirectOrder2,
-					indirect_frame << blockPagesShift, size_t{1} << blockPagesShift,
-					kHelMapProtRead | kHelMapDontRequireBacking};
+			auto indirectWindow = co_await metadataCache->access(indirect_block, false);
 
 			issue = fuse(indirect_index, num_blocks - progress,
-					reinterpret_cast<uint32_t *>(indirect_map.get()), per_indirect);
-		}else if(index >= i_range) { // Use the triple indirect block.
-			helix::LockMemoryView lock_indirect;
-			auto &&submit = helix::submitLockMemoryView(inode->indirectOrder1,
-					&lock_indirect, 0, 1 << blockPagesShift,
-					helix::Dispatcher::global());
-			co_await submit.async_wait();
-			HEL_CHECK(lock_indirect.error());
+					reinterpret_cast<uint32_t *>(indirectWindow.get()), per_indirect);
+		}else if(index >= i_range) { // Use the single indirect block.
+			auto disk_inode = inode->diskInode();
+			assert(disk_inode->data.blocks.singleIndirect);
 
-			helix::Mapping indirect_map{inode->indirectOrder1,
-					0, size_t{1} << blockPagesShift,
-					kHelMapProtRead | kHelMapDontRequireBacking};
+			auto indirectWindow = co_await metadataCache->access(
+					disk_inode->data.blocks.singleIndirect, false);
+
 			issue = fuse(index - i_range, num_blocks - progress,
-					reinterpret_cast<uint32_t *>(indirect_map.get()), per_indirect);
+					reinterpret_cast<uint32_t *>(indirectWindow.get()), per_indirect);
 		}else{
 			auto disk_inode = inode->diskInode();
 

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -411,6 +411,13 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 
 	helix::UniqueDescriptor diskLock;
 
+	// Serializes access to this inode's mapping from file offsets to filesystem blocks.
+	// blockMapMutex MUST be taken for all operations that access:
+	// - the direct pointers in the inode
+	// - the single/double/triple indirect blocks
+	// Ordered after inodeMutex.
+	async::mutex blockMapMutex;
+
 	// page cache that stores the contents of this file
 	HelHandle backingMemory;
 	HelHandle frontalMemory;
@@ -495,25 +502,32 @@ struct FileSystem final : BaseFileSystem {
 	async::result<std::vector<uint32_t>> allocateBlocks(size_t num, std::optional<uint32_t> ino = std::nullopt);
 	async::result<uint32_t> allocateInode(uint32_t parentIno = 0, bool directory = false);
 
+	// Callers must hold inode->blockMapMutex.
 	async::result<void> assignDataBlocks(Inode *inode,
 			uint64_t block_offset, size_t num_blocks);
 
+	// Callers must hold inode->blockMapMutex.
 	async::result<void>
 	readDataBlocks(std::shared_ptr<Inode> inode, uint64_t block_offset, arch::dma_buffer_view buf);
 
+	// Callers must hold inode->blockMapMutex.
 	async::result<void> writeDataBlocks(
 	    std::shared_ptr<Inode> inode, uint64_t block_offset, arch::dma_buffer_view view
 	);
 
 
+	// Callers must hold inode->blockMapMutex.
 	async::result<std::vector<ExtentBlockRange>> lookupBlocksUsingExtent(Inode *inode,
 			uint64_t block_offset, size_t num_blocks, bool errorIfNotFound);
 
+	// Callers must hold inode->blockMapMutex.
 	async::result<void> assignDataBlocksUsingExtents(Inode *inode,
 			uint64_t block_offset, size_t num_blocks);
 
+	// Callers must hold inode->blockMapMutex.
 	async::result<void> readDataBlocksUsingExtents(std::shared_ptr<Inode> inode, uint64_t block_offset,
 			arch::dma_buffer_view buf);
+	// Callers must hold inode->blockMapMutex.
 	async::result<void> writeDataBlocksUsingExtents(std::shared_ptr<Inode> inode, uint64_t block_offset,
 			arch::dma_buffer_view buf);
 

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -21,6 +21,7 @@
 #include "../common.hpp"
 #include "fs.bragi.hpp"
 #include "../fs.hpp"
+#include "../metadata-cache.hpp"
 
 namespace blockfs {
 namespace ext2fs {
@@ -427,19 +428,6 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 	async::result<frg::expected<protocols::fs::Error>>
 	resizeFile(size_t newSize);
 
-	// Caches indirection blocks reachable from the inode.
-	// - Indirection level 1/1 for single indirect blocks.
-	// - Indirection level 1/2 for double indirect blocks.
-	// - Indirection level 1/3 for triple indirect blocks.
-	helix::UniqueDescriptor indirectOrder1;
-	// Caches indirection blocks reachable from order 1 blocks.
-	// - Indirection level 2/2 for double indirect blocks.
-	// - Indirection level 2/3 for triple indirect blocks.
-	helix::UniqueDescriptor indirectOrder2;
-	// Caches indirection blocks reachable from order 2 blocks.
-	// - Indirection level 3/3 for triple indirect blocks.
-	helix::UniqueDescriptor indirectOrder3;
-
 	bool usesExtents;
 };
 
@@ -501,8 +489,6 @@ struct FileSystem final : BaseFileSystem {
 
 	async::detached initiateInode(std::shared_ptr<Inode> inode);
 	async::detached manageFileData(std::shared_ptr<Inode> inode);
-	async::detached manageIndirect(std::shared_ptr<Inode> inode, int order,
-			helix::UniqueDescriptor memory);
 
 	// Allocate up to num blocks for the given inode.
 	// This function does not write back the BGDT, this is the caller's responsibility.
@@ -574,6 +560,9 @@ struct FileSystem final : BaseFileSystem {
 	helix::Mapping inodeBitmapMapping;
 	helix::UniqueDescriptor inodeTable;
 	helix::Mapping inodeTableMapping;
+
+	// Mount-wide cache of metadata blocks (i.e., indirect blocks), indexed by disk block number.
+	std::optional<MetadataCache> metadataCache;
 
 	std::mutex activeInodesMutex;
 

--- a/drivers/libblockfs/src/ext2/extents.hpp
+++ b/drivers/libblockfs/src/ext2/extents.hpp
@@ -33,6 +33,8 @@ struct ExtentWalker {
 	 * Leave: A callback accepting `const ExtentWalkInfo &` that is called at the end going up the walked levels.
 	 *
 	 * If looking up a block returns a boolean indicating whether the block was found.
+	 *
+	 * Callers must hold inode->blockMapMutex.
 	 */
 	template<typename Enter, typename Leave>
 	async::result<bool> walk(uint64_t blockIndex, Enter enter, Leave leave) {

--- a/drivers/libblockfs/src/metadata-cache.cpp
+++ b/drivers/libblockfs/src/metadata-cache.cpp
@@ -1,0 +1,93 @@
+#include <bit>
+#include <string.h>
+
+#include "metadata-cache.hpp"
+
+namespace blockfs {
+
+namespace {
+	constexpr uint32_t pageShift = 12;
+}
+
+MetadataCache::MetadataCache(BlockDevice *device, uint64_t numBlocks, size_t blockSize)
+: device_{device}, numBlocks_{numBlocks}, blockSize_{blockSize} {
+	assert(std::has_single_bit(blockSize));
+	assert(blockSize >= device->sectorSize);
+	auto blockShift = static_cast<uint32_t>(std::countr_zero(blockSize));
+	blockPagesShift_ = blockShift < pageShift ? pageShift : blockShift;
+	sectorsPerBlock_ = blockSize / device->sectorSize;
+
+	HelHandle backing, frontal;
+	HEL_CHECK(helCreateManagedMemory(numBlocks << blockPagesShift_,
+			0, &backing, &frontal));
+	frontal_ = helix::UniqueDescriptor{frontal};
+
+	manage_(helix::UniqueDescriptor{backing});
+}
+
+async::result<MetadataCache::BlockWindow> MetadataCache::access(uint64_t block, bool writable) {
+	assert(block < numBlocks_);
+	auto frameSize = size_t{1} << blockPagesShift_;
+
+	helix::LockMemoryView lockMemory;
+	auto &&submit = helix::submitLockMemoryView(frontal_, &lockMemory,
+			block << blockPagesShift_, frameSize, helix::Dispatcher::global());
+	co_await submit.async_wait();
+	HEL_CHECK(lockMemory.error());
+
+	uint32_t flags = kHelMapProtRead | kHelMapDontRequireBacking;
+	if(writable)
+		flags |= kHelMapProtWrite;
+	helix::Mapping mapping{frontal_, static_cast<ptrdiff_t>(block << blockPagesShift_),
+			frameSize, flags};
+
+	co_return BlockWindow{lockMemory.descriptor(), std::move(mapping)};
+}
+
+async::result<void> MetadataCache::read(uint64_t block, size_t offset, size_t length, void *buffer) {
+	assert(block < numBlocks_);
+	assert(offset + length <= blockSize_);
+
+	auto readMemory = co_await helix_ng::readMemory(frontal_,
+			(block << blockPagesShift_) + offset, length, buffer);
+	HEL_CHECK(readMemory.error());
+}
+
+async::detached MetadataCache::manage_(helix::UniqueDescriptor backing) {
+	while(true) {
+		helix::ManageMemory manage;
+		auto &&submitManage = helix::submitManageMemory(backing,
+				&manage, helix::Dispatcher::global());
+		co_await submitManage.async_wait();
+		HEL_CHECK(manage.error());
+
+		auto frameSize = size_t{1} << blockPagesShift_;
+		assert(!(manage.offset() & (frameSize - 1)));
+		assert(!(manage.length() & (frameSize - 1)));
+
+		auto view = device_->pagePool->importMemory(backing, manage.offset(), manage.length());
+
+		for(size_t progress = 0; progress < manage.length(); progress += frameSize) {
+			auto block = (manage.offset() + progress) >> blockPagesShift_;
+			assert(block < numBlocks_);
+
+			auto subview = view.view().subview(progress, blockSize_);
+
+			if(manage.type() == kHelManageInitialize) {
+				co_await device_->readSectors(block * sectorsPerBlock_, subview);
+				// Zero the tail of the frame that no disk block backs.
+				if(blockSize_ < frameSize)
+					memset(view.view().subview(progress + blockSize_,
+							frameSize - blockSize_).data(), 0, frameSize - blockSize_);
+			}else{
+				assert(manage.type() == kHelManageWriteback);
+				co_await device_->writeSectors(block * sectorsPerBlock_, subview);
+			}
+		}
+
+		HEL_CHECK(helUpdateMemory(backing.getHandle(), manage.type(),
+				manage.offset(), manage.length()));
+	}
+}
+
+} // namespace blockfs

--- a/drivers/libblockfs/src/metadata-cache.hpp
+++ b/drivers/libblockfs/src/metadata-cache.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <async/result.hpp>
+#include <hel.h>
+#include <helix/ipc.hpp>
+#include <helix/memory.hpp>
+
+#include <blockfs.hpp>
+
+namespace blockfs {
+
+// Mount-wide page cache for filesystem metadata blocks, indexed by disk block number.
+// The cache offset of a block is a fixed function of its block number alone;
+// hence, servicing a page reads no mutable filesystem state (such as block maps).
+// Each block occupies its own page-aligned frame, i.e., blocks smaller than a page
+// are never packed into the same page (to keep writeback of a page confined to a
+// single block).
+struct MetadataCache {
+	// A locked and mapped view of a single metadata block.
+	// The block stays present in the cache for the lifetime of this object.
+	struct BlockWindow {
+		BlockWindow() = default;
+
+		void *get() {
+			return mapping_.get();
+		}
+
+	private:
+		friend struct MetadataCache;
+
+		BlockWindow(helix::UniqueDescriptor lock, helix::Mapping mapping)
+		: lock_{std::move(lock)}, mapping_{std::move(mapping)} { }
+
+		helix::UniqueDescriptor lock_;
+		helix::Mapping mapping_;
+	};
+
+	MetadataCache(BlockDevice *device, uint64_t numBlocks, size_t blockSize);
+
+	// The servicer coroutine started by the constructor refers back to this object.
+	MetadataCache(const MetadataCache &) = delete;
+	MetadataCache &operator=(const MetadataCache &) = delete;
+
+	// Locks and maps the given block.
+	// Writes through a writable window are eventually written back to the block.
+	async::result<BlockWindow> access(uint64_t block, bool writable);
+
+	// Reads bytes from the given block through the cache without mapping it.
+	async::result<void> read(uint64_t block, size_t offset, size_t length, void *buffer);
+
+private:
+	async::detached manage_(helix::UniqueDescriptor backing);
+
+	BlockDevice *device_;
+	uint64_t numBlocks_;
+	size_t blockSize_;
+	uint32_t blockPagesShift_;
+	size_t sectorsPerBlock_;
+	helix::UniqueDescriptor frontal_;
+};
+
+} // namespace blockfs


### PR DESCRIPTION
This also requires us to revise how we access the indirect blocks. We previously had one page cache per level of indirect blocks (i.e., single/double/triple indirect) but that was very awkward to lock because writing back e.g., a double indirect block was dependent on reading a single indirect block etc.

In the new scheme, we have one page cache for all indirect blocks that is indexed by filesystem block number (and not by its position in the hierarchy of indirect blocks). This breaks the dependency. It also makes it easier to cache extent trees in a future PR.