### PR TITLE
thor: Add rights checks for all capabilities

### DIFF
--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -138,8 +138,122 @@ enum {
 	kHelErrAlreadyExists = 22,
 	kHelErrBadPermissions = 23,
 	kHelErrOther = 24,
-	kHelErrFutexRace = 25
+	kHelErrFutexRace = 25,
+	kHelErrBadRights = 26,
 };
+
+typedef uint32_t HelRights;
+
+// No right but easier to recognize in code than a zero literal.
+// - General: descriptor properties can be queried without any rights.
+// - Memory view: memory size can be queried without any rights.
+// - Thread: statistics can be queried without any rights.
+static const HelRights kHelRightNull = 0;
+// Right to map into an object.
+// - Universe: required to transfer into the universe.
+// - Universe: required to close descriptors in the universe.
+// - Universe: required to create a thread in the universe.
+// - Address space: required to map into the space.
+// - Address space: required to change memory protection.
+// - Virtualized space: required to map into the space.
+// - DMA space: required to map into the space.
+static const HelRights kHelRightGrant = UINT32_C(1) << 0;
+// Right to map from an object.
+// - Universe: required to transfer out of the universe.
+// - Universe: required to create a thread in the universe.
+static const HelRights kHelRightTake = UINT32_C(1) << 1;
+// Right to read data.
+// - IPC queue: required to map readable.
+// - Memory view: required to read.
+// - Memory view: required to map readable.
+// - Memory slice: required to map readable.
+// - Address space: required to read from it.
+// - Address space: required to create thread.
+// - Virtualized space: required to read from it.
+// - Thread: required to read registers.
+// - Thread: required to read memory in its address space.
+// - Thread: required to get the affinity.
+// - Virtualized CPUs: required to read registers.
+static const HelRights kHelRightRead = UINT32_C(1) << 2;
+// Right to write data.
+// - IPC queue: required to map writeable.
+// - Memory view: required to write.
+// - Memory view: required to map writeable.
+// - Memory slice: required to map writeable.
+// - Address space: required to write to it.
+// - Address space: required to create thread.
+// - Virtualized space: required to write to it.
+// - Thread: required to write registers.
+// - Thread: required to write memory in its address space.
+// - Thread: required to set the affinity.
+// - Virtualized CPUs: required to write registers.
+static const HelRights kHelRightWrite = UINT32_C(1) << 3;
+// Right to execute code.
+// - Memory view: required to map executable.
+// - Memory slice: required to map executable.
+static const HelRights kHelRightExecute = UINT32_C(1) << 4;
+// Right to execute operations.
+// - IPC queue: required to submit.
+// - Lane: required to do exchange messages.
+// - Virtualized CPUs: required to run.
+static const HelRights kHelRightInvoke = UINT32_C(1) << 5;
+// Right to build new objects on top of existing ones.
+// - IPC queue: required to map.
+// - Universe: required to create thread.
+// - Address space: required to create thread.
+// - Memory view: required to map.
+// - Memory view: required to create copy-on-write view.
+// - Memory view: required to map into indirect memory.
+// - Memory view: required to create slice.
+// - Memory view: required to bind to kernlet.
+// - Memory slice: required to map.
+// - Memory slice: required to map into indirect memory.
+// - Virtualized space: required to create virtualized CPU.
+// - I/O objects: required to enable userspace I/O.
+// - Kernlets: required to create a bound kernlet from it.
+// - Bound kernlets: required to attach to an IRQ.
+static const HelRights kHelRightAssign = UINT32_C(1) << 6;
+// Right to derive new objects that affect the original one.
+// - Memory view: required to fork.
+static const HelRights kHelRightDerive = UINT32_C(1) << 7;
+// Right to add, remove or manipulate components.
+// - Memory views: required to perform loadahead.
+// - Address space: required to synchronize.
+// - Address space: required to resolve physical addresses.
+// - DMA space: required to populate.
+// - DMA space: required to resolve physical addresses.
+static const HelRights kHelRightProvision = UINT32_C(1) << 8;
+// Right to pin memory pages.
+// - Memory view: required to pin pages.
+static const HelRights kHelRightPin = UINT32_C(1) << 9;
+// Right to perform memory fences.
+// - Memory view: required for fences.
+static const HelRights kHelRightFence = UINT32_C(1) << 10;
+// Right to wait on an object.
+// - IPC queue: required to drive.
+// - Thread: required to observe.
+// - Event: required to wait.
+// - IRQ: required to wait.
+// - IRQ: required to attach a kernlet.
+static const HelRights kHelRightWait = UINT32_C(1) << 11;
+// Right to signal an object.
+// - IPC queue: required to alert.
+// - Thread: required to interrupt.
+// - Event: required to raise.
+// - Event: required to bind to kernlet.
+// - IRQ: required to acknowledge.
+// - IRQ: required to attach a kernlet.
+// - Virtualized CPUs: required to raise an interrupt.
+static const HelRights kHelRightSignal = UINT32_C(1) << 12;
+// Right to manage an object (includes potentially destructive operations).
+// - Lane: required to shut down.
+// - Memory view: required to resize.
+// - Memory view: required to manage.
+// - Memory view: required to invalidate.
+// - Thread: required to set priority.
+// - Thread: required to resume.
+// - Thread: required to kill.
+static const HelRights kHelRightManage = UINT32_C(1) << 13;
 
 struct HelX86SegmentRegister {
 	uint64_t base;
@@ -1437,6 +1551,8 @@ extern inline __attribute__ (( always_inline )) const char *_helErrorString(HelE
 		return "Out of bounds";
 	case kHelErrAlreadyExists:
 		return "Already exists";
+	case kHelErrBadRights:
+		return "Missing rights for this operation";
 	default:
 		return 0;
 	}

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -134,6 +134,7 @@ HelError translateError(Error error) {
 	case Error::badPermissions: return kHelErrBadPermissions;
 	case Error::noDescriptor: return kHelErrNoDescriptor;
 	case Error::badDescriptor: return kHelErrBadDescriptor;
+	case Error::badRights: return kHelErrBadRights;
 	case Error::other: return kHelErrOther;
 
 	// Thor-internal error cases that should not be passed down to userspace.

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -1815,8 +1815,8 @@ HelError doSubmitLockMemoryView(HelHandle handle, smarter::shared_ptr<IpcQueue> 
 			panicLogger() << "thor: Failed to create memory view lock" << frg::endlog;
 		HelHandle handle;
 		handle = universe->attachDescriptor(
-				AnyDescriptor::make<DescriptorType::memoryViewLock>(
-					std::move(*lockOutcome)));
+			AnyDescriptor::make<DescriptorType::memoryViewLock>(std::move(*lockOutcome), kHelRightNull)
+		);
 
 		HelHandleResult helResult{.error = kHelErrNone, .handle = handle};
 		QueueSource ipcSource{&helResult, sizeof(HelHandleResult), nullptr};

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -253,7 +253,7 @@ HelError helSubmitAsyncNop(HelHandle queueHandle, uintptr_t context) {
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto queueOutcome = thisUniverse->resolveObject<DescriptorType::queue>(queueHandle);
+	auto queueOutcome = thisUniverse->resolveObject<DescriptorType::queue>(queueHandle, kHelRightInvoke);
 	if(!queueOutcome)
 		return translateError(queueOutcome.error());
 
@@ -417,7 +417,11 @@ HelError helCreateQueue(const HelQueueParameters *paramsPtr, HelHandle *handle) 
 	if(!queueOutcome)
 		return translateError(queueOutcome.error());
 	*handle = thisUniverse->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::queue>(std::move(*queueOutcome)));
+		AnyDescriptor::make<DescriptorType::queue>(
+			std::move(*queueOutcome),
+			kHelRightRead | kHelRightWrite | kHelRightInvoke | kHelRightAssign | kHelRightWait | kHelRightSignal
+		)
+	);
 
 	return kHelErrNone;
 }
@@ -429,7 +433,7 @@ HelError helDriveQueue(HelHandle handle, uint32_t flags, uint32_t notifyMask) {
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto queueOutcome = thisUniverse->resolveObject<DescriptorType::queue>(handle);
+	auto queueOutcome = thisUniverse->resolveObject<DescriptorType::queue>(handle, kHelRightInvoke | kHelRightWait);
 	if(!queueOutcome)
 		return translateError(queueOutcome.error());
 	auto queue = std::move(*queueOutcome);
@@ -462,7 +466,7 @@ HelError helAlertQueue(HelHandle handle) {
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto queueOutcome = thisUniverse->resolveObject<DescriptorType::queue>(handle);
+	auto queueOutcome = thisUniverse->resolveObject<DescriptorType::queue>(handle, kHelRightSignal);
 	if(!queueOutcome)
 		return translateError(queueOutcome.error());
 	auto queue = std::move(*queueOutcome);
@@ -1130,7 +1134,7 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 				return std::unexpected{sliceOutcome.error()};
 			slice = std::move(*sliceOutcome);
 		}else if(desc.is<DescriptorType::queue>()) {
-			auto queueOutcome = desc.resolveObject<DescriptorType::queue>();
+			auto queueOutcome = desc.resolveObject<DescriptorType::queue>(requiredRights);
 			if(!queueOutcome)
 				return std::unexpected{queueOutcome.error()};
 			auto memory = (*queueOutcome)->getMemory();

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -1450,7 +1450,7 @@ HelError doSubmitReadMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 				std::move(*spaceOutcome), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 	}else if(descriptor.is<DescriptorType::thread>()) {
-		auto threadOutcome = descriptor.resolveObject<DescriptorType::thread>();
+		auto threadOutcome = descriptor.resolveObject<DescriptorType::thread>(kHelRightRead);
 		if(!threadOutcome)
 			return translateError(threadOutcome.error());
 		auto space = (*threadOutcome)->getAddressSpace().lock();
@@ -1581,7 +1581,7 @@ HelError doSubmitWriteMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> que
 				std::move(*spaceOutcome), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 	}else if(descriptor.is<DescriptorType::thread>()) {
-		auto threadOutcome = descriptor.resolveObject<DescriptorType::thread>();
+		auto threadOutcome = descriptor.resolveObject<DescriptorType::thread>(kHelRightWrite);
 		if(!threadOutcome)
 			return translateError(threadOutcome.error());
 		auto space = (*threadOutcome)->getAddressSpace().lock();
@@ -1841,7 +1841,11 @@ HelError helCreateThread(HelHandle universe_handle, HelHandle space_handle,
 		Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(new_thread));
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::thread>(std::move(new_thread)));
+		AnyDescriptor::make<DescriptorType::thread>(
+			std::move(new_thread),
+			kHelRightRead | kHelRightWrite | kHelRightWait | kHelRightSignal | kHelRightManage
+		)
+	);
 
 	return kHelErrNone;
 }
@@ -1854,7 +1858,7 @@ HelError helQueryThreadStats(HelHandle handle, HelThreadStats *user_stats) {
 	if(handle == kHelThisThread) {
 		thread = this_thread.lock();
 	}else{
-		auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
+		auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle, kHelRightNull);
 		if(!threadOutcome)
 			return translateError(threadOutcome.error());
 		thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
@@ -1878,7 +1882,7 @@ HelError helSetPriority(HelHandle handle, int priority) {
 	if(handle == kHelThisThread) {
 		thread = this_thread.lock();
 	}else{
-		auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
+		auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle, kHelRightManage);
 		if(!threadOutcome)
 			return translateError(threadOutcome.error());
 		thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
@@ -1900,7 +1904,7 @@ HelError doSubmitObserve(HelHandle handle, smarter::shared_ptr<IpcQueue> queue,
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto threadOutcome = thisUniverse->resolveObject<DescriptorType::thread>(handle);
+	auto threadOutcome = thisUniverse->resolveObject<DescriptorType::thread>(handle, kHelRightWait);
 	if(!threadOutcome)
 		return translateError(threadOutcome.error());
 	auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
@@ -1948,7 +1952,7 @@ HelError helKillThread(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
+	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle, kHelRightManage);
 	if(!threadOutcome)
 		return translateError(threadOutcome.error());
 	auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
@@ -1962,7 +1966,7 @@ HelError helInterruptThread(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
+	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle, kHelRightSignal);
 	if(!threadOutcome)
 		return translateError(threadOutcome.error());
 	auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
@@ -1976,7 +1980,7 @@ HelError helResume(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
+	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle, kHelRightManage);
 	if(!threadOutcome)
 		return translateError(threadOutcome.error());
 	auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
@@ -2000,7 +2004,7 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 	auto outcome = this_universe->inspectDescriptor(handle,
 			[&](AnyDescriptor &desc) -> std::expected<void, Error> {
 		if(desc.is<DescriptorType::thread>()) {
-			auto threadOutcome = desc.resolveObject<DescriptorType::thread>();
+			auto threadOutcome = desc.resolveObject<DescriptorType::thread>(kHelRightRead);
 			if(!threadOutcome)
 				return std::unexpected{threadOutcome.error()};
 			thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
@@ -2275,7 +2279,7 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 		auto outcome = this_universe->inspectDescriptor(handle,
 				[&](AnyDescriptor &desc) -> std::expected<void, Error> {
 			if(desc.is<DescriptorType::thread>()) {
-				auto threadOutcome = desc.resolveObject<DescriptorType::thread>();
+				auto threadOutcome = desc.resolveObject<DescriptorType::thread>(kHelRightWrite);
 				if(!threadOutcome)
 					return std::unexpected{threadOutcome.error()};
 				thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
@@ -3634,7 +3638,7 @@ HelError helGetAffinity(HelHandle handle, uint8_t *mask, size_t size, size_t *ac
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
+	auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle, kHelRightRead);
 	if(!threadOutcome)
 		return translateError(threadOutcome.error());
 	auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
@@ -3681,7 +3685,7 @@ HelError helSetAffinity(HelHandle handle, uint8_t *mask, size_t size) {
 		this_thread->_lbCb->setAffinityMask({buf.data(), maskSize});
 		Thread::migrateCurrent();
 	} else {
-		auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle);
+		auto threadOutcome = this_universe->resolveObject<DescriptorType::thread>(handle, kHelRightWrite);
 		if(!threadOutcome)
 			return translateError(threadOutcome.error());
 		auto thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -2604,9 +2604,15 @@ HelError helCreateStream(HelHandle *lane1_handle, HelHandle *lane2_handle, uint3
 	if(!lanesOutcome)
 		return translateError(lanesOutcome.error());
 	*lane1_handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::lane>(std::move(lanesOutcome->get<0>())));
+		AnyDescriptor::make<DescriptorType::lane>(
+			std::move(lanesOutcome->get<0>()), kHelRightInvoke | kHelRightManage
+		)
+	);
 	*lane2_handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::lane>(std::move(lanesOutcome->get<1>())));
+		AnyDescriptor::make<DescriptorType::lane>(
+			std::move(lanesOutcome->get<1>()), kHelRightInvoke | kHelRightManage
+		)
+	);
 
 	return kHelErrNone;
 }
@@ -2627,7 +2633,7 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto laneOutcome = thisUniverse->resolveObject<DescriptorType::lane>(laneHandle);
+	auto laneOutcome = thisUniverse->resolveObject<DescriptorType::lane>(laneHandle, kHelRightInvoke);
 	if(!laneOutcome)
 		return translateError(laneOutcome.error());
 	auto lane = std::move(*laneOutcome);
@@ -3102,7 +3108,10 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 					assert(universe);
 
 					handle = universe->attachDescriptor(
-							AnyDescriptor::make<DescriptorType::lane>(node->lane()));
+						AnyDescriptor::make<DescriptorType::lane>(
+							node->lane(), kHelRightInvoke | kHelRightManage
+						)
+					);
 				}
 
 				item->helHandleResult = {translateError(node->error()), 0, handle};
@@ -3116,7 +3125,10 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 					assert(universe);
 
 					handle = universe->attachDescriptor(
-							AnyDescriptor::make<DescriptorType::lane>(node->lane()));
+						AnyDescriptor::make<DescriptorType::lane>(
+							node->lane(), kHelRightInvoke | kHelRightManage
+						)
+					);
 				}
 
 				item->helHandleResult = {translateError(node->error()), 0, handle};
@@ -3186,7 +3198,7 @@ HelError helShutdownLane(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto laneOutcome = this_universe->resolveObject<DescriptorType::lane>(handle);
+	auto laneOutcome = this_universe->resolveObject<DescriptorType::lane>(handle, kHelRightManage);
 	if(!laneOutcome)
 		return translateError(laneOutcome.error());
 	auto lane = std::move(*laneOutcome);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -713,10 +713,10 @@ HelError helCreateSliceView(HelHandle memoryHandle,
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(memoryHandle, kHelRightAssign);
+	auto viewOutcome = this_universe->resolveCapability<DescriptorType::memoryView>(memoryHandle, kHelRightAssign);
 	if(!viewOutcome)
 		return translateError(viewOutcome.error());
-	auto view = std::move(*viewOutcome);
+	auto [view, rights] = std::move(*viewOutcome);
 
 	CachingFlags cachingFlags = 0;
 	if(flags & kHelSliceCacheWriteCombine)
@@ -725,10 +725,9 @@ HelError helCreateSliceView(HelHandle memoryHandle,
 	auto sliceOutcome = MemorySlice::create(std::move(view), offset, size, cachingFlags);
 	if(!sliceOutcome)
 		return translateError(sliceOutcome.error());
-	// TODO: We should inherit the proper rights here instead of unconditionally gaining RWX.
 	*handle = this_universe->attachDescriptor(
 		AnyDescriptor::make<DescriptorType::memorySlice>(
-			std::move(*sliceOutcome), kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign
+			std::move(*sliceOutcome), rights & (kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign)
 		)
 	);
 
@@ -740,16 +739,16 @@ HelError doSubmitForkMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightDerive);
+	auto viewOutcome = this_universe->resolveCapability<DescriptorType::memoryView>(handle, kHelRightDerive);
 	if(!viewOutcome)
 		return translateError(viewOutcome.error());
-	auto view = std::move(*viewOutcome);
+	auto [view, rights] = std::move(*viewOutcome);
 
 	if(!queue->validSize(ipcSourceSize(sizeof(HelHandleResult))))
 		return kHelErrQueueTooSmall;
 
 	[](smarter::weak_ptr<Universe> weakUniverse,
-			smarter::shared_ptr<MemoryView> view,
+			smarter::shared_ptr<MemoryView> view, uint32_t rights,
 			smarter::shared_ptr<IpcQueue> queue, uintptr_t context,
 			enable_detached_coroutine) -> void {
 		auto outcome = co_await onExceptionalWq(view->fork());
@@ -769,18 +768,17 @@ HelError doSubmitForkMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 			co_return;
 		}
 
-		// TODO: We should inherit the proper rights here instead of unconditionally gaining RWX.
 		HelHandle forkedHandle = universe->attachDescriptor(
 			AnyDescriptor::make<DescriptorType::memoryView>(
 				outcome.value(),
-				kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign | kHelRightDerive | kHelRightProvision | kHelRightPin | kHelRightFence | kHelRightManage
+				rights & (kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign | kHelRightDerive | kHelRightProvision | kHelRightPin | kHelRightFence | kHelRightManage)
 			)
 		);
 
 		HelHandleResult helResult{.error = kHelErrNone, .handle = forkedHandle};
 		QueueSource ipcSource{&helResult, sizeof(HelHandleResult), nullptr};
 		co_await queue->submit(&ipcSource, context);
-	}(this_universe.lock(), std::move(view), std::move(queue), context,
+	}(this_universe.lock(), std::move(view), rights, std::move(queue), context,
 		enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 
 	return kHelErrNone;

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3260,7 +3260,8 @@ HelError helCreateOneshotEvent(HelHandle *handle) {
 		return translateError(eventOutcome.error());
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::oneshotEvent>(std::move(*eventOutcome)));
+			AnyDescriptor::make<DescriptorType::oneshotEvent>(
+					std::move(*eventOutcome), kHelRightWait | kHelRightSignal));
 
 	return kHelErrNone;
 }
@@ -3274,7 +3275,8 @@ HelError helCreateBitsetEvent(HelHandle *handle) {
 		return translateError(eventOutcome.error());
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::bitsetEvent>(std::move(*eventOutcome)));
+			AnyDescriptor::make<DescriptorType::bitsetEvent>(
+					std::move(*eventOutcome), kHelRightWait | kHelRightSignal));
 
 	return kHelErrNone;
 }
@@ -3283,7 +3285,7 @@ HelError helRaiseEvent(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto eventOutcome = this_universe->resolveObject<DescriptorType::oneshotEvent>(handle);
+	auto eventOutcome = this_universe->resolveObject<DescriptorType::oneshotEvent>(handle, kHelRightSignal);
 	if(!eventOutcome)
 		return translateError(eventOutcome.error());
 
@@ -3311,7 +3313,7 @@ HelError helAccessIrq(int number, HelHandle *handle) {
 	IrqPin::attachSink(pin, irq.get());
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::irq>(std::move(irq)));
+			AnyDescriptor::make<DescriptorType::irq>(std::move(irq), kHelRightWait | kHelRightSignal));
 
 	return kHelErrNone;
 #else
@@ -3332,7 +3334,7 @@ HelError helAcknowledgeIrq(HelHandle handle, uint32_t flags, uint64_t sequence) 
 	if(mode != kHelAckAcknowledge && mode != kHelAckNack && mode != kHelAckKick)
 		return kHelErrIllegalArgs;
 
-	auto irqOutcome = this_universe->resolveObject<DescriptorType::irq>(handle);
+	auto irqOutcome = this_universe->resolveObject<DescriptorType::irq>(handle, kHelRightSignal);
 	if(!irqOutcome)
 		return translateError(irqOutcome.error());
 	auto irq = std::move(*irqOutcome);
@@ -3371,7 +3373,7 @@ HelError doSubmitAwaitEvent(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 		return kHelErrQueueTooSmall;
 
 	if(descriptor.is<DescriptorType::irq>()) {
-		auto irqOutcome = descriptor.resolveObject<DescriptorType::irq>();
+		auto irqOutcome = descriptor.resolveObject<DescriptorType::irq>(kHelRightWait);
 		if(!irqOutcome)
 			return translateError(irqOutcome.error());
 
@@ -3398,7 +3400,7 @@ HelError doSubmitAwaitEvent(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 		}(std::move(*irqOutcome), sequence, std::move(queue), context, std::move(cg),
 			enable_detached_coroutine{this_thread->mainWorkQueue().lock()});
 	}else if(descriptor.is<DescriptorType::oneshotEvent>()) {
-		auto eventOutcome = descriptor.resolveObject<DescriptorType::oneshotEvent>();
+		auto eventOutcome = descriptor.resolveObject<DescriptorType::oneshotEvent>(kHelRightWait);
 		if(!eventOutcome)
 			return translateError(eventOutcome.error());
 
@@ -3420,7 +3422,7 @@ HelError doSubmitAwaitEvent(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 		}(std::move(*eventOutcome), sequence, std::move(queue), context, std::move(cg),
 				enable_detached_coroutine{this_thread->mainWorkQueue().lock()});
 	}else if(descriptor.is<DescriptorType::bitsetEvent>()) {
-		auto eventOutcome = descriptor.resolveObject<DescriptorType::bitsetEvent>();
+		auto eventOutcome = descriptor.resolveObject<DescriptorType::bitsetEvent>(kHelRightWait);
 		if(!eventOutcome)
 			return translateError(eventOutcome.error());
 
@@ -3455,7 +3457,7 @@ HelError helAutomateIrq(HelHandle handle, uint32_t flags, HelHandle kernlet_hand
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto irqOutcome = this_universe->resolveObject<DescriptorType::irq>(handle);
+	auto irqOutcome = this_universe->resolveObject<DescriptorType::irq>(handle, kHelRightWait | kHelRightSignal);
 	if(!irqOutcome)
 		return translateError(irqOutcome.error());
 	auto irq = std::move(*irqOutcome);
@@ -3589,7 +3591,7 @@ HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num
 		}else{
 			assert(defn.type == KernletParameterType::bitsetEvent);
 
-			auto eventOutcome = this_universe->resolveObject<DescriptorType::bitsetEvent>(d.handle);
+			auto eventOutcome = this_universe->resolveObject<DescriptorType::bitsetEvent>(d.handle, kHelRightSignal);
 			if(!eventOutcome)
 				return translateError(eventOutcome.error());
 			auto event = std::move(*eventOutcome);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -271,7 +271,8 @@ HelError helCreateUniverse(HelHandle *handle) {
 		return translateError(universeOutcome.error());
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::universe>(std::move(*universeOutcome)));
+			AnyDescriptor::make<DescriptorType::universe>(
+					std::move(*universeOutcome), kHelRightGrant | kHelRightTake | kHelRightAssign));
 
 	return kHelErrNone;
 }
@@ -288,7 +289,14 @@ helTransferDescriptor(HelHandle handle, HelHandle universeHandle, HelTransferDes
 	if(universeHandle == kHelThisUniverse) {
 		universe = thisUniverse.lock();
 	}else{
-		auto universeOutcome = thisUniverse->resolveObject<DescriptorType::universe>(universeHandle);
+		uint32_t rightsRequired;
+		if (direction == kHelTransferDescriptorOut) {
+			rightsRequired = kHelRightGrant;
+		} else {
+			assert(direction == kHelTransferDescriptorIn);
+			rightsRequired = kHelRightTake;
+		}
+		auto universeOutcome = thisUniverse->resolveObject<DescriptorType::universe>(universeHandle, rightsRequired);
 		if(!universeOutcome)
 			return translateError(universeOutcome.error());
 		universe = std::move(*universeOutcome);
@@ -378,7 +386,7 @@ HelError helCloseDescriptor(HelHandle universeHandle, HelHandle handle) {
 	if(universeHandle == kHelThisUniverse) {
 		universe = thisUniverse.lock();
 	}else{
-		auto universeOutcome = thisUniverse->resolveObject<DescriptorType::universe>(universeHandle);
+		auto universeOutcome = thisUniverse->resolveObject<DescriptorType::universe>(universeHandle, kHelRightGrant);
 		if(!universeOutcome)
 			return translateError(universeOutcome.error());
 		universe = std::move(*universeOutcome);
@@ -1797,7 +1805,7 @@ HelError helCreateThread(HelHandle universe_handle, HelHandle space_handle,
 	if(universe_handle == kHelNullHandle) {
 		universe = this_thread->getUniverse().lock();
 	}else{
-		auto universeOutcome = this_universe->resolveObject<DescriptorType::universe>(universe_handle);
+		auto universeOutcome = this_universe->resolveObject<DescriptorType::universe>(universe_handle, kHelRightGrant | kHelRightTake | kHelRightAssign);
 		if(!universeOutcome)
 			return translateError(universeOutcome.error());
 		universe = std::move(*universeOutcome);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -852,7 +852,11 @@ HelError helCreateSpace(HelHandle *handle) {
 		return translateError(spaceOutcome.error());
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::addressSpace>(std::move(*spaceOutcome)));
+		AnyDescriptor::make<DescriptorType::addressSpace>(
+			std::move(*spaceOutcome),
+			kHelRightGrant | kHelRightRead | kHelRightWrite | kHelRightAssign | kHelRightProvision
+		)
+	);
 
 	return kHelErrNone;
 }
@@ -1108,7 +1112,7 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 		auto spaceOutcome = this_universe->inspectDescriptor(space_handle,
 				[&](AnyDescriptor &desc) -> std::expected<void, Error> {
 			if(desc.is<DescriptorType::addressSpace>()) {
-				auto addressSpaceOutcome = desc.resolveObject<DescriptorType::addressSpace>();
+				auto addressSpaceOutcome = desc.resolveObject<DescriptorType::addressSpace>(kHelRightGrant);
 				if(!addressSpaceOutcome)
 					return std::unexpected{addressSpaceOutcome.error()};
 				space = std::move(*addressSpaceOutcome);
@@ -1183,7 +1187,7 @@ HelError doSubmitProtectMemory(HelHandle space_handle, smarter::shared_ptr<IpcQu
 	if(space_handle == kHelNullHandle) {
 		space = this_thread->getAddressSpace().lock();
 	}else{
-		auto spaceOutcome = this_universe->resolveObject<DescriptorType::addressSpace>(space_handle);
+		auto spaceOutcome = this_universe->resolveObject<DescriptorType::addressSpace>(space_handle, kHelRightGrant);
 		if(!spaceOutcome)
 			return translateError(spaceOutcome.error());
 		space = std::move(*spaceOutcome);
@@ -1225,7 +1229,7 @@ HelError helUnmapMemory(HelHandle space_handle, void *pointer, size_t length) {
 		auto spaceOutcome = this_universe->inspectDescriptor(space_handle,
 				[&](AnyDescriptor &desc) -> std::expected<void, Error> {
 			if(desc.is<DescriptorType::addressSpace>()) {
-				auto addressSpaceOutcome = desc.resolveObject<DescriptorType::addressSpace>();
+				auto addressSpaceOutcome = desc.resolveObject<DescriptorType::addressSpace>(kHelRightGrant);
 				if(!addressSpaceOutcome)
 					return std::unexpected{addressSpaceOutcome.error()};
 				space = std::move(*addressSpaceOutcome);
@@ -1274,7 +1278,7 @@ HelError doSubmitSynchronizeSpace(HelHandle spaceHandle, smarter::shared_ptr<Ipc
 	if(spaceHandle == kHelNullHandle) {
 		space = thisThread->getAddressSpace().lock();
 	}else{
-		auto spaceOutcome = thisUniverse->resolveObject<DescriptorType::addressSpace>(spaceHandle);
+		auto spaceOutcome = thisUniverse->resolveObject<DescriptorType::addressSpace>(spaceHandle, kHelRightProvision);
 		if(!spaceOutcome)
 			return translateError(spaceOutcome.error());
 		space = std::move(*spaceOutcome);
@@ -1312,7 +1316,7 @@ HelError helPointerPhysical(HelHandle spaceHandle, const void *pointer, uintptr_
 		auto spaceOutcome = thisUniverse->inspectDescriptor(spaceHandle,
 				[&](AnyDescriptor &desc) -> std::expected<void, Error> {
 			if(desc.is<DescriptorType::addressSpace>()) {
-				auto addressSpaceOutcome = desc.resolveObject<DescriptorType::addressSpace>();
+				auto addressSpaceOutcome = desc.resolveObject<DescriptorType::addressSpace>(kHelRightProvision);
 				if(!addressSpaceOutcome)
 					return std::unexpected{addressSpaceOutcome.error()};
 				space = std::move(*addressSpaceOutcome);
@@ -1455,7 +1459,7 @@ HelError doSubmitReadMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 				std::move(*viewOutcome), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 	}else if(descriptor.is<DescriptorType::addressSpace>()) {
-		auto spaceOutcome = descriptor.resolveObject<DescriptorType::addressSpace>();
+		auto spaceOutcome = descriptor.resolveObject<DescriptorType::addressSpace>(kHelRightRead);
 		if(!spaceOutcome)
 			return translateError(spaceOutcome.error());
 		readVirtualSpace(
@@ -1586,7 +1590,7 @@ HelError doSubmitWriteMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> que
 				std::move(*viewOutcome), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 	}else if(descriptor.is<DescriptorType::addressSpace>()) {
-		auto spaceOutcome = descriptor.resolveObject<DescriptorType::addressSpace>();
+		auto spaceOutcome = descriptor.resolveObject<DescriptorType::addressSpace>(kHelRightWrite);
 		if(!spaceOutcome)
 			return translateError(spaceOutcome.error());
 		writeVirtualSpace(
@@ -1827,7 +1831,9 @@ HelError helCreateThread(HelHandle universe_handle, HelHandle space_handle,
 	if(space_handle == kHelNullHandle) {
 		space = this_thread->getAddressSpace().lock();
 	}else{
-		auto spaceOutcome = this_universe->resolveObject<DescriptorType::addressSpace>(space_handle);
+		auto spaceOutcome = this_universe->resolveObject<DescriptorType::addressSpace>(
+			space_handle, kHelRightRead | kHelRightWrite | kHelRightAssign
+		);
 		if(!spaceOutcome)
 			return translateError(spaceOutcome.error());
 		space = std::move(*spaceOutcome);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -507,7 +507,11 @@ HelError helAllocateMemory(size_t size, uint32_t flags,
 		return translateError(memoryOutcome.error());
 
 	*handle = thisUniverse->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*memoryOutcome)));
+		AnyDescriptor::make<DescriptorType::memoryView>(
+			std::move(*memoryOutcome),
+			kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign | kHelRightProvision | kHelRightPin | kHelRightFence | kHelRightManage
+		)
+	);
 
 	return kHelErrNone;
 }
@@ -517,7 +521,7 @@ HelError doSubmitResizeMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> qu
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightManage);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -562,9 +566,17 @@ HelError helCreateManagedMemory(size_t size, uint32_t flags,
 		return translateError(frontalOutcome.error());
 
 	*backing_handle = thisUniverse->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*backingOutcome)));
+		AnyDescriptor::make<DescriptorType::memoryView>(
+			std::move(*backingOutcome),
+			kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign | kHelRightProvision | kHelRightPin | kHelRightFence | kHelRightManage
+		)
+	);
 	*frontal_handle = thisUniverse->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*frontalOutcome)));
+		AnyDescriptor::make<DescriptorType::memoryView>(
+			std::move(*frontalOutcome),
+			kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign | kHelRightProvision | kHelRightPin | kHelRightFence | kHelRightManage
+		)
+	);
 
 	return kHelErrNone;
 }
@@ -581,7 +593,7 @@ HelError helCopyOnWrite(HelHandle memoryHandle,
 			return kHelErrBadDescriptor;
 		view = getSpecialMemoryView(memoryHandle);
 	} else {
-		auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(memoryHandle);
+		auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(memoryHandle, kHelRightAssign);
 		if(!viewOutcome)
 			return translateError(viewOutcome.error());
 		view = std::move(*viewOutcome);
@@ -591,7 +603,11 @@ HelError helCopyOnWrite(HelHandle memoryHandle,
 	if(!sliceOutcome)
 		return translateError(sliceOutcome.error());
 	*outHandle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*sliceOutcome)));
+		AnyDescriptor::make<DescriptorType::memoryView>(
+			std::move(*sliceOutcome),
+			kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign | kHelRightDerive | kHelRightProvision | kHelRightPin | kHelRightFence | kHelRightManage
+		)
+	);
 
 	return kHelErrNone;
 }
@@ -609,7 +625,11 @@ HelError helAccessPhysical(uintptr_t physical, size_t size, HelHandle *handle) {
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*memoryOutcome)));
+		AnyDescriptor::make<DescriptorType::memoryView>(
+			std::move(*memoryOutcome),
+			kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign | kHelRightProvision | kHelRightPin | kHelRightManage
+		)
+	);
 
 	return kHelErrNone;
 }
@@ -622,7 +642,11 @@ HelError helCreateIndirectMemory(size_t numSlots, HelHandle *handle) {
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memoryView>(std::move(*memoryOutcome)));
+		AnyDescriptor::make<DescriptorType::memoryView>(
+			std::move(*memoryOutcome),
+			kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign | kHelRightProvision | kHelRightFence | kHelRightManage
+		)
+	);
 
 	return kHelErrNone;
 }
@@ -632,7 +656,7 @@ HelError helAlterMemoryIndirection(HelHandle indirectHandle, size_t slot,
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();
 
-	auto indirectOutcome = thisUniverse->resolveObject<DescriptorType::memoryView>(indirectHandle);
+	auto indirectOutcome = thisUniverse->resolveObject<DescriptorType::memoryView>(indirectHandle, kHelRightManage);
 	if(!indirectOutcome)
 		return translateError(indirectOutcome.error());
 	auto indirectView = std::move(*indirectOutcome);
@@ -642,7 +666,7 @@ HelError helAlterMemoryIndirection(HelHandle indirectHandle, size_t slot,
 	auto memoryOutcome = thisUniverse->inspectDescriptor(memoryHandle,
 			[&](AnyDescriptor &desc) -> std::expected<void, Error> {
 		if(desc.is<DescriptorType::memoryView>()) {
-			auto viewOutcome = desc.resolveObject<DescriptorType::memoryView>();
+			auto viewOutcome = desc.resolveObject<DescriptorType::memoryView>(kHelRightAssign);
 			if(!viewOutcome)
 				return std::unexpected{viewOutcome.error()};
 			memoryView = std::move(*viewOutcome);
@@ -685,7 +709,7 @@ HelError helCreateSliceView(HelHandle memoryHandle,
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(memoryHandle);
+	auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(memoryHandle, kHelRightAssign);
 	if(!viewOutcome)
 		return translateError(viewOutcome.error());
 	auto view = std::move(*viewOutcome);
@@ -712,7 +736,7 @@ HelError doSubmitForkMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
+	auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightDerive);
 	if(!viewOutcome)
 		return translateError(viewOutcome.error());
 	auto view = std::move(*viewOutcome);
@@ -741,8 +765,13 @@ HelError doSubmitForkMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 			co_return;
 		}
 
+		// TODO: We should inherit the proper rights here instead of unconditionally gaining RWX.
 		HelHandle forkedHandle = universe->attachDescriptor(
-				AnyDescriptor::make<DescriptorType::memoryView>(outcome.value()));
+			AnyDescriptor::make<DescriptorType::memoryView>(
+				outcome.value(),
+				kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign | kHelRightDerive | kHelRightProvision | kHelRightPin | kHelRightFence | kHelRightManage
+			)
+		);
 
 		HelHandleResult helResult{.error = kHelErrNone, .handle = forkedHandle};
 		QueueSource ipcSource{&helResult, sizeof(HelHandleResult), nullptr};
@@ -758,7 +787,7 @@ HelError doSubmitWritebackFence(HelHandle handle, smarter::shared_ptr<IpcQueue> 
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightFence);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -787,7 +816,7 @@ HelError doSubmitInvalidateMemory(HelHandle handle, smarter::shared_ptr<IpcQueue
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightManage);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -1091,7 +1120,7 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 				return std::unexpected{sliceOutcome.error()};
 			slice = std::move(*sliceOutcome);
 		}else if(desc.is<DescriptorType::memoryView>()) {
-			auto viewOutcome = desc.resolveObject<DescriptorType::memoryView>();
+			auto viewOutcome = desc.resolveObject<DescriptorType::memoryView>(requiredRights);
 			if(!viewOutcome)
 				return std::unexpected{viewOutcome.error()};
 			auto memory = std::move(*viewOutcome);
@@ -1464,7 +1493,7 @@ HelError doSubmitReadMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 	};
 
 	if(descriptor.is<DescriptorType::memoryView>()) {
-		auto viewOutcome = descriptor.resolveObject<DescriptorType::memoryView>();
+		auto viewOutcome = descriptor.resolveObject<DescriptorType::memoryView>(kHelRightRead);
 		if(!viewOutcome)
 			return translateError(viewOutcome.error());
 		readMemoryView(thisThread.lock(),
@@ -1595,7 +1624,7 @@ HelError doSubmitWriteMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> que
 	};
 
 	if(descriptor.is<DescriptorType::memoryView>()) {
-		auto viewOutcome = descriptor.resolveObject<DescriptorType::memoryView>();
+		auto viewOutcome = descriptor.resolveObject<DescriptorType::memoryView>(kHelRightWrite);
 		if(!viewOutcome)
 			return translateError(viewOutcome.error());
 		writeMemoryView(thisThread.lock(),
@@ -1634,7 +1663,7 @@ HelError helMemoryInfo(HelHandle handle, size_t *size) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightNull);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -1647,7 +1676,7 @@ HelError doSubmitManageMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> qu
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightManage);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -1703,7 +1732,7 @@ HelError helUpdateMemory(HelHandle handle, int type,
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightManage);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -1734,7 +1763,7 @@ HelError doSubmitLockMemoryView(HelHandle handle, smarter::shared_ptr<IpcQueue> 
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightPin);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 	auto memory = std::move(*memoryOutcome);
@@ -1804,7 +1833,7 @@ HelError helLoadahead(HelHandle handle, uintptr_t offset, size_t length) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle);
+	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightProvision);
 	if(!memoryOutcome)
 		return translateError(memoryOutcome.error());
 
@@ -3609,7 +3638,7 @@ HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num
 		if(defn.type == KernletParameterType::offset) {
 			bound->setupOffsetBinding(i, d.handle);
 		}else if(defn.type == KernletParameterType::memoryView) {
-			auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(d.handle);
+			auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(d.handle, kHelRightAssign);
 			if(!memoryOutcome)
 				return translateError(memoryOutcome.error());
 			auto memory = std::move(*memoryOutcome);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -647,7 +647,7 @@ HelError helAlterMemoryIndirection(HelHandle indirectHandle, size_t slot,
 				return std::unexpected{viewOutcome.error()};
 			memoryView = std::move(*viewOutcome);
 		} else if(desc.is<DescriptorType::memorySlice>()) {
-			auto sliceOutcome = desc.resolveObject<DescriptorType::memorySlice>();
+			auto sliceOutcome = desc.resolveObject<DescriptorType::memorySlice>(kHelRightAssign);
 			if(!sliceOutcome)
 				return std::unexpected{sliceOutcome.error()};
 			memoryView = (*sliceOutcome)->getView();
@@ -697,8 +697,12 @@ HelError helCreateSliceView(HelHandle memoryHandle,
 	auto sliceOutcome = MemorySlice::create(std::move(view), offset, size, cachingFlags);
 	if(!sliceOutcome)
 		return translateError(sliceOutcome.error());
+	// TODO: We should inherit the proper rights here instead of unconditionally gaining RWX.
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::memorySlice>(std::move(*sliceOutcome)));
+		AnyDescriptor::make<DescriptorType::memorySlice>(
+			std::move(*sliceOutcome), kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign
+		)
+	);
 
 	return kHelErrNone;
 }
@@ -1071,10 +1075,18 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 	smarter::shared_ptr<VirtualSpace> vspace;
 	bool isVspace = false;
 
+	uint32_t requiredRights = kHelRightAssign;
+	if (flags & kHelMapProtRead)
+		requiredRights |= kHelRightRead;
+	if (flags & kHelMapProtWrite)
+		requiredRights |= kHelRightWrite;
+	if (flags & kHelMapProtExecute)
+		requiredRights |= kHelRightExecute;
+
 	auto memoryOutcome = this_universe->inspectDescriptor(memory_handle,
 			[&](AnyDescriptor &desc) -> std::expected<void, Error> {
 		if(desc.is<DescriptorType::memorySlice>()) {
-			auto sliceOutcome = desc.resolveObject<DescriptorType::memorySlice>();
+			auto sliceOutcome = desc.resolveObject<DescriptorType::memorySlice>(requiredRights);
 			if(!sliceOutcome)
 				return std::unexpected{sliceOutcome.error()};
 			slice = std::move(*sliceOutcome);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3470,7 +3470,7 @@ HelError helAutomateIrq(HelHandle handle, uint32_t flags, HelHandle kernlet_hand
 		return translateError(irqOutcome.error());
 	auto irq = std::move(*irqOutcome);
 
-	auto kernletOutcome = this_universe->resolveObject<DescriptorType::boundKernlet>(kernlet_handle);
+	auto kernletOutcome = this_universe->resolveObject<DescriptorType::boundKernlet>(kernlet_handle, kHelRightAssign);
 	if(!kernletOutcome)
 		return translateError(kernletOutcome.error());
 	auto kernlet = std::move(*kernletOutcome);
@@ -3540,7 +3540,7 @@ HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto kernletOutcome = this_universe->resolveObject<DescriptorType::kernletObject>(handle);
+	auto kernletOutcome = this_universe->resolveObject<DescriptorType::kernletObject>(handle, kHelRightAssign);
 	if(!kernletOutcome)
 		return translateError(kernletOutcome.error());
 	auto kernlet = std::move(*kernletOutcome);
@@ -3609,7 +3609,7 @@ HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num
 	}
 
 	*bound_handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::boundKernlet>(std::move(bound)));
+			AnyDescriptor::make<DescriptorType::boundKernlet>(std::move(bound), kHelRightAssign));
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -881,7 +881,10 @@ HelError helCreateVirtualizedSpace(HelHandle *handle) {
 	}
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::virtualizedSpace>(std::move(vspace)));
+		AnyDescriptor::make<DescriptorType::virtualizedSpace>(
+			std::move(vspace), kHelRightGrant | kHelRightRead | kHelRightWrite | kHelRightAssign
+		)
+	);
 	return kHelErrNone;
 #elif defined(__riscv) && __riscv_xlen == 64
 	if(!getCpuData()->haveVirtualization) {
@@ -896,7 +899,10 @@ HelError helCreateVirtualizedSpace(HelHandle *handle) {
 	smarter::shared_ptr<VirtualizedPageSpace> vspace = std::move(*vspaceOutcome);
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::virtualizedSpace>(std::move(vspace)));
+		AnyDescriptor::make<DescriptorType::virtualizedSpace>(
+			std::move(vspace), kHelRightGrant | kHelRightRead | kHelRightWrite | kHelRightAssign
+		)
+	);
 	return kHelErrNone;
 #else
 	(void)handle;
@@ -912,7 +918,7 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto vspaceOutcome = this_universe->resolveObject<DescriptorType::virtualizedSpace>(handle);
+	auto vspaceOutcome = this_universe->resolveObject<DescriptorType::virtualizedSpace>(handle, kHelRightAssign);
 	if(!vspaceOutcome)
 		return translateError(vspaceOutcome.error());
 	auto vspace = std::move(*vspaceOutcome);
@@ -945,7 +951,7 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto vspaceOutcome = this_universe->resolveObject<DescriptorType::virtualizedSpace>(handle);
+	auto vspaceOutcome = this_universe->resolveObject<DescriptorType::virtualizedSpace>(handle, kHelRightAssign);
 	if(!vspaceOutcome)
 		return translateError(vspaceOutcome.error());
 	auto vspace = std::move(*vspaceOutcome);
@@ -1107,7 +1113,7 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 					return std::unexpected{addressSpaceOutcome.error()};
 				space = std::move(*addressSpaceOutcome);
 			} else if(desc.is<DescriptorType::virtualizedSpace>()) {
-				auto vspaceOutcome = desc.resolveObject<DescriptorType::virtualizedSpace>();
+				auto vspaceOutcome = desc.resolveObject<DescriptorType::virtualizedSpace>(kHelRightGrant);
 				if(!vspaceOutcome)
 					return std::unexpected{vspaceOutcome.error()};
 				isVspace = true;
@@ -1464,7 +1470,7 @@ HelError doSubmitReadMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queu
 				std::move(space), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 	}else if(descriptor.is<DescriptorType::virtualizedSpace>()) {
-		auto vspaceOutcome = descriptor.resolveObject<DescriptorType::virtualizedSpace>();
+		auto vspaceOutcome = descriptor.resolveObject<DescriptorType::virtualizedSpace>(kHelRightRead);
 		if(!vspaceOutcome)
 			return translateError(vspaceOutcome.error());
 		readVirtualSpace(
@@ -1595,7 +1601,7 @@ HelError doSubmitWriteMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> que
 				std::move(space), address, length, buffer, std::move(queue), context,
 				enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 	}else if(descriptor.is<DescriptorType::virtualizedSpace>()) {
-		auto vspaceOutcome = descriptor.resolveObject<DescriptorType::virtualizedSpace>();
+		auto vspaceOutcome = descriptor.resolveObject<DescriptorType::virtualizedSpace>(kHelRightWrite);
 		if(!vspaceOutcome)
 			return translateError(vspaceOutcome.error());
 		writeVirtualSpace(

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -933,7 +933,10 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 	}
 
 	*out = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::virtualizedCpu>(std::move(vcpu)));
+		AnyDescriptor::make<DescriptorType::virtualizedCpu>(
+			std::move(vcpu), kHelRightRead | kHelRightWrite | kHelRightInvoke | kHelRightSignal
+		)
+	);
 	return kHelErrNone;
 #elif defined(__riscv) && __riscv_xlen == 64
 	if(!getCpuData()->haveVirtualization) {
@@ -954,7 +957,10 @@ HelError helCreateVirtualizedCpu(HelHandle handle, HelHandle *out) {
 	smarter::shared_ptr<VirtualizedCpu> vcpu = std::move(*vcpuOutcome);
 
 	*out = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::virtualizedCpu>(std::move(vcpu)));
+		AnyDescriptor::make<DescriptorType::virtualizedCpu>(
+			std::move(vcpu), kHelRightRead | kHelRightWrite | kHelRightInvoke | kHelRightSignal
+		)
+	);
 	return kHelErrNone;
 #else
 	(void)handle;
@@ -970,7 +976,7 @@ HelError helRunVirtualizedCpu(HelHandle handle, HelVmexitReason *exitInfo) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto vcpuOutcome = this_universe->resolveObject<DescriptorType::virtualizedCpu>(handle);
+	auto vcpuOutcome = this_universe->resolveObject<DescriptorType::virtualizedCpu>(handle, kHelRightInvoke);
 	if(!vcpuOutcome)
 		return translateError(vcpuOutcome.error());
 	auto vcpu = std::move(*vcpuOutcome);
@@ -992,7 +998,7 @@ HelError helAssertVirtualizedIrq(HelHandle handle, uint64_t irq, uint8_t level) 
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto vcpuOutcome = this_universe->resolveObject<DescriptorType::virtualizedCpu>(handle);
+	auto vcpuOutcome = this_universe->resolveObject<DescriptorType::virtualizedCpu>(handle, kHelRightSignal);
 	if(!vcpuOutcome)
 		return translateError(vcpuOutcome.error());
 	auto vcpu = std::move(*vcpuOutcome);
@@ -2009,7 +2015,7 @@ HelError helLoadRegisters(HelHandle handle, int set, void *image) {
 				return std::unexpected{threadOutcome.error()};
 			thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 		} else if(desc.is<DescriptorType::virtualizedCpu>()) {
-			auto vcpuOutcome = desc.resolveObject<DescriptorType::virtualizedCpu>();
+			auto vcpuOutcome = desc.resolveObject<DescriptorType::virtualizedCpu>(kHelRightRead);
 			if(!vcpuOutcome)
 				return std::unexpected{vcpuOutcome.error()};
 			vcpu = std::move(*vcpuOutcome);
@@ -2284,7 +2290,7 @@ HelError helStoreRegisters(HelHandle handle, int set, const void *image) {
 					return std::unexpected{threadOutcome.error()};
 				thread = smarter::rc_policy_downcast<smarter::default_rc_policy>(std::move(*threadOutcome));
 			}else if(desc.is<DescriptorType::virtualizedCpu>()) {
-				auto vcpuOutcome = desc.resolveObject<DescriptorType::virtualizedCpu>();
+				auto vcpuOutcome = desc.resolveObject<DescriptorType::virtualizedCpu>(kHelRightWrite);
 				if(!vcpuOutcome)
 					return std::unexpected{vcpuOutcome.error()};
 				vcpu = std::move(*vcpuOutcome);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -812,7 +812,7 @@ HelError doSubmitPopulateSpace(HelHandle handle, smarter::shared_ptr<IpcQueue> q
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto dmaSpaceOutcome = this_universe->resolveObject<DescriptorType::dmaSpace>(handle);
+	auto dmaSpaceOutcome = this_universe->resolveObject<DescriptorType::dmaSpace>(handle, kHelRightProvision);
 	if(!dmaSpaceOutcome)
 		return translateError(dmaSpaceOutcome.error());
 	auto space = std::move(*dmaSpaceOutcome);
@@ -1113,7 +1113,7 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 				isVspace = true;
 				vspace = std::move(*vspaceOutcome);
 			} else if(desc.is<DescriptorType::dmaSpace>()) {
-				auto dmaOutcome = desc.resolveObject<DescriptorType::dmaSpace>();
+				auto dmaOutcome = desc.resolveObject<DescriptorType::dmaSpace>(kHelRightGrant);
 				if(!dmaOutcome)
 					return std::unexpected{dmaOutcome.error()};
 				isVspace = true;
@@ -1225,7 +1225,7 @@ HelError helUnmapMemory(HelHandle space_handle, void *pointer, size_t length) {
 				space = std::move(*addressSpaceOutcome);
 				return {};
 			}else if(desc.is<DescriptorType::dmaSpace>()) {
-				auto dmaOutcome = desc.resolveObject<DescriptorType::dmaSpace>();
+				auto dmaOutcome = desc.resolveObject<DescriptorType::dmaSpace>(kHelRightGrant);
 				if(!dmaOutcome)
 					return std::unexpected{dmaOutcome.error()};
 				vspace = std::move(*dmaOutcome);
@@ -1312,7 +1312,7 @@ HelError helPointerPhysical(HelHandle spaceHandle, const void *pointer, uintptr_
 				space = std::move(*addressSpaceOutcome);
 				return {};
 			} else if(desc.is<DescriptorType::dmaSpace>()) {
-				auto dmaOutcome = desc.resolveObject<DescriptorType::dmaSpace>();
+				auto dmaOutcome = desc.resolveObject<DescriptorType::dmaSpace>(kHelRightProvision);
 				if(!dmaOutcome)
 					return std::unexpected{dmaOutcome.error()};
 				dmaSpace = std::move(*dmaOutcome);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3488,7 +3488,7 @@ HelError helAccessIo(uintptr_t *port_array, size_t num_ports,
 	}
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::io>(std::move(io_space)));
+			AnyDescriptor::make<DescriptorType::io>(std::move(io_space), kHelRightAssign));
 
 	return kHelErrNone;
 }
@@ -3498,7 +3498,7 @@ HelError helEnableIo(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto ioOutcome = this_universe->resolveObject<DescriptorType::io>(handle);
+	auto ioOutcome = this_universe->resolveObject<DescriptorType::io>(handle, kHelRightAssign);
 	if(!ioOutcome)
 		return translateError(ioOutcome.error());
 	auto io_space = std::move(*ioOutcome);

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -354,12 +354,12 @@ HelError helGetCredentials(HelHandle handle, uint32_t flags, char *credentials) 
 		auto outcome = thisUniverse->inspectDescriptor(handle,
 				[&](AnyDescriptor &desc) -> std::expected<void, Error> {
 			if(desc.is<DescriptorType::thread>()) {
-				auto threadOutcome = desc.resolveObject<DescriptorType::thread>();
+				auto threadOutcome = desc.resolveObject<DescriptorType::thread>(kHelRightNull);
 				if(!threadOutcome)
 					return std::unexpected{threadOutcome.error()};
 				creds = (*threadOutcome)->credentials();
 			}else if(desc.is<DescriptorType::lane>()) {
-				auto laneOutcome = desc.resolveObject<DescriptorType::lane>();
+				auto laneOutcome = desc.resolveObject<DescriptorType::lane>(kHelRightNull);
 				if(!laneOutcome)
 					return std::unexpected{laneOutcome.error()};
 				creds = (*laneOutcome)->credentials().credentials();
@@ -2761,17 +2761,17 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 					auto credsOutcome = thisUniverse->inspectDescriptor(recipe->handle,
 							[&](AnyDescriptor &desc) -> std::expected<void, Error> {
 						if(desc.is<DescriptorType::thread>()) {
-							auto threadOutcome = desc.resolveObject<DescriptorType::thread>();
+							auto threadOutcome = desc.resolveObject<DescriptorType::thread>(kHelRightNull);
 							if(!threadOutcome)
 								return std::unexpected{threadOutcome.error()};
 							creds = (*threadOutcome)->credentials();
 						}else if(desc.is<DescriptorType::token>()) {
-							auto tokenOutcome = desc.resolveObject<DescriptorType::token>();
+							auto tokenOutcome = desc.resolveObject<DescriptorType::token>(kHelRightNull);
 							if(!tokenOutcome)
 								return std::unexpected{tokenOutcome.error()};
 							creds = (*tokenOutcome)->credentials();
 						}else if(desc.is<DescriptorType::lane>()) {
-							auto laneOutcome = desc.resolveObject<DescriptorType::lane>();
+							auto laneOutcome = desc.resolveObject<DescriptorType::lane>(kHelRightNull);
 							if(!laneOutcome)
 								return std::unexpected{laneOutcome.error()};
 							creds = (*laneOutcome)->credentials().credentials();
@@ -3854,7 +3854,7 @@ HelError helCreateToken(HelHandle *handle) {
 		return translateError(credsOutcome.error());
 
 	*handle = thisUniverse->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::token>(std::move(*credsOutcome)));
+			AnyDescriptor::make<DescriptorType::token>(std::move(*credsOutcome), kHelRightNull));
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/kernlet.cpp
+++ b/kernel/thor/generic/kernlet.cpp
@@ -439,7 +439,7 @@ private:
 			if(respError != Error::success)
 				co_return respError;
 			auto objectError = co_await pushDescriptor(lane,
-					AnyDescriptor::make<DescriptorType::kernletObject>(std::move(kernlet)));
+					AnyDescriptor::make<DescriptorType::kernletObject>(std::move(kernlet), kHelRightAssign));
 			if(objectError != Error::success)
 				co_return objectError;
 		}else{

--- a/kernel/thor/generic/mbus.cpp
+++ b/kernel/thor/generic/mbus.cpp
@@ -59,7 +59,7 @@ coroutine<frg::expected<Error, size_t>> KernelBusObject::createObject(frg::strin
 	if (resp->error() != managarm::mbus::Error::SUCCESS)
 		co_return Error::illegalState;
 
-	auto laneOutcome = descriptor.resolveObject<DescriptorType::lane>();
+	auto laneOutcome = descriptor.resolveObject<DescriptorType::lane>(kHelRightInvoke | kHelRightManage);
 	if (!laneOutcome)
 		co_return laneOutcome.error();
 
@@ -146,8 +146,10 @@ coroutine<frg::expected<Error>> KernelBusObject::handleServeRemoteLane_() {
 
 	auto lane = initiateClient();
 
-	auto descError = co_await pushDescriptor(conversation,
-		AnyDescriptor::make<DescriptorType::lane>(lane));
+	auto descError = co_await pushDescriptor(
+		conversation,
+		AnyDescriptor::make<DescriptorType::lane>(lane, kHelRightInvoke | kHelRightManage)
+	);
 
 	if (descError != Error::success)
 		co_return descError;

--- a/kernel/thor/generic/servers.cpp
+++ b/kernel/thor/generic/servers.cpp
@@ -322,7 +322,8 @@ coroutine<void> executeModule(frg::string_view name, MfsRegular *module,
 	Handle xpipe_handle = 0;
 	if(xpipe_lane) {
 		xpipe_handle = universe->attachDescriptor(
-				AnyDescriptor::make<DescriptorType::lane>(xpipe_lane));
+			AnyDescriptor::make<DescriptorType::lane>(xpipe_lane, kHelRightInvoke)
+		);
 	}
 
 	enum {
@@ -538,7 +539,9 @@ private:
 			auto respError = co_await sendBuffer(lane, std::move(respBuffer));
 			if(respError != Error::success)
 				co_return respError;
-			auto controlError = co_await pushDescriptor(lane, AnyDescriptor::make<DescriptorType::lane>(controlLane));
+			auto controlError = co_await pushDescriptor(lane,
+				AnyDescriptor::make<DescriptorType::lane>(controlLane, kHelRightInvoke)
+			);
 			if(controlError != Error::success)
 				co_return controlError;
 		}else{

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -247,7 +247,10 @@ namespace initrd {
 					assert(respError == Error::success);
 
 					auto memoryError = co_await pushDescriptor(conversation,
-							AnyDescriptor::make<DescriptorType::memoryView>(file->module->getMemory()));
+						AnyDescriptor::make<DescriptorType::memoryView>(
+							file->module->getMemory(), kHelRightRead | kHelRightAssign | kHelRightProvision | kHelRightPin | kHelRightFence
+						)
+					);
 					// TODO: improve error handling here.
 					assert(memoryError == Error::success);
 				}else{

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -473,7 +473,7 @@ namespace posix {
 				panicLogger() << "thor: Failed to create stream" << frg::endlog;
 			auto posixStream = std::move(*posixStreamOutcome);
 			Handle posixHandle = thread->getUniverse()->attachDescriptor(
-					AnyDescriptor::make<DescriptorType::lane>(std::move(posixStream.get<1>())));
+					AnyDescriptor::make<DescriptorType::lane>(std::move(posixStream.get<1>()), kHelRightInvoke));
 
 			ThreadInfo info {
 				.thread = thread,
@@ -491,17 +491,17 @@ namespace posix {
 
 		void attachControl(smarter::shared_ptr<Thread, ActiveHandle> thread, smarter::shared_ptr<Stream, LanePolicy> lane) {
 			controlHandle = thread->getUniverse()->attachDescriptor(
-					AnyDescriptor::make<DescriptorType::lane>(lane));
+					AnyDescriptor::make<DescriptorType::lane>(lane, kHelRightInvoke));
 		}
 
 		void attachMbus(smarter::shared_ptr<Thread, ActiveHandle> thread) {
 			mbusHandle = thread->getUniverse()->attachDescriptor(
-					AnyDescriptor::make<DescriptorType::lane>(*mbusClient));
+					AnyDescriptor::make<DescriptorType::lane>(*mbusClient, kHelRightInvoke));
 		}
 
 		coroutine<int> attachFile(smarter::shared_ptr<Thread, ActiveHandle> thread, OpenFile *file) {
 			Handle handle = thread->getUniverse()->attachDescriptor(
-					AnyDescriptor::make<DescriptorType::lane>(file->clientLane));
+					AnyDescriptor::make<DescriptorType::lane>(file->clientLane, kHelRightInvoke));
 
 			for(int fd = 0; fd < (int)openFiles.size(); ++fd) {
 				if(openFiles[fd])

--- a/kernel/thor/generic/thor-internal/error.hpp
+++ b/kernel/thor/generic/thor-internal/error.hpp
@@ -24,6 +24,7 @@ enum class Error {
 	badPermissions,
 	noDescriptor,
 	badDescriptor,
+	badRights,
 	other,
 	// Internal error: the remote has violated the IPC protocol.
 	hardwareBroken,

--- a/kernel/thor/generic/thor-internal/universe.hpp
+++ b/kernel/thor/generic/thor-internal/universe.hpp
@@ -233,18 +233,26 @@ struct AnyDescriptor {
 		using std::swap;
 		swap(x.type_, y.type_);
 		swap(x.extra_, y.extra_);
+		swap(x.rights_, y.rights_);
 		swap(x.object_, y.object_);
 		swap(x.ctr_, y.ctr_);
 	}
 
 	// Constructs a descriptor of type K that takes over the given pointer's reference.
 	template<DescriptorType K>
-	static AnyDescriptor make(DescriptorPointer<K> ptr);
+	static AnyDescriptor make(DescriptorPointer<K> ptr, uint32_t rights);
+
+	// Legacy overload that sets rights to zero.
+	// TODO: Remove this after rights are integrated everywhere.
+	template<DescriptorType K>
+	static AnyDescriptor make(DescriptorPointer<K> ptr) {
+		return make<K>(std::move(ptr), 0);
+	}
 
 	AnyDescriptor() = default;
 
 	AnyDescriptor(const AnyDescriptor &other)
-	: type_{other.type_}, extra_{other.extra_}, object_{other.object_}, ctr_{other.ctr_} {
+	: type_{other.type_}, extra_{other.extra_}, rights_{other.rights_}, object_{other.object_}, ctr_{other.ctr_} {
 		if(ctr_)
 			ctr_->increment();
 	}
@@ -268,23 +276,60 @@ struct AnyDescriptor {
 		return type_;
 	}
 
+	uint32_t rights() const {
+		return rights_;
+	}
+
 	template<DescriptorType K>
 	bool is() const {
 		return type_ == K;
 	}
 
+	// Legacy overload that does not check rights.
+	// TODO: Remove this after rights are integrated everywhere.
+	template<DescriptorType K>
+	std::expected<DescriptorPointer<K>, Error> resolveObject() const {
+		if (!is<K>())
+			return std::unexpected{Error::badDescriptor};
+		return resolve_<K>();
+	}
+
 	// Resolves the descriptor to the object it holds (takes a new reference).
 	// Fails with badDescriptor unless the descriptor is of type K.
+	// Fails with badRights until the descriptor has all required rights.
 	template<DescriptorType K>
-	std::expected<DescriptorPointer<K>, Error> resolveObject() const;
+	std::expected<DescriptorPointer<K>, Error> resolveObject(uint32_t requiredRights) const {
+		if (!is<K>())
+			return std::unexpected{Error::badDescriptor};
+		if ((rights_ & requiredRights) != requiredRights)
+			return std::unexpected{Error::badRights};
+		return resolve_<K>();
+	}
+
+	// Returns both the object (see resolveObject()) and rights.
+	template<DescriptorType K>
+	std::expected<std::tuple<DescriptorPointer<K>, uint32_t>, Error>
+	resolveCapability(uint32_t requiredRights) const {
+		if (!is<K>())
+			return std::unexpected{Error::badDescriptor};
+		if ((rights_ & requiredRights) != requiredRights)
+			return std::unexpected{Error::badRights};
+		auto object = FRG_TRY(resolve_<K>());
+		return std::tuple{std::move(object), rights_};
+	}
 
 private:
+	template<DescriptorType K>
+	std::expected<DescriptorPointer<K>, Error> resolve_() const;
+
 	void releaseOnZero_();
 
 	DescriptorType type_ = DescriptorType::none;
 	// Extra per-descriptor data for some descriptor types.
 	// - For lane descriptors: the lane index.
 	uint8_t extra_ = 0;
+	// Rights associated with the descriptor.
+	uint32_t rights_ = 0;
 	// Invariant: object_ is non-null if type_ != DescriptorType::none.
 	void *object_ = nullptr;
 	// Invariant: ctr_ is non-null if type_ != DescriptorType::none.
@@ -292,12 +337,13 @@ private:
 };
 
 template<DescriptorType K>
-AnyDescriptor AnyDescriptor::make(DescriptorPointer<K> ptr) {
+AnyDescriptor AnyDescriptor::make(DescriptorPointer<K> ptr, uint32_t rights) {
 	static_assert(std::same_as<typename DescriptorTraits<K>::Policy, smarter::default_rc_policy>);
 	assert(ptr);
 
 	AnyDescriptor descriptor;
 	descriptor.type_ = K;
+	descriptor.rights_ = rights;
 	descriptor.object_ = ptr.get();
 	descriptor.ctr_ = &ptr.policy().base()->ctr();
 	ptr.release();
@@ -306,23 +352,23 @@ AnyDescriptor AnyDescriptor::make(DescriptorPointer<K> ptr) {
 
 template<>
 AnyDescriptor AnyDescriptor::make<DescriptorType::thread>(
-		smarter::shared_ptr<Thread, ActiveHandle> ptr);
+		smarter::shared_ptr<Thread, ActiveHandle> ptr, uint32_t rights);
 
 template<>
 AnyDescriptor AnyDescriptor::make<DescriptorType::addressSpace>(
-		smarter::shared_ptr<AddressSpace, BindableHandle> ptr);
+		smarter::shared_ptr<AddressSpace, BindableHandle> ptr, uint32_t rights);
 
 template<>
 AnyDescriptor AnyDescriptor::make<DescriptorType::lane>(
-		smarter::shared_ptr<Stream, LanePolicy> ptr);
+		smarter::shared_ptr<Stream, LanePolicy> ptr, uint32_t rights);
 
 template<DescriptorType K>
-std::expected<DescriptorPointer<K>, Error> AnyDescriptor::resolveObject() const {
+std::expected<DescriptorPointer<K>, Error> AnyDescriptor::resolve_() const {
 	static_assert(std::same_as<typename DescriptorTraits<K>::Policy, smarter::default_rc_policy>);
 	using ObjectType = typename DescriptorTraits<K>::Object;
 
-	if(type_ != K)
-		return std::unexpected{Error::badDescriptor};
+	assert(type_ == K);
+
 	ctr_->increment();
 	return smarter::shared_ptr<ObjectType>{
 		smarter::adopt_rc,
@@ -333,9 +379,9 @@ std::expected<DescriptorPointer<K>, Error> AnyDescriptor::resolveObject() const 
 
 template<>
 inline std::expected<smarter::shared_ptr<Thread, ActiveHandle>, Error>
-AnyDescriptor::resolveObject<DescriptorType::thread>() const {
-	if(type_ != DescriptorType::thread)
-		return std::unexpected{Error::badDescriptor};
+AnyDescriptor::resolve_<DescriptorType::thread>() const {
+	assert(type_ == DescriptorType::thread);
+
 	auto thread = static_cast<Thread *>(object_);
 	ctr_->increment();
 	return smarter::shared_ptr<Thread, ActiveHandle>{
@@ -345,9 +391,9 @@ AnyDescriptor::resolveObject<DescriptorType::thread>() const {
 
 template<>
 inline std::expected<smarter::shared_ptr<AddressSpace, BindableHandle>, Error>
-AnyDescriptor::resolveObject<DescriptorType::addressSpace>() const {
-	if(type_ != DescriptorType::addressSpace)
-		return std::unexpected{Error::badDescriptor};
+AnyDescriptor::resolve_<DescriptorType::addressSpace>() const {
+	assert(type_ == DescriptorType::addressSpace);
+
 	auto space = static_cast<AddressSpace *>(object_);
 	ctr_->increment();
 	return smarter::shared_ptr<AddressSpace, BindableHandle>{
@@ -357,7 +403,7 @@ AnyDescriptor::resolveObject<DescriptorType::addressSpace>() const {
 
 template<>
 std::expected<smarter::shared_ptr<Stream, LanePolicy>, Error>
-AnyDescriptor::resolveObject<DescriptorType::lane>() const;
+AnyDescriptor::resolve_<DescriptorType::lane>() const;
 
 // --------------------------------------------------------
 // Universe.
@@ -403,6 +449,21 @@ public:
 	std::expected<DescriptorPointer<K>, Error> resolveObject(Handle handle) {
 		return inspectDescriptor(handle, [](AnyDescriptor &desc) {
 			return desc.resolveObject<K>();
+		});
+	}
+
+	template<DescriptorType K>
+	std::expected<DescriptorPointer<K>, Error> resolveObject(Handle handle, uint32_t rights) {
+		return inspectDescriptor(handle, [&](AnyDescriptor &desc) {
+			return desc.resolveObject<K>(rights);
+		});
+	}
+
+	template<DescriptorType K>
+	std::expected<std::tuple<DescriptorPointer<K>, uint32_t>, Error>
+	resolveCapability(Handle handle, uint32_t rights) {
+		return inspectDescriptor(handle, [&](AnyDescriptor &desc) {
+			return desc.resolveCapability<K>(rights);
 		});
 	}
 

--- a/kernel/thor/generic/thor-internal/universe.hpp
+++ b/kernel/thor/generic/thor-internal/universe.hpp
@@ -242,13 +242,6 @@ struct AnyDescriptor {
 	template<DescriptorType K>
 	static AnyDescriptor make(DescriptorPointer<K> ptr, uint32_t rights);
 
-	// Legacy overload that sets rights to zero.
-	// TODO: Remove this after rights are integrated everywhere.
-	template<DescriptorType K>
-	static AnyDescriptor make(DescriptorPointer<K> ptr) {
-		return make<K>(std::move(ptr), 0);
-	}
-
 	AnyDescriptor() = default;
 
 	AnyDescriptor(const AnyDescriptor &other)
@@ -283,15 +276,6 @@ struct AnyDescriptor {
 	template<DescriptorType K>
 	bool is() const {
 		return type_ == K;
-	}
-
-	// Legacy overload that does not check rights.
-	// TODO: Remove this after rights are integrated everywhere.
-	template<DescriptorType K>
-	std::expected<DescriptorPointer<K>, Error> resolveObject() const {
-		if (!is<K>())
-			return std::unexpected{Error::badDescriptor};
-		return resolve_<K>();
 	}
 
 	// Resolves the descriptor to the object it holds (takes a new reference).
@@ -443,15 +427,7 @@ public:
 		return std::forward<Fn>(fn)(*desc);
 	}
 
-	// Looks up a handle and resolves it to the object held by its descriptor.
-	// Fails with badDescriptor unless the descriptor is of type K.
-	template<DescriptorType K>
-	std::expected<DescriptorPointer<K>, Error> resolveObject(Handle handle) {
-		return inspectDescriptor(handle, [](AnyDescriptor &desc) {
-			return desc.resolveObject<K>();
-		});
-	}
-
+	// Convenience wrapper for getDescriptor() -> resolveObject().
 	template<DescriptorType K>
 	std::expected<DescriptorPointer<K>, Error> resolveObject(Handle handle, uint32_t rights) {
 		return inspectDescriptor(handle, [&](AnyDescriptor &desc) {
@@ -459,6 +435,7 @@ public:
 		});
 	}
 
+	// Convenience wrapper for getDescriptor() -> resolveCapability().
 	template<DescriptorType K>
 	std::expected<std::tuple<DescriptorPointer<K>, uint32_t>, Error>
 	resolveCapability(Handle handle, uint32_t rights) {

--- a/kernel/thor/generic/universe.cpp
+++ b/kernel/thor/generic/universe.cpp
@@ -12,11 +12,12 @@ namespace {
 
 template<>
 AnyDescriptor AnyDescriptor::make<DescriptorType::thread>(
-		smarter::shared_ptr<Thread, ActiveHandle> ptr) {
+		smarter::shared_ptr<Thread, ActiveHandle> ptr, uint32_t rights) {
 	assert(ptr);
 
 	AnyDescriptor descriptor;
 	descriptor.type_ = DescriptorType::thread;
+	descriptor.rights_ = rights;
 	descriptor.object_ = ptr.get();
 	descriptor.ctr_ = &ptr->_activeCtr;
 	ptr.release();
@@ -25,11 +26,12 @@ AnyDescriptor AnyDescriptor::make<DescriptorType::thread>(
 
 template<>
 AnyDescriptor AnyDescriptor::make<DescriptorType::addressSpace>(
-		smarter::shared_ptr<AddressSpace, BindableHandle> ptr) {
+		smarter::shared_ptr<AddressSpace, BindableHandle> ptr, uint32_t rights) {
 	assert(ptr);
 
 	AnyDescriptor descriptor;
 	descriptor.type_ = DescriptorType::addressSpace;
+	descriptor.rights_ = rights;
 	descriptor.object_ = ptr.get();
 	descriptor.ctr_ = &ptr->_bindableCtr;
 	ptr.release();
@@ -38,13 +40,14 @@ AnyDescriptor AnyDescriptor::make<DescriptorType::addressSpace>(
 
 template<>
 AnyDescriptor AnyDescriptor::make<DescriptorType::lane>(
-		smarter::shared_ptr<Stream, LanePolicy> ptr) {
+		smarter::shared_ptr<Stream, LanePolicy> ptr, uint32_t rights) {
 	assert(ptr);
 
 	AnyDescriptor descriptor;
 	descriptor.type_ = DescriptorType::lane;
 	auto stream = ptr.get();
 	descriptor.extra_ = static_cast<uint8_t>(laneOf(ptr));
+	descriptor.rights_ = rights;
 	descriptor.object_ = stream;
 	descriptor.ctr_ = &stream->peerCounter(static_cast<int>(descriptor.extra_));
 	ptr.release();
@@ -53,9 +56,8 @@ AnyDescriptor AnyDescriptor::make<DescriptorType::lane>(
 
 template<>
 std::expected<smarter::shared_ptr<Stream, LanePolicy>, Error>
-AnyDescriptor::resolveObject<DescriptorType::lane>() const {
-	if(type_ != DescriptorType::lane)
-		return std::unexpected{Error::badDescriptor};
+AnyDescriptor::resolve_<DescriptorType::lane>() const {
+	assert(type_ == DescriptorType::lane);
 
 	auto stream = static_cast<Stream *>(object_);
 	auto lane = static_cast<int>(extra_);

--- a/kernel/thor/system/acpi/acpi.cpp
+++ b/kernel/thor/system/acpi/acpi.cpp
@@ -229,8 +229,9 @@ AcpiObject::handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) {
 
 		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
-		auto ioError =
-		    co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::io>(space));
+		auto ioError = co_await pushDescriptor(
+		    conversation, AnyDescriptor::make<DescriptorType::io>(space, kHelRightAssign)
+		);
 		if (ioError != Error::success)
 			co_return ioError;
 	} else if (preamble.id() == bragi::message_id<managarm::hw::AccessIrqRequest>) {

--- a/kernel/thor/system/acpi/acpi.cpp
+++ b/kernel/thor/system/acpi/acpi.cpp
@@ -304,8 +304,10 @@ AcpiObject::handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) {
 
 		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
-		auto irqError =
-		    co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object));
+		auto irqError = co_await pushDescriptor(
+		    conversation,
+		    AnyDescriptor::make<DescriptorType::irq>(object, kHelRightWait | kHelRightSignal)
+		);
 		if (irqError != Error::success)
 			co_return irqError;
 	} else {

--- a/kernel/thor/system/dtb/dtb_discover.cpp
+++ b/kernel/thor/system/dtb/dtb_discover.cpp
@@ -188,7 +188,9 @@ struct MbusNode final : private KernelBusObject {
 				panicLogger() << "thor: Failed to create hardware memory" << frg::endlog;
 			auto memory = std::move(*memoryOutcome);
 
-			auto descriptor = AnyDescriptor::make<DescriptorType::memoryView>(memory);
+			auto descriptor = AnyDescriptor::make<DescriptorType::memoryView>(
+				memory, kHelRightRead | kHelRightWrite | kHelRightAssign | kHelRightProvision | kHelRightPin
+			);
 
 			managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 			resp.set_error(managarm::hw::Errors::SUCCESS);

--- a/kernel/thor/system/dtb/dtb_discover.cpp
+++ b/kernel/thor/system/dtb/dtb_discover.cpp
@@ -221,7 +221,7 @@ struct MbusNode final : private KernelBusObject {
 
 			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
-			auto descError = co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object));
+			auto descError = co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object, kHelRightWait | kHelRightSignal));
 
 			if(descError != Error::success)
 				co_return descError;

--- a/kernel/thor/system/framebuffer/fb.cpp
+++ b/kernel/thor/system/framebuffer/fb.cpp
@@ -267,7 +267,9 @@ struct FbMbusNode final : private KernelBusObject {
 
 			managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 
-			auto descriptor = AnyDescriptor::make<DescriptorType::memoryView>(fb->memory);
+			auto descriptor = AnyDescriptor::make<DescriptorType::memoryView>(
+				fb->memory, kHelRightRead | kHelRightWrite | kHelRightAssign | kHelRightProvision | kHelRightPin
+			);
 			resp.set_error(managarm::hw::Errors::SUCCESS);
 
 			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));

--- a/kernel/thor/system/legacy-pc/ata.cpp
+++ b/kernel/thor/system/legacy-pc/ata.cpp
@@ -151,7 +151,7 @@ private:
 
 			FRG_CO_TRY(co_await sendResponse(lane, std::move(resp)));
 
-			auto irqError = co_await pushDescriptor(lane, AnyDescriptor::make<DescriptorType::irq>(object));
+			auto irqError = co_await pushDescriptor(lane, AnyDescriptor::make<DescriptorType::irq>(object, kHelRightWait | kHelRightSignal));
 			if(irqError != Error::success)
 				co_return irqError;
 		}else{

--- a/kernel/thor/system/legacy-pc/ata.cpp
+++ b/kernel/thor/system/legacy-pc/ata.cpp
@@ -119,7 +119,7 @@ private:
 
 			FRG_CO_TRY(co_await sendResponse(lane, std::move(resp)));
 
-			auto ioError = co_await pushDescriptor(lane, AnyDescriptor::make<DescriptorType::io>(space));
+			auto ioError = co_await pushDescriptor(lane, AnyDescriptor::make<DescriptorType::io>(space, kHelRightAssign));
 			if(ioError != Error::success)
 				co_return ioError;
 		}else if(preamble.id() == bragi::message_id<managarm::hw::AccessIrqRequest>) {

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -376,7 +376,7 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 
 		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
-		auto descError = co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object));
+		auto descError = co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object, kHelRightWait | kHelRightSignal));
 
 		if (descError != Error::success)
 			co_return descError;
@@ -445,7 +445,7 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 
 		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
-		auto descError = co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object));
+		auto descError = co_await pushDescriptor(conversation, AnyDescriptor::make<DescriptorType::irq>(object, kHelRightWait | kHelRightSignal));
 
 		if (descError != Error::success)
 			co_return descError;

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -783,9 +783,9 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 			co_return Error::protocolViolation;
 		}
 
-		auto descriptor = AnyDescriptor::make<DescriptorType::dmaSpace>(*noopDmaSpace);
+		auto descriptor = AnyDescriptor::make<DescriptorType::dmaSpace>(*noopDmaSpace, kHelRightGrant | kHelRightProvision);
 		if (iommuDomain)
-			descriptor = AnyDescriptor::make<DescriptorType::dmaSpace>(iommuDomain->space_);
+			descriptor = AnyDescriptor::make<DescriptorType::dmaSpace>(iommuDomain->space_, kHelRightGrant | kHelRightProvision);
 
 		managarm::hw::GetDmaSpaceResponse<KernelAlloc> resp{*kernelAlloc};
 		resp.set_iommu_active(iommuDomain != nullptr);

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -309,7 +309,7 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 
 		AnyDescriptor descriptor;
 		if(bars[index].type == PciBar::kBarIo) {
-			descriptor = AnyDescriptor::make<DescriptorType::io>(bars[index].io);
+			descriptor = AnyDescriptor::make<DescriptorType::io>(bars[index].io, kHelRightAssign);
 		}else{
 			assert(bars[index].type == PciBar::kBarMemory);
 			descriptor = AnyDescriptor::make<DescriptorType::memoryView>(bars[index].memory);

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -312,7 +312,9 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 			descriptor = AnyDescriptor::make<DescriptorType::io>(bars[index].io, kHelRightAssign);
 		}else{
 			assert(bars[index].type == PciBar::kBarMemory);
-			descriptor = AnyDescriptor::make<DescriptorType::memoryView>(bars[index].memory);
+			descriptor = AnyDescriptor::make<DescriptorType::memoryView>(
+				bars[index].memory, kHelRightRead | kHelRightWrite | kHelRightAssign | kHelRightProvision | kHelRightPin
+			);
 		}
 
 		managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
@@ -333,7 +335,9 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 		}
 
 		assert(expansionRom.address);
-		auto descriptor = AnyDescriptor::make<DescriptorType::memoryView>(expansionRom.memory);
+		auto descriptor = AnyDescriptor::make<DescriptorType::memoryView>(
+			expansionRom.memory, kHelRightRead | kHelRightAssign | kHelRightProvision | kHelRightPin
+		);
 
 		managarm::hw::SvrResponse<KernelAlloc> resp{*kernelAlloc};
 		resp.set_error(managarm::hw::Errors::SUCCESS);
@@ -715,7 +719,10 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
 			auto descError = co_await pushDescriptor(conversation,
-					AnyDescriptor::make<DescriptorType::memoryView>(fb->memory));
+				AnyDescriptor::make<DescriptorType::memoryView>(
+					fb->memory, kHelRightRead | kHelRightWrite | kHelRightAssign | kHelRightProvision | kHelRightPin
+				)
+			);
 			// TODO: improve error handling here.
 			assert(descError == Error::success);
 		}
@@ -771,7 +778,8 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 			FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
 			auto descError = co_await pushDescriptor(conversation,
-					AnyDescriptor::make<DescriptorType::memoryView>(vbt));
+				AnyDescriptor::make<DescriptorType::memoryView>(vbt, kHelRightRead | kHelRightAssign | kHelRightProvision | kHelRightPin)
+			);
 			// TODO: improve error handling here.
 			assert(descError == Error::success);
 		}


### PR DESCRIPTION
Prior to this PR, Managarm's kernel did not have fine-grained permission checks for capabilities. Owning a capability was binary (i.e., programs either had access to it or not). This model was fine for POSIX applications that only had access to a very limited set of capabilities anyway, but it added a lot of implicit trust to server-to-server communication (e.g., an FS server had to trust the POSIX server to not resize its memory views). This PR remediates this problem by introducing fine-grained permission checks.

Specifically, this PR introduces a set of `kHelRights*` bits that are attached to capability descriptors. Each operation that operates on capabilities checks the appropriate bits. We delete the legacy functions that allows object access without capability checks, such that all code only accesses kernel objects through appropriately checked code paths.

After this PR is merged, we still need to adjust userspace servers to restrict the sets of rights that they hand out to other servers. This handled as a follow up.