### PR TITLE
thor: Remove individual descriptor structs in favor of AnyDescriptor

### DIFF
--- a/kernel/thor/arch/x86/rtc.cpp
+++ b/kernel/thor/arch/x86/rtc.cpp
@@ -86,7 +86,7 @@ struct RtcBusObject : private KernelBusObject {
 	}
 
 private:
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override {
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) override {
 		auto [acceptError, conversation] = co_await accept(lane);
 		if(acceptError != Error::success)
 			co_return acceptError;
@@ -99,7 +99,7 @@ private:
 		if (preamble.error())
 			co_return Error::protocolViolation;
 
-		auto sendResponse = [] (LaneHandle &conversation,
+		auto sendResponse = [] (smarter::shared_ptr<Stream, LanePolicy> &conversation,
 				managarm::clock::SvrResponse<KernelAlloc> &&resp) -> coroutine<frg::expected<Error>> {
 			frg::unique_memory<KernelAlloc> respHeadBuffer{*kernelAlloc,
 				resp.head_size};

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -355,7 +355,7 @@ HelError helGetCredentials(HelHandle handle, uint32_t flags, char *credentials) 
 			if(desc.is<ThreadDescriptor>())
 				creds = desc.get<ThreadDescriptor>().thread->credentials();
 			else if(desc.is<LaneDescriptor>())
-				creds = desc.get<LaneDescriptor>().handle.getStream()->credentials().credentials();
+				creds = desc.get<LaneDescriptor>().handle->credentials().credentials();
 			else
 				return std::unexpected{Error::badDescriptor};
 			return {};
@@ -2681,7 +2681,7 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 	auto thisUniverse = thisThread->getUniverse();
 
 	auto laneOutcome = thisUniverse->inspectDescriptor(laneHandle,
-			[](AnyDescriptor &desc) -> std::expected<LaneHandle, Error> {
+			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Stream, LanePolicy>, Error> {
 		if(!desc.is<LaneDescriptor>())
 			return std::unexpected{Error::badDescriptor};
 		return desc.get<LaneDescriptor>().handle;
@@ -2750,7 +2750,7 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 						else if(desc.is<TokenDescriptor>())
 							creds = desc.get<TokenDescriptor>().credentials->credentials();
 						else if(desc.is<LaneDescriptor>())
-							creds = desc.get<LaneDescriptor>().handle.getStream()->credentials().credentials();
+							creds = desc.get<LaneDescriptor>().handle->credentials().credentials();
 						else
 							return std::unexpected{Error::badDescriptor};
 						return {};
@@ -2870,7 +2870,7 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 	[](frg::dyn_array<Item, KernelAlloc> items, size_t count,
 			smarter::weak_ptr<Universe> weakUniverse,
 			smarter::shared_ptr<IpcQueue> queue, uintptr_t context,
-			LaneHandle lane, size_t numFlows, smarter::shared_ptr<Thread> thread,
+			smarter::shared_ptr<Stream, LanePolicy> lane, size_t numFlows, smarter::shared_ptr<Thread> thread,
 			enable_detached_coroutine) -> void {
 		StreamPacket packet;
 		packet.setup(count);
@@ -3235,7 +3235,7 @@ HelError helShutdownLane(HelHandle handle) {
 	auto this_universe = this_thread->getUniverse();
 
 	auto laneOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<LaneHandle, Error> {
+			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Stream, LanePolicy>, Error> {
 		if(!desc.is<LaneDescriptor>())
 			return std::unexpected{Error::badDescriptor};
 		return desc.get<LaneDescriptor>().handle;
@@ -3244,7 +3244,7 @@ HelError helShutdownLane(HelHandle handle) {
 		return translateError(laneOutcome.error());
 	auto lane = std::move(*laneOutcome);
 
-	lane.getStream()->shutdownLane(lane.getLane());
+	lane->shutdownLane(laneOf(lane));
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -252,12 +252,7 @@ HelError helSubmitAsyncNop(HelHandle queueHandle, uintptr_t context) {
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto queueOutcome = thisUniverse->inspectDescriptor(queueHandle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<IpcQueue>, Error> {
-		if(!desc.is<QueueDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<QueueDescriptor>().queue;
-	});
+	auto queueOutcome = thisUniverse->resolveObject<DescriptorType::queue>(queueHandle);
 	if(!queueOutcome)
 		return translateError(queueOutcome.error());
 
@@ -290,12 +285,7 @@ helTransferDescriptor(HelHandle handle, HelHandle universeHandle, HelTransferDes
 	if(universeHandle == kHelThisUniverse) {
 		universe = thisUniverse.lock();
 	}else{
-		auto universeOutcome = thisUniverse->inspectDescriptor(universeHandle,
-				[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Universe>, Error> {
-			if(!desc.is<UniverseDescriptor>())
-				return std::unexpected{Error::badDescriptor};
-			return desc.get<UniverseDescriptor>().universe;
-		});
+		auto universeOutcome = thisUniverse->resolveObject<DescriptorType::universe>(universeHandle);
 		if(!universeOutcome)
 			return translateError(universeOutcome.error());
 		universe = std::move(*universeOutcome);
@@ -378,12 +368,7 @@ HelError helCloseDescriptor(HelHandle universeHandle, HelHandle handle) {
 	if(universeHandle == kHelThisUniverse) {
 		universe = thisUniverse.lock();
 	}else{
-		auto universeOutcome = thisUniverse->inspectDescriptor(universeHandle,
-				[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Universe>, Error> {
-			if(!desc.is<UniverseDescriptor>())
-				return std::unexpected{Error::badDescriptor};
-			return desc.get<UniverseDescriptor>().universe;
-		});
+		auto universeOutcome = thisUniverse->resolveObject<DescriptorType::universe>(universeHandle);
 		if(!universeOutcome)
 			return translateError(universeOutcome.error());
 		universe = std::move(*universeOutcome);
@@ -426,12 +411,7 @@ HelError helDriveQueue(HelHandle handle, uint32_t flags, uint32_t notifyMask) {
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto queueOutcome = thisUniverse->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<IpcQueue>, Error> {
-		if(!desc.is<QueueDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<QueueDescriptor>().queue;
-	});
+	auto queueOutcome = thisUniverse->resolveObject<DescriptorType::queue>(handle);
 	if(!queueOutcome)
 		return translateError(queueOutcome.error());
 	auto queue = std::move(*queueOutcome);
@@ -464,12 +444,7 @@ HelError helAlertQueue(HelHandle handle) {
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto queueOutcome = thisUniverse->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<IpcQueue>, Error> {
-		if(!desc.is<QueueDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<QueueDescriptor>().queue;
-	});
+	auto queueOutcome = thisUniverse->resolveObject<DescriptorType::queue>(handle);
 	if(!queueOutcome)
 		return translateError(queueOutcome.error());
 	auto queue = std::move(*queueOutcome);
@@ -523,12 +498,7 @@ HelError doSubmitResizeMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> qu
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -589,12 +559,7 @@ HelError helCopyOnWrite(HelHandle memoryHandle,
 			return kHelErrBadDescriptor;
 		view = getSpecialMemoryView(memoryHandle);
 	} else {
-		auto viewOutcome = this_universe->inspectDescriptor(memoryHandle,
-				[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-			if(!desc.is<MemoryViewDescriptor>())
-				return std::unexpected{Error::badDescriptor};
-			return desc.get<MemoryViewDescriptor>().memory;
-		});
+		auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(memoryHandle);
 		if(!viewOutcome)
 			return translateError(viewOutcome.error());
 		view = std::move(*viewOutcome);
@@ -642,12 +607,7 @@ HelError helAlterMemoryIndirection(HelHandle indirectHandle, size_t slot,
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto indirectOutcome = thisUniverse->inspectDescriptor(indirectHandle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto indirectOutcome = thisUniverse->resolveObject<DescriptorType::memoryView>(indirectHandle);
 	if(!indirectOutcome)
 		return translateError(indirectOutcome.error());
 	auto indirectView = std::move(*indirectOutcome);
@@ -694,12 +654,7 @@ HelError helCreateSliceView(HelHandle memoryHandle,
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto viewOutcome = this_universe->inspectDescriptor(memoryHandle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(memoryHandle);
 	if(!viewOutcome)
 		return translateError(viewOutcome.error());
 	auto view = std::move(*viewOutcome);
@@ -721,12 +676,7 @@ HelError doSubmitForkMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto viewOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
 	if(!viewOutcome)
 		return translateError(viewOutcome.error());
 	auto view = std::move(*viewOutcome);
@@ -772,12 +722,7 @@ HelError doSubmitWritebackFence(HelHandle handle, smarter::shared_ptr<IpcQueue> 
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -806,12 +751,7 @@ HelError doSubmitInvalidateMemory(HelHandle handle, smarter::shared_ptr<IpcQueue
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -840,12 +780,7 @@ HelError doSubmitPopulateSpace(HelHandle handle, smarter::shared_ptr<IpcQueue> q
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto dmaSpaceOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<DmaSpace>, Error> {
-		if(!desc.is<DmaSpaceDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<DmaSpaceDescriptor>().space;
-	});
+	auto dmaSpaceOutcome = this_universe->resolveObject<DescriptorType::dmaSpace>(handle);
 	if(!dmaSpaceOutcome)
 		return translateError(dmaSpaceOutcome.error());
 	auto space = std::move(*dmaSpaceOutcome);
@@ -949,12 +884,7 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto vspaceOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<VirtualizedPageSpace>, Error> {
-		if(!desc.is<VirtualizedSpaceDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<VirtualizedSpaceDescriptor>().space;
-	});
+	auto vspaceOutcome = this_universe->resolveObject<DescriptorType::virtualizedSpace>(handle);
 	if(!vspaceOutcome)
 		return translateError(vspaceOutcome.error());
 	auto vspace = std::move(*vspaceOutcome);
@@ -977,12 +907,7 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto vspaceOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<VirtualizedPageSpace>, Error> {
-		if(!desc.is<VirtualizedSpaceDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<VirtualizedSpaceDescriptor>().space;
-	});
+	auto vspaceOutcome = this_universe->resolveObject<DescriptorType::virtualizedSpace>(handle);
 	if(!vspaceOutcome)
 		return translateError(vspaceOutcome.error());
 	auto vspace = std::move(*vspaceOutcome);
@@ -1007,12 +932,7 @@ HelError helRunVirtualizedCpu(HelHandle handle, HelVmexitReason *exitInfo) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto vcpuOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<VirtualizedCpu>, Error> {
-		if(!desc.is<VirtualizedCpuDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<VirtualizedCpuDescriptor>().vcpu;
-	});
+	auto vcpuOutcome = this_universe->resolveObject<DescriptorType::virtualizedCpu>(handle);
 	if(!vcpuOutcome)
 		return translateError(vcpuOutcome.error());
 	auto vcpu = std::move(*vcpuOutcome);
@@ -1034,12 +954,7 @@ HelError helAssertVirtualizedIrq(HelHandle handle, uint64_t irq, uint8_t level) 
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto vcpuOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<VirtualizedCpu>, Error> {
-		if(!desc.is<VirtualizedCpuDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<VirtualizedCpuDescriptor>().vcpu;
-	});
+	auto vcpuOutcome = this_universe->resolveObject<DescriptorType::virtualizedCpu>(handle);
 	if(!vcpuOutcome)
 		return translateError(vcpuOutcome.error());
 	auto vcpu = std::move(*vcpuOutcome);
@@ -1196,12 +1111,7 @@ HelError doSubmitProtectMemory(HelHandle space_handle, smarter::shared_ptr<IpcQu
 	if(space_handle == kHelNullHandle) {
 		space = this_thread->getAddressSpace().lock();
 	}else{
-		auto spaceOutcome = this_universe->inspectDescriptor(space_handle,
-				[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<AddressSpace, BindableHandle>, Error> {
-			if(!desc.is<AddressSpaceDescriptor>())
-				return std::unexpected{Error::badDescriptor};
-			return desc.get<AddressSpaceDescriptor>().space;
-		});
+		auto spaceOutcome = this_universe->resolveObject<DescriptorType::addressSpace>(space_handle);
 		if(!spaceOutcome)
 			return translateError(spaceOutcome.error());
 		space = std::move(*spaceOutcome);
@@ -1286,12 +1196,7 @@ HelError doSubmitSynchronizeSpace(HelHandle spaceHandle, smarter::shared_ptr<Ipc
 	if(spaceHandle == kHelNullHandle) {
 		space = thisThread->getAddressSpace().lock();
 	}else{
-		auto spaceOutcome = thisUniverse->inspectDescriptor(spaceHandle,
-				[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<AddressSpace, BindableHandle>, Error> {
-			if(!desc.is<AddressSpaceDescriptor>())
-				return std::unexpected{Error::badDescriptor};
-			return desc.get<AddressSpaceDescriptor>().space;
-		});
+		auto spaceOutcome = thisUniverse->resolveObject<DescriptorType::addressSpace>(spaceHandle);
 		if(!spaceOutcome)
 			return translateError(spaceOutcome.error());
 		space = std::move(*spaceOutcome);
@@ -1613,12 +1518,7 @@ HelError helMemoryInfo(HelHandle handle, size_t *size) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -1631,12 +1531,7 @@ HelError doSubmitManageMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> qu
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -1692,12 +1587,7 @@ HelError helUpdateMemory(HelHandle handle, int type,
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -1728,12 +1618,7 @@ HelError doSubmitLockMemoryView(HelHandle handle, smarter::shared_ptr<IpcQueue> 
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -1801,12 +1686,7 @@ HelError helLoadahead(HelHandle handle, uintptr_t offset, size_t length) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	});
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 
@@ -1835,12 +1715,7 @@ HelError helCreateThread(HelHandle universe_handle, HelHandle space_handle,
 	if(universe_handle == kHelNullHandle) {
 		universe = this_thread->getUniverse().lock();
 	}else{
-		auto universeOutcome = this_universe->inspectDescriptor(universe_handle,
-				[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Universe>, Error> {
-			if(!desc.is<UniverseDescriptor>())
-				return std::unexpected{Error::badDescriptor};
-			return desc.get<UniverseDescriptor>().universe;
-		});
+		auto universeOutcome = this_universe->resolveObject<DescriptorType::universe>(universe_handle);
 		if(!universeOutcome)
 			return translateError(universeOutcome.error());
 		universe = std::move(*universeOutcome);
@@ -1850,12 +1725,7 @@ HelError helCreateThread(HelHandle universe_handle, HelHandle space_handle,
 	if(space_handle == kHelNullHandle) {
 		space = this_thread->getAddressSpace().lock();
 	}else{
-		auto spaceOutcome = this_universe->inspectDescriptor(space_handle,
-				[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<AddressSpace, BindableHandle>, Error> {
-			if(!desc.is<AddressSpaceDescriptor>())
-				return std::unexpected{Error::badDescriptor};
-			return desc.get<AddressSpaceDescriptor>().space;
-		});
+		auto spaceOutcome = this_universe->resolveObject<DescriptorType::addressSpace>(space_handle);
 		if(!spaceOutcome)
 			return translateError(spaceOutcome.error());
 		space = std::move(*spaceOutcome);
@@ -1891,15 +1761,10 @@ HelError helQueryThreadStats(HelHandle handle, HelThreadStats *user_stats) {
 	if(handle == kHelThisThread) {
 		thread = this_thread.lock();
 	}else{
-		auto threadOutcome = this_universe->inspectDescriptor(handle,
-				[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Thread>, Error> {
-			if(!desc.is<ThreadDescriptor>())
-				return std::unexpected{Error::badDescriptor};
-			return smarter::rc_policy_downcast<smarter::default_rc_policy>(desc.get<ThreadDescriptor>().thread);
-		});
+		auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
 		if(!threadOutcome)
 			return translateError(threadOutcome.error());
-		thread = std::move(*threadOutcome);
+		thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 	}
 
 	HelThreadStats stats;
@@ -1920,15 +1785,10 @@ HelError helSetPriority(HelHandle handle, int priority) {
 	if(handle == kHelThisThread) {
 		thread = this_thread.lock();
 	}else{
-		auto threadOutcome = this_universe->inspectDescriptor(handle,
-				[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Thread>, Error> {
-			if(!desc.is<ThreadDescriptor>())
-				return std::unexpected{Error::badDescriptor};
-			return smarter::rc_policy_downcast<smarter::default_rc_policy>(desc.get<ThreadDescriptor>().thread);
-		});
+		auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
 		if(!threadOutcome)
 			return translateError(threadOutcome.error());
-		thread = std::move(*threadOutcome);
+		thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 	}
 
 	Scheduler::setPriority(thread.get(), priority);
@@ -1947,15 +1807,10 @@ HelError doSubmitObserve(HelHandle handle, smarter::shared_ptr<IpcQueue> queue,
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto threadOutcome = thisUniverse->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Thread>, Error> {
-		if(!desc.is<ThreadDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return smarter::rc_policy_downcast<smarter::default_rc_policy>(desc.get<ThreadDescriptor>().thread);
-	});
+	auto threadOutcome = thisUniverse->resolveObject<DescriptorType::thread>(handle);
 	if(!threadOutcome)
 		return translateError(threadOutcome.error());
-	auto thread = std::move(*threadOutcome);
+	auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 
 	if(!queue->validSize(ipcSourceSize(sizeof(HelObserveResult))))
 		return kHelErrQueueTooSmall;
@@ -2000,15 +1855,10 @@ HelError helKillThread(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto threadOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Thread>, Error> {
-		if(!desc.is<ThreadDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return smarter::rc_policy_downcast<smarter::default_rc_policy>(desc.get<ThreadDescriptor>().thread);
-	});
+	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
 	if(!threadOutcome)
 		return translateError(threadOutcome.error());
-	auto thread = std::move(*threadOutcome);
+	auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 
 	Thread::killOther(thread);
 
@@ -2019,15 +1869,10 @@ HelError helInterruptThread(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto threadOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Thread>, Error> {
-		if(!desc.is<ThreadDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return smarter::rc_policy_downcast<smarter::default_rc_policy>(desc.get<ThreadDescriptor>().thread);
-	});
+	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
 	if(!threadOutcome)
 		return translateError(threadOutcome.error());
-	auto thread = std::move(*threadOutcome);
+	auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 
 	Thread::interruptOther(thread);
 
@@ -2038,15 +1883,10 @@ HelError helResume(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto threadOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Thread>, Error> {
-		if(!desc.is<ThreadDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return smarter::rc_policy_downcast<smarter::default_rc_policy>(desc.get<ThreadDescriptor>().thread);
-	});
+	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
 	if(!threadOutcome)
 		return translateError(threadOutcome.error());
-	auto thread = std::move(*threadOutcome);
+	auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 
 	if(auto e = Thread::resumeOther(thread); e != Error::success) {
 		if(e == Error::threadExited)
@@ -2680,12 +2520,7 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto laneOutcome = thisUniverse->inspectDescriptor(laneHandle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Stream, LanePolicy>, Error> {
-		if(!desc.is<LaneDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<LaneDescriptor>().handle;
-	});
+	auto laneOutcome = thisUniverse->resolveObject<DescriptorType::lane>(laneHandle);
 	if(!laneOutcome)
 		return translateError(laneOutcome.error());
 	auto lane = std::move(*laneOutcome);
@@ -3234,12 +3069,7 @@ HelError helShutdownLane(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto laneOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Stream, LanePolicy>, Error> {
-		if(!desc.is<LaneDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<LaneDescriptor>().handle;
-	});
+	auto laneOutcome = this_universe->resolveObject<DescriptorType::lane>(handle);
 	if(!laneOutcome)
 		return translateError(laneOutcome.error());
 	auto lane = std::move(*laneOutcome);
@@ -3340,12 +3170,7 @@ HelError helRaiseEvent(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto eventOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<OneshotEvent>, Error> {
-		if(!desc.is<OneshotEventDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<OneshotEventDescriptor>().event;
-	});
+	auto eventOutcome = this_universe->resolveObject<DescriptorType::oneshotEvent>(handle);
 	if(!eventOutcome)
 		return translateError(eventOutcome.error());
 
@@ -3391,12 +3216,7 @@ HelError helAcknowledgeIrq(HelHandle handle, uint32_t flags, uint64_t sequence) 
 	if(mode != kHelAckAcknowledge && mode != kHelAckNack && mode != kHelAckKick)
 		return kHelErrIllegalArgs;
 
-	auto irqOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<IrqObject>, Error> {
-		if(!desc.is<IrqDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<IrqDescriptor>().irq;
-	});
+	auto irqOutcome = this_universe->resolveObject<DescriptorType::irq>(handle);
 	if(!irqOutcome)
 		return translateError(irqOutcome.error());
 	auto irq = std::move(*irqOutcome);
@@ -3513,22 +3333,12 @@ HelError helAutomateIrq(HelHandle handle, uint32_t flags, HelHandle kernlet_hand
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto irqOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<IrqObject>, Error> {
-		if(!desc.is<IrqDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<IrqDescriptor>().irq;
-	});
+	auto irqOutcome = this_universe->resolveObject<DescriptorType::irq>(handle);
 	if(!irqOutcome)
 		return translateError(irqOutcome.error());
 	auto irq = std::move(*irqOutcome);
 
-	auto kernletOutcome = this_universe->inspectDescriptor(kernlet_handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<BoundKernlet>, Error> {
-		if(!desc.is<BoundKernletDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<BoundKernletDescriptor>().boundKernlet;
-	});
+	auto kernletOutcome = this_universe->resolveObject<DescriptorType::boundKernlet>(kernlet_handle);
 	if(!kernletOutcome)
 		return translateError(kernletOutcome.error());
 	auto kernlet = std::move(*kernletOutcome);
@@ -3563,12 +3373,7 @@ HelError helEnableIo(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto ioOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<IoSpace>, Error> {
-		if(!desc.is<IoDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<IoDescriptor>().ioSpace;
-	});
+	auto ioOutcome = this_universe->resolveObject<DescriptorType::io>(handle);
 	if(!ioOutcome)
 		return translateError(ioOutcome.error());
 	auto io_space = std::move(*ioOutcome);
@@ -3600,12 +3405,7 @@ HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto kernletOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<KernletObject>, Error> {
-		if(!desc.is<KernletObjectDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<KernletObjectDescriptor>().kernletObject;
-	});
+	auto kernletOutcome = this_universe->resolveObject<DescriptorType::kernletObject>(handle);
 	if(!kernletOutcome)
 		return translateError(kernletOutcome.error());
 	auto kernlet = std::move(*kernletOutcome);
@@ -3626,12 +3426,7 @@ HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num
 		if(defn.type == KernletParameterType::offset) {
 			bound->setupOffsetBinding(i, d.handle);
 		}else if(defn.type == KernletParameterType::memoryView) {
-			auto memoryOutcome = this_universe->inspectDescriptor(d.handle,
-					[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<MemoryView>, Error> {
-				if(!desc.is<MemoryViewDescriptor>())
-					return std::unexpected{Error::badDescriptor};
-				return desc.get<MemoryViewDescriptor>().memory;
-			});
+			auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(d.handle);
 			if(!memoryOutcome)
 				return translateError(memoryOutcome.error());
 			auto memory = std::move(*memoryOutcome);
@@ -3667,12 +3462,7 @@ HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num
 		}else{
 			assert(defn.type == KernletParameterType::bitsetEvent);
 
-			auto eventOutcome = this_universe->inspectDescriptor(d.handle,
-					[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<BitsetEvent>, Error> {
-				if(!desc.is<BitsetEventDescriptor>())
-					return std::unexpected{Error::badDescriptor};
-				return desc.get<BitsetEventDescriptor>().event;
-			});
+			auto eventOutcome = this_universe->resolveObject<DescriptorType::bitsetEvent>(d.handle);
 			if(!eventOutcome)
 				return translateError(eventOutcome.error());
 			auto event = std::move(*eventOutcome);
@@ -3695,15 +3485,10 @@ HelError helGetAffinity(HelHandle handle, uint8_t *mask, size_t size, size_t *ac
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto threadOutcome = this_universe->inspectDescriptor(handle,
-			[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Thread>, Error> {
-		if(!desc.is<ThreadDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return smarter::rc_policy_downcast<smarter::default_rc_policy>(desc.get<ThreadDescriptor>().thread);
-	});
+	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
 	if(!threadOutcome)
 		return translateError(threadOutcome.error());
-	auto thread = std::move(*threadOutcome);
+	auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 
 	frg::vector<uint8_t, KernelAlloc> buf{*kernelAlloc};
 	buf.resize(maskSize);
@@ -3747,15 +3532,10 @@ HelError helSetAffinity(HelHandle handle, uint8_t *mask, size_t size) {
 		this_thread->_lbCb->setAffinityMask({buf.data(), maskSize});
 		Thread::migrateCurrent();
 	} else {
-		auto threadOutcome = this_universe->inspectDescriptor(handle,
-				[](AnyDescriptor &desc) -> std::expected<smarter::shared_ptr<Thread>, Error> {
-			if(!desc.is<ThreadDescriptor>())
-				return std::unexpected{Error::badDescriptor};
-			return smarter::rc_policy_downcast<smarter::default_rc_policy>(desc.get<ThreadDescriptor>().thread);
-		});
+		auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
 		if(!threadOutcome)
 			return translateError(threadOutcome.error());
-		auto thread = std::move(*threadOutcome);
+		auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 
 		thread->_lbCb->setAffinityMask({buf.data(), maskSize});
 		infoLogger() << "thor: TODO: helSetAffinity does not migrate other threads!" << frg::endlog;

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -268,7 +268,7 @@ HelError helCreateUniverse(HelHandle *handle) {
 	auto new_universe = smarter::allocate_shared<Universe>(*kernelAlloc);
 
 	*handle = this_universe->attachDescriptor(
-			UniverseDescriptor(std::move(new_universe)));
+			AnyDescriptor::make<DescriptorType::universe>(std::move(new_universe)));
 
 	return kHelErrNone;
 }
@@ -318,7 +318,7 @@ HelError helDescriptorInfo(HelHandle handle, HelDescriptorInfo *) {
 
 	auto infoOutcome = this_universe->inspectDescriptor(handle,
 			[](AnyDescriptor &desc) -> std::expected<void, Error> {
-		switch(desc.tag()) {
+		switch(desc.type()) {
 		default:
 			return std::unexpected{Error::other};
 		}
@@ -342,12 +342,19 @@ HelError helGetCredentials(HelHandle handle, uint32_t flags, char *credentials) 
 	}else{
 		auto outcome = thisUniverse->inspectDescriptor(handle,
 				[&](AnyDescriptor &desc) -> std::expected<void, Error> {
-			if(desc.is<ThreadDescriptor>())
-				creds = desc.get<ThreadDescriptor>().thread->credentials();
-			else if(desc.is<LaneDescriptor>())
-				creds = desc.get<LaneDescriptor>().handle->credentials().credentials();
-			else
+			if(desc.is<DescriptorType::thread>()) {
+				auto threadOutcome = desc.resolveObject<DescriptorType::thread>();
+				if(!threadOutcome)
+					return std::unexpected{threadOutcome.error()};
+				creds = (*threadOutcome)->credentials();
+			}else if(desc.is<DescriptorType::lane>()) {
+				auto laneOutcome = desc.resolveObject<DescriptorType::lane>();
+				if(!laneOutcome)
+					return std::unexpected{laneOutcome.error()};
+				creds = (*laneOutcome)->credentials().credentials();
+			}else{
 				return std::unexpected{Error::badDescriptor};
+			}
 			return {};
 		});
 		if(!outcome)
@@ -399,7 +406,7 @@ HelError helCreateQueue(const HelQueueParameters *paramsPtr, HelHandle *handle) 
 	if(!queueOutcome)
 		return translateError(queueOutcome.error());
 	*handle = thisUniverse->attachDescriptor(
-			QueueDescriptor(std::move(*queueOutcome)));
+			AnyDescriptor::make<DescriptorType::queue>(std::move(*queueOutcome)));
 
 	return kHelErrNone;
 }
@@ -488,7 +495,7 @@ HelError helAllocateMemory(size_t size, uint32_t flags,
 	memory->selfPtr = memory;
 
 	*handle = thisUniverse->attachDescriptor(
-			MemoryViewDescriptor(std::move(memory)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(memory)));
 
 	return kHelErrNone;
 }
@@ -540,9 +547,9 @@ HelError helCreateManagedMemory(size_t size, uint32_t flags,
 	frontalMemory->selfPtr = frontalMemory;
 
 	*backing_handle = thisUniverse->attachDescriptor(
-			MemoryViewDescriptor(std::move(backingMemory)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(backingMemory)));
 	*frontal_handle = thisUniverse->attachDescriptor(
-			MemoryViewDescriptor(std::move(frontalMemory)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(frontalMemory)));
 
 	return kHelErrNone;
 }
@@ -569,7 +576,7 @@ HelError helCopyOnWrite(HelHandle memoryHandle,
 			offset, size);
 	slice->selfPtr = slice;
 	*outHandle = this_universe->attachDescriptor(
-			MemoryViewDescriptor(std::move(slice)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(slice)));
 
 	return kHelErrNone;
 }
@@ -586,7 +593,7 @@ HelError helAccessPhysical(uintptr_t physical, size_t size, HelHandle *handle) {
 	auto memory = smarter::allocate_shared<HardwareMemory>(*kernelAlloc, physical, size,
 			CachingMode::null);
 	*handle = this_universe->attachDescriptor(
-			MemoryViewDescriptor(std::move(memory)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(memory)));
 
 	return kHelErrNone;
 }
@@ -597,7 +604,7 @@ HelError helCreateIndirectMemory(size_t numSlots, HelHandle *handle) {
 
 	auto memory = smarter::allocate_shared<IndirectMemory>(*kernelAlloc, numSlots);
 	*handle = this_universe->attachDescriptor(
-			MemoryViewDescriptor(std::move(memory)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(memory)));
 
 	return kHelErrNone;
 }
@@ -616,12 +623,18 @@ HelError helAlterMemoryIndirection(HelHandle indirectHandle, size_t slot,
 	CachingFlags cacheFlags = 0;
 	auto memoryOutcome = thisUniverse->inspectDescriptor(memoryHandle,
 			[&](AnyDescriptor &desc) -> std::expected<void, Error> {
-		if(desc.is<MemoryViewDescriptor>()) {
-			memoryView = desc.get<MemoryViewDescriptor>().memory;
-		} else if(desc.is<MemorySliceDescriptor>()) {
-			memoryView = desc.get<MemorySliceDescriptor>().slice->getView();
-			offset += desc.get<MemorySliceDescriptor>().slice->offset();
-			cacheFlags = desc.get<MemorySliceDescriptor>().slice->getCachingFlags();
+		if(desc.is<DescriptorType::memoryView>()) {
+			auto viewOutcome = desc.resolveObject<DescriptorType::memoryView>();
+			if(!viewOutcome)
+				return std::unexpected{viewOutcome.error()};
+			memoryView = std::move(*viewOutcome);
+		} else if(desc.is<DescriptorType::memorySlice>()) {
+			auto sliceOutcome = desc.resolveObject<DescriptorType::memorySlice>();
+			if(!sliceOutcome)
+				return std::unexpected{sliceOutcome.error()};
+			memoryView = (*sliceOutcome)->getView();
+			offset += (*sliceOutcome)->offset();
+			cacheFlags = (*sliceOutcome)->getCachingFlags();
 		} else {
 			return std::unexpected{Error::badDescriptor};
 		}
@@ -666,7 +679,7 @@ HelError helCreateSliceView(HelHandle memoryHandle,
 	auto slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
 			std::move(view), offset, size, cachingFlags);
 	*handle = this_universe->attachDescriptor(
-			MemorySliceDescriptor(std::move(slice)));
+			AnyDescriptor::make<DescriptorType::memorySlice>(std::move(slice)));
 
 	return kHelErrNone;
 }
@@ -706,7 +719,7 @@ HelError doSubmitForkMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 		}
 
 		HelHandle forkedHandle = universe->attachDescriptor(
-				MemoryViewDescriptor(outcome.value()));
+				AnyDescriptor::make<DescriptorType::memoryView>(outcome.value()));
 
 		HelHandleResult helResult{.error = kHelErrNone, .handle = forkedHandle};
 		QueueSource ipcSource{&helResult, sizeof(HelHandleResult), nullptr};
@@ -818,7 +831,7 @@ HelError helCreateSpace(HelHandle *handle) {
 	auto space = AddressSpace::create();
 
 	*handle = this_universe->attachDescriptor(
-			AddressSpaceDescriptor(std::move(space)));
+			AnyDescriptor::make<DescriptorType::addressSpace>(std::move(space)));
 
 	return kHelErrNone;
 }
@@ -849,7 +862,7 @@ HelError helCreateVirtualizedSpace(HelHandle *handle) {
 	}
 
 	*handle = this_universe->attachDescriptor(
-			VirtualizedSpaceDescriptor(std::move(vspace)));
+			AnyDescriptor::make<DescriptorType::virtualizedSpace>(std::move(vspace)));
 	return kHelErrNone;
 #elif defined(__riscv) && __riscv_xlen == 64
 	if(!getCpuData()->haveVirtualization) {
@@ -868,7 +881,7 @@ HelError helCreateVirtualizedSpace(HelHandle *handle) {
 	smarter::shared_ptr<VirtualizedPageSpace> vspace = riscv_hypervisor::HypervisorSpace::create(level0);
 
 	*handle = this_universe->attachDescriptor(
-			VirtualizedSpaceDescriptor(std::move(vspace)));
+			AnyDescriptor::make<DescriptorType::virtualizedSpace>(std::move(vspace)));
 	return kHelErrNone;
 #else
 	(void)handle;
@@ -898,7 +911,7 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 		return kHelErrNoHardwareSupport;
 
 	*out = this_universe->attachDescriptor(
-			VirtualizedCpuDescriptor(std::move(vcpu)));
+			AnyDescriptor::make<DescriptorType::virtualizedCpu>(std::move(vcpu)));
 	return kHelErrNone;
 #elif defined(__riscv) && __riscv_xlen == 64
 	if(!getCpuData()->haveVirtualization) {
@@ -916,7 +929,7 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 			smarter::static_pointer_cast<riscv_hypervisor::HypervisorSpace>(vspace));
 
 	*out = this_universe->attachDescriptor(
-			VirtualizedCpuDescriptor(std::move(vcpu)));
+			AnyDescriptor::make<DescriptorType::virtualizedCpu>(std::move(vcpu)));
 	return kHelErrNone;
 #else
 	(void)handle;
@@ -1019,15 +1032,24 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 
 	auto memoryOutcome = this_universe->inspectDescriptor(memory_handle,
 			[&](AnyDescriptor &desc) -> std::expected<void, Error> {
-		if(desc.is<MemorySliceDescriptor>()) {
-			slice = desc.get<MemorySliceDescriptor>().slice;
-		}else if(desc.is<MemoryViewDescriptor>()) {
-			auto memory = desc.get<MemoryViewDescriptor>().memory;
+		if(desc.is<DescriptorType::memorySlice>()) {
+			auto sliceOutcome = desc.resolveObject<DescriptorType::memorySlice>();
+			if(!sliceOutcome)
+				return std::unexpected{sliceOutcome.error()};
+			slice = std::move(*sliceOutcome);
+		}else if(desc.is<DescriptorType::memoryView>()) {
+			auto viewOutcome = desc.resolveObject<DescriptorType::memoryView>();
+			if(!viewOutcome)
+				return std::unexpected{viewOutcome.error()};
+			auto memory = std::move(*viewOutcome);
 			auto sliceLength = memory->getLength();
 			slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
 					std::move(memory), 0, sliceLength);
-		}else if(desc.is<QueueDescriptor>()) {
-			auto memory = desc.get<QueueDescriptor>().queue->getMemory();
+		}else if(desc.is<DescriptorType::queue>()) {
+			auto queueOutcome = desc.resolveObject<DescriptorType::queue>();
+			if(!queueOutcome)
+				return std::unexpected{queueOutcome.error()};
+			auto memory = (*queueOutcome)->getMemory();
 			auto sliceLength = memory->getLength();
 			slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
 					std::move(memory), 0, sliceLength);
@@ -1044,14 +1066,23 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 	}else{
 		auto spaceOutcome = this_universe->inspectDescriptor(space_handle,
 				[&](AnyDescriptor &desc) -> std::expected<void, Error> {
-			if(desc.is<AddressSpaceDescriptor>()) {
-				space = desc.get<AddressSpaceDescriptor>().space;
-			} else if(desc.is<VirtualizedSpaceDescriptor>()) {
+			if(desc.is<DescriptorType::addressSpace>()) {
+				auto addressSpaceOutcome = desc.resolveObject<DescriptorType::addressSpace>();
+				if(!addressSpaceOutcome)
+					return std::unexpected{addressSpaceOutcome.error()};
+				space = std::move(*addressSpaceOutcome);
+			} else if(desc.is<DescriptorType::virtualizedSpace>()) {
+				auto vspaceOutcome = desc.resolveObject<DescriptorType::virtualizedSpace>();
+				if(!vspaceOutcome)
+					return std::unexpected{vspaceOutcome.error()};
 				isVspace = true;
-				vspace = desc.get<VirtualizedSpaceDescriptor>().space;
-			} else if(desc.is<DmaSpaceDescriptor>()) {
+				vspace = std::move(*vspaceOutcome);
+			} else if(desc.is<DescriptorType::dmaSpace>()) {
+				auto dmaOutcome = desc.resolveObject<DescriptorType::dmaSpace>();
+				if(!dmaOutcome)
+					return std::unexpected{dmaOutcome.error()};
 				isVspace = true;
-				vspace = desc.get<DmaSpaceDescriptor>().space;
+				vspace = std::move(*dmaOutcome);
 			} else {
 				return std::unexpected{Error::badDescriptor};
 			}
@@ -1152,11 +1183,17 @@ HelError helUnmapMemory(HelHandle space_handle, void *pointer, size_t length) {
 	}else{
 		auto spaceOutcome = this_universe->inspectDescriptor(space_handle,
 				[&](AnyDescriptor &desc) -> std::expected<void, Error> {
-			if(desc.is<AddressSpaceDescriptor>()) {
-				space = desc.get<AddressSpaceDescriptor>().space;
+			if(desc.is<DescriptorType::addressSpace>()) {
+				auto addressSpaceOutcome = desc.resolveObject<DescriptorType::addressSpace>();
+				if(!addressSpaceOutcome)
+					return std::unexpected{addressSpaceOutcome.error()};
+				space = std::move(*addressSpaceOutcome);
 				return {};
-			}else if(desc.is<DmaSpaceDescriptor>()) {
-				vspace = desc.get<DmaSpaceDescriptor>().space;
+			}else if(desc.is<DescriptorType::dmaSpace>()) {
+				auto dmaOutcome = desc.resolveObject<DescriptorType::dmaSpace>();
+				if(!dmaOutcome)
+					return std::unexpected{dmaOutcome.error()};
+				vspace = std::move(*dmaOutcome);
 				return {};
 			}
 
@@ -1233,11 +1270,17 @@ HelError helPointerPhysical(HelHandle spaceHandle, const void *pointer, uintptr_
 	}else{
 		auto spaceOutcome = thisUniverse->inspectDescriptor(spaceHandle,
 				[&](AnyDescriptor &desc) -> std::expected<void, Error> {
-			if(desc.is<AddressSpaceDescriptor>()) {
-				space = desc.get<AddressSpaceDescriptor>().space;
+			if(desc.is<DescriptorType::addressSpace>()) {
+				auto addressSpaceOutcome = desc.resolveObject<DescriptorType::addressSpace>();
+				if(!addressSpaceOutcome)
+					return std::unexpected{addressSpaceOutcome.error()};
+				space = std::move(*addressSpaceOutcome);
 				return {};
-			} else if(desc.is<DmaSpaceDescriptor>()) {
-				dmaSpace = desc.get<DmaSpaceDescriptor>().space;
+			} else if(desc.is<DescriptorType::dmaSpace>()) {
+				auto dmaOutcome = desc.resolveObject<DescriptorType::dmaSpace>();
+				if(!dmaOutcome)
+					return std::unexpected{dmaOutcome.error()};
+				dmaSpace = std::move(*dmaOutcome);
 				return {};
 			}
 			return std::unexpected{Error::badDescriptor};
@@ -1363,26 +1406,34 @@ HelError doSubmitReadMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 		co_await queue->submit(&ipcSource, context);
 	};
 
-	if(descriptor.is<MemoryViewDescriptor>()) {
-		auto view = descriptor.get<MemoryViewDescriptor>().memory;
+	if(descriptor.is<DescriptorType::memoryView>()) {
+		auto viewOutcome = descriptor.resolveObject<DescriptorType::memoryView>();
+		if(!viewOutcome)
+			return translateError(viewOutcome.error());
 		readMemoryView(thisThread.lock(),
-				std::move(view), address, length, buffer, std::move(queue), context,
+				std::move(*viewOutcome), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
-	}else if(descriptor.is<AddressSpaceDescriptor>()) {
-		auto space = descriptor.get<AddressSpaceDescriptor>().space;
+	}else if(descriptor.is<DescriptorType::addressSpace>()) {
+		auto spaceOutcome = descriptor.resolveObject<DescriptorType::addressSpace>();
+		if(!spaceOutcome)
+			return translateError(spaceOutcome.error());
+		readVirtualSpace(
+				std::move(*spaceOutcome), address, length, buffer, std::move(queue), context,
+				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
+	}else if(descriptor.is<DescriptorType::thread>()) {
+		auto threadOutcome = descriptor.resolveObject<DescriptorType::thread>();
+		if(!threadOutcome)
+			return translateError(threadOutcome.error());
+		auto space = (*threadOutcome)->getAddressSpace().lock();
 		readVirtualSpace(
 				std::move(space), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
-	}else if(descriptor.is<ThreadDescriptor>()) {
-		auto thread = descriptor.get<ThreadDescriptor>().thread;
-		auto space = thread->getAddressSpace().lock();
+	}else if(descriptor.is<DescriptorType::virtualizedSpace>()) {
+		auto vspaceOutcome = descriptor.resolveObject<DescriptorType::virtualizedSpace>();
+		if(!vspaceOutcome)
+			return translateError(vspaceOutcome.error());
 		readVirtualSpace(
-				std::move(space), address, length, buffer, std::move(queue), context,
-				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
-	}else if(descriptor.is<VirtualizedSpaceDescriptor>()) {
-		auto space = descriptor.get<VirtualizedSpaceDescriptor>().space;
-		readVirtualSpace(
-				std::move(space), address, length, buffer, std::move(queue), context,
+				std::move(*vspaceOutcome), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 	}else{
 		return kHelErrBadDescriptor;
@@ -1486,26 +1537,34 @@ HelError doSubmitWriteMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> que
 		co_await queue->submit(&ipcSource, context);
 	};
 
-	if(descriptor.is<MemoryViewDescriptor>()) {
-		auto view = descriptor.get<MemoryViewDescriptor>().memory;
+	if(descriptor.is<DescriptorType::memoryView>()) {
+		auto viewOutcome = descriptor.resolveObject<DescriptorType::memoryView>();
+		if(!viewOutcome)
+			return translateError(viewOutcome.error());
 		writeMemoryView(thisThread.lock(),
-				std::move(view), address, length, buffer, std::move(queue), context,
+				std::move(*viewOutcome), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
-	}else if(descriptor.is<AddressSpaceDescriptor>()) {
-		auto space = descriptor.get<AddressSpaceDescriptor>().space;
+	}else if(descriptor.is<DescriptorType::addressSpace>()) {
+		auto spaceOutcome = descriptor.resolveObject<DescriptorType::addressSpace>();
+		if(!spaceOutcome)
+			return translateError(spaceOutcome.error());
+		writeVirtualSpace(
+				std::move(*spaceOutcome), address, length, buffer, std::move(queue), context,
+				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
+	}else if(descriptor.is<DescriptorType::thread>()) {
+		auto threadOutcome = descriptor.resolveObject<DescriptorType::thread>();
+		if(!threadOutcome)
+			return translateError(threadOutcome.error());
+		auto space = (*threadOutcome)->getAddressSpace().lock();
 		writeVirtualSpace(
 				std::move(space), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
-	}else if(descriptor.is<ThreadDescriptor>()) {
-		auto thread = descriptor.get<ThreadDescriptor>().thread;
-		auto space = thread->getAddressSpace().lock();
+	}else if(descriptor.is<DescriptorType::virtualizedSpace>()) {
+		auto vspaceOutcome = descriptor.resolveObject<DescriptorType::virtualizedSpace>();
+		if(!vspaceOutcome)
+			return translateError(vspaceOutcome.error());
 		writeVirtualSpace(
-				std::move(space), address, length, buffer, std::move(queue), context,
-				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
-	}else if(descriptor.is<VirtualizedSpaceDescriptor>()) {
-		auto space = descriptor.get<VirtualizedSpaceDescriptor>().space;
-		writeVirtualSpace(
-				std::move(space), address, length, buffer, std::move(queue), context,
+				std::move(*vspaceOutcome), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 	}else{
 		return kHelErrBadDescriptor;
@@ -1663,9 +1722,9 @@ HelError doSubmitLockMemoryView(HelHandle handle, smarter::shared_ptr<IpcQueue> 
 
 		HelHandle handle;
 		handle = universe->attachDescriptor(
-				MemoryViewLockDescriptor{
+				AnyDescriptor::make<DescriptorType::memoryViewLock>(
 					smarter::allocate_shared<NamedMemoryViewLock>(
-						*kernelAlloc, std::move(lockHandle))});
+						*kernelAlloc, std::move(lockHandle))));
 
 		HelHandleResult helResult{.error = kHelErrNone, .handle = handle};
 		QueueSource ipcSource{&helResult, sizeof(HelHandleResult), nullptr};
@@ -1748,7 +1807,7 @@ HelError helCreateThread(HelHandle universe_handle, HelHandle space_handle,
 		Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(new_thread));
 
 	*handle = this_universe->attachDescriptor(
-			ThreadDescriptor(std::move(new_thread)));
+			AnyDescriptor::make<DescriptorType::thread>(std::move(new_thread)));
 
 	return kHelErrNone;
 }
@@ -1903,13 +1962,19 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 	auto this_universe = this_thread->getUniverse();
 
 	smarter::shared_ptr<Thread> thread;
-	VirtualizedCpuDescriptor vcpu;
+	smarter::shared_ptr<VirtualizedCpu> vcpu;
 	auto outcome = this_universe->inspectDescriptor(handle,
 			[&](AnyDescriptor &desc) -> std::expected<void, Error> {
-		if(desc.is<ThreadDescriptor>()) {
-			thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(desc.get<ThreadDescriptor>().thread);
-		} else if(desc.is<VirtualizedCpuDescriptor>()) {
-			vcpu = desc.get<VirtualizedCpuDescriptor>();
+		if(desc.is<DescriptorType::thread>()) {
+			auto threadOutcome = desc.resolveObject<DescriptorType::thread>();
+			if(!threadOutcome)
+				return std::unexpected{threadOutcome.error()};
+			thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
+		} else if(desc.is<DescriptorType::virtualizedCpu>()) {
+			auto vcpuOutcome = desc.resolveObject<DescriptorType::virtualizedCpu>();
+			if(!vcpuOutcome)
+				return std::unexpected{vcpuOutcome.error()};
+			vcpu = std::move(*vcpuOutcome);
 		}else{
 			return std::unexpected{Error::badDescriptor};
 		}
@@ -2019,19 +2084,19 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 		return kHelErrUnsupportedOperation;
 #endif
 	}else if(set == kHelRegsVirtualization) {
-		if(!vcpu.vcpu) {
+		if(!vcpu) {
 			return kHelErrIllegalArgs;
 		}
 #ifdef __x86_64__
 		HelX86VirtualizationRegs regs;
 		memset(&regs, 0, sizeof(HelX86VirtualizationRegs));
-		vcpu.vcpu->loadRegs(&regs);
+		vcpu->loadRegs(&regs);
 		if(!writeUserObject(reinterpret_cast<HelX86VirtualizationRegs *>(image), regs))
 			return kHelErrFault;
 #elif defined(__riscv) && __riscv_xlen == 64
 		HelRiscv64VirtualizationRegs regs;
 		memset(&regs, 0, sizeof(HelRiscv64VirtualizationRegs));
-		vcpu.vcpu->loadRegs(&regs);
+		vcpu->loadRegs(&regs);
 		if(!writeUserObject(reinterpret_cast<HelRiscv64VirtualizationRegs *>(image), regs))
 			return kHelErrFault;
 #else
@@ -2168,17 +2233,23 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 	auto this_universe = this_thread->getUniverse();
 
 	smarter::shared_ptr<Thread> thread;
-	VirtualizedCpuDescriptor vcpu{nullptr};
+	smarter::shared_ptr<VirtualizedCpu> vcpu;
 	if(handle == kHelThisThread) {
 		// FIXME: Properly handle this below.
 		thread = this_thread.lock();
 	}else{
 		auto outcome = this_universe->inspectDescriptor(handle,
 				[&](AnyDescriptor &desc) -> std::expected<void, Error> {
-			if(desc.is<ThreadDescriptor>()) {
-				thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(desc.get<ThreadDescriptor>().thread);
-			}else if(desc.is<VirtualizedCpuDescriptor>()) {
-				vcpu = desc.get<VirtualizedCpuDescriptor>();
+			if(desc.is<DescriptorType::thread>()) {
+				auto threadOutcome = desc.resolveObject<DescriptorType::thread>();
+				if(!threadOutcome)
+					return std::unexpected{threadOutcome.error()};
+				thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
+			}else if(desc.is<DescriptorType::virtualizedCpu>()) {
+				auto vcpuOutcome = desc.resolveObject<DescriptorType::virtualizedCpu>();
+				if(!vcpuOutcome)
+					return std::unexpected{vcpuOutcome.error()};
+				vcpu = std::move(*vcpuOutcome);
 			}else{
 				return std::unexpected{Error::badDescriptor};
 			}
@@ -2301,19 +2372,19 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 		return kHelErrUnsupportedOperation;
 #endif
 	}else if(set == kHelRegsVirtualization) {
-		if(!vcpu.vcpu) {
+		if(!vcpu) {
 			return kHelErrIllegalArgs;
 		}
 #ifdef __x86_64__
 		HelX86VirtualizationRegs regs;
 		if(!readUserObject(reinterpret_cast<const HelX86VirtualizationRegs *>(image), regs))
 			return kHelErrFault;
-		vcpu.vcpu->storeRegs(&regs);
+		vcpu->storeRegs(&regs);
 #elif defined(__riscv) && __riscv_xlen == 64
 		HelRiscv64VirtualizationRegs regs;
 		if(!readUserObject(reinterpret_cast<const HelRiscv64VirtualizationRegs *>(image), regs))
 			return kHelErrFault;
-		vcpu.vcpu->storeRegs(&regs);
+		vcpu->storeRegs(&regs);
 #else
 		return kHelErrNoHardwareSupport;
 #endif
@@ -2497,9 +2568,9 @@ HelError helCreateStream(HelHandle *lane1_handle, HelHandle *lane2_handle, uint3
 
 	auto lanes = createStream(attach_credentials);
 	*lane1_handle = this_universe->attachDescriptor(
-			LaneDescriptor(std::move(lanes.get<0>())));
+			AnyDescriptor::make<DescriptorType::lane>(std::move(lanes.get<0>())));
 	*lane2_handle = this_universe->attachDescriptor(
-			LaneDescriptor(std::move(lanes.get<1>())));
+			AnyDescriptor::make<DescriptorType::lane>(std::move(lanes.get<1>())));
 
 	return kHelErrNone;
 }
@@ -2580,14 +2651,24 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 				} else {
 					auto credsOutcome = thisUniverse->inspectDescriptor(recipe->handle,
 							[&](AnyDescriptor &desc) -> std::expected<void, Error> {
-						if(desc.is<ThreadDescriptor>())
-							creds = desc.get<ThreadDescriptor>().thread->credentials();
-						else if(desc.is<TokenDescriptor>())
-							creds = desc.get<TokenDescriptor>().credentials->credentials();
-						else if(desc.is<LaneDescriptor>())
-							creds = desc.get<LaneDescriptor>().handle->credentials().credentials();
-						else
+						if(desc.is<DescriptorType::thread>()) {
+							auto threadOutcome = desc.resolveObject<DescriptorType::thread>();
+							if(!threadOutcome)
+								return std::unexpected{threadOutcome.error()};
+							creds = (*threadOutcome)->credentials();
+						}else if(desc.is<DescriptorType::token>()) {
+							auto tokenOutcome = desc.resolveObject<DescriptorType::token>();
+							if(!tokenOutcome)
+								return std::unexpected{tokenOutcome.error()};
+							creds = (*tokenOutcome)->credentials();
+						}else if(desc.is<DescriptorType::lane>()) {
+							auto laneOutcome = desc.resolveObject<DescriptorType::lane>();
+							if(!laneOutcome)
+								return std::unexpected{laneOutcome.error()};
+							creds = (*laneOutcome)->credentials().credentials();
+						}else{
 							return std::unexpected{Error::badDescriptor};
+						}
 						return {};
 					});
 					if(!credsOutcome)
@@ -2985,7 +3066,7 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 					assert(universe);
 
 					handle = universe->attachDescriptor(
-							LaneDescriptor{node->lane()});
+							AnyDescriptor::make<DescriptorType::lane>(node->lane()));
 				}
 
 				item->helHandleResult = {translateError(node->error()), 0, handle};
@@ -2999,7 +3080,7 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 					assert(universe);
 
 					handle = universe->attachDescriptor(
-							LaneDescriptor{node->lane()});
+							AnyDescriptor::make<DescriptorType::lane>(node->lane()));
 				}
 
 				item->helHandleResult = {translateError(node->error()), 0, handle};
@@ -3149,7 +3230,7 @@ HelError helCreateOneshotEvent(HelHandle *handle) {
 	auto event = smarter::allocate_shared<OneshotEvent>(*kernelAlloc);
 
 	*handle = this_universe->attachDescriptor(
-			OneshotEventDescriptor(std::move(event)));
+			AnyDescriptor::make<DescriptorType::oneshotEvent>(std::move(event)));
 
 	return kHelErrNone;
 }
@@ -3161,7 +3242,7 @@ HelError helCreateBitsetEvent(HelHandle *handle) {
 	auto event = smarter::allocate_shared<BitsetEvent>(*kernelAlloc);
 
 	*handle = this_universe->attachDescriptor(
-			BitsetEventDescriptor(std::move(event)));
+			AnyDescriptor::make<DescriptorType::bitsetEvent>(std::move(event)));
 
 	return kHelErrNone;
 }
@@ -3195,7 +3276,7 @@ HelError helAccessIrq(int number, HelHandle *handle) {
 	IrqPin::attachSink(pin, irq.get());
 
 	*handle = this_universe->attachDescriptor(
-			IrqDescriptor(std::move(irq)));
+			AnyDescriptor::make<DescriptorType::irq>(std::move(irq)));
 
 	return kHelErrNone;
 #else
@@ -3254,8 +3335,10 @@ HelError doSubmitAwaitEvent(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 	if(!queue->validSize(ipcSourceSize(sizeof(HelEventResult))))
 		return kHelErrQueueTooSmall;
 
-	if(descriptor.is<IrqDescriptor>()) {
-		auto irq = descriptor.get<IrqDescriptor>().irq;
+	if(descriptor.is<DescriptorType::irq>()) {
+		auto irqOutcome = descriptor.resolveObject<DescriptorType::irq>();
+		if(!irqOutcome)
+			return translateError(irqOutcome.error());
 
 		[](smarter::shared_ptr<IrqObject> irq, uint64_t sequence,
 				smarter::shared_ptr<IpcQueue> queue, uintptr_t context,
@@ -3277,10 +3360,12 @@ HelError doSubmitAwaitEvent(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 			}
 			QueueSource ipcSource{&helResult, sizeof(HelEventResult), nullptr};
 			co_await queue->submit(&ipcSource, context);
-		}(std::move(irq), sequence, std::move(queue), context, std::move(cg),
+		}(std::move(*irqOutcome), sequence, std::move(queue), context, std::move(cg),
 			enable_detached_coroutine{this_thread->mainWorkQueue().lock()});
-	}else if(descriptor.is<OneshotEventDescriptor>()) {
-		auto event = descriptor.get<OneshotEventDescriptor>().event;
+	}else if(descriptor.is<DescriptorType::oneshotEvent>()) {
+		auto eventOutcome = descriptor.resolveObject<DescriptorType::oneshotEvent>();
+		if(!eventOutcome)
+			return translateError(eventOutcome.error());
 
 		[](smarter::shared_ptr<OneshotEvent> event, uint64_t sequence,
 				smarter::shared_ptr<IpcQueue> queue, uintptr_t context,
@@ -3297,10 +3382,12 @@ HelError doSubmitAwaitEvent(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 			};
 			QueueSource ipcSource{&helResult, sizeof(HelEventResult), nullptr};
 			co_await queue->submit(&ipcSource, context);
-		}(std::move(event), sequence, std::move(queue), context, std::move(cg),
+		}(std::move(*eventOutcome), sequence, std::move(queue), context, std::move(cg),
 				enable_detached_coroutine{this_thread->mainWorkQueue().lock()});
-	}else if(descriptor.is<BitsetEventDescriptor>()) {
-		auto event = descriptor.get<BitsetEventDescriptor>().event;
+	}else if(descriptor.is<DescriptorType::bitsetEvent>()) {
+		auto eventOutcome = descriptor.resolveObject<DescriptorType::bitsetEvent>();
+		if(!eventOutcome)
+			return translateError(eventOutcome.error());
 
 		[](smarter::shared_ptr<BitsetEvent> event, uint64_t sequence,
 				smarter::shared_ptr<IpcQueue> queue, uintptr_t context,
@@ -3317,7 +3404,7 @@ HelError doSubmitAwaitEvent(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 			};
 			QueueSource ipcSource{&helResult, sizeof(HelEventResult), nullptr};
 			co_await queue->submit(&ipcSource, context);
-		}(std::move(event), sequence, std::move(queue), context, std::move(cg),
+		}(std::move(*eventOutcome), sequence, std::move(queue), context, std::move(cg),
 				enable_detached_coroutine{this_thread->mainWorkQueue().lock()});
 	}else{
 		return kHelErrBadDescriptor;
@@ -3363,7 +3450,7 @@ HelError helAccessIo(uintptr_t *port_array, size_t num_ports,
 	}
 
 	*handle = this_universe->attachDescriptor(
-			IoDescriptor(std::move(io_space)));
+			AnyDescriptor::make<DescriptorType::io>(std::move(io_space)));
 
 	return kHelErrNone;
 }
@@ -3472,7 +3559,7 @@ HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num
 	}
 
 	*bound_handle = this_universe->attachDescriptor(
-			BoundKernletDescriptor(std::move(bound)));
+			AnyDescriptor::make<DescriptorType::boundKernlet>(std::move(bound)));
 
 	return kHelErrNone;
 }
@@ -3636,7 +3723,7 @@ HelError helCreateToken(HelHandle *handle) {
 	auto creds = smarter::allocate_shared<Credentials>(*kernelAlloc);
 
 	*handle = thisUniverse->attachDescriptor(
-			TokenDescriptor(std::move(creds)));
+			AnyDescriptor::make<DescriptorType::token>(std::move(creds)));
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/kerncfg.cpp
+++ b/kernel/thor/generic/kerncfg.cpp
@@ -39,7 +39,7 @@ struct KerncfgBusObject : private KernelBusObject {
 	}
 
 private:
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle boundLane) override {
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> boundLane) override {
 		auto [acceptError, lane] = co_await accept(boundLane);
 		if(acceptError != Error::success)
 			co_return acceptError;
@@ -139,7 +139,7 @@ private:
 	LogRingBuffer *buffer_;
 	frg::string_view purpose_;
 
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle boundLane) override {
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> boundLane) override {
 		auto [acceptError, lane] = co_await accept(boundLane);
 		if(acceptError != Error::success)
 			co_return acceptError;

--- a/kernel/thor/generic/kernlet.cpp
+++ b/kernel/thor/generic/kernlet.cpp
@@ -368,7 +368,7 @@ struct KernletCtlBusObject : private KernelBusObject {
 	}
 
 private:
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle boundLane) override {
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> boundLane) override {
 		auto [acceptError, lane] = co_await accept(boundLane);
 		if(acceptError != Error::success)
 			co_return acceptError;

--- a/kernel/thor/generic/kernlet.cpp
+++ b/kernel/thor/generic/kernlet.cpp
@@ -424,7 +424,7 @@ private:
 			if(respError != Error::success)
 				co_return respError;
 			auto objectError = co_await pushDescriptor(lane,
-					KernletObjectDescriptor{std::move(kernlet)});
+					AnyDescriptor::make<DescriptorType::kernletObject>(std::move(kernlet)));
 			if(objectError != Error::success)
 				co_return objectError;
 		}else{

--- a/kernel/thor/generic/mbus.cpp
+++ b/kernel/thor/generic/mbus.cpp
@@ -9,7 +9,7 @@
 namespace thor {
 
 // TODO: Move this to a header file.
-extern frg::manual_box<LaneHandle> mbusClient;
+extern frg::manual_box<smarter::shared_ptr<Stream, LanePolicy>> mbusClient;
 
 coroutine<frg::expected<Error, size_t>> KernelBusObject::createObject(frg::string_view name, Properties &&properties) {
 	auto [offerError, conversation] = co_await offer(*mbusClient);

--- a/kernel/thor/generic/mbus.cpp
+++ b/kernel/thor/generic/mbus.cpp
@@ -50,7 +50,7 @@ coroutine<frg::expected<Error, size_t>> KernelBusObject::createObject(frg::strin
 
 	if (descError != Error::success)
 		co_return descError;
-	if (!descriptor.is<LaneDescriptor>())
+	if (!descriptor.is<DescriptorType::lane>())
 		co_return Error::protocolViolation;
 
 	auto resp = bragi::parse_head_only<managarm::mbus::CreateObjectResponse>(respBuffer, *kernelAlloc);
@@ -59,8 +59,12 @@ coroutine<frg::expected<Error, size_t>> KernelBusObject::createObject(frg::strin
 	if (resp->error() != managarm::mbus::Error::SUCCESS)
 		co_return Error::illegalState;
 
+	auto laneOutcome = descriptor.resolveObject<DescriptorType::lane>();
+	if (!laneOutcome)
+		co_return laneOutcome.error();
+
 	mbusId_ = resp->id();
-	mgmtLane_ = descriptor.get<LaneDescriptor>().handle;
+	mgmtLane_ = std::move(*laneOutcome);
 
 	spawnOnWorkQueue(*kernelAlloc, WorkQueue::generalQueue().lock(), handleMbusComms_());
 
@@ -143,7 +147,7 @@ coroutine<frg::expected<Error>> KernelBusObject::handleServeRemoteLane_() {
 	auto lane = initiateClient();
 
 	auto descError = co_await pushDescriptor(conversation,
-		LaneDescriptor{lane});
+		AnyDescriptor::make<DescriptorType::lane>(lane));
 
 	if (descError != Error::success)
 		co_return descError;

--- a/kernel/thor/generic/ostrace.cpp
+++ b/kernel/thor/generic/ostrace.cpp
@@ -111,7 +111,7 @@ struct OstraceBusObject : private KernelBusObject {
 	}
 
 private:
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle boundLane) override {
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> boundLane) override {
 		auto [acceptError, lane] = co_await accept(boundLane);
 		if(acceptError == Error::endOfLane)
 			co_return Error::endOfLane;

--- a/kernel/thor/generic/servers.cpp
+++ b/kernel/thor/generic/servers.cpp
@@ -19,8 +19,8 @@ namespace thor {
 
 static bool debugLaunch = true;
 
-frg::manual_box<LaneHandle> mbusClient;
-static frg::manual_box<LaneHandle> futureMbusServer;
+frg::manual_box<smarter::shared_ptr<Stream, LanePolicy>> mbusClient;
+static frg::manual_box<smarter::shared_ptr<Stream, LanePolicy>> futureMbusServer;
 
 frg::ticket_spinlock globalMfsMutex;
 
@@ -32,14 +32,14 @@ constinit IrqSpinlock allServersMutex;
 static frg::manual_box<
 	frg::hash_map<
 		frg::string<KernelAlloc>,
-		LaneHandle,
+		smarter::shared_ptr<Stream, LanePolicy>,
 		frg::hash<frg::string<KernelAlloc>>,
 		KernelAlloc
 	>
 > allServers;
 
 // TODO: move this declaration to a header file
-void runService(frg::string<KernelAlloc> desc, LaneHandle control_lane,
+void runService(frg::string<KernelAlloc> desc, smarter::shared_ptr<Stream, LanePolicy> control_lane,
 		smarter::shared_ptr<Thread, ActiveHandle> thread);
 
 // ------------------------------------------------------------------------
@@ -264,8 +264,8 @@ uintptr_t copyToStack(frg::string<KernelAlloc> &stack_image, const T &data) {
 }
 
 coroutine<void> executeModule(frg::string_view name, MfsRegular *module,
-		LaneHandle control_lane,
-		LaneHandle xpipe_lane,
+		smarter::shared_ptr<Stream, LanePolicy> control_lane,
+		smarter::shared_ptr<Stream, LanePolicy> xpipe_lane,
 		Scheduler *scheduler) {
 	auto space = AddressSpace::create();
 
@@ -386,7 +386,7 @@ coroutine<void> runMbus() {
 	if(debugLaunch)
 		infoLogger() << "thor: Launching mbus" << frg::endlog;
 
-	frg::tuple<LaneHandle, LaneHandle> controlStream;
+	frg::tuple<smarter::shared_ptr<Stream, LanePolicy>, smarter::shared_ptr<Stream, LanePolicy>> controlStream;
 	{
 		auto lock = frg::guard(&allServersMutex);
 
@@ -404,11 +404,11 @@ coroutine<void> runMbus() {
 			std::move(*futureMbusServer), &localScheduler.get());
 }
 
-coroutine<LaneHandle> runServer(frg::string_view name) {
+coroutine<smarter::shared_ptr<Stream, LanePolicy>> runServer(frg::string_view name) {
 	if(debugLaunch)
 		infoLogger() << "thor: Launching server " << name << frg::endlog;
 
-	frg::tuple<LaneHandle, LaneHandle> controlStream;
+	frg::tuple<smarter::shared_ptr<Stream, LanePolicy>, smarter::shared_ptr<Stream, LanePolicy>> controlStream;
 	{
 		auto lock = frg::guard(&allServersMutex);
 
@@ -431,7 +431,7 @@ coroutine<LaneHandle> runServer(frg::string_view name) {
 
 	co_await executeModule(name, static_cast<MfsRegular *>(module),
 			controlStream.get<0>(),
-			LaneHandle{}, &localScheduler.get());
+			smarter::shared_ptr<Stream, LanePolicy>{}, &localScheduler.get());
 
 	co_return controlStream.get<1>();
 }
@@ -452,7 +452,7 @@ struct SvrctlBusObject : private KernelBusObject {
 	}
 
 private:
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle boundLane) override {
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> boundLane) override {
 		auto [acceptError, lane] = co_await accept(boundLane);
 		if(acceptError != Error::success)
 			co_return acceptError;

--- a/kernel/thor/generic/servers.cpp
+++ b/kernel/thor/generic/servers.cpp
@@ -306,7 +306,7 @@ coroutine<void> executeModule(frg::string_view name, MfsRegular *module,
 	Handle xpipe_handle = 0;
 	if(xpipe_lane) {
 		xpipe_handle = universe->attachDescriptor(
-				LaneDescriptor(xpipe_lane));
+				AnyDescriptor::make<DescriptorType::lane>(xpipe_lane));
 	}
 
 	enum {
@@ -511,7 +511,7 @@ private:
 			auto respError = co_await sendBuffer(lane, std::move(respBuffer));
 			if(respError != Error::success)
 				co_return respError;
-			auto controlError = co_await pushDescriptor(lane, LaneDescriptor{controlLane});
+			auto controlError = co_await pushDescriptor(lane, AnyDescriptor::make<DescriptorType::lane>(controlLane));
 			if(controlError != Error::success)
 				co_return controlError;
 		}else{

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -22,21 +22,21 @@
 
 namespace thor {
 
-extern frg::manual_box<LaneHandle> mbusClient;
+extern frg::manual_box<smarter::shared_ptr<Stream, LanePolicy>> mbusClient;
 
 coroutine<bool> createMfsFile(frg::string_view path, const void *buffer, size_t size,
 		MfsRegular **out);
 
 static MfsRegular *urandomNode = nullptr;
 
-void runService(frg::string<KernelAlloc> name, LaneHandle controlLane, smarter::shared_ptr<Thread, ActiveHandle> thread);
+void runService(frg::string<KernelAlloc> name, smarter::shared_ptr<Stream, LanePolicy> controlLane, smarter::shared_ptr<Thread, ActiveHandle> thread);
 
 struct OpenFile {
 	OpenFile()
 	: isTerminal{false} { };
 
 	bool isTerminal;
-	LaneHandle clientLane;
+	smarter::shared_ptr<Stream, LanePolicy> clientLane;
 };
 
 struct StdioFile : OpenFile {
@@ -46,7 +46,7 @@ struct StdioFile : OpenFile {
 };
 
 namespace stdio {
-	coroutine<void> runStdioRequests(LaneHandle lane) {
+	coroutine<void> runStdioRequests(smarter::shared_ptr<Stream, LanePolicy> lane) {
 		frg::string<KernelAlloc> lineBuffer{*kernelAlloc};
 
 		while(true) {
@@ -160,7 +160,7 @@ namespace initrd {
 	// initrd file handling.
 	// ----------------------------------------------------
 
-	coroutine<void> runRegularRequests(OpenRegular *file, LaneHandle lane) {
+	coroutine<void> runRegularRequests(OpenRegular *file, smarter::shared_ptr<Stream, LanePolicy> lane) {
 		while(true) {
 			auto [acceptError, conversation] = co_await accept(lane);
 			if(acceptError == Error::endOfLane)
@@ -270,7 +270,7 @@ namespace initrd {
 		}
 	}
 
-	coroutine<void> runDirectoryRequests(OpenDirectory *file, LaneHandle lane) {
+	coroutine<void> runDirectoryRequests(OpenDirectory *file, smarter::shared_ptr<Stream, LanePolicy> lane) {
 		while(true) {
 			auto [acceptError, conversation] = co_await accept(lane);
 			if(acceptError == Error::endOfLane)
@@ -363,7 +363,7 @@ namespace initrd {
 namespace urandom {
 	struct OpenUrandom : OpenFile { };
 
-	coroutine<void> runUrandomRequests(OpenUrandom *, LaneHandle lane) {
+	coroutine<void> runUrandomRequests(OpenUrandom *, smarter::shared_ptr<Stream, LanePolicy> lane) {
 		while(true) {
 			auto [acceptError, conversation] = co_await accept(lane);
 			if(acceptError == Error::endOfLane)
@@ -456,7 +456,7 @@ namespace posix {
 			clientFileTable = result.value();
 		}
 
-		coroutine<void> runPosixRequests(ThreadInfo info, LaneHandle posixLane);
+		coroutine<void> runPosixRequests(ThreadInfo info, smarter::shared_ptr<Stream, LanePolicy> posixLane);
 		coroutine<void> runObserveLoop(ThreadInfo info);
 
 		frg::string_view name() {
@@ -482,7 +482,7 @@ namespace posix {
 			return _thread.push_back(std::move(info));
 		}
 
-		void attachControl(smarter::shared_ptr<Thread, ActiveHandle> thread, LaneHandle lane) {
+		void attachControl(smarter::shared_ptr<Thread, ActiveHandle> thread, smarter::shared_ptr<Stream, LanePolicy> lane) {
 			controlHandle = thread->getUniverse()->attachDescriptor(
 					LaneDescriptor{lane});
 		}
@@ -526,7 +526,7 @@ namespace posix {
 		VirtualAddr clientFileTable;
 	};
 
-	coroutine<void> Process::runPosixRequests(ThreadInfo info, LaneHandle posixLane) {
+	coroutine<void> Process::runPosixRequests(ThreadInfo info, smarter::shared_ptr<Stream, LanePolicy> posixLane) {
 		while(true) {
 			auto [acceptError, conversation] = co_await accept(posixLane);
 			if(acceptError != Error::success) {
@@ -1180,7 +1180,7 @@ coroutine<void> initPosixEmulation() {
 	co_await createMfsFile("/dev/urandom", nullptr, 0, &urandomNode);
 }
 
-void runService(frg::string<KernelAlloc> name, LaneHandle controlLane,
+void runService(frg::string<KernelAlloc> name, smarter::shared_ptr<Stream, LanePolicy> controlLane,
 		smarter::shared_ptr<Thread, ActiveHandle> thread) {
 	KernelFiber::run([name, thread, controlLane = std::move(controlLane)] () mutable {
 		auto stdioStream = createStream();

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -247,7 +247,7 @@ namespace initrd {
 					assert(respError == Error::success);
 
 					auto memoryError = co_await pushDescriptor(conversation,
-							MemoryViewDescriptor{file->module->getMemory()});
+							AnyDescriptor::make<DescriptorType::memoryView>(file->module->getMemory()));
 					// TODO: improve error handling here.
 					assert(memoryError == Error::success);
 				}else{
@@ -466,7 +466,7 @@ namespace posix {
 		ThreadInfo &attachThread(smarter::shared_ptr<Thread, ActiveHandle> thread) {
 			auto posixStream = createStream();
 			Handle posixHandle = thread->getUniverse()->attachDescriptor(
-					LaneDescriptor{std::move(posixStream.get<1>())});
+					AnyDescriptor::make<DescriptorType::lane>(std::move(posixStream.get<1>())));
 
 			ThreadInfo info {
 				.thread = thread,
@@ -484,17 +484,17 @@ namespace posix {
 
 		void attachControl(smarter::shared_ptr<Thread, ActiveHandle> thread, smarter::shared_ptr<Stream, LanePolicy> lane) {
 			controlHandle = thread->getUniverse()->attachDescriptor(
-					LaneDescriptor{lane});
+					AnyDescriptor::make<DescriptorType::lane>(lane));
 		}
 
 		void attachMbus(smarter::shared_ptr<Thread, ActiveHandle> thread) {
 			mbusHandle = thread->getUniverse()->attachDescriptor(
-					LaneDescriptor{*mbusClient});
+					AnyDescriptor::make<DescriptorType::lane>(*mbusClient));
 		}
 
 		coroutine<int> attachFile(smarter::shared_ptr<Thread, ActiveHandle> thread, OpenFile *file) {
 			Handle handle = thread->getUniverse()->attachDescriptor(
-					LaneDescriptor(file->clientLane));
+					AnyDescriptor::make<DescriptorType::lane>(file->clientLane));
 
 			for(int fd = 0; fd < (int)openFiles.size(); ++fd) {
 				if(openFiles[fd])

--- a/kernel/thor/generic/stream.cpp
+++ b/kernel/thor/generic/stream.cpp
@@ -3,18 +3,15 @@
 
 namespace thor {
 
-LaneHandle::LaneHandle(const LaneHandle &other)
-: _stream(other._stream), _lane(other._lane) {
-	if(_stream)
-		Stream::incrementPeers(_stream.get(), _lane);
+void LanePolicy::increment() const {
+	stream_->peerCounter(lane_).increment();
 }
 
-LaneHandle::~LaneHandle() {
-	if(!_stream)
-		return;
-
-	if(Stream::decrementPeers(_stream.get(), _lane))
-		_stream.policy().decrement();
+void LanePolicy::decrement() const {
+	if(stream_->peerCounter(lane_).decrement_and_check_if_zero()) {
+		Stream::onPeersZero(stream_, lane_);
+		stream_->selfPtr.policy().decrement();
+	}
 }
 
 struct OfferAccept { };
@@ -73,7 +70,7 @@ static void transfer(PushPull, StreamNode *push, StreamNode *pull) {
 	pull->complete();
 }
 
-void Stream::Submitter::enqueue(const LaneHandle &lane, StreamList &chain) {
+void Stream::Submitter::enqueue(const smarter::shared_ptr<Stream, LanePolicy> &lane, StreamList &chain) {
 	while(!chain.empty()) {
 		auto node = chain.pop_front();
 		node->_transmitLane = lane;
@@ -87,13 +84,13 @@ void Stream::Submitter::run() {
 		StreamNode *v = nullptr;
 
 		// Note: Try to do as little work as possible while holding the lock.
-		auto s = u->_transmitLane.getStream();
+		auto s = u->_transmitLane.get();
 		bool laneShutdown = false;
 		bool laneBroken = false;
 		{
 			// p/q is the number of the local/remote lane.
 			// u/v is the local/remote item that we are processing.
-			int p = u->_transmitLane.getLane();
+			int p = laneOf(u->_transmitLane);
 			assert(!(p & ~int(1)));
 			int q = 1 - p;
 
@@ -155,10 +152,11 @@ void Stream::Submitter::run() {
 			// * One reference for each of the two lanes.
 			auto branch = smarter::allocate_shared<Stream>(*kernelAlloc);
 			assert(branch.policy().base()->ctr().check_count() == 1);
+			branch->selfPtr = branch;
 			branch.policy().increment();
 			branch.policy().increment();
-			u->_lane = LaneHandle{adoptLane, branch, 0};
-			v->_lane = LaneHandle{adoptLane, branch, 1};
+			u->_lane = adoptLane(branch, 0);
+			v->_lane = adoptLane(branch, 1);
 
 			enqueue(u->_lane, u->ancillaryChain);
 			enqueue(v->_lane, v->ancillaryChain);
@@ -241,18 +239,7 @@ void Stream::Submitter::run() {
 	}
 }
 
-void Stream::incrementPeers(Stream *stream, int lane) {
-	auto count = stream->_peerCount[lane].fetch_add(1, std::memory_order_relaxed);
-	assert(count);
-}
-
-bool Stream::decrementPeers(Stream *stream, int lane) {
-	auto count = stream->_peerCount[lane].fetch_sub(1, std::memory_order_release);
-	if(count > 1)
-		return false;
-
-	std::atomic_thread_fence(std::memory_order_acquire);
-
+void Stream::onPeersZero(Stream *stream, int lane) {
 	frg::intrusive_list<
 		StreamNode,
 		frg::locate_member<
@@ -275,14 +262,12 @@ bool Stream::decrementPeers(Stream *stream, int lane) {
 		auto item = pending.pop_front();
 		_cancelItem(item, Error::endOfLane);
 	}
-
-	return true;
 }
 
 Stream::Stream(bool withCredentials)
 : _laneBroken{false, false}, _laneShutDown{false, false}, _withCredentials{withCredentials} {
-	_peerCount[0].store(1, std::memory_order_relaxed);
-	_peerCount[1].store(1, std::memory_order_relaxed);
+	_peerCount[0].setup(smarter::adopt_rc, 1);
+	_peerCount[1].setup(smarter::adopt_rc, 1);
 	if(withCredentials)
 		_creds = Credentials{};
 }
@@ -345,14 +330,16 @@ void Stream::_cancelItem(StreamNode *item, Error error) {
 	}
 }
 
-frg::tuple<LaneHandle, LaneHandle> createStream(bool withCredentials) {
+frg::tuple<smarter::shared_ptr<Stream, LanePolicy>, smarter::shared_ptr<Stream, LanePolicy>>
+createStream(bool withCredentials) {
 	auto stream = smarter::allocate_shared<Stream>(*kernelAlloc, withCredentials);
 	assert(stream.policy().base()->ctr().check_count() == 1);
+	stream->selfPtr = stream;
 	stream.policy().increment();
-	LaneHandle handle1(adoptLane, stream, 0);
-	LaneHandle handle2(adoptLane, stream, 1);
+	auto handle1 = adoptLane(stream, 0);
+	auto handle2 = adoptLane(stream, 1);
 	stream.release();
-	return frg::make_tuple(handle1, handle2);
+	return frg::make_tuple(std::move(handle1), std::move(handle2));
 }
 
 } // namespace thor

--- a/kernel/thor/generic/thor-internal/mbus.hpp
+++ b/kernel/thor/generic/thor-internal/mbus.hpp
@@ -42,10 +42,10 @@ struct KernelBusObject {
 	coroutine<frg::expected<Error, size_t>> createObject(frg::string_view name, Properties &&properties);
 	coroutine<Error> updateProperties(Properties &properties);
 
-	virtual LaneHandle initiateClient() {
+	virtual smarter::shared_ptr<Stream, LanePolicy> initiateClient() {
 		auto stream = createStream();
 
-		spawnOnWorkQueue(*kernelAlloc, WorkQueue::generalQueue().lock(), [] (LaneHandle lane,
+		spawnOnWorkQueue(*kernelAlloc, WorkQueue::generalQueue().lock(), [] (smarter::shared_ptr<Stream, LanePolicy> lane,
 				KernelBusObject *self) -> coroutine<void> {
 			while(true) {
 				auto result = co_await self->handleRequest(lane);
@@ -62,7 +62,7 @@ struct KernelBusObject {
 		return stream.get<1>();
 	}
 
-	virtual coroutine<frg::expected<Error>> handleRequest(LaneHandle lane)  {
+	virtual coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane)  {
 		co_return Error::illegalObject;
 	}
 
@@ -71,7 +71,7 @@ private:
 	coroutine<frg::expected<Error>> handleServeRemoteLane_();
 
 	int64_t mbusId_;
-	LaneHandle mgmtLane_;
+	smarter::shared_ptr<Stream, LanePolicy> mgmtLane_;
 };
 
 } // namespace thor

--- a/kernel/thor/generic/thor-internal/servers.hpp
+++ b/kernel/thor/generic/thor-internal/servers.hpp
@@ -9,6 +9,6 @@ void initializeSvrctl();
 void initializeMbusStream();
 coroutine<void> initPosixEmulation();
 coroutine<void> runMbus();
-coroutine<LaneHandle> runServer(frg::string_view name);
+coroutine<smarter::shared_ptr<Stream, LanePolicy>> runServer(frg::string_view name);
 
 } // namespace thor

--- a/kernel/thor/generic/thor-internal/stream.hpp
+++ b/kernel/thor/generic/thor-internal/stream.hpp
@@ -107,7 +107,7 @@ struct StreamNode {
 			_packet->completion.raise();
 	}
 
-	LaneHandle _transmitLane;
+	smarter::shared_ptr<Stream, LanePolicy> _transmitLane;
 
 	int _tag;
 	StreamPacket *_packet;
@@ -163,7 +163,7 @@ public:
 		return _transmitCredentials;
 	}
 
-	LaneHandle lane() {
+	smarter::shared_ptr<Stream, LanePolicy> lane() {
 		return std::move(_lane);
 	}
 
@@ -176,7 +176,7 @@ public:
 	frg::array<char, 16> _transmitCredentials;
 	size_t _actualLength = 0;
 	frg::unique_memory<KernelAlloc> _transmitBuffer;
-	LaneHandle _lane;
+	smarter::shared_ptr<Stream, LanePolicy> _lane;
 	AnyDescriptor _descriptor;
 };
 
@@ -191,7 +191,7 @@ using StreamList = frg::intrusive_list<
 
 struct Stream final {
 	struct Submitter {
-		void enqueue(const LaneHandle &lane, StreamList &chain);
+		void enqueue(const smarter::shared_ptr<Stream, LanePolicy> &lane, StreamList &chain);
 
 		void run();
 
@@ -199,23 +199,27 @@ struct Stream final {
 		StreamList _pending;
 	};
 
-	// manage the peer counter of each lane.
-	// incrementing a peer counter that is already at zero is undefined.
-	// decrementPeers() returns true if the counter reaches zero.
-	static void incrementPeers(Stream *stream, int lane);
-	static bool decrementPeers(Stream *stream, int lane);
+	// Breaks the lane after its peer counter reached zero.
+	// Does not drop the reference that the peer counter holds on the Stream.
+	static void onPeersZero(Stream *stream, int lane);
+
+	smarter::counter &peerCounter(int lane) {
+		return _peerCount[lane];
+	}
 
 	Stream(bool withCredentials = false);
 	~Stream();
 
 	// Submits a chain of operations to the stream.
-	static void transmit(const LaneHandle &lane, StreamList &chain) {
+	static void transmit(const smarter::shared_ptr<Stream, LanePolicy> &lane, StreamList &chain) {
 		Submitter submitter;
 		submitter.enqueue(lane, chain);
 		submitter.run();
 	}
 
 	void shutdownLane(int lane);
+
+	smarter::borrowed_ptr<Stream> selfPtr;
 
 	Credentials &credentials() {
 		assert(_withCredentials);
@@ -226,7 +230,7 @@ struct Stream final {
 private:
 	static void _cancelItem(StreamNode *item, Error error);
 
-	std::atomic<int> _peerCount[2];
+	smarter::counter _peerCount[2];
 
 	frg::optional<Credentials> _creds;
 
@@ -253,14 +257,14 @@ private:
 	bool _withCredentials;
 };
 
-frg::tuple<LaneHandle, LaneHandle> createStream(bool withCredentials = false);
+frg::tuple<smarter::shared_ptr<Stream, LanePolicy>, smarter::shared_ptr<Stream, LanePolicy>> createStream(bool withCredentials = false);
 
 //---------------------------------------------------------------------------------------
 // In-kernel stream utilities.
 // Those are only used internally; not by the hel API.
 //---------------------------------------------------------------------------------------
 
-inline coroutine<Error> dismiss(LaneHandle lane) {
+inline coroutine<Error> dismiss(smarter::shared_ptr<Stream, LanePolicy> lane) {
 	StreamPacket packet;
 	StreamNode node;
 	packet.setup(1);
@@ -274,7 +278,7 @@ inline coroutine<Error> dismiss(LaneHandle lane) {
 	co_return node.error();
 }
 
-inline coroutine<frg::tuple<Error, LaneHandle>> offer(LaneHandle lane) {
+inline coroutine<frg::tuple<Error, smarter::shared_ptr<Stream, LanePolicy>>> offer(smarter::shared_ptr<Stream, LanePolicy> lane) {
 	StreamPacket packet;
 	StreamNode node;
 	packet.setup(1);
@@ -288,7 +292,7 @@ inline coroutine<frg::tuple<Error, LaneHandle>> offer(LaneHandle lane) {
 	co_return frg::make_tuple(node.error(), node.lane());
 }
 
-inline coroutine<frg::tuple<Error, LaneHandle>> accept(LaneHandle lane) {
+inline coroutine<frg::tuple<Error, smarter::shared_ptr<Stream, LanePolicy>>> accept(smarter::shared_ptr<Stream, LanePolicy> lane) {
 	StreamPacket packet;
 	StreamNode node;
 	packet.setup(1);
@@ -302,7 +306,7 @@ inline coroutine<frg::tuple<Error, LaneHandle>> accept(LaneHandle lane) {
 	co_return frg::make_tuple(node.error(), node.lane());
 }
 
-inline coroutine<frg::tuple<Error, frg::array<char, 16>>> extractCredentials(LaneHandle lane) {
+inline coroutine<frg::tuple<Error, frg::array<char, 16>>> extractCredentials(smarter::shared_ptr<Stream, LanePolicy> lane) {
 	StreamPacket packet;
 	StreamNode node;
 	packet.setup(1);
@@ -316,7 +320,7 @@ inline coroutine<frg::tuple<Error, frg::array<char, 16>>> extractCredentials(Lan
 	co_return frg::make_tuple(node.error(), node.credentials());
 }
 
-inline coroutine<Error> sendBuffer(LaneHandle lane, frg::unique_memory<KernelAlloc> buffer) {
+inline coroutine<Error> sendBuffer(smarter::shared_ptr<Stream, LanePolicy> lane, frg::unique_memory<KernelAlloc> buffer) {
 	StreamPacket packet;
 	StreamNode node;
 	packet.setup(1);
@@ -331,7 +335,7 @@ inline coroutine<Error> sendBuffer(LaneHandle lane, frg::unique_memory<KernelAll
 	co_return node.error();
 }
 
-inline coroutine<frg::tuple<Error, frg::unique_memory<KernelAlloc>>> recvBuffer(LaneHandle lane) {
+inline coroutine<frg::tuple<Error, frg::unique_memory<KernelAlloc>>> recvBuffer(smarter::shared_ptr<Stream, LanePolicy> lane) {
 	StreamPacket packet;
 	StreamNode node;
 	packet.setup(1);
@@ -346,7 +350,7 @@ inline coroutine<frg::tuple<Error, frg::unique_memory<KernelAlloc>>> recvBuffer(
 	co_return frg::make_tuple(node.error(), node.transmitBuffer());
 }
 
-inline coroutine<Error> pushDescriptor(LaneHandle lane, AnyDescriptor descriptor) {
+inline coroutine<Error> pushDescriptor(smarter::shared_ptr<Stream, LanePolicy> lane, AnyDescriptor descriptor) {
 	StreamPacket packet;
 	StreamNode node;
 	packet.setup(1);
@@ -361,7 +365,7 @@ inline coroutine<Error> pushDescriptor(LaneHandle lane, AnyDescriptor descriptor
 	co_return node.error();
 }
 
-inline coroutine<frg::tuple<Error, AnyDescriptor>> pullDescriptor(LaneHandle lane) {
+inline coroutine<frg::tuple<Error, AnyDescriptor>> pullDescriptor(smarter::shared_ptr<Stream, LanePolicy> lane) {
 	StreamPacket packet;
 	StreamNode node;
 	packet.setup(1);

--- a/kernel/thor/generic/thor-internal/universe.hpp
+++ b/kernel/thor/generic/thor-internal/universe.hpp
@@ -2,6 +2,8 @@
 
 #include <expected>
 #include <optional>
+#include <stdint.h>
+#include <type_traits>
 #include <utility>
 #include <frg/variant.hpp>
 #include <assert.h>
@@ -238,6 +240,28 @@ struct TokenDescriptor {
 // AnyDescriptor
 // --------------------------------------------------------
 
+enum class DescriptorType : uint8_t {
+	none,
+	universe,
+	queue,
+	memoryView,
+	memorySlice,
+	addressSpace,
+	virtualizedSpace,
+	dmaSpace,
+	virtualizedCpu,
+	memoryViewLock,
+	thread,
+	lane,
+	irq,
+	oneshotEvent,
+	bitsetEvent,
+	io,
+	kernletObject,
+	boundKernlet,
+	token,
+};
+
 typedef frg::variant<
 	UniverseDescriptor,
 	QueueDescriptor,
@@ -258,6 +282,207 @@ typedef frg::variant<
 	BoundKernletDescriptor,
 	TokenDescriptor
 > AnyDescriptor;
+
+template<DescriptorType K>
+struct DescriptorTraits;
+
+template<>
+struct DescriptorTraits<DescriptorType::universe> {
+	using Pointer = smarter::shared_ptr<Universe>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<UniverseDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<UniverseDescriptor>().universe;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::queue> {
+	using Pointer = smarter::shared_ptr<IpcQueue>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<QueueDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<QueueDescriptor>().queue;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::memoryView> {
+	using Pointer = smarter::shared_ptr<MemoryView>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<MemoryViewDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<MemoryViewDescriptor>().memory;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::memorySlice> {
+	using Pointer = smarter::shared_ptr<MemorySlice>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<MemorySliceDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<MemorySliceDescriptor>().slice;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::addressSpace> {
+	using Pointer = smarter::shared_ptr<AddressSpace, BindableHandle>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<AddressSpaceDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<AddressSpaceDescriptor>().space;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::virtualizedSpace> {
+	using Pointer = smarter::shared_ptr<VirtualizedPageSpace>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<VirtualizedSpaceDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<VirtualizedSpaceDescriptor>().space;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::dmaSpace> {
+	using Pointer = smarter::shared_ptr<DmaSpace>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<DmaSpaceDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<DmaSpaceDescriptor>().space;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::virtualizedCpu> {
+	using Pointer = smarter::shared_ptr<VirtualizedCpu>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<VirtualizedCpuDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<VirtualizedCpuDescriptor>().vcpu;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::memoryViewLock> {
+	using Pointer = smarter::shared_ptr<NamedMemoryViewLock>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<MemoryViewLockDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<MemoryViewLockDescriptor>().lock;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::thread> {
+	using Pointer = smarter::shared_ptr<Thread, ActiveHandle>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<ThreadDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<ThreadDescriptor>().thread;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::lane> {
+	using Pointer = smarter::shared_ptr<Stream, LanePolicy>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<LaneDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<LaneDescriptor>().handle;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::irq> {
+	using Pointer = smarter::shared_ptr<IrqObject>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<IrqDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<IrqDescriptor>().irq;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::oneshotEvent> {
+	using Pointer = smarter::shared_ptr<OneshotEvent>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<OneshotEventDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<OneshotEventDescriptor>().event;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::bitsetEvent> {
+	using Pointer = smarter::shared_ptr<BitsetEvent>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<BitsetEventDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<BitsetEventDescriptor>().event;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::io> {
+	using Pointer = smarter::shared_ptr<IoSpace>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<IoDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<IoDescriptor>().ioSpace;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::kernletObject> {
+	using Pointer = smarter::shared_ptr<KernletObject>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<KernletObjectDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<KernletObjectDescriptor>().kernletObject;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::boundKernlet> {
+	using Pointer = smarter::shared_ptr<BoundKernlet>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<BoundKernletDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<BoundKernletDescriptor>().boundKernlet;
+	}
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::token> {
+	using Pointer = smarter::shared_ptr<Credentials>;
+
+	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
+		if(!desc.is<TokenDescriptor>())
+			return std::unexpected{Error::badDescriptor};
+		return desc.get<TokenDescriptor>().credentials;
+	}
+};
 
 // --------------------------------------------------------
 // Universe.
@@ -290,6 +515,15 @@ public:
 		if(!desc)
 			return ResultType{std::unexpect, Error::noDescriptor};
 		return std::forward<Fn>(fn)(*desc);
+	}
+
+	// Looks up a handle and resolves it to the object held by its descriptor.
+	// Fails with badDescriptor unless the descriptor is of type K.
+	template<DescriptorType K>
+	std::expected<typename DescriptorTraits<K>::Pointer, Error> resolveObject(Handle handle) {
+		return inspectDescriptor(handle, [](AnyDescriptor &desc) {
+			return DescriptorTraits<K>::extract(desc);
+		});
 	}
 
 	frg::optional<AnyDescriptor> detachDescriptor(Handle handle);

--- a/kernel/thor/generic/thor-internal/universe.hpp
+++ b/kernel/thor/generic/thor-internal/universe.hpp
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <type_traits>
 #include <utility>
-#include <frg/variant.hpp>
+#include <frg/optional.hpp>
 #include <assert.h>
 #include <smarter.hpp>
 #include <thor-internal/error.hpp>
@@ -29,88 +29,12 @@ struct KernletObject;
 struct BoundKernlet;
 struct Credentials;
 struct DmaSpace;
-
-struct QueueDescriptor {
-	QueueDescriptor(smarter::shared_ptr<IpcQueue> queue)
-	: queue(std::move(queue)) { }
-
-	smarter::shared_ptr<IpcQueue> queue;
-};
-
-struct UniverseDescriptor {
-	UniverseDescriptor(smarter::shared_ptr<Universe> universe)
-	: universe(std::move(universe)) { }
-
-	smarter::shared_ptr<Universe> universe;
-};
+struct IrqObject;
+struct OneshotEvent;
+struct BitsetEvent;
 
 // --------------------------------------------------------
-// Memory related descriptors
-// --------------------------------------------------------
-
-struct MemoryViewDescriptor {
-	MemoryViewDescriptor(smarter::shared_ptr<MemoryView> memory)
-	: memory(std::move(memory)) { }
-
-	smarter::shared_ptr<MemoryView> memory;
-};
-
-struct MemorySliceDescriptor {
-	MemorySliceDescriptor(smarter::shared_ptr<MemorySlice> slice)
-	: slice(std::move(slice)) { }
-
-	smarter::shared_ptr<MemorySlice> slice;
-};
-
-struct AddressSpaceDescriptor {
-	AddressSpaceDescriptor(smarter::shared_ptr<AddressSpace, BindableHandle> space)
-	: space(std::move(space)) { }
-
-	smarter::shared_ptr<AddressSpace, BindableHandle> space;
-};
-
-struct MemoryViewLockDescriptor {
-	MemoryViewLockDescriptor(smarter::shared_ptr<NamedMemoryViewLock> lock)
-	: lock(std::move(lock)) { }
-
-	smarter::shared_ptr<NamedMemoryViewLock> lock;
-};
-
-struct VirtualizedSpaceDescriptor {
-	VirtualizedSpaceDescriptor(smarter::shared_ptr<VirtualizedPageSpace> space)
-	: space(std::move(space)) { }
-
-	smarter::shared_ptr<VirtualizedPageSpace> space;
-};
-
-struct DmaSpaceDescriptor {
-	DmaSpaceDescriptor(smarter::shared_ptr<DmaSpace> space)
-	: space(std::move(space)) { }
-
-	smarter::shared_ptr<DmaSpace> space;
-};
-
-struct VirtualizedCpuDescriptor {
-	VirtualizedCpuDescriptor() : vcpu(nullptr) { }
-	VirtualizedCpuDescriptor(smarter::shared_ptr<VirtualizedCpu> vcpu)
-	: vcpu(std::move(vcpu)) { }
-
-	smarter::shared_ptr<VirtualizedCpu> vcpu;
-};
-
-// --------------------------------------------------------
-// Threading related descriptors
-// --------------------------------------------------------
-
-struct ThreadDescriptor {
-	ThreadDescriptor(smarter::shared_ptr<Thread, ActiveHandle> thread)
-	: thread(std::move(thread)) { }
-
-	smarter::shared_ptr<Thread, ActiveHandle> thread;
-};
-
-// --------------------------------------------------------
-// IPC related descriptors
+// Lane handles.
 // --------------------------------------------------------
 
 struct StreamControl;
@@ -158,84 +82,6 @@ inline int laneOf(const smarter::shared_ptr<Stream, LanePolicy> &lane) {
 	return lane.policy().lane();
 }
 
-struct LaneDescriptor {
-	LaneDescriptor() = default;
-
-	explicit LaneDescriptor(smarter::shared_ptr<Stream, LanePolicy> handle)
-	: handle(std::move(handle)) { }
-
-	smarter::shared_ptr<Stream, LanePolicy> handle;
-};
-
-// --------------------------------------------------------
-// Event related descriptors.
-// --------------------------------------------------------
-
-struct IrqObject;
-struct OneshotEvent;
-struct BitsetEvent;
-
-struct OneshotEventDescriptor {
-	OneshotEventDescriptor(smarter::shared_ptr<OneshotEvent> event)
-	: event{std::move(event)} { }
-
-	smarter::shared_ptr<OneshotEvent> event;
-};
-
-struct BitsetEventDescriptor {
-	BitsetEventDescriptor(smarter::shared_ptr<BitsetEvent> event)
-	: event{std::move(event)} { }
-
-	smarter::shared_ptr<BitsetEvent> event;
-};
-
-struct IrqDescriptor {
-	IrqDescriptor(smarter::shared_ptr<IrqObject> irq)
-	: irq{std::move(irq)} { }
-
-	smarter::shared_ptr<IrqObject> irq;
-};
-
-// --------------------------------------------------------
-// I/O related descriptors.
-// --------------------------------------------------------
-
-struct IoDescriptor {
-	IoDescriptor(smarter::shared_ptr<IoSpace> io_space)
-	: ioSpace(std::move(io_space)) { }
-
-	smarter::shared_ptr<IoSpace> ioSpace;
-};
-
-// --------------------------------------------------------
-// Kernlet related descriptors.
-// --------------------------------------------------------
-
-struct KernletObjectDescriptor {
-	KernletObjectDescriptor(smarter::shared_ptr<KernletObject> kernlet_object)
-	: kernletObject(std::move(kernlet_object)) { }
-
-	smarter::shared_ptr<KernletObject> kernletObject;
-};
-
-struct BoundKernletDescriptor {
-	BoundKernletDescriptor(smarter::shared_ptr<BoundKernlet> bound_kernlet)
-	: boundKernlet(std::move(bound_kernlet)) { }
-
-	smarter::shared_ptr<BoundKernlet> boundKernlet;
-};
-
-// --------------------------------------------------------
-// Token related descriptors.
-// --------------------------------------------------------
-
-struct TokenDescriptor {
-	TokenDescriptor(smarter::shared_ptr<Credentials> credentials)
-	: credentials(std::move(credentials)) { }
-
-	smarter::shared_ptr<Credentials> credentials;
-};
-
 // --------------------------------------------------------
 // AnyDescriptor
 // --------------------------------------------------------
@@ -262,227 +108,256 @@ enum class DescriptorType : uint8_t {
 	token,
 };
 
-typedef frg::variant<
-	UniverseDescriptor,
-	QueueDescriptor,
-	MemoryViewDescriptor,
-	MemorySliceDescriptor,
-	AddressSpaceDescriptor,
-	VirtualizedSpaceDescriptor,
-	DmaSpaceDescriptor,
-	VirtualizedCpuDescriptor,
-	MemoryViewLockDescriptor,
-	ThreadDescriptor,
-	LaneDescriptor,
-	IrqDescriptor,
-	OneshotEventDescriptor,
-	BitsetEventDescriptor,
-	IoDescriptor,
-	KernletObjectDescriptor,
-	BoundKernletDescriptor,
-	TokenDescriptor
-> AnyDescriptor;
-
+// Maps a descriptor type to the object type and the smarter::shared_ptr refcount
+// policy that a descriptor of that type holds.
 template<DescriptorType K>
 struct DescriptorTraits;
 
 template<>
 struct DescriptorTraits<DescriptorType::universe> {
-	using Pointer = smarter::shared_ptr<Universe>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<UniverseDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<UniverseDescriptor>().universe;
-	}
+	using Object = Universe;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::queue> {
-	using Pointer = smarter::shared_ptr<IpcQueue>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<QueueDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<QueueDescriptor>().queue;
-	}
+	using Object = IpcQueue;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::memoryView> {
-	using Pointer = smarter::shared_ptr<MemoryView>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<MemoryViewDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewDescriptor>().memory;
-	}
+	using Object = MemoryView;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::memorySlice> {
-	using Pointer = smarter::shared_ptr<MemorySlice>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<MemorySliceDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemorySliceDescriptor>().slice;
-	}
+	using Object = MemorySlice;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::addressSpace> {
-	using Pointer = smarter::shared_ptr<AddressSpace, BindableHandle>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<AddressSpaceDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<AddressSpaceDescriptor>().space;
-	}
+	using Object = AddressSpace;
+	using Policy = BindableHandle;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::virtualizedSpace> {
-	using Pointer = smarter::shared_ptr<VirtualizedPageSpace>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<VirtualizedSpaceDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<VirtualizedSpaceDescriptor>().space;
-	}
+	using Object = VirtualizedPageSpace;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::dmaSpace> {
-	using Pointer = smarter::shared_ptr<DmaSpace>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<DmaSpaceDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<DmaSpaceDescriptor>().space;
-	}
+	using Object = DmaSpace;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::virtualizedCpu> {
-	using Pointer = smarter::shared_ptr<VirtualizedCpu>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<VirtualizedCpuDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<VirtualizedCpuDescriptor>().vcpu;
-	}
+	using Object = VirtualizedCpu;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::memoryViewLock> {
-	using Pointer = smarter::shared_ptr<NamedMemoryViewLock>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<MemoryViewLockDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<MemoryViewLockDescriptor>().lock;
-	}
+	using Object = NamedMemoryViewLock;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::thread> {
-	using Pointer = smarter::shared_ptr<Thread, ActiveHandle>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<ThreadDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<ThreadDescriptor>().thread;
-	}
+	using Object = Thread;
+	using Policy = ActiveHandle;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::lane> {
-	using Pointer = smarter::shared_ptr<Stream, LanePolicy>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<LaneDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<LaneDescriptor>().handle;
-	}
+	using Object = Stream;
+	using Policy = LanePolicy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::irq> {
-	using Pointer = smarter::shared_ptr<IrqObject>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<IrqDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<IrqDescriptor>().irq;
-	}
+	using Object = IrqObject;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::oneshotEvent> {
-	using Pointer = smarter::shared_ptr<OneshotEvent>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<OneshotEventDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<OneshotEventDescriptor>().event;
-	}
+	using Object = OneshotEvent;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::bitsetEvent> {
-	using Pointer = smarter::shared_ptr<BitsetEvent>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<BitsetEventDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<BitsetEventDescriptor>().event;
-	}
+	using Object = BitsetEvent;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::io> {
-	using Pointer = smarter::shared_ptr<IoSpace>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<IoDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<IoDescriptor>().ioSpace;
-	}
+	using Object = IoSpace;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::kernletObject> {
-	using Pointer = smarter::shared_ptr<KernletObject>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<KernletObjectDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<KernletObjectDescriptor>().kernletObject;
-	}
+	using Object = KernletObject;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::boundKernlet> {
-	using Pointer = smarter::shared_ptr<BoundKernlet>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<BoundKernletDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<BoundKernletDescriptor>().boundKernlet;
-	}
+	using Object = BoundKernlet;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>
 struct DescriptorTraits<DescriptorType::token> {
-	using Pointer = smarter::shared_ptr<Credentials>;
-
-	static std::expected<Pointer, Error> extract(AnyDescriptor &desc) {
-		if(!desc.is<TokenDescriptor>())
-			return std::unexpected{Error::badDescriptor};
-		return desc.get<TokenDescriptor>().credentials;
-	}
+	using Object = Credentials;
+	using Policy = smarter::default_rc_policy;
 };
+
+// smarter::shared_ptr type that a descriptor of type K holds.
+template<DescriptorType K>
+using DescriptorPointer = smarter::shared_ptr<
+	typename DescriptorTraits<K>::Object,
+	typename DescriptorTraits<K>::Policy
+>;
+
+struct AnyDescriptor {
+	friend void swap(AnyDescriptor &x, AnyDescriptor &y) {
+		using std::swap;
+		swap(x.type_, y.type_);
+		swap(x.extra_, y.extra_);
+		swap(x.object_, y.object_);
+		swap(x.ctr_, y.ctr_);
+	}
+
+	// Constructs a descriptor of type K that takes over the given pointer's reference.
+	template<DescriptorType K>
+	static AnyDescriptor make(DescriptorPointer<K> ptr);
+
+	AnyDescriptor() = default;
+
+	AnyDescriptor(const AnyDescriptor &other)
+	: type_{other.type_}, extra_{other.extra_}, object_{other.object_}, ctr_{other.ctr_} {
+		if(ctr_)
+			ctr_->increment();
+	}
+
+	AnyDescriptor(AnyDescriptor &&other)
+	: AnyDescriptor{} {
+		swap(*this, other);
+	}
+
+	~AnyDescriptor() {
+		if(ctr_ && ctr_->decrement_and_check_if_zero())
+			releaseOnZero_();
+	}
+
+	AnyDescriptor &operator= (AnyDescriptor other) {
+		swap(*this, other);
+		return *this;
+	}
+
+	DescriptorType type() const {
+		return type_;
+	}
+
+	template<DescriptorType K>
+	bool is() const {
+		return type_ == K;
+	}
+
+	// Resolves the descriptor to the object it holds (takes a new reference).
+	// Fails with badDescriptor unless the descriptor is of type K.
+	template<DescriptorType K>
+	std::expected<DescriptorPointer<K>, Error> resolveObject() const;
+
+private:
+	void releaseOnZero_();
+
+	DescriptorType type_ = DescriptorType::none;
+	// Extra per-descriptor data for some descriptor types.
+	// - For lane descriptors: the lane index.
+	uint8_t extra_ = 0;
+	// Invariant: object_ is non-null if type_ != DescriptorType::none.
+	void *object_ = nullptr;
+	// Invariant: ctr_ is non-null if type_ != DescriptorType::none.
+	smarter::counter *ctr_ = nullptr;
+};
+
+template<DescriptorType K>
+AnyDescriptor AnyDescriptor::make(DescriptorPointer<K> ptr) {
+	static_assert(std::same_as<typename DescriptorTraits<K>::Policy, smarter::default_rc_policy>);
+	assert(ptr);
+
+	AnyDescriptor descriptor;
+	descriptor.type_ = K;
+	descriptor.object_ = ptr.get();
+	descriptor.ctr_ = &ptr.policy().base()->ctr();
+	ptr.release();
+	return descriptor;
+}
+
+template<>
+AnyDescriptor AnyDescriptor::make<DescriptorType::thread>(
+		smarter::shared_ptr<Thread, ActiveHandle> ptr);
+
+template<>
+AnyDescriptor AnyDescriptor::make<DescriptorType::addressSpace>(
+		smarter::shared_ptr<AddressSpace, BindableHandle> ptr);
+
+template<>
+AnyDescriptor AnyDescriptor::make<DescriptorType::lane>(
+		smarter::shared_ptr<Stream, LanePolicy> ptr);
+
+template<DescriptorType K>
+std::expected<DescriptorPointer<K>, Error> AnyDescriptor::resolveObject() const {
+	static_assert(std::same_as<typename DescriptorTraits<K>::Policy, smarter::default_rc_policy>);
+	using ObjectType = typename DescriptorTraits<K>::Object;
+
+	if(type_ != K)
+		return std::unexpected{Error::badDescriptor};
+	ctr_->increment();
+	return smarter::shared_ptr<ObjectType>{
+		smarter::adopt_rc,
+		static_cast<ObjectType *>(object_),
+		smarter::default_rc_policy{smarter::meta_object_base::from_ctr(ctr_)}
+	};
+}
+
+template<>
+inline std::expected<smarter::shared_ptr<Thread, ActiveHandle>, Error>
+AnyDescriptor::resolveObject<DescriptorType::thread>() const {
+	if(type_ != DescriptorType::thread)
+		return std::unexpected{Error::badDescriptor};
+	auto thread = static_cast<Thread *>(object_);
+	ctr_->increment();
+	return smarter::shared_ptr<Thread, ActiveHandle>{
+		smarter::adopt_rc, thread, ActiveHandle{thread}
+	};
+}
+
+template<>
+inline std::expected<smarter::shared_ptr<AddressSpace, BindableHandle>, Error>
+AnyDescriptor::resolveObject<DescriptorType::addressSpace>() const {
+	if(type_ != DescriptorType::addressSpace)
+		return std::unexpected{Error::badDescriptor};
+	auto space = static_cast<AddressSpace *>(object_);
+	ctr_->increment();
+	return smarter::shared_ptr<AddressSpace, BindableHandle>{
+		smarter::adopt_rc, space, BindableHandle{space}
+	};
+}
+
+template<>
+std::expected<smarter::shared_ptr<Stream, LanePolicy>, Error>
+AnyDescriptor::resolveObject<DescriptorType::lane>() const;
 
 // --------------------------------------------------------
 // Universe.
@@ -520,9 +395,9 @@ public:
 	// Looks up a handle and resolves it to the object held by its descriptor.
 	// Fails with badDescriptor unless the descriptor is of type K.
 	template<DescriptorType K>
-	std::expected<typename DescriptorTraits<K>::Pointer, Error> resolveObject(Handle handle) {
+	std::expected<DescriptorPointer<K>, Error> resolveObject(Handle handle) {
 		return inspectDescriptor(handle, [](AnyDescriptor &desc) {
-			return DescriptorTraits<K>::extract(desc);
+			return desc.resolveObject<K>();
 		});
 	}
 

--- a/kernel/thor/generic/thor-internal/universe.hpp
+++ b/kernel/thor/generic/thor-internal/universe.hpp
@@ -114,62 +114,55 @@ struct ThreadDescriptor {
 struct StreamControl;
 struct Stream;
 
-struct AdoptLane { };
-static constexpr AdoptLane adoptLane;
+// Refcount policy for smarter::shared_ptr.
+// A lane handle is a Stream pointer plus a lane index.
+// The refcount that it manipulates is the lane's peer counter.
+struct LanePolicy {
+	LanePolicy() = default;
 
-// TODO: implement SharedLaneHandle + UnsafeLaneHandle?
-struct LaneHandle {
-	friend void swap(LaneHandle &a, LaneHandle &b) {
-		using std::swap;
-		swap(a._stream, b._stream);
-		swap(a._lane, b._lane);
+	LanePolicy(Stream *stream, int lane)
+	: stream_{stream}, lane_{lane} { }
+
+	explicit operator bool () const {
+		return stream_;
 	}
 
-	// Initialize _lane so that the compiler does not complain about uninitialized values.
-	LaneHandle()
-	: _lane{-1} { };
+	void increment() const;
+	void decrement() const;
 
-	explicit LaneHandle(AdoptLane, smarter::borrowed_ptr<Stream> stream, int lane)
-	: _stream(stream), _lane(lane) { }
-
-	LaneHandle(const LaneHandle &other);
-
-	LaneHandle(LaneHandle &&other)
-	: LaneHandle() {
-		swap(*this, other);
+	Stream *stream() const {
+		return stream_;
 	}
 
-	~LaneHandle();
-
-	explicit operator bool () {
-		return static_cast<bool>(_stream);
-	}
-
-	LaneHandle &operator= (LaneHandle other) {
-		swap(*this, other);
-		return *this;
-	}
-
-	smarter::borrowed_ptr<Stream> getStream() {
-		return _stream;
-	}
-
-	int getLane() {
-		return _lane;
+	int lane() const {
+		return lane_;
 	}
 
 private:
-	smarter::borrowed_ptr<Stream> _stream;
-	int _lane;
+	Stream *stream_ = nullptr;
+	int lane_ = -1;
 };
+static_assert(smarter::rc_policy<LanePolicy>);
+
+// Constructs a lane handle that adopts an existing peer reference on the stream.
+inline smarter::shared_ptr<Stream, LanePolicy> adoptLane(
+		smarter::borrowed_ptr<Stream> stream, int lane) {
+	return smarter::shared_ptr<Stream, LanePolicy>{
+			smarter::adopt_rc, stream.get(), LanePolicy{stream.get(), lane}};
+}
+
+// Extracts the numeric lane index of a lane handle.
+inline int laneOf(const smarter::shared_ptr<Stream, LanePolicy> &lane) {
+	return lane.policy().lane();
+}
 
 struct LaneDescriptor {
 	LaneDescriptor() = default;
 
-	explicit LaneDescriptor(LaneHandle handle)
+	explicit LaneDescriptor(smarter::shared_ptr<Stream, LanePolicy> handle)
 	: handle(std::move(handle)) { }
 
-	LaneHandle handle;
+	smarter::shared_ptr<Stream, LanePolicy> handle;
 };
 
 // --------------------------------------------------------

--- a/kernel/thor/generic/universe.cpp
+++ b/kernel/thor/generic/universe.cpp
@@ -100,6 +100,8 @@ Universe::~Universe() {
 }
 
 Handle Universe::attachDescriptor(AnyDescriptor descriptor) {
+	assert(descriptor.type() != DescriptorType::none);
+
 	auto irqLock = frg::guard(&irqMutex());
 	Guard guard(lock);
 

--- a/kernel/thor/generic/universe.cpp
+++ b/kernel/thor/generic/universe.cpp
@@ -1,4 +1,6 @@
+#include <thor-internal/address-space.hpp>
 #include <thor-internal/ipl.hpp>
+#include <thor-internal/stream.hpp>
 #include <thor-internal/thread.hpp>
 #include <thor-internal/universe.hpp>
 
@@ -6,6 +8,87 @@ namespace thor {
 
 namespace {
 	constexpr bool logCleanup = false;
+}
+
+template<>
+AnyDescriptor AnyDescriptor::make<DescriptorType::thread>(
+		smarter::shared_ptr<Thread, ActiveHandle> ptr) {
+	assert(ptr);
+
+	AnyDescriptor descriptor;
+	descriptor.type_ = DescriptorType::thread;
+	descriptor.object_ = ptr.get();
+	descriptor.ctr_ = &ptr->_activeCtr;
+	ptr.release();
+	return descriptor;
+}
+
+template<>
+AnyDescriptor AnyDescriptor::make<DescriptorType::addressSpace>(
+		smarter::shared_ptr<AddressSpace, BindableHandle> ptr) {
+	assert(ptr);
+
+	AnyDescriptor descriptor;
+	descriptor.type_ = DescriptorType::addressSpace;
+	descriptor.object_ = ptr.get();
+	descriptor.ctr_ = &ptr->_bindableCtr;
+	ptr.release();
+	return descriptor;
+}
+
+template<>
+AnyDescriptor AnyDescriptor::make<DescriptorType::lane>(
+		smarter::shared_ptr<Stream, LanePolicy> ptr) {
+	assert(ptr);
+
+	AnyDescriptor descriptor;
+	descriptor.type_ = DescriptorType::lane;
+	auto stream = ptr.get();
+	descriptor.extra_ = static_cast<uint8_t>(laneOf(ptr));
+	descriptor.object_ = stream;
+	descriptor.ctr_ = &stream->peerCounter(static_cast<int>(descriptor.extra_));
+	ptr.release();
+	return descriptor;
+}
+
+template<>
+std::expected<smarter::shared_ptr<Stream, LanePolicy>, Error>
+AnyDescriptor::resolveObject<DescriptorType::lane>() const {
+	if(type_ != DescriptorType::lane)
+		return std::unexpected{Error::badDescriptor};
+
+	auto stream = static_cast<Stream *>(object_);
+	auto lane = static_cast<int>(extra_);
+	stream->peerCounter(lane).increment();
+	return adoptLane(stream->selfPtr, lane);
+}
+
+void AnyDescriptor::releaseOnZero_() {
+	switch(type_) {
+	case DescriptorType::thread: {
+		auto thread = static_cast<Thread *>(object_);
+		thread->dispose();
+		thread->self.policy().decrement();
+		break;
+	}
+	case DescriptorType::addressSpace: {
+		auto space = static_cast<AddressSpace *>(object_);
+		space->dispose();
+		space->selfPtr.policy().decrement();
+		break;
+	}
+	case DescriptorType::lane: {
+		auto stream = static_cast<Stream *>(object_);
+		Stream::onPeersZero(stream, static_cast<int>(extra_));
+		stream->selfPtr.policy().decrement();
+		break;
+	}
+	default: {
+		// All remaining descriptor types hold a reference through the meta object's counter.
+		smarter::meta_object_base::from_ctr(ctr_)->finalize();
+		break;
+	}
+	}
 }
 
 Universe::Universe()

--- a/kernel/thor/system/acpi/acpi.cpp
+++ b/kernel/thor/system/acpi/acpi.cpp
@@ -226,7 +226,8 @@ AcpiObject::handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) {
 
 		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
-		auto ioError = co_await pushDescriptor(conversation, IoDescriptor{space});
+		auto ioError =
+		    co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::io>(space));
 		if (ioError != Error::success)
 			co_return ioError;
 	} else if (preamble.id() == bragi::message_id<managarm::hw::AccessIrqRequest>) {
@@ -297,7 +298,8 @@ AcpiObject::handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) {
 
 		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
-		auto irqError = co_await pushDescriptor(conversation, IrqDescriptor{object});
+		auto irqError =
+		    co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object));
 		if (irqError != Error::success)
 			co_return irqError;
 	} else {

--- a/kernel/thor/system/acpi/acpi.cpp
+++ b/kernel/thor/system/acpi/acpi.cpp
@@ -45,7 +45,8 @@ coroutine<void> AcpiObject::run(Properties acpi_properties) {
 	completion.raise();
 }
 
-coroutine<frg::expected<Error>> AcpiObject::handleRequest(LaneHandle lane) {
+coroutine<frg::expected<Error>>
+AcpiObject::handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) {
 	auto [acceptError, conversation] = co_await accept(lane);
 	if (acceptError != Error::success)
 		co_return acceptError;
@@ -59,9 +60,9 @@ coroutine<frg::expected<Error>> AcpiObject::handleRequest(LaneHandle lane) {
 	if (preamble.error())
 		co_return Error::protocolViolation;
 
-	auto sendResponse = [](
-	                        LaneHandle &conversation, managarm::hw::SvrResponse<KernelAlloc> &&resp
-	                    ) -> coroutine<frg::expected<Error>> {
+	auto sendResponse =
+	    [](smarter::shared_ptr<Stream, LanePolicy> &conversation,
+	       managarm::hw::SvrResponse<KernelAlloc> &&resp) -> coroutine<frg::expected<Error>> {
 		frg::unique_memory<KernelAlloc> respHeadBuffer{*kernelAlloc, resp.head_size};
 
 		frg::unique_memory<KernelAlloc> respTailBuffer{*kernelAlloc, resp.size_of_tail()};

--- a/kernel/thor/system/acpi/battery.cpp
+++ b/kernel/thor/system/acpi/battery.cpp
@@ -23,7 +23,8 @@ struct BatteryBusObject final : public KernelBusObject {
 	coroutine<void> run();
 
 private:
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override;
+	coroutine<frg::expected<Error>>
+	handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) override;
 	static uacpi_status notification(uacpi_handle, uacpi_namespace_node *node, uacpi_u64 value);
 
 	void updateBIF();
@@ -141,7 +142,8 @@ coroutine<void> BatteryBusObject::run() {
 	});
 }
 
-coroutine<frg::expected<Error>> BatteryBusObject::handleRequest(LaneHandle lane) {
+coroutine<frg::expected<Error>>
+BatteryBusObject::handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) {
 	auto [acceptError, conversation] = co_await accept(lane);
 	if (acceptError != Error::success)
 		co_return acceptError;

--- a/kernel/thor/system/acpi/pm-interface.cpp
+++ b/kernel/thor/system/acpi/pm-interface.cpp
@@ -42,7 +42,8 @@ struct PmInterfaceBusObject : private KernelBusObject {
 	}
 
 private:
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override {
+	coroutine<frg::expected<Error>>
+	handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) override {
 		auto [acceptError, conversation] = co_await accept(lane);
 		if (acceptError != Error::success)
 			co_return acceptError;

--- a/kernel/thor/system/acpi/ps2.cpp
+++ b/kernel/thor/system/acpi/ps2.cpp
@@ -27,7 +27,8 @@ struct AcpiStatus final : public thor::KernelBusObject {
 		(co_await createObject("acpi-status", std::move(props))).unwrap();
 	}
 
-	coroutine<frg::expected<thor::Error>> handleRequest(thor::LaneHandle lane) override {
+	coroutine<frg::expected<thor::Error>>
+	handleRequest(smarter::shared_ptr<thor::Stream, thor::LanePolicy> lane) override {
 		auto [acceptError, conversation] = co_await thor::accept(lane);
 		if (acceptError != thor::Error::success)
 			co_return acceptError;

--- a/kernel/thor/system/acpi/thor-internal/acpi/acpi.hpp
+++ b/kernel/thor/system/acpi/thor-internal/acpi/acpi.hpp
@@ -73,7 +73,8 @@ struct AcpiObject final : public KernelBusObject {
 	}
 
 	coroutine<void> run(Properties props = {});
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override;
+	coroutine<frg::expected<Error>>
+	handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) override;
 
 	size_t mbus_id;
 	uacpi_namespace_node *node;

--- a/kernel/thor/system/dtb/dtb_discover.cpp
+++ b/kernel/thor/system/dtb/dtb_discover.cpp
@@ -171,7 +171,7 @@ struct MbusNode final : private KernelBusObject {
 					(regs[index].length + (kPageSize - 1)) & ~(kPageSize - 1),
 					CachingMode::mmioNonPosted);
 
-			MemoryViewDescriptor descriptor{memory};
+			auto descriptor = AnyDescriptor::make<DescriptorType::memoryView>(memory);
 
 			managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 			resp.set_error(managarm::hw::Errors::SUCCESS);
@@ -204,7 +204,7 @@ struct MbusNode final : private KernelBusObject {
 
 			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
-			auto descError = co_await pushDescriptor(conversation, IrqDescriptor{object});
+			auto descError = co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object));
 
 			if(descError != Error::success)
 				co_return descError;

--- a/kernel/thor/system/dtb/dtb_discover.cpp
+++ b/kernel/thor/system/dtb/dtb_discover.cpp
@@ -93,7 +93,7 @@ struct MbusNode final : private KernelBusObject {
 		mbusPublished.raise();
 	}
 
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override {
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) override {
 		auto [acceptError, conversation] = co_await accept(lane);
 		if(acceptError != Error::success)
 			co_return acceptError;
@@ -106,7 +106,7 @@ struct MbusNode final : private KernelBusObject {
 		if(preamble.error())
 			co_return Error::protocolViolation;
 
-		auto sendResponse = [] (LaneHandle &conversation,
+		auto sendResponse = [] (smarter::shared_ptr<Stream, LanePolicy> &conversation,
 				managarm::hw::SvrResponse<KernelAlloc> &&resp) -> coroutine<frg::expected<Error>> {
 			frg::unique_memory<KernelAlloc> respHeadBuffer{*kernelAlloc,
 				resp.head_size};

--- a/kernel/thor/system/framebuffer/fb.cpp
+++ b/kernel/thor/system/framebuffer/fb.cpp
@@ -192,7 +192,7 @@ struct FbMbusNode final : private KernelBusObject {
 		assert(ret);
 	}
 
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override {
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) override {
 		auto [acceptError, conversation] = co_await accept(lane);
 		if(acceptError != Error::success)
 			co_return acceptError;
@@ -205,7 +205,7 @@ struct FbMbusNode final : private KernelBusObject {
 		if(preamble.error())
 			co_return Error::protocolViolation;
 
-		auto sendResponse = [] (LaneHandle &conversation,
+		auto sendResponse = [] (smarter::shared_ptr<Stream, LanePolicy> &conversation,
 				managarm::hw::SvrResponse<KernelAlloc> &&resp) -> coroutine<frg::expected<Error>> {
 			frg::unique_memory<KernelAlloc> respHeadBuffer{*kernelAlloc,
 				resp.head_size};

--- a/kernel/thor/system/framebuffer/fb.cpp
+++ b/kernel/thor/system/framebuffer/fb.cpp
@@ -261,11 +261,10 @@ struct FbMbusNode final : private KernelBusObject {
 		}else if(preamble.id() == bragi::message_id<managarm::hw::AccessFbMemoryRequest>) {
 			auto req = bragi::parse_head_only<managarm::hw::AccessFbMemoryRequest>(reqBuffer, *kernelAlloc);
 			auto fb = associatedFrameBuffer;
-			MemoryViewDescriptor descriptor{nullptr};
 
 			managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 
-			descriptor = MemoryViewDescriptor{fb->memory};
+			auto descriptor = AnyDescriptor::make<DescriptorType::memoryView>(fb->memory);
 			resp.set_error(managarm::hw::Errors::SUCCESS);
 
 			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));

--- a/kernel/thor/system/legacy-pc/ata.cpp
+++ b/kernel/thor/system/legacy-pc/ata.cpp
@@ -116,7 +116,7 @@ private:
 
 			FRG_CO_TRY(co_await sendResponse(lane, std::move(resp)));
 
-			auto ioError = co_await pushDescriptor(lane, IoDescriptor{space});
+			auto ioError = co_await pushDescriptor(lane, AnyDescriptor::make<DescriptorType::io>(space));
 			if(ioError != Error::success)
 				co_return ioError;
 		}else if(preamble.id() == bragi::message_id<managarm::hw::AccessIrqRequest>) {
@@ -145,7 +145,7 @@ private:
 
 			FRG_CO_TRY(co_await sendResponse(lane, std::move(resp)));
 
-			auto irqError = co_await pushDescriptor(lane, IrqDescriptor{object});
+			auto irqError = co_await pushDescriptor(lane, AnyDescriptor::make<DescriptorType::irq>(object));
 			if(irqError != Error::success)
 				co_return irqError;
 		}else{

--- a/kernel/thor/system/legacy-pc/ata.cpp
+++ b/kernel/thor/system/legacy-pc/ata.cpp
@@ -23,8 +23,8 @@ struct AtaBusObject : private KernelBusObject {
 	}
 
 private:
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle boundLane) override {
-		auto sendResponse = [] (LaneHandle &conversation,
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> boundLane) override {
+		auto sendResponse = [] (smarter::shared_ptr<Stream, LanePolicy> &conversation,
 				managarm::hw::SvrResponse<KernelAlloc> &&resp) -> coroutine<frg::expected<Error>> {
 			frg::unique_memory<KernelAlloc> respHeadBuffer{*kernelAlloc,
 				resp.head_size};

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -17,7 +17,7 @@
 namespace thor {
 
 // TODO: Move this to a header file.
-extern frg::manual_box<LaneHandle> mbusClient;
+extern frg::manual_box<smarter::shared_ptr<Stream, LanePolicy>> mbusClient;
 
 namespace pci {
 
@@ -84,7 +84,7 @@ void PciBus::runRootBus() {
 	});
 }
 
-coroutine<frg::expected<Error>> PciBus::handleRequest(LaneHandle lane) {
+coroutine<frg::expected<Error>> PciBus::handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) {
 	// TODO(qookie): Implement this properly :^)
 	auto dismissError = co_await dismiss(lane);
 	if (dismissError != Error::success)
@@ -181,7 +181,7 @@ void PciDevice::runDevice() {
 // PciEntity implementation.
 // --------------------------------------------------------
 
-coroutine<frg::expected<Error>> PciEntity::handleRequest(LaneHandle lane) {
+coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) {
 	auto [acceptError, conversation] = co_await accept(lane);
 	if(acceptError != Error::success)
 		co_return acceptError;
@@ -194,7 +194,7 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(LaneHandle lane) {
 	if (preamble.error())
 		co_return Error::protocolViolation;
 
-	auto sendResponse = [] (LaneHandle &conversation,
+	auto sendResponse = [] (smarter::shared_ptr<Stream, LanePolicy> &conversation,
 			managarm::hw::SvrResponse<KernelAlloc> &&resp) -> coroutine<frg::expected<Error>> {
 		frg::unique_memory<KernelAlloc> respHeadBuffer{*kernelAlloc,
 			resp.head_size};
@@ -217,7 +217,7 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(LaneHandle lane) {
 		co_return frg::success;
 	};
 
-	auto sendResponseHead = [] (LaneHandle &conversation,
+	auto sendResponseHead = [] (smarter::shared_ptr<Stream, LanePolicy> &conversation,
 			auto &&resp) -> coroutine<frg::expected<Error>> {
 		frg::unique_memory<KernelAlloc> respHeadBuffer{*kernelAlloc,
 			resp.head_size};

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -701,22 +701,21 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 		}
 
 		auto fb = static_cast<PciDevice *>(this)->associatedFrameBuffer;
-		AnyDescriptor descriptor;
 
 		managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 
 		if (!fb) {
 			resp.set_error(managarm::hw::Errors::ILLEGAL_ARGUMENTS);
+			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 		} else {
-			descriptor = AnyDescriptor::make<DescriptorType::memoryView>(fb->memory);
 			resp.set_error(managarm::hw::Errors::SUCCESS);
+			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
+
+			auto descError = co_await pushDescriptor(conversation,
+					AnyDescriptor::make<DescriptorType::memoryView>(fb->memory));
+			// TODO: improve error handling here.
+			assert(descError == Error::success);
 		}
-
-		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
-
-		auto descError = co_await pushDescriptor(conversation, std::move(descriptor));
-		// TODO: improve error handling here.
-		assert(descError == Error::success);
 	}else if(preamble.id() == bragi::message_id<managarm::hw::EnableDmaRequest>) {
 		auto req = bragi::parse_head_only<managarm::hw::EnableDmaRequest>(reqBuffer, *kernelAlloc);
 
@@ -757,23 +756,22 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 		}
 
 		auto vbt = static_cast<PciDevice *>(this)->igdVbt;
-		AnyDescriptor descriptor;
 
 		managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 
 		if(!vbt) {
 			resp.set_error(managarm::hw::Errors::ILLEGAL_ARGUMENTS);
+			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 		} else {
-			descriptor = AnyDescriptor::make<DescriptorType::memoryView>(vbt);
 			resp.set_error(managarm::hw::Errors::SUCCESS);
 			resp.set_vbt_size(vbt->getLength());
+			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
+
+			auto descError = co_await pushDescriptor(conversation,
+					AnyDescriptor::make<DescriptorType::memoryView>(vbt));
+			// TODO: improve error handling here.
+			assert(descError == Error::success);
 		}
-
-		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
-
-		auto descError = co_await pushDescriptor(conversation, std::move(descriptor));
-		// TODO: improve error handling here.
-		assert(descError == Error::success);
 	}else if(preamble.id() == bragi::message_id<managarm::hw::GetDmaSpaceRequest>) {
 		auto req = bragi::parse_head_only<managarm::hw::GetDmaSpaceRequest>(reqBuffer, *kernelAlloc);
 

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -309,10 +309,10 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 
 		AnyDescriptor descriptor;
 		if(bars[index].type == PciBar::kBarIo) {
-			descriptor = IoDescriptor{bars[index].io};
+			descriptor = AnyDescriptor::make<DescriptorType::io>(bars[index].io);
 		}else{
 			assert(bars[index].type == PciBar::kBarMemory);
-			descriptor = MemoryViewDescriptor{bars[index].memory};
+			descriptor = AnyDescriptor::make<DescriptorType::memoryView>(bars[index].memory);
 		}
 
 		managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
@@ -333,7 +333,7 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 		}
 
 		assert(expansionRom.address);
-		AnyDescriptor descriptor = MemoryViewDescriptor{expansionRom.memory};
+		auto descriptor = AnyDescriptor::make<DescriptorType::memoryView>(expansionRom.memory);
 
 		managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 		resp.set_error(managarm::hw::Errors::SUCCESS);
@@ -376,7 +376,7 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 
 		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
-		auto descError = co_await pushDescriptor(conversation, IrqDescriptor{object});
+		auto descError = co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object));
 
 		if (descError != Error::success)
 			co_return descError;
@@ -442,7 +442,7 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 
 		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
-		auto descError = co_await pushDescriptor(conversation, IrqDescriptor{object});
+		auto descError = co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object));
 
 		if (descError != Error::success)
 			co_return descError;
@@ -701,14 +701,14 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 		}
 
 		auto fb = static_cast<PciDevice *>(this)->associatedFrameBuffer;
-		MemoryViewDescriptor descriptor{nullptr};
+		AnyDescriptor descriptor;
 
 		managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 
 		if (!fb) {
 			resp.set_error(managarm::hw::Errors::ILLEGAL_ARGUMENTS);
 		} else {
-			descriptor = MemoryViewDescriptor{fb->memory};
+			descriptor = AnyDescriptor::make<DescriptorType::memoryView>(fb->memory);
 			resp.set_error(managarm::hw::Errors::SUCCESS);
 		}
 
@@ -757,14 +757,14 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 		}
 
 		auto vbt = static_cast<PciDevice *>(this)->igdVbt;
-		MemoryViewDescriptor descriptor{nullptr};
+		AnyDescriptor descriptor;
 
 		managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 
 		if(!vbt) {
 			resp.set_error(managarm::hw::Errors::ILLEGAL_ARGUMENTS);
 		} else {
-			descriptor = MemoryViewDescriptor{vbt};
+			descriptor = AnyDescriptor::make<DescriptorType::memoryView>(vbt);
 			resp.set_error(managarm::hw::Errors::SUCCESS);
 			resp.set_vbt_size(vbt->getLength());
 		}
@@ -782,9 +782,9 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 			co_return Error::protocolViolation;
 		}
 
-		DmaSpaceDescriptor descriptor{*noopDmaSpace};
+		auto descriptor = AnyDescriptor::make<DescriptorType::dmaSpace>(*noopDmaSpace);
 		if (iommuDomain)
-			descriptor = DmaSpaceDescriptor{iommuDomain->space_};
+			descriptor = AnyDescriptor::make<DescriptorType::dmaSpace>(iommuDomain->space_);
 
 		managarm::hw::GetDmaSpaceResponse<KernelAlloc> resp{*kernelAlloc};
 		resp.set_iommu_active(iommuDomain != nullptr);

--- a/kernel/thor/system/pci/thor-internal/pci/pci.hpp
+++ b/kernel/thor/system/pci/thor-internal/pci/pci.hpp
@@ -251,7 +251,7 @@ struct PciBus : private KernelBusObject {
 	async::oneshot_event mbusPublished;
 
 private:
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override;
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) override;
 };
 
 struct PciBar {
@@ -359,7 +359,7 @@ struct PciEntity : protected KernelBusObject {
 	IommuDomain *iommuDomain = nullptr;
 
 private:
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override;
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) override;
 
 protected:
 	~PciEntity() = default;

--- a/kernel/thor/system/smbios/smbios3.cpp
+++ b/kernel/thor/system/smbios/smbios3.cpp
@@ -15,7 +15,7 @@ namespace {
 using namespace thor;
 
 struct NoSmbios final : KernelBusObject {
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override {
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) override {
 		auto [acceptError, conversation] = co_await accept(lane);
 		if (acceptError != Error::success)
 			co_return acceptError;
@@ -76,7 +76,7 @@ struct Smbios3 final : KernelBusObject {
 		return true;
 	}
 
-	coroutine<frg::expected<Error>> handleRequest(LaneHandle lane) override {
+	coroutine<frg::expected<Error>> handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) override {
 		auto [acceptError, conversation] = co_await accept(lane);
 		if (acceptError != Error::success)
 			co_return acceptError;


### PR DESCRIPTION
The existing code basically only ever used individual descriptor types to convert to/from `AnyDescriptor`. Cut these out and use `AnyDescriptor` directly. We achieve this by destructuring the `shared_ptr<T, Policy>`s into their `T *` and their `smarter::counter *` and by type-erasing both pointers individually.

This strategy has two advantages: on the one hand, it is now easier to add fields to descriptors (and we will add a permission bitmask in the future), on the other hand it is cheaper to copy and move `AnyDescriptor` now since it is not a variant anymore.