### PR TITLE
thor: Parallelize Thor load-balancer ownership transfers

### DIFF
--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3733,12 +3733,7 @@ HelError helSetAffinity(HelHandle handle, uint8_t *mask, size_t size) {
 	if (!readUserArray(mask, buf.data(), size))
 		return kHelErrFault;
 
-	size_t n = 0;
-	for (auto i : buf) {
-		n += __builtin_popcount(i);
-	}
-
-	if (n < 1) {
+	if (LbControlBlock::findFirstCpu({buf.data(), maskSize}) == static_cast<size_t>(-1)) {
 		return kHelErrIllegalArgs;
 	}
 
@@ -3746,16 +3741,14 @@ HelError helSetAffinity(HelHandle handle, uint8_t *mask, size_t size) {
 	auto this_universe = this_thread->getUniverse();
 
 	if(handle == kHelThisThread) {
-		this_thread->_lbCb->setAffinityMask({buf.data(), maskSize});
-		Thread::migrateCurrent();
+		LoadBalancer::singleton().setAffinity(this_thread.get(), {buf.data(), maskSize});
 	} else {
 		auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle, kHelRightWrite);
 		if(!threadOutcome)
 			return translateError(threadOutcome.error());
 		auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 
-		thread->_lbCb->setAffinityMask({buf.data(), maskSize});
-		infoLogger() << "thor: TODO: helSetAffinity does not migrate other threads!" << frg::endlog;
+		LoadBalancer::singleton().setAffinity(thread.get(), {buf.data(), maskSize});
 	}
 
 	return kHelErrNone;

--- a/kernel/thor/generic/load-balancing.cpp
+++ b/kernel/thor/generic/load-balancing.cpp
@@ -66,8 +66,8 @@ void LoadBalancer::connect(Thread *thread, CpuData *cpu) {
 		auto lock = frg::guard(&node->mutex);
 
 		node->tasks.push_back(cb);
-		cb->node_.store(node, std::memory_order_release);
 		cb->setAssignedCpu(cpu);
+		cb->node_.store(node, std::memory_order_release);
 	}
 	thread->_lbCb = cb;
 }
@@ -115,8 +115,8 @@ void LoadBalancer::setAffinity(Thread *thread, frg::span<const uint8_t> mask) {
 				newNode->tasks.push_back(cb);
 				newNode->currentLoad += cb->load_;
 			}
-			cb->node_.store(newNode, std::memory_order_release);
 			cb->setAssignedCpu(assignedCpu);
+			cb->node_.store(newNode, std::memory_order_release);
 		});
 
 		cb->affinityUpdateActive_.store(false, std::memory_order_release);
@@ -398,8 +398,8 @@ void LoadBalancer::balanceBetween_(LbNode *srcNode, LbNode *dstNode, uint64_t id
 				srcNode->currentLoad -= cb->load_;
 				dstNode->tasks.push_back(cb);
 				dstNode->currentLoad += cb->load_;
-				cb->node_.store(dstNode, std::memory_order_release);
 				cb->setAssignedCpu(dstNode->cpu);
+				cb->node_.store(dstNode, std::memory_order_release);
 				committed[i] = true;
 			}
 		});

--- a/kernel/thor/generic/load-balancing.cpp
+++ b/kernel/thor/generic/load-balancing.cpp
@@ -369,6 +369,11 @@ void LoadBalancer::balanceBetween_(LbNode *srcNode, LbNode *dstNode, uint64_t id
 		}
 	}
 
+	// Most source/destination pairs are already balanced. Avoid taking both
+	// node locks in that steady-state case.
+	if(!numCandidates)
+		return;
+
 	// Revalidate and commit at most this one batch. Stale selections are
 	// rejected until the next balancing round instead of being retried.
 	{

--- a/kernel/thor/generic/load-balancing.cpp
+++ b/kernel/thor/generic/load-balancing.cpp
@@ -218,6 +218,10 @@ void LoadBalancer::balanceBetween_(LbNode *srcNode, LbNode *dstNode, uint64_t &n
 			cb->_assignedCpu.store(dstNode->cpu, std::memory_order_relaxed);
 			stolenTasks.push_back(cb);
 
+			// Notify the thread such that it eventually moves to its assigned CPU.
+			if (auto thread = cb->thread_.lock())
+				Thread::migrateOther(thread);
+
 			srcNode->currentLoad -= cb->load_;
 			newLoad += cb->load_;
 		}

--- a/kernel/thor/generic/load-balancing.cpp
+++ b/kernel/thor/generic/load-balancing.cpp
@@ -18,6 +18,25 @@ constexpr uint64_t lbDecayInterval = 1'000'000'000;
 
 frg::eternal<LoadBalancer> loadBalancer;
 
+template<typename F>
+void withOrderedNodeLocks(LbNode *a, LbNode *b, F &&f) {
+	if(a == b) {
+		auto lock = frg::guard(&a->mutex);
+		f();
+		return;
+	}
+
+	if(a->cpu->cpuIndex < b->cpu->cpuIndex) {
+		auto aLock = frg::guard(&a->mutex);
+		auto bLock = frg::guard(&b->mutex);
+		f();
+	} else {
+		auto bLock = frg::guard(&b->mutex);
+		auto aLock = frg::guard(&a->mutex);
+		f();
+	}
+}
+
 } // namespace
 
 THOR_DEFINE_PERCPU(lbNode);
@@ -39,17 +58,73 @@ void LoadBalancer::connect(Thread *thread, CpuData *cpu) {
 	assert(!thread->_lbCb);
 	auto *node = &lbNode.get(cpu);
 
-	auto cb = frg::construct<LbControlBlock>(*kernelAlloc, thread, node);
-	cb->_assignedCpu.store(cpu, std::memory_order_relaxed);
-	thread->_lbCb = cb;
+	auto cb = frg::construct<LbControlBlock>(*kernelAlloc, thread);
 
-	// The LbControlBlock is now owned by the node.
+	// Publish the control block only after its initial list membership exists.
 	{
 		auto irqLock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&node->mutex);
 
 		node->tasks.push_back(cb);
+		cb->node_.store(node, std::memory_order_release);
+		cb->setAssignedCpu(cpu);
 	}
+	thread->_lbCb = cb;
+}
+
+void LoadBalancer::setAffinity(Thread *thread, frg::span<const uint8_t> mask) {
+	assert(thread->_lbCb);
+	assert(mask.size() == LbControlBlock::affinityMaskSize());
+	assert(LbControlBlock::findFirstCpu(mask) != static_cast<size_t>(-1));
+
+	auto *cb = thread->_lbCb;
+	{
+		auto irqLock = frg::guard(&irqMutex());
+		auto setterLock = frg::guard(&cb->affinitySetterMutex_);
+		cb->affinityUpdateActive_.store(true, std::memory_order_release);
+
+		// Wait out a balancing commit that passed its active check immediately
+		// before the setter published the flag. Do not carry this lock into the
+		// node acquisition below.
+		{
+			auto metadataLock = frg::guard(&cb->mutex_);
+		}
+
+		auto *oldNode = cb->getNode();
+		auto *oldAssignedCpu = cb->getAssignedCpu();
+		auto *assignedCpu = oldAssignedCpu;
+		if(!assignedCpu || !(mask[assignedCpu->cpuIndex / 8]
+				& (1 << (assignedCpu->cpuIndex % 8))))
+			assignedCpu = getCpuData(LbControlBlock::findFirstCpu(mask));
+		auto *newNode = &lbNode.get(assignedCpu);
+
+		withOrderedNodeLocks(oldNode, newNode, [&] {
+			auto metadataLock = frg::guard(&cb->mutex_);
+
+			// The setter mutex and quiescence barrier make either mismatch a
+			// protocol violation rather than a retry case.
+			assert(cb->getNode() == oldNode);
+			assert(cb->getAssignedCpu() == oldAssignedCpu);
+			assert(cb->affinityUpdateActive_.load(std::memory_order_acquire));
+
+			cb->setAffinityMaskLocked(mask);
+			assert(oldNode->currentLoad >= cb->load_);
+			if(oldNode != newNode) {
+				oldNode->tasks.erase(oldNode->tasks.iterator_to(cb));
+				oldNode->currentLoad -= cb->load_;
+				newNode->tasks.push_back(cb);
+				newNode->currentLoad += cb->load_;
+			}
+			cb->node_.store(newNode, std::memory_order_release);
+			cb->setAssignedCpu(assignedCpu);
+		});
+
+		cb->affinityUpdateActive_.store(false, std::memory_order_release);
+	}
+
+	// Raising a condition takes the thread mutex, while accounting can take it
+	// after a node mutex. Keep this outside of all load-balancer locks.
+	Thread::migrateOther(thread->self);
 }
 
 coroutine<void> LoadBalancer::run_(CpuData *cpu) {
@@ -57,6 +132,13 @@ coroutine<void> LoadBalancer::run_(CpuData *cpu) {
 
 	bool joined = false;
 	uint64_t lastDecay = getClockNanos();
+	size_t balanceOffset = 1;
+	struct AccountingEntry {
+		LbControlBlock *cb;
+		smarter::shared_ptr<Thread> thread;
+		uint64_t load;
+	};
+	frg::vector<AccountingEntry, KernelAlloc> entries{*kernelAlloc};
 
 	while(true) {
 		// Global barrier to wait for initiation of load balancing.
@@ -89,6 +171,9 @@ coroutine<void> LoadBalancer::run_(CpuData *cpu) {
 				&LbControlBlock::hook_
 			>
 		> staleCbs;
+		// Size the snapshot without retaining the node lock across allocation.
+		entries.resize(0);
+		size_t snapshotCapacity = 0;
 		{
 			auto irqLock = frg::guard(&irqMutex());
 			auto lock = frg::guard(&thisNode->mutex);
@@ -107,17 +192,59 @@ coroutine<void> LoadBalancer::run_(CpuData *cpu) {
 					staleCbs.push_back(cb);
 					continue;
 				}
+				++snapshotCapacity;
+			}
+		}
+		entries.resize(snapshotCapacity);
 
-				thread->updateLoad();
-				if (applyDecay)
-					thread->decayLoad(lbDecay, 8);
-				cb->load_ = thread->loadLevel();
-				load += cb->load_;
+		// Pin a best-effort snapshot. Threads that arrive after sizing retain
+		// their previous load until the next round.
+		size_t numEntries = 0;
+		{
+			auto irqLock = frg::guard(&irqMutex());
+			auto lock = frg::guard(&thisNode->mutex);
+
+			for(auto *cb : thisNode->tasks) {
+				if(numEntries == entries.size())
+					break;
+				if(auto thread = cb->thread_.lock())
+					entries[numEntries++] = AccountingEntry{cb, std::move(thread), 0};
 			}
 		}
 
-		thisNode->totalLoad = load;
-		thisNode->currentLoad = load;
+		// Thread load updates take Thread::_mutex. Keep them outside of the node
+		// lock so affinity changes and ownership commits are not serialized here.
+		for(size_t i = 0; i < numEntries; ++i) {
+			entries[i].thread->updateLoad(applyDecay, lbDecay, 8);
+			entries[i].load = entries[i].thread->loadLevel();
+		}
+
+		{
+			auto irqLock = frg::guard(&irqMutex());
+			auto lock = frg::guard(&thisNode->mutex);
+
+			for(size_t i = 0; i < numEntries; ++i)
+				if(entries[i].cb->getNode() == thisNode)
+					entries[i].cb->load_ = entries[i].load;
+
+			auto it = thisNode->tasks.begin();
+			while(it != thisNode->tasks.end()) {
+				auto currentIt = it++;
+				auto *cb = *currentIt;
+				if(!cb->thread_.lock()) {
+					thisNode->tasks.erase(currentIt);
+					staleCbs.push_back(cb);
+					continue;
+				}
+				load += cb->load_;
+			}
+
+			// This is an accounting snapshot. Transfers keep currentLoad live,
+			// while totalLoad is only used to derive this round's ideal load.
+			thisNode->totalLoad = load;
+			thisNode->currentLoad = load;
+		}
+		entries.resize(0);
 
 		// Destroy stale CBs outside of locks.
 		while(!staleCbs.empty())
@@ -129,27 +256,29 @@ coroutine<void> LoadBalancer::run_(CpuData *cpu) {
 		// Global barrier to wait until all CPUs know their load level.
 		co_await barrier_.async_wait(barrier_.arrive());
 
-		// Sum load of all CPUs.
-		// TODO: Doing this on all CPUs is unnecessary. However, it is also reasonably fast
-		//       and might be preferable over synchronization overhead.
-		uint64_t systemLoad = 0;
-		for (size_t i = 0; i < getCpuCount(); ++i)
-			systemLoad += lbNode.getFor(i).totalLoad;
+		// Sum load once, then publish it to all CPUs through the barrier.
+		if (!cpu->cpuIndex) {
+			systemLoad_ = 0;
+			for (size_t i = 0; i < getCpuCount(); ++i)
+				systemLoad_ += lbNode.getFor(i).totalLoad;
+		}
+		co_await barrier_.async_wait(barrier_.arrive());
+
+		auto systemLoad = systemLoad_;
 		uint64_t idealLoad = systemLoad / getCpuCount();
 		if (debugLb && cpu == getCpuData(0))
 			infoLogger() << "Total system load is " << systemLoad
 					<< " (ideal load: " << idealLoad << ")" << frg::endlog;
 
-		if (enableLb) {
-			// Distribute load from other CPUs to this CPU.
-			// TODO: This loop probably does not scale very well since all CPUs try to pull from
-			//       all other CPUs in the same order (and this can cause lock contention).
-			uint64_t newLoad = thisNode->totalLoad;
-			for (size_t i = 0; i < getCpuCount(); ++i) {
-				auto *toCpu = getCpuData(i);
-				if (cpu != toCpu)
-					balanceBetween_(&lbNode.get(toCpu), thisNode, newLoad, idealLoad);
-			}
+		auto numCpus = getCpuCount();
+		if (enableLb && numCpus > 1) {
+			// Visit one source per destination and round. Rotating the offset covers
+			// every directed CPU pair over numCpus - 1 rounds without quadratic work.
+			auto sourceIndex = (cpu->cpuIndex + balanceOffset) % numCpus;
+			balanceBetween_(&lbNode.getFor(sourceIndex), thisNode, idealLoad);
+
+			if (++balanceOffset == numCpus)
+				balanceOffset = 1;
 		}
 
 		// Balance load again after some time has passed.
@@ -161,7 +290,7 @@ coroutine<void> LoadBalancer::run_(CpuData *cpu) {
 	co_return;
 }
 
-void LoadBalancer::balanceBetween_(LbNode *srcNode, LbNode *dstNode, uint64_t &newLoad, uint64_t idealLoad) {
+void LoadBalancer::balanceBetween_(LbNode *srcNode, LbNode *dstNode, uint64_t idealLoad) {
 	auto improvesBalance = [] (uint64_t srcLoad, uint64_t dstLoad, uint64_t stolenLoad) -> bool {
 		uint64_t srcLoadPostMove = srcLoad - stolenLoad;
 		uint64_t dstLoadPostMove = dstLoad + stolenLoad;
@@ -171,75 +300,116 @@ void LoadBalancer::balanceBetween_(LbNode *srcNode, LbNode *dstNode, uint64_t &n
 		return maxLoadPostMove < maxLoad;
 	};
 
-	// Remove tasks from srcNode, put them into a temporary list.
-	frg::intrusive_list<
-		LbControlBlock,
-		frg::locate_member<
-			LbControlBlock,
-			frg::default_list_hook<LbControlBlock>,
-			&LbControlBlock::hook_
-		>
-	> stolenTasks;
+	// Tunable: maximum tasks considered for one CPU-pair commit. Larger batches
+	// can converge faster, at the cost of stack space and longer lock hold times.
+	constexpr size_t candidateCapacity = 8;
+	// Tunable: maximum source-list entries inspected per CPU-pair pass. Larger
+	// scans find sparse candidates sooner but increase IRQ-disabled lock time.
+	constexpr size_t scanCapacity = 64;
+	struct Candidate {
+		LbControlBlock *cb;
+		smarter::shared_ptr<Thread> thread;
+	};
+	frg::array<Candidate, candidateCapacity> candidates;
+	frg::array<bool, candidateCapacity> committed{};
+	size_t numCandidates = 0;
+
+	uint64_t simulatedDstLoad = 0;
 	{
 		auto irqLock = frg::guard(&irqMutex());
-		auto lock = frg::guard(&srcNode->mutex);
+		auto dstLock = frg::guard(&dstNode->mutex);
+		simulatedDstLoad = dstNode->currentLoad;
+	}
 
-		auto it = srcNode->tasks.begin();
-		while (it != srcNode->tasks.end()) {
-			auto currentIt = it;
-			auto *cb = *currentIt;
-			++it;
+	// Select a bounded batch under only the source node lock. Strong thread
+	// references pin selected control blocks through notification below. Rotate
+	// visited entries to keep later entries reachable across bounded scans.
+	{
+		auto irqLock = frg::guard(&irqMutex());
+		auto srcLock = frg::guard(&srcNode->mutex);
+		auto simulatedSrcLoad = srcNode->currentLoad;
+		auto *first = srcNode->tasks.empty() ? nullptr : srcNode->tasks.front();
+		size_t numScanned = 0;
 
+		while (!srcNode->tasks.empty() && numScanned < scanCapacity) {
 			// Do not attempt to do load balancing if source and destination are both
 			// undersubscribed. While it may still be possible to improve the balance,
 			// it is probably not worth it in terms of effort and cache degradation.
-			if (srcNode->currentLoad < idealLoad && newLoad < idealLoad)
+			if (simulatedSrcLoad < idealLoad && simulatedDstLoad < idealLoad)
+				break;
+
+			auto *cb = srcNode->tasks.pop_front();
+			srcNode->tasks.push_back(cb);
+			if(numScanned++ && cb == first)
 				break;
 
 			// Do not move threads with tiny contributions to the total load.
 			if (!cb->load_)
 				continue;
 
-			if (!cb->inAffinityMask(dstNode->cpu->cpuIndex))
+			if (cb->affinityUpdateActive_.load(std::memory_order_acquire))
 				continue;
 
-			if (!improvesBalance(srcNode->currentLoad, newLoad, cb->load_))
+			auto metadataLock = frg::guard(&cb->mutex_);
+			if (cb->affinityUpdateActive_.load(std::memory_order_acquire))
+				continue;
+			if (!cb->inAffinityMaskLocked(dstNode->cpu->cpuIndex))
+				continue;
+			if (!improvesBalance(simulatedSrcLoad, simulatedDstLoad, cb->load_))
 				continue;
 
-			if (debugLb)
-				infoLogger() << "Moving thread with load " << cb->load_
-						<< " from CPU " << srcNode->cpu->cpuIndex
-						<< " to CPU " << dstNode->cpu->cpuIndex << frg::endlog;
-
-			// Move ownership from srcNode to dstNode.
-			assert(cb->node_ == srcNode);
-			srcNode->tasks.erase(currentIt);
-			cb->node_ = dstNode;
-			cb->_assignedCpu.store(dstNode->cpu, std::memory_order_relaxed);
-			stolenTasks.push_back(cb);
-
-			// Notify the thread such that it eventually moves to its assigned CPU.
-			if (auto thread = cb->thread_.lock())
-				Thread::migrateOther(thread);
-
-			srcNode->currentLoad -= cb->load_;
-			newLoad += cb->load_;
+			if(auto thread = cb->thread_.lock()) {
+				assert(numCandidates < candidateCapacity);
+				candidates[numCandidates++] = Candidate{cb, std::move(thread)};
+				simulatedSrcLoad -= cb->load_;
+				simulatedDstLoad += cb->load_;
+				if(numCandidates == candidateCapacity)
+					break;
+			}
 		}
 	}
 
-	// Notify the threads such that they eventually move to their assigned CPUs.
-	for (auto *cb : stolenTasks) {
-		if (auto thread = cb->thread_.lock())
-			Thread::migrateOther(thread);
-	}
-
-	// Add tasks from temporary list to dstNode.
+	// Revalidate and commit at most this one batch. Stale selections are
+	// rejected until the next balancing round instead of being retried.
 	{
 		auto irqLock = frg::guard(&irqMutex());
-		auto lock = frg::guard(&dstNode->mutex);
+		withOrderedNodeLocks(srcNode, dstNode, [&] {
+			for(size_t i = 0; i < numCandidates; ++i) {
+				auto *cb = candidates[i].cb;
+				auto metadataLock = frg::guard(&cb->mutex_);
 
-		dstNode->tasks.splice(dstNode->tasks.end(), stolenTasks);
+				if(cb->affinityUpdateActive_.load(std::memory_order_acquire))
+					continue;
+				if(cb->getNode() != srcNode || !cb->load_)
+					continue;
+				if(!cb->inAffinityMaskLocked(dstNode->cpu->cpuIndex))
+					continue;
+				if(srcNode->currentLoad < cb->load_)
+					panicLogger() << "thor: load-balancer source load underflow" << frg::endlog;
+				if(!improvesBalance(srcNode->currentLoad, dstNode->currentLoad, cb->load_))
+					continue;
+
+				if(debugLb)
+					infoLogger() << "Moving thread with load " << cb->load_
+							<< " from CPU " << srcNode->cpu->cpuIndex
+							<< " to CPU " << dstNode->cpu->cpuIndex << frg::endlog;
+
+				srcNode->tasks.erase(srcNode->tasks.iterator_to(cb));
+				srcNode->currentLoad -= cb->load_;
+				dstNode->tasks.push_back(cb);
+				dstNode->currentLoad += cb->load_;
+				cb->node_.store(dstNode, std::memory_order_release);
+				cb->setAssignedCpu(dstNode->cpu);
+				committed[i] = true;
+			}
+		});
 	}
+
+	// migrateOther() can take Thread::_mutex; do not invert accounting's
+	// node -> Thread::_mutex order.
+	for(size_t i = 0; i < numCandidates; ++i)
+		if(committed[i])
+			Thread::migrateOther(candidates[i].thread);
 }
 
 } // namespace thor

--- a/kernel/thor/generic/thor-internal/load-balancing.hpp
+++ b/kernel/thor/generic/thor-internal/load-balancing.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <async/barrier.hpp>
+#include <frg/array.hpp>
 #include <frg/span.hpp>
 #include <thor-internal/coroutine.hpp>
 #include <thor-internal/cpu-data.hpp>
@@ -19,15 +20,23 @@ struct LbControlBlock {
 		return (getCpuCount() + 7) / 8;
 	}
 
-	LbControlBlock(Thread *thread, LbNode *node)
-	: thread_{thread->self.lock()}, node_{node}, affinityMask_{*kernelAlloc} {
+	LbControlBlock(Thread *thread)
+	: thread_{thread->self.lock()}, affinityMask_{*kernelAlloc} {
 		affinityMask_.resize(affinityMaskSize());
 		for (size_t i = 0; i < getCpuCount(); ++i)
 			affinityMask_[i / 8] |= (1 << (i % 8));
 	}
 
 	CpuData *getAssignedCpu() {
-		return _assignedCpu.load(std::memory_order_relaxed);
+		return _assignedCpu.load(std::memory_order_acquire);
+	}
+
+	void setAssignedCpu(CpuData *cpu) {
+		_assignedCpu.store(cpu, std::memory_order_release);
+	}
+
+	LbNode *getNode() {
+		return node_.load(std::memory_order_acquire);
 	}
 
 	// Precondition: mask.size() == affinityMaskSize().
@@ -35,8 +44,7 @@ struct LbControlBlock {
 		auto irqLock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&mutex_);
 
-		assert(affinityMask_.size() == mask.size());
-		memcpy(mask.data(), affinityMask_.data(), affinityMaskSize());
+		getAffinityMaskLocked(mask);
 	}
 
 	// Precondition: mask.size() == affinityMaskSize().
@@ -45,16 +53,21 @@ struct LbControlBlock {
 		auto irqLock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&mutex_);
 
-		assert(affinityMask_.size() == mask.size());
-		assert(std::any_of(mask.begin(), mask.end(), [] (uint8_t x) -> bool { return x; }));
-		memcpy(affinityMask_.data(), mask.data(), affinityMaskSize());
+		setAffinityMaskLocked(mask);
 	}
 
 	bool inAffinityMask(size_t cpuIndex) {
 		auto irqLock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&mutex_);
 
-		return affinityMask_[cpuIndex / 8] & (1 << (cpuIndex % 8));
+		return inAffinityMaskLocked(cpuIndex);
+	}
+
+	static size_t findFirstCpu(frg::span<const uint8_t> mask) {
+		for(size_t i = 0; i < getCpuCount(); ++i)
+			if(mask[i / 8] & (1 << (i % 8)))
+				return i;
+		return static_cast<size_t>(-1);
 	}
 
 private:
@@ -65,8 +78,9 @@ private:
 	// Not necessarily the CPU that the thread runs on currently.
 	std::atomic<CpuData *> _assignedCpu{nullptr};
 
-	// Protected by the LbNode that currently owns the node.
-	LbNode *node_{nullptr};
+	// Advisory ownership snapshot. List membership under the expected node's
+	// mutex is authoritative.
+	std::atomic<LbNode *> node_{nullptr};
 
 	// Protected by the LbNode that currently owns the node.
 	frg::default_list_hook<LbControlBlock> hook_;
@@ -75,12 +89,34 @@ private:
 	// Protected by the LbNode that currently owns the node.
 	uint64_t load_{0};
 
-	// Protects members that can be written by public functions.
-	// Note that this mutex does not protect assigendCpu_, node_, hook_, load_ etc.
+	// Serializes explicit affinity setters for this control block.
+	frg::ticket_spinlock affinitySetterMutex_;
+
+	// Set while an explicit setter owns affinitySetterMutex_. Automatic
+	// balancing rejects active control blocks instead of waiting on them.
+	std::atomic<bool> affinityUpdateActive_{false};
+
+	// Protects affinityMask_. Ownership transactions acquire this after their
+	// node locks. It does not protect assignedCpu_, node_, hook_ or load_.
 	frg::ticket_spinlock mutex_;
 
-	// Protected by mutex_;
+	// Protected by mutex_.
 	frg::vector<uint8_t, KernelAlloc> affinityMask_;
+
+	void getAffinityMaskLocked(frg::span<uint8_t> mask) {
+		assert(affinityMask_.size() == mask.size());
+		memcpy(mask.data(), affinityMask_.data(), affinityMaskSize());
+	}
+
+	void setAffinityMaskLocked(frg::span<const uint8_t> mask) {
+		assert(affinityMask_.size() == mask.size());
+		assert(findFirstCpu(mask) != static_cast<size_t>(-1));
+		memcpy(affinityMask_.data(), mask.data(), affinityMaskSize());
+	}
+
+	bool inAffinityMaskLocked(size_t cpuIndex) {
+		return affinityMask_[cpuIndex / 8] & (1 << (cpuIndex % 8));
+	}
 };
 
 // Per-CPU load balancing data structure.
@@ -99,11 +135,10 @@ struct LbNode {
 		>
 	> tasks;
 
-	// Constant during main phase of load balancing.
+	// Protected accounting snapshot used to derive ideal load.
 	uint64_t totalLoad{0};
 
-	// Equal to totalLoad before load balancing but updated during load balancing.
-	// Protected by mutex during main phase of load balancing.
+	// Live list ownership accounting. Protected by mutex.
 	uint64_t currentLoad{0};
 };
 
@@ -125,14 +160,18 @@ struct LoadBalancer {
 	// The thread is detached from the load balancer when the weak reference goes out of scope.
 	void connect(Thread *thread, CpuData *cpu);
 
+	// Synchronously commit affinity metadata and ownership, then request an
+	// asynchronous migration at the next return-to-user condition point.
+	void setAffinity(Thread *thread, frg::span<const uint8_t> mask);
+
 private:
 	coroutine<void> run_(CpuData *cpu);
 
-	// Move tasks from srcNode to dstNode to balance load.
-	// newLoad: newLoad at dstNode after balancing.
-	void balanceBetween_(LbNode *srcNode, LbNode *dstNode, uint64_t &newLoad, uint64_t idealLoad);
+	// Move a bounded batch of tasks from srcNode to dstNode to balance load.
+	void balanceBetween_(LbNode *srcNode, LbNode *dstNode, uint64_t idealLoad);
 
 	async::barrier barrier_;
+	uint64_t systemLoad_{0};
 };
 
 } // namespace thor

--- a/kernel/thor/generic/thor-internal/thread.hpp
+++ b/kernel/thor/generic/thor-internal/thread.hpp
@@ -270,7 +270,6 @@ public:
 
 	// If any conditions in checkedConditions is set, we do not block.
 	static void blockCurrent(Condition checkedConditions);
-	static void migrateCurrent();
 	static void deferCurrent();
 	static void deferCurrent(IrqImageAccessor image);
 	static void suspendCurrent(IrqImageAccessor image);
@@ -518,10 +517,8 @@ public:
 	// Load level of the thread.
 	std::atomic<uint64_t> _loadLevel{0};
 
-	// Update the load factor.
-	void updateLoad();
-	// Called periodically by load balancing code.
-	void decayLoad(uint64_t decayFactor, int decayScale);
+	// Update the load factor and optionally decay its history.
+	void updateLoad(bool applyDecay, uint64_t decayFactor, int decayScale);
 
 	// Return the load factor.
 	uint64_t loadLevel() {

--- a/kernel/thor/generic/thread.cpp
+++ b/kernel/thor/generic/thread.cpp
@@ -26,57 +26,6 @@ namespace {
 // Thread
 // --------------------------------------------------------
 
-void Thread::migrateCurrent() {
-	assert(currentIpl() < ipl::noSchedule);
-
-	auto this_thread = getCurrentThread().get();
-	auto maskSize = LbControlBlock::affinityMaskSize();
-
-	frg::vector<uint8_t, KernelAlloc> mask{*kernelAlloc};
-	mask.resize(maskSize);
-	this_thread->_lbCb->getAffinityMask({mask.data(), maskSize});
-
-	StatelessIrqLock irq_lock;
-	auto lock = frg::guard(&this_thread->_mutex);
-
-	assert(this_thread->_runState == kRunActive);
-	localScheduler.get().update();
-	Scheduler::suspendCurrent();
-	this_thread->_updateRunTime();
-	this_thread->_runState = kRunDeferred;
-	this_thread->_uninvoke();
-
-	Scheduler::unassociate(this_thread);
-
-	size_t n = -1;
-	for (size_t i = 0; i < getCpuCount(); i++) {
-		bool bit = 0;
-		if (i / 8 < mask.size())
-			bit = mask[i / 8] & (1 << (i % 8));
-
-		if (bit) {
-			n = i;
-			break;
-		}
-	}
-	// Affinity masks are guaranteed to not be all zeros.
-	assert(n != static_cast<size_t>(-1));
-
-	auto *new_scheduler = &localScheduler.getFor(n);
-
-	Scheduler::associate(this_thread, new_scheduler);
-	Scheduler::resume(this_thread);
-	localScheduler.get().forceReschedule();
-
-	forkExecutor([&] {
-		runOnStack([] (Continuation cont, Executor *executor, frg::unique_lock<Mutex> lock) {
-			scrubStack(executor, cont);
-			lock.unlock();
-			localScheduler.get().commitReschedule();
-		}, getCpuData()->detachedStack.base(), &this_thread->_executor, std::move(lock));
-	}, &this_thread->_executor);
-}
-
 void Thread::blockCurrent(Condition checkedConditions) {
 	assert(currentIpl() < ipl::noSchedule);
 
@@ -783,7 +732,7 @@ void Thread::AssociatedWorkQueue::wakeup() {
 	}
 }
 
-void Thread::updateLoad() {
+void Thread::updateLoad(bool applyDecay, uint64_t decayFactor, int decayScale) {
 	auto irqLock = frg::guard(&irqMutex());
 	auto lock = frg::guard(&_mutex);
 
@@ -794,17 +743,14 @@ void Thread::updateLoad() {
 	if (_loadRunnable)
 		factor = (_loadRunnable << loadShift) / (_loadRunnable + _loadNotRunnable);
 	_loadLevel.store(factor, std::memory_order_relaxed);
-}
-
-void Thread::decayLoad(uint64_t decayFactor, int decayScale) {
-	auto irqLock = frg::guard(&irqMutex());
-	auto lock = frg::guard(&_mutex);
 
 	// Apply a decay factor. Since this affects both numerator and denominator of the load level,
 	// the load level is not immediately affected by this decay.
-	auto decayTime = [&] (uint64_t t) -> uint64_t { return (t * decayFactor) >> decayScale; };
-	_loadRunnable = decayTime(_loadRunnable);
-	_loadNotRunnable = decayTime(_loadNotRunnable);
+	if(applyDecay) {
+		auto decayTime = [&] (uint64_t t) -> uint64_t { return (t * decayFactor) >> decayScale; };
+		_loadRunnable = decayTime(_loadRunnable);
+		_loadNotRunnable = decayTime(_loadNotRunnable);
+	}
 }
 
 } // namespace thor

--- a/testsuites/kernel-tests/meson.build
+++ b/testsuites/kernel-tests/meson.build
@@ -1,6 +1,7 @@
 executable('kernel-tests',
 	[
 		'src/main.cpp',
+		'src/affinity.cpp',
 		'src/faults.cpp',
 		'src/mapping.cpp',
 		'src/memory.cpp',

--- a/testsuites/kernel-tests/src/affinity.cpp
+++ b/testsuites/kernel-tests/src/affinity.cpp
@@ -30,15 +30,12 @@ int stoppedThreadPark = 0;
 	// helGetCurrentCpu() samples before its return path consumes cpuMigration.
 	stoppedThreadFirstCpu[index].store(cpu, std::memory_order_release);
 
-	for(size_t i = 0; i < 10'000; ++i) {
-		assert(helYield() == kHelErrNone);
-		assert(helGetCurrentCpu(&cpu) == kHelErrNone);
-		if(cpu == stoppedThreadTargetCpu.load(std::memory_order_acquire)) {
-			stoppedThreadFinalCpu[index].store(cpu, std::memory_order_release);
-			stoppedThreadDone.fetch_add(1, std::memory_order_release);
-			break;
-		}
-	}
+	// The first syscall's return path consumes cpuMigration. Yield once to
+	// reach a subsequent safe point, then sample the CPU after that migration.
+	assert(helYield() == kHelErrNone);
+	assert(helGetCurrentCpu(&cpu) == kHelErrNone);
+	stoppedThreadFinalCpu[index].store(cpu, std::memory_order_release);
+	stoppedThreadDone.fetch_add(1, std::memory_order_release);
 
 	while(true)
 		assert(helFutexWait(&stoppedThreadPark, 0, -1) == kHelErrNone);
@@ -105,7 +102,7 @@ DEFINE_TEST(affinity_stopped_thread, ([] {
 	for(auto thread : threads)
 		assert(helResume(thread) == kHelErrNone);
 
-	for(size_t i = 0; i < 10'000
+	for(size_t i = 0; i < 1'000'000
 			&& stoppedThreadDone.load(std::memory_order_acquire) != stoppedThreadCount; ++i)
 		assert(helYield() == kHelErrNone);
 	assert(stoppedThreadDone.load(std::memory_order_acquire) == stoppedThreadCount);

--- a/testsuites/kernel-tests/src/affinity.cpp
+++ b/testsuites/kernel-tests/src/affinity.cpp
@@ -12,25 +12,30 @@
 namespace {
 
 constexpr size_t testStackSize = 64 * 1024;
-alignas(16) std::array<std::byte, testStackSize> stoppedThreadStack;
-std::atomic<int> stoppedThreadFirstCpu{-1};
-std::atomic<int> stoppedThreadFinalCpu{-1};
-std::atomic<bool> stoppedThreadDone{false};
+constexpr size_t stoppedThreadCount = 2;
+alignas(16) std::array<std::byte, testStackSize> stoppedThreadStacks[stoppedThreadCount];
+std::atomic<size_t> stoppedThreadStarts{0};
+std::atomic<size_t> stoppedThreadDone{0};
+std::atomic<int> stoppedThreadFirstCpu[stoppedThreadCount];
+std::atomic<int> stoppedThreadFinalCpu[stoppedThreadCount];
 std::atomic<int> stoppedThreadTargetCpu{-1};
 int stoppedThreadPark = 0;
 
 [[noreturn]] void stoppedThreadEntry() {
+	auto index = stoppedThreadStarts.fetch_add(1, std::memory_order_relaxed);
+	assert(index < stoppedThreadCount);
+
 	int cpu = -1;
 	assert(helGetCurrentCpu(&cpu) == kHelErrNone);
 	// helGetCurrentCpu() samples before its return path consumes cpuMigration.
-	stoppedThreadFirstCpu.store(cpu, std::memory_order_release);
+	stoppedThreadFirstCpu[index].store(cpu, std::memory_order_release);
 
 	for(size_t i = 0; i < 10'000; ++i) {
 		assert(helYield() == kHelErrNone);
 		assert(helGetCurrentCpu(&cpu) == kHelErrNone);
 		if(cpu == stoppedThreadTargetCpu.load(std::memory_order_acquire)) {
-			stoppedThreadFinalCpu.store(cpu, std::memory_order_release);
-			stoppedThreadDone.store(true, std::memory_order_release);
+			stoppedThreadFinalCpu[index].store(cpu, std::memory_order_release);
+			stoppedThreadDone.fetch_add(1, std::memory_order_release);
 			break;
 		}
 	}
@@ -39,8 +44,8 @@ int stoppedThreadPark = 0;
 		assert(helFutexWait(&stoppedThreadPark, 0, -1) == kHelErrNone);
 }
 
-void *stoppedThreadStackTop() {
-	auto top = reinterpret_cast<uintptr_t>(stoppedThreadStack.data() + testStackSize);
+void *stoppedThreadStackTop(size_t index) {
+	auto top = reinterpret_cast<uintptr_t>(stoppedThreadStacks[index].data() + testStackSize);
 	top &= ~uintptr_t{0xF};
 	top -= sizeof(uintptr_t);
 	*reinterpret_cast<uintptr_t *>(top) = 0;
@@ -65,36 +70,50 @@ DEFINE_TEST(affinity_stopped_thread, ([] {
 			== kHelErrNone);
 	assert(actualSize > 0 && actualSize <= allowedMask.size());
 
-	int initialCpu = -1;
-	assert(helGetCurrentCpu(&initialCpu) == kHelErrNone);
 	int targetCpu = -1;
-	for(size_t i = 0; i < actualSize * 8; ++i)
-		if((allowedMask[i / 8] & (1 << (i % 8))) && static_cast<int>(i) != initialCpu) {
-			targetCpu = static_cast<int>(i);
-			break;
+	bool hasOtherCpu = false;
+	for(size_t i = 0; i < actualSize * 8; ++i) {
+		if(allowedMask[i / 8] & (1 << (i % 8))) {
+			if(targetCpu < 0) {
+				targetCpu = static_cast<int>(i);
+			} else {
+				hasOtherCpu = true;
+			}
 		}
-	// There is no distinct target CPU on UP systems.
-	if(targetCpu < 0)
+	}
+	// There is no distinct initial CPU to test against on UP systems.
+	if(!hasOtherCpu)
 		return;
 
 	std::array<uint8_t, 128> targetMask{};
 	targetMask[targetCpu / 8] = static_cast<uint8_t>(1 << (targetCpu % 8));
-	stoppedThreadFirstCpu.store(-1, std::memory_order_relaxed);
-	stoppedThreadFinalCpu.store(-1, std::memory_order_relaxed);
-	stoppedThreadDone.store(false, std::memory_order_relaxed);
+	stoppedThreadStarts.store(0, std::memory_order_relaxed);
+	stoppedThreadDone.store(0, std::memory_order_relaxed);
+	for(size_t i = 0; i < stoppedThreadCount; ++i) {
+		stoppedThreadFirstCpu[i].store(-1, std::memory_order_relaxed);
+		stoppedThreadFinalCpu[i].store(-1, std::memory_order_relaxed);
+	}
 	stoppedThreadTargetCpu.store(targetCpu, std::memory_order_release);
 
-	HelHandle thread;
-	assert(helCreateThread(kHelNullHandle, kHelNullHandle, kHelAbiSystemV,
-			reinterpret_cast<void *>(stoppedThreadEntry), stoppedThreadStackTop(),
-			kHelThreadStopped, &thread) == kHelErrNone);
-	assert(helSetAffinity(thread, targetMask.data(), actualSize) == kHelErrNone);
-	assert(helResume(thread) == kHelErrNone);
+	std::array<HelHandle, stoppedThreadCount> threads;
+	for(size_t i = 0; i < stoppedThreadCount; ++i) {
+		assert(helCreateThread(kHelNullHandle, kHelNullHandle, kHelAbiSystemV,
+				reinterpret_cast<void *>(stoppedThreadEntry), stoppedThreadStackTop(i),
+				kHelThreadStopped, &threads[i]) == kHelErrNone);
+		assert(helSetAffinity(threads[i], targetMask.data(), actualSize) == kHelErrNone);
+	}
+	for(auto thread : threads)
+		assert(helResume(thread) == kHelErrNone);
 
 	for(size_t i = 0; i < 10'000
-			&& !stoppedThreadDone.load(std::memory_order_acquire); ++i)
+			&& stoppedThreadDone.load(std::memory_order_acquire) != stoppedThreadCount; ++i)
 		assert(helYield() == kHelErrNone);
-	assert(stoppedThreadDone.load(std::memory_order_acquire));
-	assert(stoppedThreadFirstCpu.load(std::memory_order_acquire) == initialCpu);
-	assert(stoppedThreadFinalCpu.load(std::memory_order_acquire) == targetCpu);
+	assert(stoppedThreadDone.load(std::memory_order_acquire) == stoppedThreadCount);
+
+	bool observedDeferredMigration = false;
+	for(size_t i = 0; i < stoppedThreadCount; ++i) {
+		observedDeferredMigration |= stoppedThreadFirstCpu[i].load(std::memory_order_acquire) != targetCpu;
+		assert(stoppedThreadFinalCpu[i].load(std::memory_order_acquire) == targetCpu);
+	}
+	assert(observedDeferredMigration);
 }));

--- a/testsuites/kernel-tests/src/affinity.cpp
+++ b/testsuites/kernel-tests/src/affinity.cpp
@@ -1,0 +1,100 @@
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include <hel.h>
+#include <hel-syscalls.h>
+
+#include "testsuite.hpp"
+
+namespace {
+
+constexpr size_t testStackSize = 64 * 1024;
+alignas(16) std::array<std::byte, testStackSize> stoppedThreadStack;
+std::atomic<int> stoppedThreadFirstCpu{-1};
+std::atomic<int> stoppedThreadFinalCpu{-1};
+std::atomic<bool> stoppedThreadDone{false};
+std::atomic<int> stoppedThreadTargetCpu{-1};
+int stoppedThreadPark = 0;
+
+[[noreturn]] void stoppedThreadEntry() {
+	int cpu = -1;
+	assert(helGetCurrentCpu(&cpu) == kHelErrNone);
+	// helGetCurrentCpu() samples before its return path consumes cpuMigration.
+	stoppedThreadFirstCpu.store(cpu, std::memory_order_release);
+
+	for(size_t i = 0; i < 10'000; ++i) {
+		assert(helYield() == kHelErrNone);
+		assert(helGetCurrentCpu(&cpu) == kHelErrNone);
+		if(cpu == stoppedThreadTargetCpu.load(std::memory_order_acquire)) {
+			stoppedThreadFinalCpu.store(cpu, std::memory_order_release);
+			stoppedThreadDone.store(true, std::memory_order_release);
+			break;
+		}
+	}
+
+	while(true)
+		assert(helFutexWait(&stoppedThreadPark, 0, -1) == kHelErrNone);
+}
+
+void *stoppedThreadStackTop() {
+	auto top = reinterpret_cast<uintptr_t>(stoppedThreadStack.data() + testStackSize);
+	top &= ~uintptr_t{0xF};
+	top -= sizeof(uintptr_t);
+	*reinterpret_cast<uintptr_t *>(top) = 0;
+	return reinterpret_cast<void *>(top);
+}
+
+} // namespace
+
+DEFINE_TEST(affinity_current_thread, ([] {
+	std::array<uint8_t, 128> mask{};
+	size_t actualSize = 0;
+	assert(helGetAffinity(kHelThisThread, mask.data(), mask.size(), &actualSize)
+			== kHelErrNone);
+	assert(actualSize > 0 && actualSize <= mask.size());
+	assert(helSetAffinity(kHelThisThread, mask.data(), actualSize) == kHelErrNone);
+}));
+
+DEFINE_TEST(affinity_stopped_thread, ([] {
+	std::array<uint8_t, 128> allowedMask{};
+	size_t actualSize = 0;
+	assert(helGetAffinity(kHelThisThread, allowedMask.data(), allowedMask.size(), &actualSize)
+			== kHelErrNone);
+	assert(actualSize > 0 && actualSize <= allowedMask.size());
+
+	int initialCpu = -1;
+	assert(helGetCurrentCpu(&initialCpu) == kHelErrNone);
+	int targetCpu = -1;
+	for(size_t i = 0; i < actualSize * 8; ++i)
+		if((allowedMask[i / 8] & (1 << (i % 8))) && static_cast<int>(i) != initialCpu) {
+			targetCpu = static_cast<int>(i);
+			break;
+		}
+	// There is no distinct target CPU on UP systems.
+	if(targetCpu < 0)
+		return;
+
+	std::array<uint8_t, 128> targetMask{};
+	targetMask[targetCpu / 8] = static_cast<uint8_t>(1 << (targetCpu % 8));
+	stoppedThreadFirstCpu.store(-1, std::memory_order_relaxed);
+	stoppedThreadFinalCpu.store(-1, std::memory_order_relaxed);
+	stoppedThreadDone.store(false, std::memory_order_relaxed);
+	stoppedThreadTargetCpu.store(targetCpu, std::memory_order_release);
+
+	HelHandle thread;
+	assert(helCreateThread(kHelNullHandle, kHelNullHandle, kHelAbiSystemV,
+			reinterpret_cast<void *>(stoppedThreadEntry), stoppedThreadStackTop(),
+			kHelThreadStopped, &thread) == kHelErrNone);
+	assert(helSetAffinity(thread, targetMask.data(), actualSize) == kHelErrNone);
+	assert(helResume(thread) == kHelErrNone);
+
+	for(size_t i = 0; i < 10'000
+			&& !stoppedThreadDone.load(std::memory_order_acquire); ++i)
+		assert(helYield() == kHelErrNone);
+	assert(stoppedThreadDone.load(std::memory_order_acquire));
+	assert(stoppedThreadFirstCpu.load(std::memory_order_acquire) == initialCpu);
+	assert(stoppedThreadFinalCpu.load(std::memory_order_acquire) == targetCpu);
+}));


### PR DESCRIPTION
This parallelizes Thor’s load-balancer ownership transfers while keeping affinity, assigned CPU, ownership, and load accounting synchronized.

Previously, balancing serialized ownership changes and repeatedly scanned every CPU pair, increasing lock contention and balancing overhead. Accounting also held node locks while updating individual thread load state, and affinity tests left helper threads runnable after completing.

Ownership transfers now use ordered per-CPU node locks, bounded and rotating scans, and rotating CPU-pair scheduling. Load accounting avoids holding node locks while updating threads and aggregates system load once per round. The tests also cover deferred affinity migration, respect round-robin placement, skip unnecessary empty transfers, and park helper threads after validation.

Blocked on #1502 