### PR TITLE
eir: Implement scrolling for the framebuffer

### DIFF
--- a/kernel/eir/generic/debug.cpp
+++ b/kernel/eir/generic/debug.cpp
@@ -1,6 +1,7 @@
 #include <eir-internal/arch.hpp>
 #include <eir-internal/debug.hpp>
 #include <eir-internal/generic.hpp>
+#include <eir-internal/log-ring.hpp>
 #include <frg/logging.hpp>
 
 namespace eir {
@@ -14,6 +15,18 @@ using HandlerList = frg::intrusive_list<
 HandlerList &accessHandlerList() {
 	static frg::eternal<HandlerList> singleton;
 	return *singleton;
+}
+
+// Handlers may read back earlier lines from the ring, hence the ring is updated first.
+void postLine(frg::string_view line) {
+	if (line.size() > maxLogLine)
+		line = line.sub_string(0, maxLogLine);
+	bootLogRing().enqueue(line.data(), line.size());
+
+	auto &handlerList = accessHandlerList();
+	for (auto *handler : handlerList) {
+		handler->emit(line);
+	}
 }
 
 } // anonymous namespace
@@ -38,10 +51,16 @@ void OutputSink::print(char c) {
 }
 
 void OutputSink::print(const char *str) {
-	auto &handlerList = accessHandlerList();
-	for (auto *handler : handlerList) {
-		handler->emit(str);
+	// Split at newlines such that a log record always holds exactly one line.
+	frg::string_view view{str};
+	while (true) {
+		auto pos = view.find_first('\n');
+		if (pos == size_t(-1))
+			break;
+		postLine(view.sub_string(0, pos));
+		view = view.sub_string(pos + 1, view.size() - pos - 1);
 	}
+	postLine(view);
 
 	while (*str)
 		print(*(str++));

--- a/kernel/eir/generic/eir-internal/log-ring.hpp
+++ b/kernel/eir/generic/eir-internal/log-ring.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <frg/optional.hpp>
+#include <stddef.h>
+#include <stdint.h>
+
+namespace eir {
+
+// Upper bound on the size of a log record; matches the stack_buffer_loggers in debug.hpp.
+constexpr size_t maxLogLine = 128;
+
+// Single-producer record ring; the wire format matches Thor's LogRingBuffer.
+// Eir is single-threaded during its run, so the atomics that Thor needs are not required.
+class EirLogRing {
+public:
+	struct Record {
+		uint64_t nextPtr;
+		size_t size;
+	};
+
+	constexpr EirLogRing(char *buffer, size_t size) : buffer_{buffer}, ringSize_{size} {}
+
+	void enqueue(const void *data, size_t recordSize);
+
+	// Copies at most `maxSize` bytes of the record at `deqPtr`; null once `deqPtr` hits the head.
+	frg::optional<Record> dequeueAt(uint64_t deqPtr, void *data, size_t maxSize) const;
+
+	uint64_t headPtr() const { return headPtr_; }
+	uint64_t tailPtr() const { return tailPtr_; }
+
+private:
+	static constexpr size_t headerSize = sizeof(size_t);
+	static constexpr size_t recordAlign = sizeof(size_t);
+
+	static constexpr size_t effectiveSize(size_t recordSize) {
+		return (headerSize + recordSize + recordAlign - 1) & ~(recordAlign - 1);
+	}
+
+	char *buffer_;
+	size_t ringSize_;
+	uint64_t tailPtr_ = 0;
+	uint64_t headPtr_ = 0;
+};
+
+EirLogRing &bootLogRing();
+
+} // namespace eir

--- a/kernel/eir/generic/framebuffer.cpp
+++ b/kernel/eir/generic/framebuffer.cpp
@@ -3,7 +3,10 @@
 #include <eir-internal/debug.hpp>
 #include <eir-internal/framebuffer.hpp>
 #include <eir-internal/generic.hpp>
+#include <eir-internal/log-ring.hpp>
+#include <frg/utility.hpp>
 #include <render-text.hpp>
+#include <string.h>
 
 namespace eir {
 
@@ -17,6 +20,7 @@ frg::optional<EirFramebuffer> &accessGlobalFb() {
 	return *singleton;
 }
 
+// Renders the boot log ring to the framebuffer, scrolling by dropping the oldest lines.
 struct FbLogHandler : LogHandler {
 	// Check whether eir can log to this framebuffer.
 	static bool suitable(const EirFramebuffer &fb) {
@@ -27,40 +31,133 @@ struct FbLogHandler : LogHandler {
 		return true;
 	}
 
+	void initialize(const EirFramebuffer &fb) {
+		window_ = physToVirt<void>(fb.fbAddress);
+		pitch_ = fb.fbPitch / sizeof(uint32_t);
+		numCols_ = fb.fbWidth / fontWidth;
+		numRows_ = fb.fbHeight / fontHeight;
+
+		// Paint the lines that were logged before the framebuffer became available.
+		redraw();
+	}
+
 	void emit(frg::string_view line) override {
-		auto &fb = *accessGlobalFb();
-		for (size_t i = 0; i < line.size(); ++i) {
-			auto c = line[i];
-			if (c == '\n') {
-				outputX_ = 0;
-				outputY_++;
-			} else if (outputX_ >= fb.fbWidth / fontWidth) {
-				outputX_ = 0;
-				outputY_++;
-			} else if (outputY_ >= fb.fbHeight / fontHeight) {
-				// TODO: Scroll.
-			} else {
-				renderChars(
-				    physToVirt<void>(fb.fbAddress),
-				    fb.fbPitch / sizeof(uint32_t),
-				    outputX_,
-				    outputY_,
-				    &c,
-				    1,
-				    15,
-				    -1,
-				    std::integral_constant<int, fontWidth>{},
-				    std::integral_constant<int, fontHeight>{}
-				);
-				outputX_++;
-			}
+		// OutputSink::print() posted the line to the log ring already.
+		if (outputY_ + rowsFor(line.size()) > numRows_) {
+			redraw();
+			return;
 		}
-		outputX_ = 0;
-		outputY_++;
+		renderLine(outputY_, line);
+		outputY_ += rowsFor(line.size());
 	}
 
 private:
-	unsigned int outputX_{0};
+	// Drops records until the tail of the log ring fits onto the screen, then renders it.
+	void redraw() {
+		auto &ring = bootLogRing();
+		char buffer[maxLogLine];
+
+		if (topPtr_ < ring.tailPtr())
+			topPtr_ = ring.tailPtr();
+		auto rows = rowsFrom(topPtr_);
+		while (rows > numRows_) {
+			auto record = ring.dequeueAt(topPtr_, buffer, maxLogLine);
+			assert(record);
+			rows -= rowsFor(record->size);
+			topPtr_ = record->nextPtr;
+		}
+
+		outputY_ = 0;
+		auto ptr = topPtr_;
+		while (auto record = ring.dequeueAt(ptr, buffer, maxLogLine)) {
+			renderLine(outputY_, {buffer, record->size});
+			outputY_ += rowsFor(record->size);
+			ptr = record->nextPtr;
+		}
+
+		for (auto y = outputY_; y < numRows_; ++y)
+			blank(0, y, numCols_);
+	}
+
+	// Number of rows that the records in [ptr, head) occupy.
+	unsigned int rowsFrom(uint64_t ptr) {
+		auto &ring = bootLogRing();
+		char buffer[maxLogLine];
+
+		unsigned int rows = 0;
+		while (auto record = ring.dequeueAt(ptr, buffer, maxLogLine)) {
+			rows += rowsFor(record->size);
+			ptr = record->nextPtr;
+		}
+		return rows;
+	}
+
+	// Number of rows that a line of `length` characters occupies once it is wrapped.
+	unsigned int rowsFor(size_t length) const {
+		if (!length)
+			return 1;
+		return (length + numCols_ - 1) / numCols_;
+	}
+
+	// Renders `line` at row `y`, wrapping and padding each row to the right edge.
+	void renderLine(unsigned int y, frg::string_view line) {
+		unsigned int offset = 0;
+		unsigned int row = 0;
+		do {
+			if (y + row >= numRows_)
+				return;
+			auto n = frg::min(static_cast<unsigned int>(line.size()) - offset, numCols_);
+			renderChars(
+			    window_,
+			    pitch_,
+			    0,
+			    y + row,
+			    line.data() + offset,
+			    n,
+			    15,
+			    -1,
+			    std::integral_constant<int, fontWidth>{},
+			    std::integral_constant<int, fontHeight>{}
+			);
+			blank(n, y + row, numCols_ - n);
+			offset += n;
+			++row;
+		} while (offset < line.size());
+	}
+
+	void blank(unsigned int x, unsigned int y, unsigned int count) {
+		if (y >= numRows_)
+			return;
+
+		char spaces[16];
+		memset(spaces, ' ', sizeof(spaces));
+		while (count) {
+			auto n = frg::min(count, static_cast<unsigned int>(sizeof(spaces)));
+			renderChars(
+			    window_,
+			    pitch_,
+			    x,
+			    y,
+			    spaces,
+			    n,
+			    15,
+			    -1,
+			    std::integral_constant<int, fontWidth>{},
+			    std::integral_constant<int, fontHeight>{}
+			);
+			x += n;
+			count -= n;
+		}
+	}
+
+	void *window_{nullptr};
+	unsigned int pitch_{0};
+	unsigned int numCols_{0};
+	unsigned int numRows_{0};
+
+	// Ring pointer of the first record that is displayed on screen.
+	uint64_t topPtr_{0};
+	// Row that the next line is rendered at.
 	unsigned int outputY_{0};
 };
 
@@ -77,6 +174,7 @@ void initFramebuffer(const EirFramebuffer &fb) {
 	globalFb = fb;
 
 	if (FbLogHandler::suitable(fb)) {
+		fbLogHandler.initialize(fb);
 		enableLogHandler(&fbLogHandler);
 	} else {
 		infoLogger() << "eir: Framebuffer is not suitable for logging" << frg::endlog;

--- a/kernel/eir/generic/log-ring.cpp
+++ b/kernel/eir/generic/log-ring.cpp
@@ -1,0 +1,90 @@
+#include <assert.h>
+
+#include <eir-internal/log-ring.hpp>
+#include <frg/utility.hpp>
+#include <string.h>
+
+namespace eir {
+
+namespace {
+
+// 32 KiB is more than enough to back a full screen of text.
+constexpr size_t bootLogRingSize = 0x8000;
+static_assert(bootLogRingSize && !(bootLogRingSize & (bootLogRingSize - 1)));
+
+alignas(8) constinit char bootLogRingBuffer[bootLogRingSize];
+
+constinit EirLogRing logRing{bootLogRingBuffer, bootLogRingSize};
+
+} // anonymous namespace
+
+void EirLogRing::enqueue(const void *data, size_t recordSize) {
+	auto p = reinterpret_cast<const char *>(data);
+	assert(effectiveSize(recordSize) <= ringSize_);
+
+	auto enqPtr = headPtr_;
+
+	// Compute the invalidated part of the ring buffer.
+	auto invalPtr = tailPtr_;
+	while (invalPtr + ringSize_ < enqPtr + headerSize + recordSize) {
+		assert(invalPtr < enqPtr);
+		auto tailOffset = static_cast<size_t>(invalPtr & (ringSize_ - 1));
+		// Alignment guarantees that the header fits contiguously.
+		assert(!(tailOffset > ringSize_ - headerSize));
+
+		size_t tailSize;
+		memcpy(&tailSize, buffer_ + tailOffset, sizeof(size_t));
+		assert(tailSize <= ringSize_);
+
+		invalPtr += effectiveSize(tailSize);
+	}
+
+	// Invalidate the ring *before* writing to it.
+	assert(!(invalPtr & (recordAlign - 1)));
+	tailPtr_ = invalPtr;
+
+	// Copy to the ring.
+	auto recordOffset = static_cast<size_t>(enqPtr & (ringSize_ - 1));
+	// Alignment guarantees that the header fits contiguously.
+	assert(!(recordOffset > ringSize_ - headerSize));
+
+	memcpy(buffer_ + recordOffset, &recordSize, sizeof(size_t));
+	auto preWrapSize = frg::min(ringSize_ - (recordOffset + headerSize), recordSize);
+	memcpy(buffer_ + recordOffset + sizeof(size_t), p, preWrapSize);
+	memcpy(buffer_, p + preWrapSize, recordSize - preWrapSize);
+
+	// Commit the operation *after* writing to the ring.
+	headPtr_ = enqPtr + effectiveSize(recordSize);
+}
+
+frg::optional<EirLogRing::Record>
+EirLogRing::dequeueAt(uint64_t deqPtr, void *data, size_t maxSize) const {
+	auto p = reinterpret_cast<char *>(data);
+
+	// Records before the tail have been invalidated by now.
+	if (deqPtr < tailPtr_)
+		deqPtr = tailPtr_;
+	if (deqPtr == headPtr_)
+		return frg::null_opt;
+	assert(deqPtr < headPtr_);
+
+	// Copy from the ring.
+	auto recordOffset = static_cast<size_t>(deqPtr & (ringSize_ - 1));
+	// Alignment guarantees that the header fits contiguously.
+	assert(!(recordOffset > ringSize_ - headerSize));
+
+	size_t recordSize;
+	memcpy(&recordSize, buffer_ + recordOffset, sizeof(size_t));
+	assert(recordSize <= ringSize_ - headerSize);
+
+	auto chunkSize = frg::min(recordSize, maxSize);
+	auto preWrapSize = frg::min(ringSize_ - (recordOffset + headerSize), chunkSize);
+	memcpy(p, buffer_ + recordOffset + sizeof(size_t), preWrapSize);
+	memcpy(p + preWrapSize, buffer_, chunkSize - preWrapSize);
+
+	return Record{deqPtr + effectiveSize(recordSize), chunkSize};
+}
+
+EirLogRing &bootLogRing() { return logRing; }
+
+} // namespace eir

--- a/kernel/eir/meson.build
+++ b/kernel/eir/meson.build
@@ -7,6 +7,7 @@ eir_generic_sources = files(
 	'../common/uart/pl011.cpp',
 	'../common/uart/samsung.cpp',
 	'generic/cmdline.cpp',
+	'generic/log-ring.cpp',
 	'generic/main.cpp',
 	'generic/memory-layout.cpp',
 	'generic/debug.cpp',


### PR DESCRIPTION
We let Eir write its logs to a ring buffer. Then we use the ring buffer to record old messages to be able to redraw the entire screen when scrolling.