### PR TITLE
drivers/libblockfs: Cache ext2 extent tree blocks

### DIFF
--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1736,6 +1736,9 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 			co_await walker.walk(index,
 				[](const ExtentWalkInfo &) -> async::result<void> { co_return; },
 				async::lambda([&](ExtentWalkInfo &info) -> async::result<ExtentIterDecision> {
+					MetadataCache::BlockWindow newBlockWindow;
+					MetadataCache::BlockWindow newRootWindow;
+
 					if(std::holds_alternative<UpdateMinBlock>(writeExtent)) {
 						assert(info.indices);
 						auto &idx = info.indices[info.index];
@@ -1743,10 +1746,8 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 						if(index < idx.block) {
 							idx.block = index;
 
-							if(info.block) {
+							if(info.block)
 								updateExtentChecksum(*this, inode, info.hdr);
-								co_await device->writeSectors(*info.block * sectorsPerBlock, info.blockView);
-							}
 
 							co_return ExtentIterDecision::keepGoing;
 						}else {
@@ -1766,8 +1767,8 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 
 						diskInode->blocks += blockSize / 512;
 
-						arch::dma_buffer newBlockBuffer{pool, sectorsPerBlock * device->sectorSize};
-						auto newHdr = reinterpret_cast<ExtentHeader *>(newBlockBuffer.data());
+						newBlockWindow = co_await metadataCache->access(newBlock[0], true);
+						auto newHdr = reinterpret_cast<ExtentHeader *>(newBlockWindow.get());
 
 						newHdr->magic = EXT4_EXTENT_MAGIC;
 						newHdr->max = (blockSize - sizeof(ExtentHeader)) / sizeof(Extent);
@@ -1808,9 +1809,10 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 
 						assert(newBlock[0] != 0);
 						updateExtentChecksum(*this, inode, newHdr);
-					    co_await device->writeSectors(
-					        newBlock[0] * sectorsPerBlock, newBlockBuffer
-					    );
+
+						// The block lost entriesToMove-many entries, so update its checksum.
+						if(info.block)
+							updateExtentChecksum(*this, inode, info.hdr);
 
 						if(!info.block) {
 							// The root is full, allocate a new level for the entries that would have been left at root.
@@ -1819,8 +1821,8 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 
 							diskInode->blocks += blockSize / 512;
 
-							arch::dma_buffer newRootBuffer{pool, sectorsPerBlock * device->sectorSize};
-							auto newRootHdr = reinterpret_cast<ExtentHeader *>(newRootBuffer.data());
+							newRootWindow = co_await metadataCache->access(newRoot[0], true);
+							auto newRootHdr = reinterpret_cast<ExtentHeader *>(newRootWindow.get());
 
 							memcpy(newRootHdr, info.hdr, sizeof(ExtentHeader) + info.hdr->entries * sizeof(Extent));
 							// Update the max count as the inode can store less entries than a block.
@@ -1828,9 +1830,6 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 
 							assert(newRoot[0] != 0);
 							updateExtentChecksum(*this, inode, newRootHdr);
-						    co_await device->writeSectors(
-						        newRoot[0] * sectorsPerBlock, newRootBuffer
-						    );
 
 							info.hdr->entries = 2;
 							info.hdr->depth++;
@@ -1906,7 +1905,6 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 					if(info.block) {
 						assert(*info.block != 0);
 						updateExtentChecksum(*this, inode, info.hdr);
-						co_await device->writeSectors(*info.block * sectorsPerBlock, info.blockView);
 					}
 
 					writeExtent = nextWriteExtent;

--- a/drivers/libblockfs/src/ext2/extents.hpp
+++ b/drivers/libblockfs/src/ext2/extents.hpp
@@ -8,7 +8,6 @@ struct ExtentWalkInfo {
 	ExtentHeader *hdr;
 	// null for the inode embedded level
 	std::optional<uint64_t> block;
-	arch::dma_buffer_view blockView;
 	uint16_t index;
 
 	// for non-leaf levels
@@ -38,14 +37,13 @@ struct ExtentWalker {
 	 */
 	template<typename Enter, typename Leave>
 	async::result<bool> walk(uint64_t blockIndex, Enter enter, Leave leave) {
-		auto bufferBytesPerBlock = fs->sectorsPerBlock * fs->device->sectorSize;
-		arch::dma_buffer blockBuffer{fs->pool, bufferBytesPerBlock * maxExtentDepthAfterInode};
-		arch::dma_buffer_view subview;
-
 		auto hdr = &inode->diskInode()->data.extents.hdr;
 		std::optional<uint64_t> currentBlock;
 
 		ExtentWalkInfo path[5];
+		// Cache windows backing the on-disk nodes in path: windows[k] backs path[k].
+		// The inode-embedded root (path[0]) has no backing window.
+		MetadataCache::BlockWindow windows[5];
 		int pathCount = 0;
 
 		while(hdr->depth != 0) {
@@ -76,7 +74,6 @@ struct ExtentWalker {
 			path[pathCount++] = {
 				.hdr = hdr,
 				.block = currentBlock,
-				.blockView = subview,
 				.index = static_cast<uint16_t>(prevIndex),
 				.indices = indices,
 				.extents = nullptr
@@ -88,10 +85,9 @@ struct ExtentWalker {
 			uint64_t nextBlock = static_cast<uint64_t>(idx.leafLow)
 					| (static_cast<uint64_t>(idx.leafHigh) << 32);
 
-			subview = blockBuffer.subview((pathCount - 1) * bufferBytesPerBlock, bufferBytesPerBlock);
-			co_await fs->device->readSectors(nextBlock * fs->sectorsPerBlock, subview);
+			windows[pathCount] = co_await fs->metadataCache->access(nextBlock, !lookup);
 			currentBlock = nextBlock;
-			hdr = reinterpret_cast<ExtentHeader *>(subview.data());
+			hdr = reinterpret_cast<ExtentHeader *>(windows[pathCount].get());
 		}
 
 		assert(hdr->magic == EXT4_EXTENT_MAGIC);
@@ -121,7 +117,6 @@ struct ExtentWalker {
 		path[pathCount++] = {
 			.hdr = hdr,
 			.block = currentBlock,
-			.blockView = subview,
 			.index = static_cast<uint16_t>(prevIndex),
 			.indices = nullptr,
 			.extents = extents


### PR DESCRIPTION
This adds caching for the extent tree by wiring it through `MetadataCache`.