### PR TITLE
thor: Use static create() factory functions for virtualization related structs

### DIFF
--- a/kernel/thor/arch/riscv/hypervisor-space.cpp
+++ b/kernel/thor/arch/riscv/hypervisor-space.cpp
@@ -80,7 +80,7 @@ frg::expected<Error, PagesAffected> Operations::agePages(VirtualAddr va, size_t 
 	return agePagesByCursor<HypervisorCursor>(pageSpace_, va, size, vacate);
 }
 
-HypervisorSpace::HypervisorSpace(PhysicalAddr root)
+HypervisorSpace::HypervisorSpace(CtorToken, PhysicalAddr root)
 : VirtualizedPageSpace{&ops_},
   pageSpace_{root},
   ops_{&pageSpace_} {

--- a/kernel/thor/arch/riscv/hypervisor.cpp
+++ b/kernel/thor/arch/riscv/hypervisor.cpp
@@ -105,7 +105,7 @@ void init() {
 	}
 }
 
-Vcpu::Vcpu(smarter::shared_ptr<HypervisorSpace> space) : space_{std::move(space)} {
+Vcpu::Vcpu(CtorToken, smarter::shared_ptr<HypervisorSpace> space) : space_{std::move(space)} {
 	state_.kernelMode = true;
 }
 

--- a/kernel/thor/arch/riscv/thor-internal/arch/hypervisor-space.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/hypervisor-space.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <expected>
+
 #include <thor-internal/arch-generic/paging.hpp>
 #include <thor-internal/error.hpp>
 #include <thor-internal/virtualization.hpp>
@@ -16,6 +18,10 @@ struct HypervisorPageSpace : PageSpace {
 };
 
 struct HypervisorSpace final : VirtualizedPageSpace {
+private:
+	struct CtorToken {};
+
+public:
 	struct Operations final : VirtualOperations {
 		Operations(HypervisorPageSpace *pageSpace);
 
@@ -55,13 +61,13 @@ struct HypervisorSpace final : VirtualizedPageSpace {
 		HypervisorPageSpace *pageSpace_;
 	};
 
-	HypervisorSpace(PhysicalAddr root);
+	HypervisorSpace(CtorToken, PhysicalAddr root);
 
 	HypervisorSpace(const HypervisorSpace &) = delete;
 	HypervisorSpace &operator=(const HypervisorSpace &) = delete;
 
-	static smarter::shared_ptr<HypervisorSpace> create(PhysicalAddr root) {
-		auto ptr = smarter::allocate_shared<HypervisorSpace>(Allocator{}, root);
+	static std::expected<smarter::shared_ptr<HypervisorSpace>, Error> create(PhysicalAddr root) {
+		auto ptr = smarter::allocate_shared<HypervisorSpace>(Allocator{}, CtorToken{}, root);
 		ptr->selfPtr = ptr;
 		// TODO: This could be bigger on sv48/sv57 or when taking advantage of the bigger level 0
 		// table, it's unlikely to be an issue in practice though.

--- a/kernel/thor/arch/riscv/thor-internal/arch/hypervisor-space.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/hypervisor-space.hpp
@@ -4,6 +4,7 @@
 
 #include <thor-internal/arch-generic/paging.hpp>
 #include <thor-internal/error.hpp>
+#include <thor-internal/physical.hpp>
 #include <thor-internal/virtualization.hpp>
 
 namespace thor::riscv_hypervisor {
@@ -66,7 +67,13 @@ public:
 	HypervisorSpace(const HypervisorSpace &) = delete;
 	HypervisorSpace &operator=(const HypervisorSpace &) = delete;
 
-	static std::expected<smarter::shared_ptr<HypervisorSpace>, Error> create(PhysicalAddr root) {
+	static std::expected<smarter::shared_ptr<HypervisorSpace>, Error> create() {
+		PhysicalAddr root = physicalAllocator->allocate(0x4000);
+		if (root == static_cast<PhysicalAddr>(-1))
+			return std::unexpected{Error::noMemory};
+		PageAccessor accessor{root};
+		memset(accessor.get(), 0, 0x4000);
+
 		auto ptr = smarter::allocate_shared<HypervisorSpace>(Allocator{}, CtorToken{}, root);
 		ptr->selfPtr = ptr;
 		// TODO: This could be bigger on sv48/sv57 or when taking advantage of the bigger level 0

--- a/kernel/thor/arch/riscv/thor-internal/arch/hypervisor.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/hypervisor.hpp
@@ -15,7 +15,17 @@ namespace thor::riscv_hypervisor {
 void init();
 
 struct Vcpu final : VirtualizedCpu {
-	Vcpu(smarter::shared_ptr<HypervisorSpace> space);
+private:
+	struct CtorToken {};
+
+public:
+	static std::expected<smarter::shared_ptr<Vcpu>, Error>
+	create(smarter::shared_ptr<HypervisorSpace> space) {
+		auto ptr = smarter::allocate_shared<Vcpu>(Allocator{}, CtorToken{}, std::move(space));
+		return ptr;
+	}
+
+	Vcpu(CtorToken, smarter::shared_ptr<HypervisorSpace> space);
 	~Vcpu();
 
 	Vcpu(const Vcpu &) = delete;

--- a/kernel/thor/arch/x86/ept.cpp
+++ b/kernel/thor/arch/x86/ept.cpp
@@ -156,7 +156,7 @@ frg::expected<Error, PagesAffected> EptOperations::agePages(VirtualAddr, size_t,
 	return PagesAffected{};
 }
 
-EptSpace::EptSpace(PhysicalAddr root)
+EptSpace::EptSpace(CtorToken, PhysicalAddr root)
 : VirtualizedPageSpace{&eptOps_}, eptOps_{&pageSpace_}, pageSpace_{root} { }
 
 EptSpace::~EptSpace() { }

--- a/kernel/thor/arch/x86/npt.cpp
+++ b/kernel/thor/arch/x86/npt.cpp
@@ -144,7 +144,7 @@ frg::expected<Error, PagesAffected> NptOperations::agePages(VirtualAddr, size_t,
 	return PagesAffected{};
 }
 
-NptSpace::NptSpace(PhysicalAddr root)
+NptSpace::NptSpace(CtorToken, PhysicalAddr root)
 : VirtualizedPageSpace{&nptOps_}, nptOps_{&pageSpace_}, pageSpace_{root} { }
 
 NptSpace::~NptSpace() { }

--- a/kernel/thor/arch/x86/svm.cpp
+++ b/kernel/thor/arch/x86/svm.cpp
@@ -24,7 +24,7 @@ namespace thor::svm {
 		return true;
 	}
 
-	Vcpu::Vcpu(smarter::shared_ptr<NptSpace> npt) : space{npt} {
+	Vcpu::Vcpu(CtorToken, smarter::shared_ptr<NptSpace> npt) : space{npt} {
 		vmcb_region = physicalAllocator->allocate(kPageSize);
 		host_additional_save_region = physicalAllocator->allocate(kPageSize);
 		PageAccessor regionAccessor{vmcb_region};

--- a/kernel/thor/arch/x86/thor-internal/arch/ept.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/ept.hpp
@@ -59,7 +59,11 @@ struct EptSpace final : VirtualizedPageSpace {
 	friend struct Vmcs;
 	friend struct ShootNode;
 
-	EptSpace(PhysicalAddr root);
+private:
+	struct CtorToken {};
+
+public:
+	EptSpace(CtorToken, PhysicalAddr root);
 
 	EptSpace(const EptSpace &) = delete;
 
@@ -67,8 +71,8 @@ struct EptSpace final : VirtualizedPageSpace {
 
 	EptSpace& operator=(const EptSpace &) = delete;
 
-	static smarter::shared_ptr<EptSpace> create(PhysicalAddr root) {
-		auto ptr = smarter::allocate_shared<EptSpace>(Allocator{}, root);
+	static std::expected<smarter::shared_ptr<EptSpace>, Error> create(PhysicalAddr root) {
+		auto ptr = smarter::allocate_shared<EptSpace>(Allocator{}, CtorToken{}, root);
 		ptr->selfPtr = ptr;
 		ptr->setupInitialHole(0, 0x7ffffff00000);
 		return ptr;

--- a/kernel/thor/arch/x86/thor-internal/arch/ept.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/ept.hpp
@@ -2,6 +2,7 @@
 
 #include <thor-internal/arch-generic/paging.hpp>
 #include <thor-internal/error.hpp>
+#include <thor-internal/physical.hpp>
 #include <thor-internal/virtualization.hpp>
 
 constexpr uint64_t EPT_READ = (0);
@@ -71,7 +72,13 @@ public:
 
 	EptSpace& operator=(const EptSpace &) = delete;
 
-	static std::expected<smarter::shared_ptr<EptSpace>, Error> create(PhysicalAddr root) {
+	static std::expected<smarter::shared_ptr<EptSpace>, Error> create() {
+		PhysicalAddr root = physicalAllocator->allocate(kPageSize);
+		if(root == static_cast<PhysicalAddr>(-1))
+			return std::unexpected{Error::noMemory};
+		PageAccessor accessor{root};
+		memset(accessor.get(), 0, kPageSize);
+
 		auto ptr = smarter::allocate_shared<EptSpace>(Allocator{}, CtorToken{}, root);
 		ptr->selfPtr = ptr;
 		ptr->setupInitialHole(0, 0x7ffffff00000);

--- a/kernel/thor/arch/x86/thor-internal/arch/npt.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/npt.hpp
@@ -2,6 +2,7 @@
 
 #include <thor-internal/arch-generic/paging.hpp>
 #include <thor-internal/error.hpp>
+#include <thor-internal/physical.hpp>
 #include <thor-internal/virtualization.hpp>
 
 namespace thor::svm {
@@ -61,7 +62,13 @@ namespace thor::svm {
 
 		NptSpace& operator=(const NptSpace &) = delete;
 
-		static std::expected<smarter::shared_ptr<NptSpace>, Error> create(PhysicalAddr root) {
+		static std::expected<smarter::shared_ptr<NptSpace>, Error> create() {
+			PhysicalAddr root = physicalAllocator->allocate(kPageSize);
+			if(root == static_cast<PhysicalAddr>(-1))
+				return std::unexpected{Error::noMemory};
+			PageAccessor accessor{root};
+			memset(accessor.get(), 0, kPageSize);
+
 			auto ptr = smarter::allocate_shared<NptSpace>(Allocator{}, CtorToken{}, root);
 			ptr->selfPtr = ptr;
 			ptr->setupInitialHole(0, 0x7ffffff00000);

--- a/kernel/thor/arch/x86/thor-internal/arch/npt.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/npt.hpp
@@ -49,7 +49,11 @@ namespace thor::svm {
 		friend struct ShootNode;
 		friend struct Vcpu;
 
-		NptSpace(PhysicalAddr root);
+	private:
+		struct CtorToken {};
+
+	public:
+		NptSpace(CtorToken, PhysicalAddr root);
 
 		NptSpace(const NptSpace &) = delete;
 
@@ -57,8 +61,8 @@ namespace thor::svm {
 
 		NptSpace& operator=(const NptSpace &) = delete;
 
-		static smarter::shared_ptr<NptSpace> create(PhysicalAddr root) {
-			auto ptr = smarter::allocate_shared<NptSpace>(Allocator{}, root);
+		static std::expected<smarter::shared_ptr<NptSpace>, Error> create(PhysicalAddr root) {
+			auto ptr = smarter::allocate_shared<NptSpace>(Allocator{}, CtorToken{}, root);
 			ptr->selfPtr = ptr;
 			ptr->setupInitialHole(0, 0x7ffffff00000);
 			return ptr;

--- a/kernel/thor/arch/x86/thor-internal/arch/svm.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/svm.hpp
@@ -200,7 +200,17 @@ namespace thor::svm {
 	};
 
 	struct Vcpu final : VirtualizedCpu {
-		Vcpu(smarter::shared_ptr<NptSpace> npt);
+	private:
+		struct CtorToken {};
+
+	public:
+		static std::expected<smarter::shared_ptr<Vcpu>, Error> create(
+				smarter::shared_ptr<NptSpace> npt) {
+			auto ptr = smarter::allocate_shared<Vcpu>(Allocator{}, CtorToken{}, std::move(npt));
+			return ptr;
+		}
+
+		Vcpu(CtorToken, smarter::shared_ptr<NptSpace> npt);
 		~Vcpu();
 		
 		Vcpu(const Vcpu &) = delete;

--- a/kernel/thor/arch/x86/thor-internal/arch/vmx.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/vmx.hpp
@@ -158,7 +158,17 @@ namespace thor::vmx {
 	bool vmxon();
 
 	struct Vmcs final : VirtualizedCpu {
-		Vmcs(smarter::shared_ptr<EptSpace> ept);
+	private:
+		struct CtorToken {};
+
+	public:
+		static std::expected<smarter::shared_ptr<Vmcs>, Error> create(
+				smarter::shared_ptr<EptSpace> ept) {
+			auto ptr = smarter::allocate_shared<Vmcs>(Allocator{}, CtorToken{}, std::move(ept));
+			return ptr;
+		}
+
+		Vmcs(CtorToken, smarter::shared_ptr<EptSpace> ept);
 		~Vmcs();
 
 		Vmcs(const Vmcs& vmcs) = delete;

--- a/kernel/thor/arch/x86/vmx.cpp
+++ b/kernel/thor/arch/x86/vmx.cpp
@@ -119,7 +119,7 @@ namespace thor::vmx {
 		return successful;
 	}
 
-	Vmcs::Vmcs(smarter::shared_ptr<EptSpace> ept) : space(ept) {
+	Vmcs::Vmcs(CtorToken, smarter::shared_ptr<EptSpace> ept) : space(ept) {
 		infoLogger() << "vmx: Creating VMCS" << frg::endlog;
 		region = (void*)physicalAllocator->allocate(kPageSize);
 		PageAccessor regionAccessor{(PhysicalAddr)region};

--- a/kernel/thor/arch/x86/vt_d.cpp
+++ b/kernel/thor/arch/x86/vt_d.cpp
@@ -508,10 +508,15 @@ private:
 };
 
 struct IntelIommuDmaSpace final : DmaSpace {
-	IntelIommuDmaSpace(IntelIommuOperations *ops) : DmaSpace(ops), iommuOps_{ops} {}
+private:
+	struct CtorToken {};
 
-	static smarter::shared_ptr<IntelIommuDmaSpace> create(IntelIommuOperations *ops) {
-		auto ptr = smarter::allocate_shared<IntelIommuDmaSpace>(*kernelAlloc, ops);
+public:
+	IntelIommuDmaSpace(CtorToken, IntelIommuOperations *ops) : DmaSpace(ops), iommuOps_{ops} {}
+
+	static std::expected<smarter::shared_ptr<IntelIommuDmaSpace>, Error> create(
+			IntelIommuOperations *ops) {
+		auto ptr = smarter::allocate_shared<IntelIommuDmaSpace>(*kernelAlloc, CtorToken{}, ops);
 		ptr->selfPtr = ptr;
 		ptr->setupInitialHole(0x1000, (1UL << 39) - 0x1000);
 		return ptr;
@@ -1746,7 +1751,10 @@ IommuDomain *newDomain(IntelIommu *iommu) {
 	auto domainId = iommu->allocateHardwareDomainId();
 
 	auto ops = frg::construct<IntelIommuOperations>(*kernelAlloc, rootLevel, iommu, domainId);
-	return frg::construct<IntelIommuDomain>(*kernelAlloc, domainId, IntelIommuDmaSpace::create(ops));
+	auto spaceOutcome = IntelIommuDmaSpace::create(ops);
+	if(!spaceOutcome)
+		panicLogger() << "thor: Failed to create DMA space" << frg::endlog;
+	return frg::construct<IntelIommuDomain>(*kernelAlloc, domainId, std::move(*spaceOutcome));
 };
 
 }

--- a/kernel/thor/arch/x86/vt_d.cpp
+++ b/kernel/thor/arch/x86/vt_d.cpp
@@ -512,24 +512,32 @@ private:
 	struct CtorToken {};
 
 public:
-	IntelIommuDmaSpace(CtorToken, IntelIommuOperations *ops) : DmaSpace(ops), iommuOps_{ops} {}
+	IntelIommuDmaSpace(CtorToken, PhysicalAddr root, IntelIommu *iommu, uint16_t domainId)
+	: DmaSpace(&iommuOps_), iommuOps_{root, iommu, domainId} {}
 
 	static std::expected<smarter::shared_ptr<IntelIommuDmaSpace>, Error> create(
-			IntelIommuOperations *ops) {
-		auto ptr = smarter::allocate_shared<IntelIommuDmaSpace>(*kernelAlloc, CtorToken{}, ops);
+			IntelIommu *iommu, uint16_t domainId) {
+		PhysicalAddr root = physicalAllocator->allocate(kPageSize);
+		if(root == static_cast<PhysicalAddr>(-1))
+			return std::unexpected{Error::noMemory};
+		PageAccessor accessor{root};
+		memset(accessor.get(), 0, kPageSize);
+
+		auto ptr = smarter::allocate_shared<IntelIommuDmaSpace>(
+				*kernelAlloc, CtorToken{}, root, iommu, domainId);
 		ptr->selfPtr = ptr;
 		ptr->setupInitialHole(0x1000, (1UL << 39) - 0x1000);
 		return ptr;
 	}
 
-	IntelIommuOperations *intelIommuOps() const {
-		return iommuOps_;
+	IntelIommuOperations *intelIommuOps() {
+		return &iommuOps_;
 	}
 
 	frg::vector<smarter::shared_ptr<HardwareMemory>, KernelAlloc> reservedRegions_{*kernelAlloc};
 
 private:
-	IntelIommuOperations *iommuOps_;
+	IntelIommuOperations iommuOps_;
 };
 
 struct IntelIommuDomain : IommuDomain {
@@ -1741,17 +1749,9 @@ IommuDomain *newDomain(IntelIommu *iommu) {
 	if (!iommu)
 		return nullptr;
 
-	PhysicalAddr rootLevel = physicalAllocator->allocate(kPageSize);
-	if (rootLevel == static_cast<PhysicalAddr>(-1))
-		panicLogger() << "thor: failed to allocate physical memory for IOMMU page tables" << frg::endlog;
-
-	PageAccessor accessor{rootLevel};
-	memset(accessor.get(), 0, kPageSize);
-
 	auto domainId = iommu->allocateHardwareDomainId();
 
-	auto ops = frg::construct<IntelIommuOperations>(*kernelAlloc, rootLevel, iommu, domainId);
-	auto spaceOutcome = IntelIommuDmaSpace::create(ops);
+	auto spaceOutcome = IntelIommuDmaSpace::create(iommu, domainId);
 	if(!spaceOutcome)
 		panicLogger() << "thor: Failed to create DMA space" << frg::endlog;
 	return frg::construct<IntelIommuDomain>(*kernelAlloc, domainId, std::move(*spaceOutcome));

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -884,7 +884,10 @@ HelError helCreateVirtualizedSpace(HelHandle *handle) {
 	PageAccessor paccessor{level0};
 	memset(paccessor.get(), 0, 0x4000);
 
-	smarter::shared_ptr<VirtualizedPageSpace> vspace = riscv_hypervisor::HypervisorSpace::create(level0);
+	auto vspaceOutcome = riscv_hypervisor::HypervisorSpace::create(level0);
+	if(!vspaceOutcome)
+		return translateError(vspaceOutcome.error());
+	smarter::shared_ptr<VirtualizedPageSpace> vspace = std::move(*vspaceOutcome);
 
 	*handle = this_universe->attachDescriptor(
 			AnyDescriptor::make<DescriptorType::virtualizedSpace>(std::move(vspace)));

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -844,26 +844,18 @@ HelError helCreateVirtualizedSpace(HelHandle *handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	PhysicalAddr pml4e = physicalAllocator->allocate(kPageSize);
-	if(pml4e == static_cast<PhysicalAddr>(-1)) {
-		return kHelErrNoMemory;
-	}
-	PageAccessor paccessor{pml4e};
-	memset(paccessor.get(), 0, kPageSize);
-
 	smarter::shared_ptr<VirtualizedPageSpace> vspace;
 	if(getGlobalCpuFeatures()->haveVmx) {
-		auto vspaceOutcome = thor::vmx::EptSpace::create(pml4e);
+		auto vspaceOutcome = thor::vmx::EptSpace::create();
 		if(!vspaceOutcome)
 			return translateError(vspaceOutcome.error());
 		vspace = std::move(*vspaceOutcome);
 	} else if(getGlobalCpuFeatures()->haveSvm) {
-		auto vspaceOutcome = thor::svm::NptSpace::create(pml4e);
+		auto vspaceOutcome = thor::svm::NptSpace::create();
 		if(!vspaceOutcome)
 			return translateError(vspaceOutcome.error());
 		vspace = std::move(*vspaceOutcome);
 	} else {
-		physicalAllocator->free(pml4e, kPageSize);
 		return kHelErrNoHardwareSupport;
 	}
 
@@ -877,14 +869,7 @@ HelError helCreateVirtualizedSpace(HelHandle *handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	PhysicalAddr level0 = physicalAllocator->allocate(0x4000);
-	if(level0 == static_cast<PhysicalAddr>(-1)) {
-		return kHelErrNoMemory;
-	}
-	PageAccessor paccessor{level0};
-	memset(paccessor.get(), 0, 0x4000);
-
-	auto vspaceOutcome = riscv_hypervisor::HypervisorSpace::create(level0);
+	auto vspaceOutcome = riscv_hypervisor::HypervisorSpace::create();
 	if(!vspaceOutcome)
 		return translateError(vspaceOutcome.error());
 	smarter::shared_ptr<VirtualizedPageSpace> vspace = std::move(*vspaceOutcome);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -853,7 +853,10 @@ HelError helCreateVirtualizedSpace(HelHandle *handle) {
 
 	smarter::shared_ptr<VirtualizedPageSpace> vspace;
 	if(getGlobalCpuFeatures()->haveVmx) {
-		vspace = thor::vmx::EptSpace::create(pml4e);
+		auto vspaceOutcome = thor::vmx::EptSpace::create(pml4e);
+		if(!vspaceOutcome)
+			return translateError(vspaceOutcome.error());
+		vspace = std::move(*vspaceOutcome);
 	} else if(getGlobalCpuFeatures()->haveSvm) {
 		vspace = thor::svm::NptSpace::create(pml4e);
 	} else {

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -917,10 +917,14 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 		if(!vcpuOutcome)
 			return translateError(vcpuOutcome.error());
 		vcpu = std::move(*vcpuOutcome);
-	} else if(getGlobalCpuFeatures()->haveSvm)
-		vcpu = smarter::allocate_shared<svm::Vcpu>(Allocator{}, (smarter::static_pointer_cast<thor::svm::NptSpace>(vspace)));
-	else
+	} else if(getGlobalCpuFeatures()->haveSvm) {
+		auto vcpuOutcome = svm::Vcpu::create(smarter::static_pointer_cast<thor::svm::NptSpace>(vspace));
+		if(!vcpuOutcome)
+			return translateError(vcpuOutcome.error());
+		vcpu = std::move(*vcpuOutcome);
+	} else {
 		return kHelErrNoHardwareSupport;
+	}
 
 	*out = this_universe->attachDescriptor(
 			AnyDescriptor::make<DescriptorType::virtualizedCpu>(std::move(vcpu)));

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -941,8 +941,11 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 		return translateError(vspaceOutcome.error());
 	auto vspace = std::move(*vspaceOutcome);
 
-	smarter::shared_ptr<VirtualizedCpu> vcpu = smarter::allocate_shared<riscv_hypervisor::Vcpu>(Allocator{},
+	auto vcpuOutcome = riscv_hypervisor::Vcpu::create(
 			smarter::static_pointer_cast<riscv_hypervisor::HypervisorSpace>(vspace));
+	if(!vcpuOutcome)
+		return translateError(vcpuOutcome.error());
+	smarter::shared_ptr<VirtualizedCpu> vcpu = std::move(*vcpuOutcome);
 
 	*out = this_universe->attachDescriptor(
 			AnyDescriptor::make<DescriptorType::virtualizedCpu>(std::move(vcpu)));

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -858,7 +858,10 @@ HelError helCreateVirtualizedSpace(HelHandle *handle) {
 			return translateError(vspaceOutcome.error());
 		vspace = std::move(*vspaceOutcome);
 	} else if(getGlobalCpuFeatures()->haveSvm) {
-		vspace = thor::svm::NptSpace::create(pml4e);
+		auto vspaceOutcome = thor::svm::NptSpace::create(pml4e);
+		if(!vspaceOutcome)
+			return translateError(vspaceOutcome.error());
+		vspace = std::move(*vspaceOutcome);
 	} else {
 		physicalAllocator->free(pml4e, kPageSize);
 		return kHelErrNoHardwareSupport;

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -912,9 +912,12 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 	auto vspace = std::move(*vspaceOutcome);
 
 	smarter::shared_ptr<VirtualizedCpu> vcpu;
-	if(getGlobalCpuFeatures()->haveVmx)
-		vcpu = smarter::allocate_shared<vmx::Vmcs>(Allocator{}, (smarter::static_pointer_cast<thor::vmx::EptSpace>(vspace)));
-	else if(getGlobalCpuFeatures()->haveSvm)
+	if(getGlobalCpuFeatures()->haveVmx) {
+		auto vcpuOutcome = vmx::Vmcs::create(smarter::static_pointer_cast<thor::vmx::EptSpace>(vspace));
+		if(!vcpuOutcome)
+			return translateError(vcpuOutcome.error());
+		vcpu = std::move(*vcpuOutcome);
+	} else if(getGlobalCpuFeatures()->haveSvm)
 		vcpu = smarter::allocate_shared<svm::Vcpu>(Allocator{}, (smarter::static_pointer_cast<thor::svm::NptSpace>(vspace)));
 	else
 		return kHelErrNoHardwareSupport;

--- a/kernel/thor/generic/thor-internal/iommu.hpp
+++ b/kernel/thor/generic/thor-internal/iommu.hpp
@@ -31,15 +31,20 @@ private:
 
 // A page space used specifically for DMA.
 struct DmaSpace : VirtualSpace {
+protected:
 	DmaSpace(VirtualOperations *ops)
 	: VirtualSpace{ops} { }
 };
 
 struct NoopDmaSpace final : DmaSpace {
-	NoopDmaSpace() : DmaSpace(&ops_) {}
+private:
+	struct CtorToken {};
 
-	static smarter::shared_ptr<NoopDmaSpace> create() {
-		auto ptr = smarter::allocate_shared<NoopDmaSpace>(*kernelAlloc);
+public:
+	NoopDmaSpace(CtorToken) : DmaSpace(&ops_) {}
+
+	static std::expected<smarter::shared_ptr<NoopDmaSpace>, Error> create() {
+		auto ptr = smarter::allocate_shared<NoopDmaSpace>(*kernelAlloc, CtorToken{});
 		ptr->selfPtr = ptr;
 		ptr->setupInitialHole(0, 1UL << 39);
 		return ptr;

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -2117,8 +2117,12 @@ void enumerateAll() {
 	if (!allDevices)
 		allDevices.initialize(*kernelAlloc);
 
-	if (!noopDmaSpace)
-		noopDmaSpace.initialize(NoopDmaSpace::create());
+	if (!noopDmaSpace) {
+		auto spaceOutcome = NoopDmaSpace::create();
+		if(!spaceOutcome)
+			panicLogger() << "thor: Failed to create DMA space" << frg::endlog;
+		noopDmaSpace.initialize(std::move(*spaceOutcome));
+	}
 
 	for(size_t i = 0; i < enumerationQueue->size(); i++) {
 		auto bus = (*enumerationQueue)[i];


### PR DESCRIPTION
Same as #1496 but for virtualization-related structs. The last two commits are cleanup to fix leaks on error paths.