### PR TITLE
thor: Use static `create()` factory functions for memory management related structs

### DIFF
--- a/kernel/thor/arch/x86/vt_d.cpp
+++ b/kernel/thor/arch/x86/vt_d.cpp
@@ -1602,10 +1602,12 @@ bool handleRmrr(frg::span<uint8_t> remappingStructureTypes) {
 							    func
 							) << frg::endlog;
 
-							auto reservedMemory = smarter::allocate_shared<HardwareMemory>(
-							    *kernelAlloc, rmrr.memory_base, size, CachingMode::null
+							auto reservedMemoryOutcome = HardwareMemory::create(
+							    rmrr.memory_base, size, CachingMode::null
 							);
-							space->reservedRegions_.push_back(std::move(reservedMemory));
+							if(!reservedMemoryOutcome)
+								panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
+							space->reservedRegions_.push_back(std::move(*reservedMemoryOutcome));
 
 							auto slice = smarter::allocate_shared<MemorySlice>(
 							    *kernelAlloc, space->reservedRegions_.back(), 0, size
@@ -1660,10 +1662,12 @@ bool handleRmrr(frg::span<uint8_t> remappingStructureTypes) {
 							    func
 							) << frg::endlog;
 
-							auto reservedMemory = smarter::allocate_shared<HardwareMemory>(
-							    *kernelAlloc, rmrr.memory_base, size, CachingMode::null
+							auto reservedMemoryOutcome = HardwareMemory::create(
+							    rmrr.memory_base, size, CachingMode::null
 							);
-							space->reservedRegions_.push_back(std::move(reservedMemory));
+							if(!reservedMemoryOutcome)
+								panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
+							space->reservedRegions_.push_back(std::move(*reservedMemoryOutcome));
 
 							auto slice = smarter::allocate_shared<MemorySlice>(
 							    *kernelAlloc, space->reservedRegions_.back(), 0, size

--- a/kernel/thor/arch/x86/vt_d.cpp
+++ b/kernel/thor/arch/x86/vt_d.cpp
@@ -1609,9 +1609,12 @@ bool handleRmrr(frg::span<uint8_t> remappingStructureTypes) {
 								panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
 							space->reservedRegions_.push_back(std::move(*reservedMemoryOutcome));
 
-							auto slice = smarter::allocate_shared<MemorySlice>(
-							    *kernelAlloc, space->reservedRegions_.back(), 0, size
+							auto sliceOutcome = MemorySlice::create(
+							    space->reservedRegions_.back(), 0, size
 							);
+							if(!sliceOutcome)
+								panicLogger() << "thor: Failed to create memory slice" << frg::endlog;
+							auto slice = std::move(*sliceOutcome);
 
 							auto res = KernelFiber::asyncBlockCurrent(space->map(
 							    std::move(slice),
@@ -1669,9 +1672,12 @@ bool handleRmrr(frg::span<uint8_t> remappingStructureTypes) {
 								panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
 							space->reservedRegions_.push_back(std::move(*reservedMemoryOutcome));
 
-							auto slice = smarter::allocate_shared<MemorySlice>(
-							    *kernelAlloc, space->reservedRegions_.back(), 0, size
+							auto sliceOutcome = MemorySlice::create(
+							    space->reservedRegions_.back(), 0, size
 							);
+							if(!sliceOutcome)
+								panicLogger() << "thor: Failed to create memory slice" << frg::endlog;
+							auto slice = std::move(*sliceOutcome);
 
 							auto res = KernelFiber::asyncBlockCurrent(space->map(
 							    std::move(slice),

--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -34,7 +34,15 @@ namespace {
 
 // --------------------------------------------------------
 
-MemorySlice::MemorySlice(smarter::shared_ptr<MemoryView> view,
+std::expected<smarter::shared_ptr<MemorySlice>, Error> MemorySlice::create(
+		smarter::shared_ptr<MemoryView> view, ptrdiff_t view_offset, size_t view_size,
+		CachingFlags cachingFlags) {
+	auto ptr = smarter::allocate_shared<MemorySlice>(*kernelAlloc, CtorToken{},
+			std::move(view), view_offset, view_size, cachingFlags);
+	return ptr;
+}
+
+MemorySlice::MemorySlice(CtorToken, smarter::shared_ptr<MemoryView> view,
 		ptrdiff_t view_offset, size_t view_size, CachingFlags cachingFlags)
 : _view{std::move(view)}, _viewOffset{view_offset}, _viewSize{view_size}, cachingFlags_{cachingFlags} {
 	assert(!(_viewOffset & (kPageSize - 1)));

--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -1281,7 +1281,7 @@ void AddressSpace::activate(smarter::shared_ptr<AddressSpace, BindableHandle> sp
 	PageSpace::activate(smarter::shared_ptr<PageSpace>{space->selfPtr.lock(), pageSpace});
 }
 
-AddressSpace::AddressSpace()
+AddressSpace::AddressSpace(CtorToken)
 : VirtualSpace{&ops_}, ops_{this} { }
 
 AddressSpace::~AddressSpace() { }

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -1732,11 +1732,13 @@ HelError doSubmitLockMemoryView(HelHandle handle, smarter::shared_ptr<IpcQueue> 
 			co_return;
 		}
 
+		auto lockOutcome = NamedMemoryViewLock::create(std::move(lockHandle));
+		if(!lockOutcome)
+			panicLogger() << "thor: Failed to create memory view lock" << frg::endlog;
 		HelHandle handle;
 		handle = universe->attachDescriptor(
 				AnyDescriptor::make<DescriptorType::memoryViewLock>(
-					smarter::allocate_shared<NamedMemoryViewLock>(
-						*kernelAlloc, std::move(lockHandle))));
+					std::move(*lockOutcome)));
 
 		HelHandleResult helResult{.error = kHelErrNone, .handle = handle};
 		QueueSource ipcSource{&helResult, sizeof(HelHandleResult), nullptr};

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -482,20 +482,21 @@ HelError helAllocateMemory(size_t size, uint32_t flags,
 		if(!readUserMemory(&effective, restrictions, sizeof(HelAllocRestrictions)))
 			return kHelErrFault;
 
-	smarter::shared_ptr<AllocatedMemory> memory;
+	std::expected<smarter::shared_ptr<AllocatedMemory>, Error> memoryOutcome;
 	if(flags & kHelAllocContinuous) {
-		memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, size, effective.addressBits,
+		memoryOutcome = AllocatedMemory::create(size, effective.addressBits,
 				size, kPageSize);
 	}else if(flags & kHelAllocOnDemand) {
-		memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, size, effective.addressBits);
+		memoryOutcome = AllocatedMemory::create(size, effective.addressBits);
 	}else{
 		// TODO:
-		memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, size, effective.addressBits);
+		memoryOutcome = AllocatedMemory::create(size, effective.addressBits);
 	}
-	memory->selfPtr = memory;
+	if(!memoryOutcome)
+		return translateError(memoryOutcome.error());
 
 	*handle = thisUniverse->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(memory)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*memoryOutcome)));
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -836,10 +836,12 @@ HelError helCreateSpace(HelHandle *handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto space = AddressSpace::create();
+	auto spaceOutcome = AddressSpace::create();
+	if(!spaceOutcome)
+		return translateError(spaceOutcome.error());
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::addressSpace>(std::move(space)));
+			AnyDescriptor::make<DescriptorType::addressSpace>(std::move(*spaceOutcome)));
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -576,11 +576,11 @@ HelError helCopyOnWrite(HelHandle memoryHandle,
 		view = std::move(*viewOutcome);
 	}
 
-	auto slice = smarter::allocate_shared<CopyOnWriteMemory>(*kernelAlloc, std::move(view),
-			offset, size);
-	slice->selfPtr = slice;
+	auto sliceOutcome = CopyOnWriteMemory::create(std::move(view), offset, size);
+	if(!sliceOutcome)
+		return translateError(sliceOutcome.error());
 	*outHandle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(slice)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*sliceOutcome)));
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -543,12 +543,14 @@ HelError helCreateManagedMemory(size_t size, uint32_t flags,
 	auto managed = smarter::allocate_shared<ManagedSpace>(*kernelAlloc, size,
 			flags & kHelManagedReadahead);
 	managed->selfPtr = managed;
-	auto backingMemory = smarter::allocate_shared<BackingMemory>(*kernelAlloc, managed);
+	auto backingOutcome = BackingMemory::create(managed);
+	if(!backingOutcome)
+		return translateError(backingOutcome.error());
 	auto frontalMemory = smarter::allocate_shared<FrontalMemory>(*kernelAlloc, std::move(managed));
 	frontalMemory->selfPtr = frontalMemory;
 
 	*backing_handle = thisUniverse->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(backingMemory)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*backingOutcome)));
 	*frontal_handle = thisUniverse->attachDescriptor(
 			AnyDescriptor::make<DescriptorType::memoryView>(std::move(frontalMemory)));
 

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -607,9 +607,11 @@ HelError helCreateIndirectMemory(size_t numSlots, HelHandle *handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memory = smarter::allocate_shared<IndirectMemory>(*kernelAlloc, numSlots);
+	auto memoryOutcome = IndirectMemory::create(numSlots);
+	if(!memoryOutcome)
+		return translateError(memoryOutcome.error());
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(memory)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*memoryOutcome)));
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -590,10 +590,11 @@ HelError helAccessPhysical(uintptr_t physical, size_t size, HelHandle *handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memory = smarter::allocate_shared<HardwareMemory>(*kernelAlloc, physical, size,
-			CachingMode::null);
+	auto memoryOutcome = HardwareMemory::create(physical, size, CachingMode::null);
+	if(!memoryOutcome)
+		return translateError(memoryOutcome.error());
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(memory)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*memoryOutcome)));
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -683,10 +683,11 @@ HelError helCreateSliceView(HelHandle memoryHandle,
 	if(flags & kHelSliceCacheWriteCombine)
 		cachingFlags = cacheWriteCombine;
 
-	auto slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
-			std::move(view), offset, size, cachingFlags);
+	auto sliceOutcome = MemorySlice::create(std::move(view), offset, size, cachingFlags);
+	if(!sliceOutcome)
+		return translateError(sliceOutcome.error());
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memorySlice>(std::move(slice)));
+			AnyDescriptor::make<DescriptorType::memorySlice>(std::move(*sliceOutcome)));
 
 	return kHelErrNone;
 }
@@ -1050,16 +1051,20 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 				return std::unexpected{viewOutcome.error()};
 			auto memory = std::move(*viewOutcome);
 			auto sliceLength = memory->getLength();
-			slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
-					std::move(memory), 0, sliceLength);
+			auto sliceOutcome = MemorySlice::create(std::move(memory), 0, sliceLength);
+			if(!sliceOutcome)
+				return std::unexpected{sliceOutcome.error()};
+			slice = std::move(*sliceOutcome);
 		}else if(desc.is<DescriptorType::queue>()) {
 			auto queueOutcome = desc.resolveObject<DescriptorType::queue>();
 			if(!queueOutcome)
 				return std::unexpected{queueOutcome.error()};
 			auto memory = (*queueOutcome)->getMemory();
 			auto sliceLength = memory->getLength();
-			slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
-					std::move(memory), 0, sliceLength);
+			auto sliceOutcome = MemorySlice::create(std::move(memory), 0, sliceLength);
+			if(!sliceOutcome)
+				return std::unexpected{sliceOutcome.error()};
+			slice = std::move(*sliceOutcome);
 		}else{
 			return std::unexpected{Error::badDescriptor};
 		}

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -546,13 +546,14 @@ HelError helCreateManagedMemory(size_t size, uint32_t flags,
 	auto backingOutcome = BackingMemory::create(managed);
 	if(!backingOutcome)
 		return translateError(backingOutcome.error());
-	auto frontalMemory = smarter::allocate_shared<FrontalMemory>(*kernelAlloc, std::move(managed));
-	frontalMemory->selfPtr = frontalMemory;
+	auto frontalOutcome = FrontalMemory::create(std::move(managed));
+	if(!frontalOutcome)
+		return translateError(frontalOutcome.error());
 
 	*backing_handle = thisUniverse->attachDescriptor(
 			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*backingOutcome)));
 	*frontal_handle = thisUniverse->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(frontalMemory)));
+			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*frontalOutcome)));
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -325,9 +325,11 @@ extern "C" void thorMain() {
 	//				if(logInitialization)
 						debugLogger() << "thor: initrd file " << path << frg::endlog;
 
-					auto memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc,
+					auto memoryOutcome = AllocatedMemory::create(
 							(file_size + (kPageSize - 1)) & ~size_t{kPageSize - 1});
-					memory->selfPtr = memory;
+					if(!memoryOutcome)
+						panicLogger() << "thor: Failed to create memory" << frg::endlog;
+					auto memory = std::move(*memoryOutcome);
 					auto copyOutcome = KernelFiber::asyncBlockCurrent(memory->copyTo(0,
 							data, file_size));
 					assert(copyOutcome);

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -1257,6 +1257,12 @@ void ManagedSpace::markDirty(CachePage *cachePage) {
 // BackingMemory
 // --------------------------------------------------------
 
+std::expected<smarter::shared_ptr<BackingMemory>, Error> BackingMemory::create(
+		smarter::shared_ptr<ManagedSpace> managed) {
+	auto ptr = smarter::allocate_shared<BackingMemory>(*kernelAlloc, CtorToken{}, std::move(managed));
+	return ptr;
+}
+
 coroutine<frg::expected<Error>> BackingMemory::resize(size_t newSize) {
 	assert(currentIpl() == ipl::exceptionalWork);
 	assert(!(newSize & (kPageSize - 1)));

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -706,7 +706,14 @@ ImmediateWindow::~ImmediateWindow() {
 // HardwareMemory
 // --------------------------------------------------------
 
-HardwareMemory::HardwareMemory(PhysicalAddr base, size_t length, CachingMode cache_mode)
+std::expected<smarter::shared_ptr<HardwareMemory>, Error> HardwareMemory::create(
+		PhysicalAddr base, size_t length, CachingMode cache_mode) {
+	auto ptr = smarter::allocate_shared<HardwareMemory>(*kernelAlloc, CtorToken{},
+			base, length, cache_mode);
+	return ptr;
+}
+
+HardwareMemory::HardwareMemory(CtorToken, PhysicalAddr base, size_t length, CachingMode cache_mode)
 : _base{base}, _length{length}, _cacheMode{cache_mode} {
 	assert(!(base % kPageSize));
 	assert(!(length % kPageSize));

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -552,9 +552,7 @@ smarter::shared_ptr<MemoryView> getZeroMemory() {
 
 std::expected<smarter::shared_ptr<ImmediateMemory>, Error>
 ImmediateMemory::create(size_t length) {
-	auto ptr = smarter::allocate_shared<ImmediateMemory>(*kernelAlloc);
-	if(!ptr)
-		return std::unexpected{Error::noMemory};
+	auto ptr = smarter::allocate_shared<ImmediateMemory>(*kernelAlloc, CtorToken{});
 	ptr->selfPtr = ptr;
 
 	auto numPages = (length + kPageSize - 1) >> kPageShift;
@@ -573,7 +571,7 @@ ImmediateMemory::create(size_t length) {
 	return ptr;
 }
 
-ImmediateMemory::ImmediateMemory()
+ImmediateMemory::ImmediateMemory(CtorToken)
 : _physicalPages{*kernelAlloc} { }
 
 ImmediateMemory::~ImmediateMemory() {

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -1595,6 +1595,13 @@ coroutine<frg::expected<Error>> BackingMemory::invalidateRange(uintptr_t offset,
 // FrontalMemory
 // --------------------------------------------------------
 
+std::expected<smarter::shared_ptr<FrontalMemory>, Error> FrontalMemory::create(
+		smarter::shared_ptr<ManagedSpace> managed) {
+	auto ptr = smarter::allocate_shared<FrontalMemory>(*kernelAlloc, CtorToken{}, std::move(managed));
+	ptr->selfPtr = ptr;
+	return ptr;
+}
+
 Error FrontalMemory::lockRange(uintptr_t offset, size_t size) {
 	return _managed->lockPages(offset, size);
 }

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -1878,7 +1878,15 @@ CowPage::~CowPage() {
 	physicalAllocator->free(physical, kPageSize);
 }
 
-CopyOnWriteMemory::CopyOnWriteMemory(smarter::shared_ptr<MemoryView> view,
+std::expected<smarter::shared_ptr<CopyOnWriteMemory>, Error> CopyOnWriteMemory::create(
+		smarter::shared_ptr<MemoryView> view, uintptr_t offset, size_t length) {
+	auto ptr = smarter::allocate_shared<CopyOnWriteMemory>(*kernelAlloc, CtorToken{},
+			std::move(view), offset, length, nullptr);
+	ptr->selfPtr = ptr;
+	return ptr;
+}
+
+CopyOnWriteMemory::CopyOnWriteMemory(CtorToken, smarter::shared_ptr<MemoryView> view,
 		uintptr_t offset, size_t length,
 		smarter::shared_ptr<CowChain> chain)
 : MemoryView{&_evictQueue}, _view{std::move(view)},
@@ -1921,8 +1929,8 @@ coroutine<frg::expected<Error, smarter::shared_ptr<MemoryView>>> CopyOnWriteMemo
 		_copyChain = newChain;
 
 		// Create a new mapping in the forked space.
-		forked = smarter::allocate_shared<CopyOnWriteMemory>(*kernelAlloc,
-						_view, _viewOffset, _length, newChain);
+		forked = smarter::allocate_shared<CopyOnWriteMemory>(*kernelAlloc, CtorToken{},
+				_view, _viewOffset, _length, newChain);
 		forked->selfPtr = forked;
 
 		// Inspect all copied pages owned by the original mapping.

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -778,7 +778,15 @@ size_t HardwareMemory::getLength() {
 // AllocatedMemory
 // --------------------------------------------------------
 
-AllocatedMemory::AllocatedMemory(size_t desiredLngth,
+std::expected<smarter::shared_ptr<AllocatedMemory>, Error> AllocatedMemory::create(
+		size_t length, int addressBits, size_t chunkSize, size_t chunkAlign) {
+	auto ptr = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, CtorToken{},
+			length, addressBits, chunkSize, chunkAlign);
+	ptr->selfPtr = ptr;
+	return ptr;
+}
+
+AllocatedMemory::AllocatedMemory(CtorToken, size_t desiredLngth,
 		int addressBits, size_t desiredChunkSize, size_t chunkAlign)
 : _physicalChunks{*kernelAlloc},
 		_addressBits{addressBits}, _chunkAlign{chunkAlign} {

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -1729,7 +1729,12 @@ size_t FrontalMemory::getLength() {
 // IndirectMemory
 // --------------------------------------------------------
 
-IndirectMemory::IndirectMemory(size_t numSlots)
+std::expected<smarter::shared_ptr<IndirectMemory>, Error> IndirectMemory::create(size_t numSlots) {
+	auto ptr = smarter::allocate_shared<IndirectMemory>(*kernelAlloc, CtorToken{}, numSlots);
+	return ptr;
+}
+
+IndirectMemory::IndirectMemory(CtorToken, size_t numSlots)
 : indirections_{*kernelAlloc} {
 	indirections_.resize(numSlots);
 }

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -460,7 +460,17 @@ coroutine<frg::expected<Error>> copyBetweenViews(
 namespace {
 
 struct ZeroMemory final : MemoryView {
-	ZeroMemory() {
+private:
+	struct CtorToken {};
+
+public:
+	static std::expected<smarter::shared_ptr<ZeroMemory>, Error> create() {
+		auto ptr = smarter::allocate_shared<ZeroMemory>(*kernelAlloc, CtorToken{});
+		ptr->selfPtr = ptr;
+		return ptr;
+	}
+
+	ZeroMemory(CtorToken) {
 		_zeroPage = physicalAllocator->allocate(kPageSize);
 		if (_zeroPage == PhysicalAddr(-1))
 			panicLogger() << "thor: OOM when trying to allocate zero page" << frg::endlog;
@@ -528,9 +538,10 @@ private:
 
 smarter::shared_ptr<MemoryView> getZeroMemory() {
 	static frg::eternal<smarter::shared_ptr<ZeroMemory>> singleton = [] {
-		auto memory = smarter::allocate_shared<ZeroMemory>(*kernelAlloc);
-		memory->selfPtr = memory;
-		return memory;
+		auto memoryOutcome = ZeroMemory::create();
+		if(!memoryOutcome)
+			panicLogger() << "thor: Failed to create zero memory" << frg::endlog;
+		return std::move(*memoryOutcome);
 	}();
 	return singleton.get();
 }

--- a/kernel/thor/generic/servers.cpp
+++ b/kernel/thor/generic/servers.cpp
@@ -273,7 +273,10 @@ coroutine<void> executeModule(frg::string_view name, MfsRegular *module,
 		smarter::shared_ptr<Stream, LanePolicy> control_lane,
 		smarter::shared_ptr<Stream, LanePolicy> xpipe_lane,
 		Scheduler *scheduler) {
-	auto space = AddressSpace::create();
+	auto spaceOutcome = AddressSpace::create();
+	if(!spaceOutcome)
+		panicLogger() << "thor: Failed to create address space" << frg::endlog;
+	auto space = std::move(*spaceOutcome);
 
 	ImageInfo exec_info = co_await loadModuleImage(space, 0, module->getMemory());
 

--- a/kernel/thor/generic/servers.cpp
+++ b/kernel/thor/generic/servers.cpp
@@ -49,9 +49,11 @@ void runService(frg::string<KernelAlloc> desc, smarter::shared_ptr<Stream, LaneP
 coroutine<bool> createMfsFile(frg::string_view path, const void *buffer, size_t size,
 		MfsRegular **out) {
 	// Copy to the memory object before taking locks below.
-	auto memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc,
+	auto memoryOutcome = AllocatedMemory::create(
 			(size + (kPageSize - 1)) & ~size_t{kPageSize - 1});
-	memory->selfPtr = memory;
+	if(!memoryOutcome)
+		panicLogger() << "thor: Failed to create memory" << frg::endlog;
+	auto memory = std::move(*memoryOutcome);
 	auto copyOutcome = co_await memory->copyTo(0, buffer, size);
 	assert(copyOutcome);
 
@@ -200,8 +202,10 @@ coroutine<ImageInfo> loadModuleImage(smarter::shared_ptr<AddressSpace, BindableH
 			if((virt_length % kPageSize) != 0)
 				virt_length += kPageSize - virt_length % kPageSize;
 			
-			auto memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, virt_length);
-			memory->selfPtr = memory;
+			auto memoryOutcome = AllocatedMemory::create(virt_length);
+			if(!memoryOutcome)
+				panicLogger() << "thor: Failed to create memory" << frg::endlog;
+			auto memory = std::move(*memoryOutcome);
 			auto copyResult = co_await copyBetweenViews(memory.get(), phdr.p_vaddr - virt_address,
 					image.get(), phdr.p_offset, phdr.p_filesz);
 			assert(copyResult);
@@ -280,8 +284,10 @@ coroutine<void> executeModule(frg::string_view name, MfsRegular *module,
 
 	// allocate and map memory for the user mode stack
 	size_t stack_size = 0x10000;
-	auto stack_memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, stack_size);
-	stack_memory->selfPtr = stack_memory;
+	auto stackMemoryOutcome = AllocatedMemory::create(stack_size);
+	if(!stackMemoryOutcome)
+		panicLogger() << "thor: Failed to create memory" << frg::endlog;
+	auto stack_memory = std::move(*stackMemoryOutcome);
 	auto stack_view = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
 			stack_memory, 0, stack_size);
 

--- a/kernel/thor/generic/servers.cpp
+++ b/kernel/thor/generic/servers.cpp
@@ -210,8 +210,10 @@ coroutine<ImageInfo> loadModuleImage(smarter::shared_ptr<AddressSpace, BindableH
 					image.get(), phdr.p_offset, phdr.p_filesz);
 			assert(copyResult);
 
-			auto view = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
-					std::move(memory), 0, virt_length);
+			auto viewOutcome = MemorySlice::create(std::move(memory), 0, virt_length);
+			if(!viewOutcome)
+				panicLogger() << "thor: Failed to create memory slice" << frg::endlog;
+			auto view = std::move(*viewOutcome);
 
 			if((phdr.p_flags & (PF_R | PF_W | PF_X)) == (PF_R | PF_W)) {
 				auto mapResult = co_await space->map(std::move(view),
@@ -288,8 +290,10 @@ coroutine<void> executeModule(frg::string_view name, MfsRegular *module,
 	if(!stackMemoryOutcome)
 		panicLogger() << "thor: Failed to create memory" << frg::endlog;
 	auto stack_memory = std::move(*stackMemoryOutcome);
-	auto stack_view = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
-			stack_memory, 0, stack_size);
+	auto stackViewOutcome = MemorySlice::create(stack_memory, 0, stack_size);
+	if(!stackViewOutcome)
+		panicLogger() << "thor: Failed to create memory slice" << frg::endlog;
+	auto stack_view = std::move(*stackViewOutcome);
 
 	auto mapResult = co_await space->map(std::move(stack_view), 0, 0, stack_size,
 			AddressSpace::kMapPreferTop | AddressSpace::kMapProtRead

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -449,8 +449,10 @@ namespace posix {
 		}
 
 		coroutine<void> setupAddressSpace(smarter::shared_ptr<Thread, ActiveHandle> thread) {
-			auto view = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
-					fileTableMemory, 0, 0x1000);
+			auto viewOutcome = MemorySlice::create(fileTableMemory, 0, 0x1000);
+			if(!viewOutcome)
+				panicLogger() << "thor: Failed to create memory slice" << frg::endlog;
+			auto view = std::move(*viewOutcome);
 			auto result = co_await thread->getAddressSpace()->map(std::move(view),
 					0, 0, 0x1000,
 					AddressSpace::kMapPreferTop | AddressSpace::kMapProtRead);
@@ -875,8 +877,11 @@ namespace posix {
 							std::move(fileMemory), req->rel_offset(), req->size());
 					if(!cowOutcome)
 						panicLogger() << "thor: Failed to create copy-on-write memory" << frg::endlog;
-					slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
+					auto sliceOutcome = MemorySlice::create(
 							std::move(*cowOutcome), 0, req->size());
+					if(!sliceOutcome)
+						panicLogger() << "thor: Failed to create memory slice" << frg::endlog;
+					slice = std::move(*sliceOutcome);
 				}else{
 					assert(!"TODO: implement shared mappings");
 				}
@@ -1012,8 +1017,10 @@ namespace posix {
 						std::move(*fileMemoryOutcome), 0, size);
 				if(!cowOutcome)
 					panicLogger() << "thor: Failed to create copy-on-write memory" << frg::endlog;
-				auto slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
-						std::move(*cowOutcome), 0, size);
+				auto sliceOutcome = MemorySlice::create(std::move(*cowOutcome), 0, size);
+				if(!sliceOutcome)
+					panicLogger() << "thor: Failed to create memory slice" << frg::endlog;
+				auto slice = std::move(*sliceOutcome);
 
 				auto space = info.thread->getAddressSpace();
 				auto mapResult = co_await space->map(std::move(slice),

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -871,11 +871,12 @@ namespace posix {
 
 				smarter::shared_ptr<MemorySlice> slice;
 				if(req->flags() & MAP_PRIVATE) { // MAP_PRIVATE.
-					auto cowMemory = smarter::allocate_shared<CopyOnWriteMemory>(*kernelAlloc,
+					auto cowOutcome = CopyOnWriteMemory::create(
 							std::move(fileMemory), req->rel_offset(), req->size());
-					cowMemory->selfPtr = cowMemory;
+					if(!cowOutcome)
+						panicLogger() << "thor: Failed to create copy-on-write memory" << frg::endlog;
 					slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
-							std::move(cowMemory), 0, req->size());
+							std::move(*cowOutcome), 0, req->size());
 				}else{
 					assert(!"TODO: implement shared mappings");
 				}
@@ -1007,11 +1008,12 @@ namespace posix {
 				auto fileMemoryOutcome = AllocatedMemory::create(size);
 				if(!fileMemoryOutcome)
 					panicLogger() << "thor: Failed to create memory" << frg::endlog;
-				auto cowMemory = smarter::allocate_shared<CopyOnWriteMemory>(*kernelAlloc,
+				auto cowOutcome = CopyOnWriteMemory::create(
 						std::move(*fileMemoryOutcome), 0, size);
-				cowMemory->selfPtr = cowMemory;
+				if(!cowOutcome)
+					panicLogger() << "thor: Failed to create copy-on-write memory" << frg::endlog;
 				auto slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
-						std::move(cowMemory), 0, size);
+						std::move(*cowOutcome), 0, size);
 
 				auto space = info.thread->getAddressSpace();
 				auto mapResult = co_await space->map(std::move(slice),

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -442,8 +442,10 @@ namespace posix {
 	struct Process {
 		Process(frg::string<KernelAlloc> name)
 		: _name{std::move(name)}, openFiles(*kernelAlloc) {
-			fileTableMemory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, 0x1000);
-			fileTableMemory->selfPtr = fileTableMemory;
+			auto memoryOutcome = AllocatedMemory::create(0x1000);
+			if(!memoryOutcome)
+				panicLogger() << "thor: Failed to create memory" << frg::endlog;
+			fileTableMemory = std::move(*memoryOutcome);
 		}
 
 		coroutine<void> setupAddressSpace(smarter::shared_ptr<Thread, ActiveHandle> thread) {
@@ -854,10 +856,10 @@ namespace posix {
 					if(req->flags() & MAP_PRIVATE) { // MAP_PRIVATE.
 						fileMemory = getZeroMemory();
 					}else{
-						auto memory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc,
-								req->size());
-						memory->selfPtr = memory;
-						fileMemory = std::move(memory);
+						auto memoryOutcome = AllocatedMemory::create(req->size());
+						if(!memoryOutcome)
+							panicLogger() << "thor: Failed to create memory" << frg::endlog;
+						fileMemory = std::move(*memoryOutcome);
 					}
 				}else{
 					// TODO: improve error handling here.
@@ -1002,10 +1004,11 @@ namespace posix {
 				});
 				if(!readOutcome)
 					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
-				auto fileMemory = smarter::allocate_shared<AllocatedMemory>(*kernelAlloc, size);
-				fileMemory->selfPtr = fileMemory;
+				auto fileMemoryOutcome = AllocatedMemory::create(size);
+				if(!fileMemoryOutcome)
+					panicLogger() << "thor: Failed to create memory" << frg::endlog;
 				auto cowMemory = smarter::allocate_shared<CopyOnWriteMemory>(*kernelAlloc,
-						std::move(fileMemory), 0, size);
+						std::move(*fileMemoryOutcome), 0, size);
 				cowMemory->selfPtr = cowMemory;
 				auto slice = smarter::allocate_shared<MemorySlice>(*kernelAlloc,
 						std::move(cowMemory), 0, size);

--- a/kernel/thor/generic/thor-internal/address-space.hpp
+++ b/kernel/thor/generic/thor-internal/address-space.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <expected>
 
 #include <async/basic.hpp>
 #include <async/mutex.hpp>
@@ -942,7 +943,18 @@ private:
 };
 
 struct NamedMemoryViewLock {
-	NamedMemoryViewLock(MemoryViewLockHandle handle)
+private:
+	struct CtorToken {};
+
+public:
+	static std::expected<smarter::shared_ptr<NamedMemoryViewLock>, Error> create(
+			MemoryViewLockHandle handle) {
+		auto ptr = smarter::allocate_shared<NamedMemoryViewLock>(*kernelAlloc, CtorToken{},
+				std::move(handle));
+		return ptr;
+	}
+
+	NamedMemoryViewLock(CtorToken, MemoryViewLockHandle handle)
 	: _handle{std::move(handle)} { }
 
 	NamedMemoryViewLock(const NamedMemoryViewLock &) = delete;

--- a/kernel/thor/generic/thor-internal/address-space.hpp
+++ b/kernel/thor/generic/thor-internal/address-space.hpp
@@ -803,6 +803,10 @@ private:
 struct AddressSpace final : VirtualSpace {
 	friend struct Mapping;
 
+private:
+	struct CtorToken {};
+
+public:
 	struct Operations final : VirtualOperations {
 		Operations(AddressSpace *space)
 		: space_{space} { }
@@ -861,11 +865,11 @@ public:
 		return smarter::shared_ptr<AddressSpace, BindableHandle>{smarter::adopt_rc, space, BindableHandle{space}};
 	}
 
-	static smarter::shared_ptr<AddressSpace, BindableHandle> create() {
+	static std::expected<smarter::shared_ptr<AddressSpace, BindableHandle>, Error> create() {
 		// Note: technically, we do not rely on RCU here.
 		//       However, the refcount may be decrement in IRQ context
 		//       and RCU ensures that freeing happens on a work queue.
-		auto ptr = allocate_rcu_shared<AddressSpace>(Allocator{});
+		auto ptr = allocate_rcu_shared<AddressSpace>(Allocator{}, CtorToken{});
 		ptr->selfPtr = ptr;
 		ptr->setupInitialHole(0x1000, (UINT64_C(1) << getLowerHalfBits()) - 0x1000);
 		spawnOnWorkQueue(*kernelAlloc, WorkQueue::generalQueue().lock(), ptr->runAgingLoop());
@@ -874,7 +878,7 @@ public:
 
 	static void activate(smarter::shared_ptr<AddressSpace, BindableHandle> space);
 
-	AddressSpace();
+	AddressSpace(CtorToken);
 
 	~AddressSpace();
 

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -795,8 +795,14 @@ private:
 };
 
 struct FrontalMemory final : MemoryView {
+private:
+	struct CtorToken {};
+
 public:
-	FrontalMemory(smarter::shared_ptr<ManagedSpace> managed)
+	static std::expected<smarter::shared_ptr<FrontalMemory>, Error> create(
+			smarter::shared_ptr<ManagedSpace> managed);
+
+	FrontalMemory(CtorToken, smarter::shared_ptr<ManagedSpace> managed)
 	: MemoryView{&managed->_evictQueue}, _managed{std::move(managed)} { }
 
 	FrontalMemory(const FrontalMemory &) = delete;

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -824,7 +824,13 @@ private:
 };
 
 struct IndirectMemory final : MemoryView {
-	IndirectMemory(size_t numSlots);
+private:
+	struct CtorToken {};
+
+public:
+	static std::expected<smarter::shared_ptr<IndirectMemory>, Error> create(size_t numSlots);
+
+	IndirectMemory(CtorToken, size_t numSlots);
 	IndirectMemory(const IndirectMemory &) = delete;
 	~IndirectMemory();
 

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -893,10 +893,16 @@ struct CowChain {
 };
 
 struct CopyOnWriteMemory final : MemoryView /*, MemoryObserver */ {
+private:
+	struct CtorToken {};
+
 public:
-	CopyOnWriteMemory(smarter::shared_ptr<MemoryView> view,
+	static std::expected<smarter::shared_ptr<CopyOnWriteMemory>, Error> create(
+			smarter::shared_ptr<MemoryView> view, uintptr_t offset, size_t length);
+
+	CopyOnWriteMemory(CtorToken, smarter::shared_ptr<MemoryView> view,
 			uintptr_t offset, size_t length,
-			smarter::shared_ptr<CowChain> chain = nullptr);
+			smarter::shared_ptr<CowChain> chain);
 	CopyOnWriteMemory(const CopyOnWriteMemory &) = delete;
 
 	~CopyOnWriteMemory();

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -562,7 +562,14 @@ private:
 };
 
 struct HardwareMemory final : MemoryView {
-	HardwareMemory(PhysicalAddr base, size_t length, CachingMode cache_mode);
+private:
+	struct CtorToken {};
+
+public:
+	static std::expected<smarter::shared_ptr<HardwareMemory>, Error> create(
+			PhysicalAddr base, size_t length, CachingMode cache_mode);
+
+	HardwareMemory(CtorToken, PhysicalAddr base, size_t length, CachingMode cache_mode);
 	HardwareMemory(const HardwareMemory &) = delete;
 	~HardwareMemory();
 

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -413,8 +413,16 @@ struct SliceRange {
 };
 
 struct MemorySlice {
-	MemorySlice(smarter::shared_ptr<MemoryView> view,
-			ptrdiff_t view_offset, size_t view_size, CachingFlags cachingFlags = 0);
+private:
+	struct CtorToken {};
+
+public:
+	static std::expected<smarter::shared_ptr<MemorySlice>, Error> create(
+			smarter::shared_ptr<MemoryView> view, ptrdiff_t view_offset, size_t view_size,
+			CachingFlags cachingFlags = 0);
+
+	MemorySlice(CtorToken, smarter::shared_ptr<MemoryView> view,
+			ptrdiff_t view_offset, size_t view_size, CachingFlags cachingFlags);
 
 	smarter::shared_ptr<MemoryView> getView() {
 		return _view;

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -589,8 +589,16 @@ private:
 };
 
 struct AllocatedMemory final : MemoryView {
-	AllocatedMemory(size_t length, int addressBits = 64,
+private:
+	struct CtorToken {};
+
+public:
+	static std::expected<smarter::shared_ptr<AllocatedMemory>, Error> create(
+			size_t length, int addressBits = 64,
 			size_t chunkSize = kPageSize, size_t chunkAlign = kPageSize);
+
+	AllocatedMemory(CtorToken, size_t length, int addressBits,
+			size_t chunkSize, size_t chunkAlign);
 	AllocatedMemory(const AllocatedMemory &) = delete;
 	~AllocatedMemory();
 

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -764,8 +764,14 @@ struct ManagedSpace : CacheBundle {
 };
 
 struct BackingMemory final : MemoryView {
+private:
+	struct CtorToken {};
+
 public:
-	BackingMemory(smarter::shared_ptr<ManagedSpace> managed)
+	static std::expected<smarter::shared_ptr<BackingMemory>, Error> create(
+			smarter::shared_ptr<ManagedSpace> managed);
+
+	BackingMemory(CtorToken, smarter::shared_ptr<ManagedSpace> managed)
 	: MemoryView{&managed->_evictQueue}, _managed{std::move(managed)} { }
 
 	BackingMemory(const BackingMemory &) = delete;

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -447,10 +447,14 @@ smarter::shared_ptr<MemoryView> getZeroMemory();
 // Memory that is allocated by the kernel and never swapped out.
 // In contrast to most other memory objects, it can be accessed synchronously.
 struct ImmediateMemory final : MemoryView {
+private:
+	struct CtorToken {};
+
+public:
 	static std::expected<smarter::shared_ptr<ImmediateMemory>, Error>
 	create(size_t length);
 
-	ImmediateMemory();
+	ImmediateMemory(CtorToken);
 	ImmediateMemory(const ImmediateMemory &) = delete;
 	~ImmediateMemory();
 

--- a/kernel/thor/system/dtb/dtb_discover.cpp
+++ b/kernel/thor/system/dtb/dtb_discover.cpp
@@ -166,10 +166,13 @@ struct MbusNode final : private KernelBusObject {
 				co_return Error::illegalArgs;
 			}
 
-			auto memory = smarter::allocate_shared<HardwareMemory>(*kernelAlloc,
+			auto memoryOutcome = HardwareMemory::create(
 					regs[index].address & ~(kPageSize - 1),
 					(regs[index].length + (kPageSize - 1)) & ~(kPageSize - 1),
 					CachingMode::mmioNonPosted);
+			if(!memoryOutcome)
+				panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
+			auto memory = std::move(*memoryOutcome);
 
 			auto descriptor = AnyDescriptor::make<DescriptorType::memoryView>(memory);
 

--- a/kernel/thor/system/framebuffer/fb.cpp
+++ b/kernel/thor/system/framebuffer/fb.cpp
@@ -135,10 +135,13 @@ void transitionBootFb() {
 	bootDisplay->setWindow(window);
 
 	assert(!(bootInfo->address & (kPageSize - 1)));
-	bootInfo->memory = smarter::allocate_shared<HardwareMemory>(*kernelAlloc,
+	auto memoryOutcome = HardwareMemory::create(
 			bootInfo->address & ~(kPageSize - 1),
 			(bootInfo->height * bootInfo->pitch + (kPageSize - 1)) & ~(kPageSize - 1),
 			CachingMode::writeCombine);
+	if(!memoryOutcome)
+		panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
+	bootInfo->memory = std::move(*memoryOutcome);
 
 	// Try to attached the framebuffer to a PCI device.
 	pci::PciDevice *owner = nullptr;

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -1046,10 +1046,13 @@ void readEntityBars(PciEntity *entity, int nBars) {
 					bars[i].hostType = PciBar::kBarMemory;
 					bars[i].allocated = true;
 					bars[i].offset = offset;
-					bars[i].memory = smarter::allocate_shared<HardwareMemory>(*kernelAlloc,
+					auto memoryOutcome = HardwareMemory::create(
 							hostAddress & ~(kPageSize - 1),
 							(length + offset + (kPageSize - 1)) & ~(kPageSize - 1),
 							CachingMode::mmioNonPosted);
+					if(!memoryOutcome)
+						panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
+					bars[i].memory = std::move(*memoryOutcome);
 				} else {
 					bars[i].hostType = PciBar::kBarIo;
 					bars[i].allocated = true;
@@ -1111,10 +1114,13 @@ void readEntityBars(PciEntity *entity, int nBars) {
 				bars[i].hostType = PciBar::kBarMemory;
 				bars[i].allocated = true;
 				auto offset = address & (kPageSize - 1);
-				bars[i].memory = smarter::allocate_shared<HardwareMemory>(*kernelAlloc,
+				auto memoryOutcome = HardwareMemory::create(
 						address & ~(kPageSize - 1),
 						(length + offset + (kPageSize - 1)) & ~(kPageSize - 1),
 						CachingMode::mmio);
+				if(!memoryOutcome)
+					panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
+				bars[i].memory = std::move(*memoryOutcome);
 				bars[i].offset = offset;
 
 				infoLogger() << "            32-bit memory BAR #" << i
@@ -1175,10 +1181,13 @@ void readEntityBars(PciEntity *entity, int nBars) {
 				bars[i].hostType = PciBar::kBarMemory;
 				bars[i].allocated = true;
 				auto offset = address & (kPageSize - 1);
-				bars[i].memory = smarter::allocate_shared<HardwareMemory>(*kernelAlloc,
+				auto memoryOutcome = HardwareMemory::create(
 						address & ~(kPageSize - 1),
 						(length + offset + (kPageSize - 1)) & ~(kPageSize - 1),
 						CachingMode::mmio);
+				if(!memoryOutcome)
+					panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
+				bars[i].memory = std::move(*memoryOutcome);
 				bars[i].offset = offset;
 
 				infoLogger() << "            64-bit memory BAR #" << i
@@ -1296,10 +1305,13 @@ void checkPciFunction(PciBus *bus, uint32_t slot, uint32_t function,
 			io->writeConfigWord(bus, slot, function, offset, expansion_rom_addr | 1);
 			// Map it
 			auto offset = expansion_rom_addr & (kPageSize - 1);
-			device->expansionRom.memory = smarter::allocate_shared<HardwareMemory>(*kernelAlloc,
+			auto memoryOutcome = HardwareMemory::create(
 						expansion_rom_addr & ~(kPageSize - 1),
 						(expansion_rom_length + offset + (kPageSize - 1)) & ~(kPageSize - 1),
 						CachingMode::uncached); // Some cards have problems with caching the PCI Expansion Rom
+			if(!memoryOutcome)
+				panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
+			device->expansionRom.memory = std::move(*memoryOutcome);
 			device->expansionRom.offset = offset;
 			device->expansionRom.address = expansion_rom_addr;
 			device->expansionRom.length = expansion_rom_length;
@@ -1967,12 +1979,15 @@ void allocateBars(PciBus *bus) {
 			bar.address = childBase;
 			bar.hostType = PciBar::kBarMemory;
 			auto offset = hostBase & (kPageSize - 1);
-			bar.memory = smarter::allocate_shared<HardwareMemory>(*kernelAlloc,
+			auto memoryOutcome = HardwareMemory::create(
 					hostBase & ~(kPageSize - 1),
 					(req.size + offset + (kPageSize - 1)) & ~(kPageSize - 1),
 					flags == PciBusResource::io
 						? CachingMode::mmioNonPosted
 						: CachingMode::mmio);
+			if(!memoryOutcome)
+				panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
+			bar.memory = std::move(*memoryOutcome);
 			bar.offset = offset;
 		}
 

--- a/kernel/thor/system/pci/pci_quirks.cpp
+++ b/kernel/thor/system/pci/pci_quirks.cpp
@@ -71,14 +71,15 @@ void readIntelIntegratedGraphicsVbt(pci::PciDevice *dev) {
 		}
 
 		// OpRegion 2.0: rvda is a physical address
-		auto vbt = smarter::allocate_shared<HardwareMemory>(
-		    *kernelAlloc,
+		auto vbtOutcome = HardwareMemory::create(
 		    rvda & ~(kPageSize - 1),
 		    (asle->rvds + (kPageSize - 1)) & ~(kPageSize - 1),
 		    CachingMode::uncached
 		);
+		if(!vbtOutcome)
+			panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
 
-		dev->igdVbt = std::move(vbt);
+		dev->igdVbt = std::move(*vbtOutcome);
 		return;
 	}
 
@@ -91,14 +92,15 @@ void readIntelIntegratedGraphicsVbt(pci::PciDevice *dev) {
 	    ((opregion->mbox & IGD_MBOX_ASLE_EXT) ? IGD_OPREGION_ASLE_EXT_OFFSET : IGD_OPREGION_SIZE)
 	    - IGD_OPREGION_VBT_OFFSET;
 
-	auto vbt = smarter::allocate_shared<HardwareMemory>(
-	    *kernelAlloc,
+	auto vbtOutcome = HardwareMemory::create(
 	    (aslsPhys + IGD_OPREGION_VBT_OFFSET) & ~(kPageSize - 1),
 	    (vbtSize + (kPageSize - 1)) & ~(kPageSize - 1),
 	    CachingMode::uncached
 	);
+	if(!vbtOutcome)
+		panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
 
-	dev->igdVbt = std::move(vbt);
+	dev->igdVbt = std::move(*vbtOutcome);
 }
 
 void enableNvidiaHda(pci::PciDevice *dev) {


### PR DESCRIPTION
We will use RCU for these structs in the future. Centralize their creation into `create()` functions. This will also make it easier to handle allocations failures in the future.