### PR TITLE
general: Let userspace hand out rights and require rights as needed

### DIFF
--- a/core/drm/src/core.cpp
+++ b/core/drm/src/core.cpp
@@ -312,8 +312,8 @@ struct ServeDeviceVisitor {
 
 			auto [send_resp, push_pt, push_page] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax),
-				helix_ng::pushDescriptor(file->statusPageMemory(), kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage),
+				helix_ng::pushDescriptor(file->statusPageMemory(), kHelRightRead | kHelRightAssign)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_pt.error());
@@ -321,7 +321,7 @@ struct ServeDeviceVisitor {
 		}else if(req.req_type() == managarm::fs::CntReqType::OPEN_FD_LANE) {
 			auto [fd_lane] = co_await helix_ng::exchangeMsgs(
 				conversation,
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(fd_lane.error());
 

--- a/core/drm/src/core.cpp
+++ b/core/drm/src/core.cpp
@@ -312,8 +312,8 @@ struct ServeDeviceVisitor {
 
 			auto [send_resp, push_pt, push_page] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(remote_lane),
-				helix_ng::pushDescriptor(file->statusPageMemory())
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax),
+				helix_ng::pushDescriptor(file->statusPageMemory(), kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_pt.error());
@@ -321,7 +321,7 @@ struct ServeDeviceVisitor {
 		}else if(req.req_type() == managarm::fs::CntReqType::OPEN_FD_LANE) {
 			auto [fd_lane] = co_await helix_ng::exchangeMsgs(
 				conversation,
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			);
 			HEL_CHECK(fd_lane.error());
 

--- a/core/drm/src/ioctl.cpp
+++ b/core/drm/src/ioctl.cpp
@@ -1264,7 +1264,7 @@ struct drm_core::File::HandleIoctl {
 				self->_device->_posixLane,
 				helix_ng::offer(
 					helix_ng::sendBuffer(fd_ser.data(), fd_ser.size()),
-					helix_ng::pushDescriptor(helix::BorrowedDescriptor(remote_lane), kHelRightsMax),
+					helix_ng::pushDescriptor(helix::BorrowedDescriptor(remote_lane), kHelRightInvoke | kHelRightManage),
 					helix_ng::recvInline())
 			);
 			HEL_CHECK(offer.error());

--- a/core/drm/src/ioctl.cpp
+++ b/core/drm/src/ioctl.cpp
@@ -1264,7 +1264,7 @@ struct drm_core::File::HandleIoctl {
 				self->_device->_posixLane,
 				helix_ng::offer(
 					helix_ng::sendBuffer(fd_ser.data(), fd_ser.size()),
-					helix_ng::pushDescriptor(helix::BorrowedDescriptor(remote_lane)),
+					helix_ng::pushDescriptor(helix::BorrowedDescriptor(remote_lane), kHelRightsMax),
 					helix_ng::recvInline())
 			);
 			HEL_CHECK(offer.error());

--- a/core/lib/clock.cpp
+++ b/core/lib/clock.cpp
@@ -24,7 +24,7 @@ async::result<void> fetchTrackerPage() {
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		)
 	);
 	HEL_CHECK(offer.error());

--- a/core/lib/clock.cpp
+++ b/core/lib/clock.cpp
@@ -24,7 +24,7 @@ async::result<void> fetchTrackerPage() {
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightRead | kHelRightAssign)
 		)
 	);
 	HEL_CHECK(offer.error());
@@ -39,7 +39,7 @@ async::result<void> fetchTrackerPage() {
 
 	globalTrackerPageMemory = pullMemory.descriptor();
 
-	trackerPageMapping = helix::Mapping{globalTrackerPageMemory, 0, 0x1000};
+	trackerPageMapping = helix::Mapping{globalTrackerPageMemory, 0, 0x1000, kHelMapProtRead};
 }
 
 } // anonymous namespace

--- a/drivers/clocktracker/src/main.cpp
+++ b/drivers/clocktracker/src/main.cpp
@@ -76,7 +76,7 @@ struct HandleRequest {
 		auto [sendResp, sendMemory] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(trackerPageMemory)
+			helix_ng::pushDescriptor(trackerPageMemory, kHelRightsMax)
 		);
 		HEL_CHECK(sendResp.error());
 		HEL_CHECK(sendMemory.error());

--- a/drivers/clocktracker/src/main.cpp
+++ b/drivers/clocktracker/src/main.cpp
@@ -76,7 +76,7 @@ struct HandleRequest {
 		auto [sendResp, sendMemory] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(trackerPageMemory, kHelRightsMax)
+			helix_ng::pushDescriptor(trackerPageMemory, kHelRightRead | kHelRightAssign)
 		);
 		HEL_CHECK(sendResp.error());
 		HEL_CHECK(sendMemory.error());

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -137,7 +137,7 @@ struct HandlePartition {
 		auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBuffer(ser.data(), ser.size()),
-			helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+			helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 		);
 		HEL_CHECK(send_resp.error());
 		HEL_CHECK(push_node.error());

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -80,7 +80,7 @@ struct HandlePartition {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
@@ -540,7 +540,7 @@ struct HandleDevice {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -61,7 +61,7 @@ struct HandlePartition {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
@@ -80,7 +80,7 @@ struct HandlePartition {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
@@ -117,13 +117,11 @@ struct HandlePartition {
 			resp.set_error(managarm::fs::Errors::NO_BACKING_DEVICE);
 
 			auto ser = resp.SerializeAsString();
-			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
 				conversation,
-				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor({})
+				helix_ng::sendBuffer(ser.data(), ser.size())
 			);
 			HEL_CHECK(send_resp.error());
-			HEL_CHECK(push_node.error());
 			co_return {};
 		}
 
@@ -139,7 +137,7 @@ struct HandlePartition {
 		auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBuffer(ser.data(), ser.size()),
-			helix_ng::pushDescriptor(remote_lane)
+			helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 		);
 		HEL_CHECK(send_resp.error());
 		HEL_CHECK(push_node.error());
@@ -542,7 +540,7 @@ struct HandleDevice {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
@@ -565,13 +563,11 @@ struct HandleDevice {
 		resp.set_error(managarm::fs::Errors::ILLEGAL_OPERATION_TARGET);
 
 		auto ser = resp.SerializeAsString();
-		auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
+		auto [send_resp] = co_await helix_ng::exchangeMsgs(
 			conversation,
-			helix_ng::sendBuffer(ser.data(), ser.size()),
-			helix_ng::pushDescriptor({})
+			helix_ng::sendBuffer(ser.data(), ser.size())
 		);
 		HEL_CHECK(send_resp.error());
-		HEL_CHECK(push_node.error());
 		co_return {};
 	}
 

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -61,7 +61,7 @@ struct HandlePartition {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());

--- a/drivers/libevbackend/src/libevbackend.cpp
+++ b/drivers/libevbackend/src/libevbackend.cpp
@@ -440,8 +440,8 @@ struct HandleDevice {
 			auto [send_resp, push_pt, push_page] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane),
-				helix_ng::pushDescriptor(file->_statusPage.getMemory())
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax),
+				helix_ng::pushDescriptor(file->_statusPage.getMemory(), kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_pt.error());

--- a/drivers/libevbackend/src/libevbackend.cpp
+++ b/drivers/libevbackend/src/libevbackend.cpp
@@ -440,8 +440,8 @@ struct HandleDevice {
 			auto [send_resp, push_pt, push_page] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax),
-				helix_ng::pushDescriptor(file->_statusPage.getMemory(), kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage),
+				helix_ng::pushDescriptor(file->_statusPage.getMemory(), kHelRightRead | kHelRightAssign)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_pt.error());

--- a/drivers/libsound/src/card.cpp
+++ b/drivers/libsound/src/card.cpp
@@ -227,7 +227,7 @@ async::detached serveCard(sound::Card *card,
 			auto [send_resp, push_pt] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_pt.error());

--- a/drivers/libsound/src/card.cpp
+++ b/drivers/libsound/src/card.cpp
@@ -227,7 +227,7 @@ async::detached serveCard(sound::Card *card,
 			auto [send_resp, push_pt] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_pt.error());

--- a/drivers/libsound/src/device.cpp
+++ b/drivers/libsound/src/device.cpp
@@ -1141,8 +1141,8 @@ async::detached serveDevice(sound::Device *device,
 			auto [send_resp, push_pt, push_page] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(remote_lane),
-				helix_ng::pushDescriptor(file->statusPage.getMemory())
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax),
+				helix_ng::pushDescriptor(file->statusPage.getMemory(), kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_pt.error());

--- a/drivers/libsound/src/device.cpp
+++ b/drivers/libsound/src/device.cpp
@@ -1141,8 +1141,8 @@ async::detached serveDevice(sound::Device *device,
 			auto [send_resp, push_pt, push_page] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax),
-				helix_ng::pushDescriptor(file->statusPage.getMemory(), kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage),
+				helix_ng::pushDescriptor(file->statusPage.getMemory(), kHelRightRead | kHelRightAssign)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_pt.error());

--- a/drivers/nic/usb_net/src/usb-mbim.cpp
+++ b/drivers/nic/usb_net/src/usb-mbim.cpp
@@ -169,7 +169,7 @@ struct HandleDevice {
 			auto ser = resp.SerializeAsString();
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());

--- a/drivers/nic/usb_net/src/usb-mbim.cpp
+++ b/drivers/nic/usb_net/src/usb-mbim.cpp
@@ -169,7 +169,7 @@ struct HandleDevice {
 			auto ser = resp.SerializeAsString();
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());

--- a/drivers/uart/src/main.cpp
+++ b/drivers/uart/src/main.cpp
@@ -292,7 +292,7 @@ struct HandleRequest {
 			auto ser = resp.SerializeAsString();
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());

--- a/drivers/uart/src/main.cpp
+++ b/drivers/uart/src/main.cpp
@@ -292,7 +292,7 @@ struct HandleRequest {
 			auto ser = resp.SerializeAsString();
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());

--- a/drivers/usb/devices/serial/src/main.cpp
+++ b/drivers/usb/devices/serial/src/main.cpp
@@ -273,7 +273,7 @@ struct HandleTerminal {
 			auto ser = resp.SerializeAsString();
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());

--- a/drivers/usb/devices/serial/src/main.cpp
+++ b/drivers/usb/devices/serial/src/main.cpp
@@ -273,7 +273,7 @@ struct HandleTerminal {
 			auto ser = resp.SerializeAsString();
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());

--- a/hel/include/hel-stubs-aarch64.h
+++ b/hel/include/hel-stubs-aarch64.h
@@ -260,6 +260,25 @@ extern inline __attribute__ (( always_inline )) HelError helSyscall5(int number,
 	return error;
 }
 
+extern inline __attribute__ (( always_inline )) HelError helSyscall5_1(int number,
+		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3, HelWord arg4, HelWord *res0) {
+	register HelWord error asm("x0");
+	register HelWord code asm("x0") = number;
+	register HelWord in0 asm("x1") = arg0;
+	register HelWord in1 asm("x2") = arg1;
+	register HelWord in2 asm("x3") = arg2;
+	register HelWord in3 asm("x4") = arg3;
+	register HelWord in4 asm("x5") = arg4;
+	register HelWord out0 asm("x1");
+
+	asm volatile ( "svc 0" : "=r" (error), "=r" (out0)
+			: "r" (code), "r" (in0), "r" (in1), "r" (in2), "r" (in3), "r" (in4)
+			: "memory" );
+
+	*res0 = out0;
+	return error;
+}
+
 extern inline __attribute__ (( always_inline )) HelError helSyscall6(int number,
 		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3, HelWord arg4,
 		HelWord arg5) {

--- a/hel/include/hel-stubs-riscv64.h
+++ b/hel/include/hel-stubs-riscv64.h
@@ -263,6 +263,25 @@ extern inline __attribute__ (( always_inline )) HelError helSyscall5 (int number
 	return error;
 }
 
+extern inline __attribute__ (( always_inline )) HelError helSyscall5_1 (int number,
+		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3, HelWord arg4, HelWord *res0) {
+	register HelWord error asm("a0");
+	register HelWord code asm("a0") = number;
+	register HelWord in0 asm("a1") = arg0;
+	register HelWord in1 asm("a2") = arg1;
+	register HelWord in2 asm("a3") = arg2;
+	register HelWord in3 asm("a4") = arg3;
+	register HelWord in4 asm("a5") = arg4;
+	register HelWord out0 asm("a1");
+
+	asm volatile ( "ecall" : "=r" (error), "=r" (out0)
+			: "r" (code), "r" (in0), "r" (in1), "r" (in2), "r" (in3), "r" (in4)
+			: "memory" );
+
+	*res0 = out0;
+	return error;
+}
+
 extern inline __attribute__ (( always_inline )) HelError helSyscall6 (int number,
 		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3, HelWord arg4,
 		HelWord arg5) {

--- a/hel/include/hel-stubs-x86_64.h
+++ b/hel/include/hel-stubs-x86_64.h
@@ -261,6 +261,25 @@ extern inline __attribute__ (( always_inline )) HelError helSyscall5(int number,
 	return error;
 }
 
+extern inline __attribute__ (( always_inline )) HelError helSyscall5_1(int number,
+		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3, HelWord arg4, HelWord *res0) {
+	register HelWord in0 asm("rsi") = arg0;
+	register HelWord in1 asm("rdx") = arg1;
+	register HelWord in2 asm("rax") = arg2;
+	register HelWord in3 asm("r8") = arg3;
+	register HelWord in4 asm("r9") = arg4;
+
+	HelWord error;
+	register HelWord out0 asm("rsi");
+
+	asm volatile ( "syscall" : "=D" (error), "=r" (out0)
+			: "D" (number), "r" (in0), "r" (in1), "r" (in2), "r" (in3), "r" (in4)
+			: "rcx", "r11", "rbx", "memory" );
+
+	*res0 = out0;
+	return error;
+}
+
 extern inline __attribute__ (( always_inline )) HelError helSyscall6(int number,
 		HelWord arg0, HelWord arg1, HelWord arg2, HelWord arg3, HelWord arg4,
 		HelWord arg5) {

--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -36,10 +36,10 @@ extern inline __attribute__ (( always_inline )) HelError helCreateUniverse(HelHa
 };
 
 extern inline __attribute__ (( always_inline )) HelError helTransferDescriptor(HelHandle handle,
-		HelHandle universe_handle, enum HelTransferDescriptorFlags direction, HelHandle *out_handle) {
+		HelHandle universe_handle, uint32_t flags, uint32_t exposedRights, uint32_t requiredRights, HelHandle *out_handle) {
 	HelWord hel_out_handle;
-	HelError error = helSyscall3_1(kHelCallTransferDescriptor, (HelWord)handle,
-			(HelWord) universe_handle, (HelWord) direction, &hel_out_handle);
+	HelError error = helSyscall5_1(kHelCallTransferDescriptor, (HelWord)handle,
+			(HelWord)universe_handle, (HelWord)flags, (HelWord)exposedRights, (HelWord)requiredRights, &hel_out_handle);
 	*out_handle = (HelHandle)hel_out_handle;
 	return error;
 };

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -170,6 +170,7 @@ static const HelRights kHelRightTake = UINT32_C(1) << 1;
 // - Address space: required to read from it.
 // - Address space: required to create thread.
 // - Virtualized space: required to read from it.
+// - I/O objects: required to enable userspace I/O.
 // - Thread: required to read registers.
 // - Thread: required to read memory in its address space.
 // - Thread: required to get the affinity.
@@ -183,6 +184,7 @@ static const HelRights kHelRightRead = UINT32_C(1) << 2;
 // - Address space: required to write to it.
 // - Address space: required to create thread.
 // - Virtualized space: required to write to it.
+// - I/O objects: required to enable userspace I/O.
 // - Thread: required to write registers.
 // - Thread: required to write memory in its address space.
 // - Thread: required to set the affinity.

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -408,10 +408,24 @@ struct HelSgItem {
 struct HelAction {
 	int type;
 	uint32_t flags;
-	// TODO: the following fields could be put into unions
-	void *buffer;
-	size_t length;
-	HelHandle handle;
+	// TODO: It may be worth to restructure this to a union of structs
+	//       (e.g., a HelActionDataBufferSize, HelActionDataDescriptorRights, ...),
+	//       but that requires simultaneous mlibc and Managarm changes.
+	union {
+		uintptr_t word0;
+		void *buffer;
+	};
+	union {
+		uintptr_t word1;
+		size_t length;
+		// For kHelPushDescriptor, kHelPullDescriptor.
+		uint32_t rights;
+	};
+	union {
+		uintptr_t word2;
+		// For kHelActionImbueCredentials, kHelPushDescriptor, kHelPullDescriptor.
+		HelHandle handle;
+	};
 };
 
 struct HelDescriptorInfo {

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -254,6 +254,8 @@ static const HelRights kHelRightSignal = UINT32_C(1) << 12;
 // - Thread: required to resume.
 // - Thread: required to kill.
 static const HelRights kHelRightManage = UINT32_C(1) << 13;
+// All rights (even unspecified ones). Easier to recognize in code than a literal.
+static const HelRights kHelRightsMax = ~UINT32_C(0);
 
 struct HelX86SegmentRegister {
 	uint64_t base;
@@ -395,10 +397,8 @@ enum {
 	kHelItemWantLane = (1 << 16),
 };
 
-enum HelTransferDescriptorFlags {
-	kHelTransferDescriptorOut,
-	kHelTransferDescriptorIn,
-};
+static const uint32_t kHelTransferDescriptorOut = UINT32_C(1) << 0;
+static const uint32_t kHelTransferDescriptorIn = UINT32_C(1) << 1;
 
 struct HelSgItem {
 	void *buffer;
@@ -1073,7 +1073,7 @@ HEL_C_LINKAGE HelError helCreateUniverse(HelHandle *handle);
 //!    	Handle to the copied descriptor (valid in the universe specified by @p universeHandle).
 HEL_C_LINKAGE HelError
 helTransferDescriptor(HelHandle handle, HelHandle universeHandle,
-		enum HelTransferDescriptorFlags direction, HelHandle *outHandle);
+		uint32_t flags, uint32_t exposedRights, uint32_t requiredRights, HelHandle *outHandle);
 
 HEL_C_LINKAGE HelError helDescriptorInfo(HelHandle handle, struct HelDescriptorInfo *info);
 

--- a/hel/include/helix/ipc-structs.hpp
+++ b/hel/include/helix/ipc-structs.hpp
@@ -495,9 +495,12 @@ struct RecvInline { };
 
 struct PushDescriptor {
 	HelHandle handle;
+	uint32_t exposedRights;
 };
 
-struct PullDescriptor { };
+struct PullDescriptor {
+	uint32_t requiredRights;
+};
 
 template <typename Allocator>
 struct SendBragiHeadTail {
@@ -586,12 +589,17 @@ inline auto recvInline() {
 	return RecvInline{};
 }
 
-inline auto pushDescriptor(BorrowedDescriptor desc) {
-	return PushDescriptor{desc.getHandle()};
+inline auto pushDescriptor(BorrowedDescriptor desc, uint32_t exposedRights) {
+	return PushDescriptor{
+		.handle = desc.getHandle(),
+		.exposedRights = exposedRights
+	};
 }
 
-inline auto pullDescriptor() {
-	return PullDescriptor{};
+inline auto pullDescriptor(uint32_t requiredRights) {
+	return PullDescriptor{
+		.requiredRights = requiredRights
+	};
 }
 
 template <typename Message, typename Allocator>
@@ -734,14 +742,16 @@ inline auto createActionsArrayFor(bool chain, const PushDescriptor &item) {
 	action.type = kHelActionPushDescriptor;
 	action.flags = chain ? kHelItemChain : 0;
 	action.handle = item.handle;
+	action.rights = item.exposedRights;
 
 	return frg::array<HelAction, 1>{action};
 }
 
-inline auto createActionsArrayFor(bool chain, const PullDescriptor &) {
+inline auto createActionsArrayFor(bool chain, const PullDescriptor &item) {
 	HelAction action{};
 	action.type = kHelActionPullDescriptor;
 	action.flags = chain ? kHelItemChain : 0;
+	action.rights = item.requiredRights;
 
 	return frg::array<HelAction, 1>{action};
 }

--- a/hel/include/helix/ipc-structs.hpp
+++ b/hel/include/helix/ipc-structs.hpp
@@ -61,7 +61,14 @@ struct UniqueDescriptor {
 		if(!_handle)
 			return {};
 		HelHandle newHandle;
-		HEL_CHECK(helTransferDescriptor(getHandle(), kHelThisUniverse, kHelTransferDescriptorOut, &newHandle));
+		HEL_CHECK(helTransferDescriptor(
+			getHandle(),
+			kHelThisUniverse,
+			kHelTransferDescriptorOut,
+			kHelRightsMax,
+			kHelRightNull,
+			&newHandle
+		));
 		return UniqueDescriptor(newHandle);
 	}
 
@@ -92,7 +99,14 @@ struct BorrowedDescriptor {
 
 	UniqueDescriptor dup() const {
 		HelHandle new_handle;
-		HEL_CHECK(helTransferDescriptor(getHandle(), kHelThisUniverse, kHelTransferDescriptorOut, &new_handle));
+		HEL_CHECK(helTransferDescriptor(
+			getHandle(),
+			kHelThisUniverse,
+			kHelTransferDescriptorOut,
+			kHelRightsMax,
+			kHelRightNull,
+			&new_handle
+		));
 		return UniqueDescriptor(new_handle);
 	}
 

--- a/hel/include/helix/ipc.hpp
+++ b/hel/include/helix/ipc.hpp
@@ -83,7 +83,14 @@ struct BorrowedResource : BorrowedDescriptor {
 
 	UniqueResource<Tag> dup() const {
 		HelHandle new_handle;
-		HEL_CHECK(helTransferDescriptor(getHandle(), kHelThisUniverse, kHelTransferDescriptorOut, &new_handle));
+		HEL_CHECK(helTransferDescriptor(
+			getHandle(),
+			kHelThisUniverse,
+			kHelTransferDescriptorOut,
+			kHelRightsMax,
+			kHelRightNull,
+			&new_handle
+		));
 		return UniqueResource<Tag>(new_handle);
 	}
 };

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -2869,6 +2869,8 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 					return kHelErrNoDescriptor;
 				operand = std::move(*wrapper);
 
+				operand.exposeRights(recipe->rights);
+
 				node->_tag = kTagPushDescriptor;
 				node->_inDescriptor = std::move(operand);
 				ipcSize += ipcSourceSize(sizeof(HelSimpleResult));
@@ -3248,15 +3250,23 @@ HelError doSubmitExchangeMsgs(HelHandle laneHandle, smarter::shared_ptr<IpcQueue
 				link(&item->mainSource);
 			}else if(recipe->type == kHelActionPullDescriptor) {
 				// TODO: This condition should be replaced. Just test if lane is valid.
+				Error e = Error::success;
 				HelHandle handle = kHelNullHandle;
-				if(node->error() == Error::success) {
-					auto universe = weakUniverse.lock();
-					assert(universe);
+				if(node->error() != Error::success) {
+					e = node->error();
+				} else {
+					auto descriptor = node->descriptor();
+					if (!checkRights(descriptor.rights(), recipe->rights)) {
+						e = Error::badRights;
+					} else {
+						auto universe = weakUniverse.lock();
+						assert(universe);
 
-					handle = universe->attachDescriptor(node->descriptor());
+						handle = universe->attachDescriptor(std::move(descriptor));
+					}
 				}
 
-				item->helHandleResult = {translateError(node->error()), 0, handle};
+				item->helHandleResult = {translateError(e), 0, handle};
 				item->mainSource.setup(&item->helHandleResult, sizeof(HelHandleResult));
 				link(&item->mainSource);
 			}else{

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -278,7 +278,17 @@ HelError helCreateUniverse(HelHandle *handle) {
 }
 
 HelError
-helTransferDescriptor(HelHandle handle, HelHandle universeHandle, HelTransferDescriptorFlags direction, HelHandle *outHandle) {
+helTransferDescriptor(
+	HelHandle handle,
+	HelHandle universeHandle,
+	uint32_t flags,
+	uint32_t exposedRights,
+	uint32_t requiredRights,
+	HelHandle *outHandle
+) {
+	if(flags & ~(kHelTransferDescriptorOut | kHelTransferDescriptorIn))
+		return kHelErrIllegalArgs;
+	uint32_t direction = flags & (kHelTransferDescriptorOut | kHelTransferDescriptorIn);
 	if(direction != kHelTransferDescriptorOut && direction != kHelTransferDescriptorIn)
 		return kHelErrIllegalArgs;
 
@@ -316,10 +326,14 @@ helTransferDescriptor(HelHandle handle, HelHandle universeHandle, HelTransferDes
 	auto maybeDescriptor = srcUniverse->getDescriptor(handle);
 	if (!maybeDescriptor)
 		return kHelErrNoDescriptor;
+	auto descriptor = std::move(*maybeDescriptor);
 
-	// TODO: make sure the descriptor is copyable.
+	descriptor.exposeRights(exposedRights);
 
-	*outHandle = dstUniverse->attachDescriptor(std::move(*maybeDescriptor));
+	if (!checkRights(descriptor.rights(), requiredRights))
+		return kHelErrBadRights;
+
+	*outHandle = dstUniverse->attachDescriptor(std::move(descriptor));
 	return kHelErrNone;
 }
 

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3599,7 +3599,7 @@ HelError helAccessIo(uintptr_t *port_array, size_t num_ports,
 	}
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::io>(std::move(io_space), kHelRightAssign));
+			AnyDescriptor::make<DescriptorType::io>(std::move(io_space), kHelRightRead | kHelRightWrite | kHelRightAssign));
 
 	return kHelErrNone;
 }
@@ -3609,7 +3609,7 @@ HelError helEnableIo(HelHandle handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto ioOutcome = this_universe->resolveObject<DescriptorType::io>(handle, kHelRightAssign);
+	auto ioOutcome = this_universe->resolveObject<DescriptorType::io>(handle, kHelRightRead | kHelRightWrite | kHelRightAssign);
 	if(!ioOutcome)
 		return translateError(ioOutcome.error());
 	auto io_space = std::move(*ioOutcome);

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -610,9 +610,13 @@ void handleSyscall(SyscallImageAccessor image) {
 	} break;
 	case kHelCallTransferDescriptor: {
 		HelHandle out_handle;
-		*image.error() =
-			helTransferDescriptor((HelHandle)arg0, (HelHandle)arg1,
-				(HelTransferDescriptorFlags) arg2, &out_handle);
+		*image.error() = helTransferDescriptor(
+			(HelHandle)arg0,
+			(HelHandle)arg1,
+			(uint32_t)arg2,
+			(uint32_t)arg3,
+			(uint32_t)arg4,
+			&out_handle);
 		*image.out0() = out_handle;
 	} break;
 	case kHelCallDescriptorInfo: {

--- a/kernel/thor/generic/thor-internal/universe.hpp
+++ b/kernel/thor/generic/thor-internal/universe.hpp
@@ -33,6 +33,10 @@ struct IrqObject;
 struct OneshotEvent;
 struct BitsetEvent;
 
+inline bool checkRights(uint32_t rights, uint32_t requiredRights) {
+	return (rights & requiredRights) == requiredRights;
+}
+
 // --------------------------------------------------------
 // Lane handles.
 // --------------------------------------------------------
@@ -285,7 +289,7 @@ struct AnyDescriptor {
 	std::expected<DescriptorPointer<K>, Error> resolveObject(uint32_t requiredRights) const {
 		if (!is<K>())
 			return std::unexpected{Error::badDescriptor};
-		if ((rights_ & requiredRights) != requiredRights)
+		if (!checkRights(rights_, requiredRights))
 			return std::unexpected{Error::badRights};
 		return resolve_<K>();
 	}
@@ -296,10 +300,15 @@ struct AnyDescriptor {
 	resolveCapability(uint32_t requiredRights) const {
 		if (!is<K>())
 			return std::unexpected{Error::badDescriptor};
-		if ((rights_ & requiredRights) != requiredRights)
+		if (!checkRights(rights_, requiredRights))
 			return std::unexpected{Error::badRights};
 		auto object = FRG_TRY(resolve_<K>());
 		return std::tuple{std::move(object), rights_};
+	}
+
+	// Keep only the rights in the exposedRights mask.
+	void exposeRights(uint32_t exposedRights) {
+		rights_ &= exposedRights;
 	}
 
 private:

--- a/kernel/thor/system/acpi/acpi.cpp
+++ b/kernel/thor/system/acpi/acpi.cpp
@@ -230,7 +230,10 @@ AcpiObject::handleRequest(smarter::shared_ptr<Stream, LanePolicy> lane) {
 		FRG_CO_TRY(co_await sendResponse(conversation, std::move(resp)));
 
 		auto ioError = co_await pushDescriptor(
-		    conversation, AnyDescriptor::make<DescriptorType::io>(space, kHelRightAssign)
+		    conversation,
+		    AnyDescriptor::make<DescriptorType::io>(
+		        space, kHelRightRead | kHelRightWrite | kHelRightAssign
+		    )
 		);
 		if (ioError != Error::success)
 			co_return ioError;

--- a/kernel/thor/system/legacy-pc/ata.cpp
+++ b/kernel/thor/system/legacy-pc/ata.cpp
@@ -119,7 +119,7 @@ private:
 
 			FRG_CO_TRY(co_await sendResponse(lane, std::move(resp)));
 
-			auto ioError = co_await pushDescriptor(lane, AnyDescriptor::make<DescriptorType::io>(space, kHelRightAssign));
+			auto ioError = co_await pushDescriptor(lane, AnyDescriptor::make<DescriptorType::io>(space, kHelRightRead | kHelRightWrite | kHelRightAssign));
 			if(ioError != Error::success)
 				co_return ioError;
 		}else if(preamble.id() == bragi::message_id<managarm::hw::AccessIrqRequest>) {

--- a/kernel/thor/system/pci/pci_discover.cpp
+++ b/kernel/thor/system/pci/pci_discover.cpp
@@ -309,7 +309,7 @@ coroutine<frg::expected<Error>> PciEntity::handleRequest(smarter::shared_ptr<Str
 
 		AnyDescriptor descriptor;
 		if(bars[index].type == PciBar::kBarIo) {
-			descriptor = AnyDescriptor::make<DescriptorType::io>(bars[index].io, kHelRightAssign);
+			descriptor = AnyDescriptor::make<DescriptorType::io>(bars[index].io, kHelRightRead | kHelRightWrite | kHelRightAssign);
 		}else{
 			assert(bars[index].type == PciBar::kBarMemory);
 			descriptor = AnyDescriptor::make<DescriptorType::memoryView>(

--- a/mbus/src/main.cpp
+++ b/mbus/src/main.cpp
@@ -337,7 +337,7 @@ async::detached doGetRemoteLane(helix::UniqueLane conversation, std::shared_ptr<
 		co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(remoteLane, kHelRightsMax)
+			helix_ng::pushDescriptor(remoteLane, kHelRightInvoke | kHelRightManage)
 		);
 	HEL_CHECK(sendResp.error());
 	HEL_CHECK(pushLane.error());
@@ -348,7 +348,7 @@ struct HandleMgmtRequest {
 		auto [pullLane] =
 			co_await helix_ng::exchangeMsgs(
 				conversation,
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			);
 		HEL_CHECK(pullLane.error());
 
@@ -498,7 +498,7 @@ struct HandleRequest {
 			co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(remoteLane, kHelRightsMax)
+				helix_ng::pushDescriptor(remoteLane, kHelRightInvoke | kHelRightManage)
 			);
 		HEL_CHECK(sendResp.error());
 		HEL_CHECK(pushLane.error());

--- a/mbus/src/main.cpp
+++ b/mbus/src/main.cpp
@@ -337,7 +337,7 @@ async::detached doGetRemoteLane(helix::UniqueLane conversation, std::shared_ptr<
 		co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(remoteLane)
+			helix_ng::pushDescriptor(remoteLane, kHelRightsMax)
 		);
 	HEL_CHECK(sendResp.error());
 	HEL_CHECK(pushLane.error());
@@ -348,7 +348,7 @@ struct HandleMgmtRequest {
 		auto [pullLane] =
 			co_await helix_ng::exchangeMsgs(
 				conversation,
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			);
 		HEL_CHECK(pullLane.error());
 
@@ -498,7 +498,7 @@ struct HandleRequest {
 			co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(remoteLane)
+				helix_ng::pushDescriptor(remoteLane, kHelRightsMax)
 			);
 		HEL_CHECK(sendResp.error());
 		HEL_CHECK(pushLane.error());

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -380,7 +380,7 @@ FutureMaybe<std::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lan
 		helix_ng::offer(
 			helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull))
+			helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage))
 	);
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -252,8 +252,8 @@ openExternalDevice(helix::BorrowedLane lane,
 		helix_ng::offer(
 			helix_ng::sendBuffer(ser.data(), ser.size()),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull),
-			helix_ng::pullDescriptor(kHelRightNull))
+			helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage),
+			helix_ng::pullDescriptor(kHelRightRead | kHelRightAssign))
 	);
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_req.error());
@@ -268,7 +268,7 @@ openExternalDevice(helix::BorrowedLane lane,
 	helix::Mapping status_mapping;
 	if(resp.caps() & managarm::fs::FileCaps::FC_STATUS_PAGE) {
 		assert(!pull_page.error());
-		status_mapping = helix::Mapping{pull_page.descriptor(), 0, 0x1000};
+		status_mapping = helix::Mapping{pull_page.descriptor(), 0, 0x1000, kHelMapProtRead};
 	}
 
 	auto file = smarter::make_shared<DeviceFile>(helix::UniqueLane{},
@@ -287,7 +287,7 @@ openExternalDevice(helix::BorrowedLane lane,
 		auto [fd_offer, fd_send_req, fd_lane] = co_await helix_ng::exchangeMsgs(lane,
 			helix_ng::offer(
 				helix_ng::sendBuffer(fd_ser.data(), fd_ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			)
 		);
 		HEL_CHECK(fd_offer.error());

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -252,8 +252,8 @@ openExternalDevice(helix::BorrowedLane lane,
 		helix_ng::offer(
 			helix_ng::sendBuffer(ser.data(), ser.size()),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(),
-			helix_ng::pullDescriptor())
+			helix_ng::pullDescriptor(kHelRightNull),
+			helix_ng::pullDescriptor(kHelRightNull))
 	);
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_req.error());
@@ -287,7 +287,7 @@ openExternalDevice(helix::BorrowedLane lane,
 		auto [fd_offer, fd_send_req, fd_lane] = co_await helix_ng::exchangeMsgs(lane,
 			helix_ng::offer(
 				helix_ng::sendBuffer(fd_ser.data(), fd_ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			)
 		);
 		HEL_CHECK(fd_offer.error());
@@ -335,7 +335,7 @@ async::result<void> serveServerLane(helix::UniqueDescriptor lane) {
 
 			auto [recv_handle] = co_await helix_ng::exchangeMsgs(
 				conversation,
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			);
 			HEL_CHECK(recv_handle.error());
 
@@ -380,7 +380,7 @@ FutureMaybe<std::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lan
 		helix_ng::offer(
 			helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor())
+			helix_ng::pullDescriptor(kHelRightNull))
 	);
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -335,7 +335,7 @@ async::result<void> serveServerLane(helix::UniqueDescriptor lane) {
 
 			auto [recv_handle] = co_await helix_ng::exchangeMsgs(
 				conversation,
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(recv_handle.error());
 

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -341,8 +341,8 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage),
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -528,7 +528,7 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -591,7 +591,8 @@ private:
 		auto [recv_tail, pull_desc] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::recvBuffer(tail.data(), tail.size()),
-			helix_ng::pullDescriptor(kHelRightNull)
+			// TODO: We can just use the conversation lane instead.
+			helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 		);
 		HEL_CHECK(recv_tail.error());
 
@@ -611,7 +612,7 @@ private:
 		for (size_t i = 0; i < resp.ids().size(); i++) {
 			auto [pull_node] = co_await helix_ng::exchangeMsgs(
 				pull_lane,
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			);
 
 			HEL_CHECK(pull_node.error());
@@ -649,7 +650,7 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -686,7 +687,7 @@ private:
 				helix_ng::sendBuffer(name.data(), name.size()),
 				helix_ng::sendBuffer(path.data(), path.size()),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -727,7 +728,7 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -766,7 +767,7 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -869,8 +870,8 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage),
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -924,7 +925,7 @@ FutureMaybe<std::shared_ptr<FsNode>> Superblock::createRegular(Process *process)
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 		)
 	);
 	HEL_CHECK(offer.error());

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -341,8 +341,8 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull),
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -528,7 +528,7 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -591,7 +591,7 @@ private:
 		auto [recv_tail, pull_desc] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::recvBuffer(tail.data(), tail.size()),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		);
 		HEL_CHECK(recv_tail.error());
 
@@ -611,7 +611,7 @@ private:
 		for (size_t i = 0; i < resp.ids().size(); i++) {
 			auto [pull_node] = co_await helix_ng::exchangeMsgs(
 				pull_lane,
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			);
 
 			HEL_CHECK(pull_node.error());
@@ -649,7 +649,7 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -686,7 +686,7 @@ private:
 				helix_ng::sendBuffer(name.data(), name.size()),
 				helix_ng::sendBuffer(path.data(), path.size()),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -727,7 +727,7 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -766,7 +766,7 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -869,8 +869,8 @@ private:
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull),
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -924,7 +924,7 @@ FutureMaybe<std::shared_ptr<FsNode>> Superblock::createRegular(Process *process)
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		)
 	);
 	HEL_CHECK(offer.error());

--- a/posix/subsystem/src/extern_socket.cpp
+++ b/posix/subsystem/src/extern_socket.cpp
@@ -56,8 +56,8 @@ struct Socket : File {
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull),
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -109,8 +109,8 @@ async::result<smarter::shared_ptr<File, FileHandle>> createSocket(helix::Borrowe
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull),
+			helix_ng::pullDescriptor(kHelRightNull)
 		)
 	);
 	HEL_CHECK(offer.error());

--- a/posix/subsystem/src/extern_socket.cpp
+++ b/posix/subsystem/src/extern_socket.cpp
@@ -56,8 +56,8 @@ struct Socket : File {
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage),
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			)
 		);
 		HEL_CHECK(offer.error());
@@ -109,8 +109,8 @@ async::result<smarter::shared_ptr<File, FileHandle>> createSocket(helix::Borrowe
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage),
+			helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 		)
 	);
 	HEL_CHECK(offer.error());

--- a/posix/subsystem/src/observations.cpp
+++ b/posix/subsystem/src/observations.cpp
@@ -19,6 +19,8 @@ void alertRemoteQueue(Process *self) {
 	    self->accessThreadPage()->queueHandle,
 	    self->fileContext()->getUniverse().getHandle(),
 	    kHelTransferDescriptorIn,
+		kHelRightsMax,
+		kHelRightNull,
 	    &handle
 	);
 

--- a/posix/subsystem/src/observations.cpp
+++ b/posix/subsystem/src/observations.cpp
@@ -19,8 +19,8 @@ void alertRemoteQueue(Process *self) {
 	    self->accessThreadPage()->queueHandle,
 	    self->fileContext()->getUniverse().getHandle(),
 	    kHelTransferDescriptorIn,
-		kHelRightsMax,
-		kHelRightNull,
+		kHelRightSignal,
+		kHelRightSignal,
 	    &handle
 	);
 

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -364,8 +364,8 @@ std::shared_ptr<FileContext> FileContext::create() {
 	    posixMbusClient,
 		context->_universe.getHandle(),
 		kHelTransferDescriptorOut,
-		kHelRightsMax,
-		kHelRightNull,
+		kHelRightInvoke,
+		kHelRightInvoke,
 		&context->_clientMbusLane
 	));
 
@@ -396,8 +396,8 @@ std::shared_ptr<FileContext> FileContext::clone(std::shared_ptr<FileContext> ori
 	    posixMbusClient,
 		context->_universe.getHandle(),
 		kHelTransferDescriptorOut,
-		kHelRightsMax,
-		kHelRightNull,
+		kHelRightInvoke,
+		kHelRightInvoke,
 		&context->_clientMbusLane
 	));
 
@@ -416,8 +416,8 @@ std::expected<int, Error> FileContext::attachFile(smarter::shared_ptr<File, File
 	    file->getPassthroughLane().getHandle(),
 		_universe.getHandle(),
 		kHelTransferDescriptorOut,
-		kHelRightsMax,
-		kHelRightNull,
+		kHelRightInvoke,
+		kHelRightInvoke,
 		&handle
 	));
 
@@ -447,8 +447,8 @@ std::expected<void, Error> FileContext::attachFile(int fd, smarter::shared_ptr<F
 	    file->getPassthroughLane().getHandle(),
 		_universe.getHandle(),
 		kHelTransferDescriptorOut,
-		kHelRightsMax,
-		kHelRightNull,
+		kHelRightInvoke,
+		kHelRightInvoke,
 		&handle
 	));
 
@@ -1323,8 +1323,8 @@ async::result<std::shared_ptr<ThreadGroup>> Process::init(std::string path) {
 	    client_lane.getHandle(),
 	    process->_fileContext->getUniverse().getHandle(),
 	    kHelTransferDescriptorOut,
-		kHelRightsMax,
-		kHelRightNull,
+		kHelRightInvoke,
+		kHelRightInvoke,
 	    &process->_clientPosixLane
 	));
 	client_lane.release();
@@ -1403,8 +1403,8 @@ async::result<std::shared_ptr<Process>> Process::fork(std::shared_ptr<Process> o
 	    client_lane.getHandle(),
 	    process->_fileContext->getUniverse().getHandle(),
 	    kHelTransferDescriptorOut,
-		kHelRightsMax,
-		kHelRightNull,
+		kHelRightInvoke,
+		kHelRightInvoke,
 	    &process->_clientPosixLane
 	));
 	client_lane.release();
@@ -1537,8 +1537,8 @@ Process::clone(std::shared_ptr<Process> original, void *ip, void *sp, posix::sup
 	    client_lane.getHandle(),
 	    process->_fileContext->getUniverse().getHandle(),
 	    kHelTransferDescriptorOut,
-		kHelRightsMax,
-		kHelRightNull,
+		kHelRightInvoke,
+		kHelRightInvoke,
 	    &process->_clientPosixLane
 	));
 	client_lane.release();
@@ -1605,8 +1605,8 @@ async::result<Error> Process::exec(std::shared_ptr<Process> process,
 	    client_lane.getHandle(),
 	    process->_fileContext->getUniverse().getHandle(),
 	    kHelTransferDescriptorOut,
-		kHelRightsMax,
-		kHelRightNull,
+		kHelRightInvoke,
+		kHelRightInvoke,
 	    &exec_posix_lane
 	));
 	client_lane.release();

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -361,7 +361,12 @@ std::shared_ptr<FileContext> FileContext::create() {
 	context->fileTableWindow_ = helix::Mapping{context->_fileTableMemory, 0, 0x1000};
 
 	HEL_CHECK(helTransferDescriptor(
-	    posixMbusClient, context->_universe.getHandle(), kHelTransferDescriptorOut, &context->_clientMbusLane
+	    posixMbusClient,
+		context->_universe.getHandle(),
+		kHelTransferDescriptorOut,
+		kHelRightsMax,
+		kHelRightNull,
+		&context->_clientMbusLane
 	));
 
 	return context;
@@ -388,7 +393,12 @@ std::shared_ptr<FileContext> FileContext::clone(std::shared_ptr<FileContext> ori
 	}
 
 	HEL_CHECK(helTransferDescriptor(
-	    posixMbusClient, context->_universe.getHandle(), kHelTransferDescriptorOut, &context->_clientMbusLane
+	    posixMbusClient,
+		context->_universe.getHandle(),
+		kHelTransferDescriptorOut,
+		kHelRightsMax,
+		kHelRightNull,
+		&context->_clientMbusLane
 	));
 
 	return context;
@@ -403,7 +413,12 @@ std::expected<int, Error> FileContext::attachFile(smarter::shared_ptr<File, File
 		bool closeOnExec, int startAt) {
 	HelHandle handle;
 	HEL_CHECK(helTransferDescriptor(
-	    file->getPassthroughLane().getHandle(), _universe.getHandle(), kHelTransferDescriptorOut, &handle
+	    file->getPassthroughLane().getHandle(),
+		_universe.getHandle(),
+		kHelTransferDescriptorOut,
+		kHelRightsMax,
+		kHelRightNull,
+		&handle
 	));
 
 	for(int fd = startAt; ; fd++) {
@@ -429,7 +444,12 @@ std::expected<void, Error> FileContext::attachFile(int fd, smarter::shared_ptr<F
 
 	HelHandle handle;
 	HEL_CHECK(helTransferDescriptor(
-	    file->getPassthroughLane().getHandle(), _universe.getHandle(), kHelTransferDescriptorOut, &handle
+	    file->getPassthroughLane().getHandle(),
+		_universe.getHandle(),
+		kHelTransferDescriptorOut,
+		kHelRightsMax,
+		kHelRightNull,
+		&handle
 	));
 
 	if(logFileAttach)
@@ -1303,6 +1323,8 @@ async::result<std::shared_ptr<ThreadGroup>> Process::init(std::string path) {
 	    client_lane.getHandle(),
 	    process->_fileContext->getUniverse().getHandle(),
 	    kHelTransferDescriptorOut,
+		kHelRightsMax,
+		kHelRightNull,
 	    &process->_clientPosixLane
 	));
 	client_lane.release();
@@ -1381,6 +1403,8 @@ async::result<std::shared_ptr<Process>> Process::fork(std::shared_ptr<Process> o
 	    client_lane.getHandle(),
 	    process->_fileContext->getUniverse().getHandle(),
 	    kHelTransferDescriptorOut,
+		kHelRightsMax,
+		kHelRightNull,
 	    &process->_clientPosixLane
 	));
 	client_lane.release();
@@ -1513,6 +1537,8 @@ Process::clone(std::shared_ptr<Process> original, void *ip, void *sp, posix::sup
 	    client_lane.getHandle(),
 	    process->_fileContext->getUniverse().getHandle(),
 	    kHelTransferDescriptorOut,
+		kHelRightsMax,
+		kHelRightNull,
 	    &process->_clientPosixLane
 	));
 	client_lane.release();
@@ -1579,6 +1605,8 @@ async::result<Error> Process::exec(std::shared_ptr<Process> process,
 	    client_lane.getHandle(),
 	    process->_fileContext->getUniverse().getHandle(),
 	    kHelTransferDescriptorOut,
+		kHelRightsMax,
+		kHelRightNull,
 	    &exec_posix_lane
 	));
 	client_lane.release();

--- a/protocols/fs/src/client.cpp
+++ b/protocols/fs/src/client.cpp
@@ -284,7 +284,9 @@ async::result<helix::UniqueDescriptor> File::accessMemory() {
 			helix_ng::offer(
 				helix_ng::sendBuffer(ser.data(), ser.size()),
 				helix_ng::recvBuffer(buffer, 128),
-				helix_ng::pullDescriptor(kHelRightNull)
+				// We do not require any RWX bits at the protocol level.
+				// The caller needs to know or determine the RWX bits (e.g., before mapping the memory view).
+				helix_ng::pullDescriptor(kHelRightAssign)
 			)
 		);
 

--- a/protocols/fs/src/client.cpp
+++ b/protocols/fs/src/client.cpp
@@ -313,7 +313,7 @@ async::result<frg::expected<Error, File>> File::createSocket(helix::BorrowedLane
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 		)
 	);
 	HEL_CHECK(offer.error());

--- a/protocols/fs/src/client.cpp
+++ b/protocols/fs/src/client.cpp
@@ -284,7 +284,7 @@ async::result<helix::UniqueDescriptor> File::accessMemory() {
 			helix_ng::offer(
 				helix_ng::sendBuffer(ser.data(), ser.size()),
 				helix_ng::recvBuffer(buffer, 128),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 
@@ -313,7 +313,7 @@ async::result<frg::expected<Error, File>> File::createSocket(helix::BorrowedLane
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		)
 	);
 	HEL_CHECK(offer.error());

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -1632,7 +1632,7 @@ struct HandleNodeRequest {
 				auto [sendResp, pushNode] = co_await helix_ng::exchangeMsgs(
 					conversation,
 					helix_ng::sendBuffer(ser.data(), ser.size()),
-					helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+					helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 				);
 				HEL_CHECK(sendResp.error());
 				HEL_CHECK(pushNode.error());
@@ -1773,7 +1773,7 @@ struct HandleNodeRequest {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
@@ -1844,6 +1844,7 @@ struct HandleNodeRequest {
 			throw std::runtime_error("Unexpected file type");
 		}
 
+		// TODO: We can just use the conversation lane instead.
 		// TODO: this is a workaround for not being able to get the offer lane on the offer side
 		helix::UniqueLane local_push, remote_push;
 		std::tie(local_push, remote_push) = helix::createStream();
@@ -1855,7 +1856,7 @@ struct HandleNodeRequest {
 		auto [send_resp, send_tail, push_desc] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadTail(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(remote_push, kHelRightsMax)
+			helix_ng::pushDescriptor(remote_push, kHelRightInvoke | kHelRightManage)
 		);
 
 		HEL_CHECK(send_resp.error());
@@ -1870,7 +1871,7 @@ struct HandleNodeRequest {
 
 			auto [push_node] = co_await helix_ng::exchangeMsgs(
 				local_push,
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 
 			HEL_CHECK(push_node.error());
@@ -1904,7 +1905,7 @@ struct HandleNodeRequest {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
@@ -1962,7 +1963,7 @@ struct HandleNodeRequest {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
@@ -2071,8 +2072,8 @@ struct HandleNodeRequest {
 		auto [send_resp, push_file, push_pt] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBuffer(ser.data(), ser.size()),
-			helix_ng::pushDescriptor(std::get<0>(result), kHelRightsMax),
-			helix_ng::pushDescriptor(std::get<1>(result), kHelRightsMax)
+			helix_ng::pushDescriptor(std::get<0>(result), kHelRightInvoke | kHelRightManage),
+			helix_ng::pushDescriptor(std::get<1>(result), kHelRightInvoke | kHelRightManage)
 		);
 		HEL_CHECK(send_resp.error());
 		HEL_CHECK(push_file.error());
@@ -2171,7 +2172,7 @@ struct HandleNodeRequest {
 			auto [send_resp, send_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
+				helix_ng::pushDescriptor(remote_lane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_node.error());

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -287,7 +287,7 @@ struct HandleFileRequest {
 			auto [send_resp, push_memory] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(memory)
+				helix_ng::pushDescriptor(memory, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_memory.error());
@@ -1144,8 +1144,8 @@ struct HandleFileRequest {
 			auto [sendResp, pushCtrl, pushPt] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(ctrlLane),
-				helix_ng::pushDescriptor(ptLane)
+				helix_ng::pushDescriptor(ctrlLane, kHelRightsMax),
+				helix_ng::pushDescriptor(ptLane, kHelRightsMax)
 			);
 			HEL_CHECK(sendResp.error());
 			HEL_CHECK(pushCtrl.error());
@@ -1632,7 +1632,7 @@ struct HandleNodeRequest {
 				auto [sendResp, pushNode] = co_await helix_ng::exchangeMsgs(
 					conversation,
 					helix_ng::sendBuffer(ser.data(), ser.size()),
-					helix_ng::pushDescriptor(remote_lane)
+					helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 				);
 				HEL_CHECK(sendResp.error());
 				HEL_CHECK(pushNode.error());
@@ -1773,7 +1773,7 @@ struct HandleNodeRequest {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
@@ -1855,7 +1855,7 @@ struct HandleNodeRequest {
 		auto [send_resp, send_tail, push_desc] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadTail(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(remote_push)
+			helix_ng::pushDescriptor(remote_push, kHelRightsMax)
 		);
 
 		HEL_CHECK(send_resp.error());
@@ -1870,7 +1870,7 @@ struct HandleNodeRequest {
 
 			auto [push_node] = co_await helix_ng::exchangeMsgs(
 				local_push,
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 
 			HEL_CHECK(push_node.error());
@@ -1904,7 +1904,7 @@ struct HandleNodeRequest {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
@@ -1962,7 +1962,7 @@ struct HandleNodeRequest {
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_node.error());
@@ -2071,8 +2071,8 @@ struct HandleNodeRequest {
 		auto [send_resp, push_file, push_pt] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBuffer(ser.data(), ser.size()),
-			helix_ng::pushDescriptor(std::get<0>(result)),
-			helix_ng::pushDescriptor(std::get<1>(result))
+			helix_ng::pushDescriptor(std::get<0>(result), kHelRightsMax),
+			helix_ng::pushDescriptor(std::get<1>(result), kHelRightsMax)
 		);
 		HEL_CHECK(send_resp.error());
 		HEL_CHECK(push_file.error());
@@ -2171,7 +2171,7 @@ struct HandleNodeRequest {
 			auto [send_resp, send_node] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(remote_lane)
+				helix_ng::pushDescriptor(remote_lane, kHelRightsMax)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(send_node.error());

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -287,7 +287,7 @@ struct HandleFileRequest {
 			auto [send_resp, push_memory] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(memory, kHelRightsMax)
+				helix_ng::pushDescriptor(memory, kHelRightRead | kHelRightWrite | kHelRightExecute | kHelRightAssign | kHelRightProvision | kHelRightPin | kHelRightFence)
 			);
 			HEL_CHECK(send_resp.error());
 			HEL_CHECK(push_memory.error());

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -1144,8 +1144,8 @@ struct HandleFileRequest {
 			auto [sendResp, pushCtrl, pushPt] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::sendBuffer(ser.data(), ser.size()),
-				helix_ng::pushDescriptor(ctrlLane, kHelRightsMax),
-				helix_ng::pushDescriptor(ptLane, kHelRightsMax)
+				helix_ng::pushDescriptor(ctrlLane, kHelRightInvoke | kHelRightManage),
+				helix_ng::pushDescriptor(ptLane, kHelRightInvoke | kHelRightManage)
 			);
 			HEL_CHECK(sendResp.error());
 			HEL_CHECK(pushCtrl.error());

--- a/protocols/hw/src/client.cpp
+++ b/protocols/hw/src/client.cpp
@@ -116,7 +116,7 @@ async::result<helix::UniqueDescriptor> Device::accessBar(int index) {
 	auto [recv_tail, pull_bar] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightRead | kHelRightWrite | kHelRightAssign)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -154,7 +154,7 @@ async::result<helix::UniqueDescriptor> Device::accessExpansionRom() {
 	auto [recv_tail, pull_bar] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightRead | kHelRightAssign)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -193,7 +193,7 @@ async::result<helix::UniqueDescriptor> Device::accessIrq(size_t index) {
 	auto [recv_tail, pull_irq] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightWait | kHelRightSignal)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -231,7 +231,7 @@ async::result<helix::UniqueDescriptor> Device::installMsi(int index) {
 	auto [recv_tail, pull_msi] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightWait | kHelRightSignal)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -554,7 +554,7 @@ async::result<helix::UniqueDescriptor> Device::accessFbMemory() {
 	auto [recv_tail, pull_bar] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightRead | kHelRightWrite | kHelRightAssign)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -846,7 +846,7 @@ async::result<helix::UniqueDescriptor> Device::accessDtRegister(uint32_t index) 
 	auto [recv_tail, pull_reg] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightRead | kHelRightWrite | kHelRightAssign)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -885,7 +885,7 @@ async::result<helix::UniqueDescriptor> Device::installDtIrq(uint32_t index) {
 	auto [recv_tail, pull_irq] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightWait | kHelRightSignal)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -1011,7 +1011,7 @@ async::result<std::pair<helix::UniqueDescriptor, uint32_t>> Device::getVbt() {
 	auto [recv_tail, pull_desc] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightRead | kHelRightAssign)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -1034,7 +1034,7 @@ async::result<std::pair<bool, helix::UniqueDescriptor>> Device::getDmaSpace() {
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightGrant | kHelRightProvision)
 			)
 		);
 

--- a/protocols/hw/src/client.cpp
+++ b/protocols/hw/src/client.cpp
@@ -116,7 +116,7 @@ async::result<helix::UniqueDescriptor> Device::accessBar(int index) {
 	auto [recv_tail, pull_bar] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -154,7 +154,7 @@ async::result<helix::UniqueDescriptor> Device::accessExpansionRom() {
 	auto [recv_tail, pull_bar] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -193,7 +193,7 @@ async::result<helix::UniqueDescriptor> Device::accessIrq(size_t index) {
 	auto [recv_tail, pull_irq] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -231,7 +231,7 @@ async::result<helix::UniqueDescriptor> Device::installMsi(int index) {
 	auto [recv_tail, pull_msi] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -554,7 +554,7 @@ async::result<helix::UniqueDescriptor> Device::accessFbMemory() {
 	auto [recv_tail, pull_bar] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -846,7 +846,7 @@ async::result<helix::UniqueDescriptor> Device::accessDtRegister(uint32_t index) 
 	auto [recv_tail, pull_reg] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -885,7 +885,7 @@ async::result<helix::UniqueDescriptor> Device::installDtIrq(uint32_t index) {
 	auto [recv_tail, pull_irq] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -1011,7 +1011,7 @@ async::result<std::pair<helix::UniqueDescriptor, uint32_t>> Device::getVbt() {
 	auto [recv_tail, pull_desc] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
 			helix_ng::recvBuffer(tailBuffer.data(), tailBuffer.size()),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		);
 
 	HEL_CHECK(recv_tail.error());
@@ -1034,7 +1034,7 @@ async::result<std::pair<bool, helix::UniqueDescriptor>> Device::getDmaSpace() {
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 

--- a/protocols/kernlet/src/compiler.cpp
+++ b/protocols/kernlet/src/compiler.cpp
@@ -60,7 +60,7 @@ async::result<helix::UniqueDescriptor> compile(void *code, size_t size,
 			helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 			helix_ng::sendBuffer(code, size),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		)
 	);
 	HEL_CHECK(offer.error());

--- a/protocols/kernlet/src/compiler.cpp
+++ b/protocols/kernlet/src/compiler.cpp
@@ -60,7 +60,7 @@ async::result<helix::UniqueDescriptor> compile(void *code, size_t size,
 			helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 			helix_ng::sendBuffer(code, size),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightAssign)
 		)
 	);
 	HEL_CHECK(offer.error());

--- a/protocols/mbus/src/client_ng.cpp
+++ b/protocols/mbus/src/client_ng.cpp
@@ -106,7 +106,7 @@ Instance::createEntity(std::string_view name, const Properties &properties) {
 			helix_ng::offer(
 				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 
@@ -194,7 +194,7 @@ async::result<Result<helix::UniqueLane>> Entity::getRemoteLane() const {
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor()
+				helix_ng::pullDescriptor(kHelRightNull)
 			)
 		);
 
@@ -229,7 +229,7 @@ async::result<Result<void>> EntityManager::serveRemoteLane(helix::UniqueLane lan
 			mgmtLane_,
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(lane),
+				helix_ng::pushDescriptor(lane, kHelRightsMax),
 				helix_ng::recvInline()
 			)
 		);

--- a/protocols/mbus/src/client_ng.cpp
+++ b/protocols/mbus/src/client_ng.cpp
@@ -106,7 +106,7 @@ Instance::createEntity(std::string_view name, const Properties &properties) {
 			helix_ng::offer(
 				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			)
 		);
 
@@ -194,7 +194,7 @@ async::result<Result<helix::UniqueLane>> Entity::getRemoteLane() const {
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 				helix_ng::recvInline(),
-				helix_ng::pullDescriptor(kHelRightNull)
+				helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 			)
 		);
 
@@ -229,7 +229,7 @@ async::result<Result<void>> EntityManager::serveRemoteLane(helix::UniqueLane lan
 			mgmtLane_,
 			helix_ng::offer(
 				helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
-				helix_ng::pushDescriptor(lane, kHelRightsMax),
+				helix_ng::pushDescriptor(lane, kHelRightInvoke | kHelRightManage),
 				helix_ng::recvInline()
 			)
 		);

--- a/protocols/usb/src/client.cpp
+++ b/protocols/usb/src/client.cpp
@@ -164,7 +164,7 @@ async::result<frg::expected<UsbError, Configuration>> DeviceState::useConfigurat
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		)
 	);
 
@@ -260,7 +260,7 @@ ConfigurationState::useInterface(int number, int alternative) {
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		)
 	);
 
@@ -291,7 +291,7 @@ InterfaceState::getEndpoint(PipeType type, int number) {
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor()
+			helix_ng::pullDescriptor(kHelRightNull)
 		)
 	);
 

--- a/protocols/usb/src/client.cpp
+++ b/protocols/usb/src/client.cpp
@@ -164,7 +164,7 @@ async::result<frg::expected<UsbError, Configuration>> DeviceState::useConfigurat
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 		)
 	);
 
@@ -260,7 +260,7 @@ ConfigurationState::useInterface(int number, int alternative) {
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 		)
 	);
 
@@ -291,7 +291,7 @@ InterfaceState::getEndpoint(PipeType type, int number) {
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull)
+			helix_ng::pullDescriptor(kHelRightInvoke | kHelRightManage)
 		)
 	);
 

--- a/protocols/usb/src/server.cpp
+++ b/protocols/usb/src/server.cpp
@@ -153,7 +153,7 @@ struct HandleGetEndpoint {
 		auto [sendResp, sendLane] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(remoteLane)
+			helix_ng::pushDescriptor(remoteLane, kHelRightsMax)
 		);
 
 		HEL_CHECK(sendResp.error());
@@ -189,7 +189,7 @@ struct HandleUseInterface {
 		auto [sendResp, sendLane] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(remoteLane)
+			helix_ng::pushDescriptor(remoteLane, kHelRightsMax)
 		);
 
 		HEL_CHECK(sendResp.error());
@@ -346,7 +346,7 @@ struct HandleServe {
 		auto [sendResp, sendLane] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(remoteLane)
+			helix_ng::pushDescriptor(remoteLane, kHelRightsMax)
 		);
 
 		HEL_CHECK(sendResp.error());

--- a/protocols/usb/src/server.cpp
+++ b/protocols/usb/src/server.cpp
@@ -153,7 +153,7 @@ struct HandleGetEndpoint {
 		auto [sendResp, sendLane] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(remoteLane, kHelRightsMax)
+			helix_ng::pushDescriptor(remoteLane, kHelRightInvoke | kHelRightManage)
 		);
 
 		HEL_CHECK(sendResp.error());
@@ -189,7 +189,7 @@ struct HandleUseInterface {
 		auto [sendResp, sendLane] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(remoteLane, kHelRightsMax)
+			helix_ng::pushDescriptor(remoteLane, kHelRightInvoke | kHelRightManage)
 		);
 
 		HEL_CHECK(sendResp.error());
@@ -346,7 +346,7 @@ struct HandleServe {
 		auto [sendResp, sendLane] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::sendBragiHeadOnly(resp, frg::stl_allocator{}),
-			helix_ng::pushDescriptor(remoteLane, kHelRightsMax)
+			helix_ng::pushDescriptor(remoteLane, kHelRightInvoke | kHelRightManage)
 		);
 
 		HEL_CHECK(sendResp.error());

--- a/rust/hel/src/executor.rs
+++ b/rust/hel/src/executor.rs
@@ -44,7 +44,12 @@ impl ExecutorInner {
     }
 
     /// Pushes an element to the submission queue using a gather list.
-    pub fn push_sq(&self, opcode: u32, context: usize, segments: &[&[u8]]) -> crate::result::Result<()> {
+    pub fn push_sq(
+        &self,
+        opcode: u32,
+        context: usize,
+        segments: &[&[u8]],
+    ) -> crate::result::Result<()> {
         self.queue.borrow_mut().push_sq(opcode, context, segments)
     }
 }

--- a/rust/hel/src/handle.rs
+++ b/rust/hel/src/handle.rs
@@ -105,7 +105,14 @@ impl Handle {
         let mut new_handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
 
         hel_check(unsafe {
-            hel_sys::helTransferDescriptor(self.handle, universe.handle, hel_sys::kHelTransferDescriptorOut, &mut new_handle)
+            hel_sys::helTransferDescriptor(
+                self.handle,
+                universe.handle,
+                hel_sys::kHelTransferDescriptorOut,
+                hel_sys::kHelRightsMax,
+                hel_sys::kHelRightNull,
+                &mut new_handle,
+            )
         })?;
 
         Ok(Handle {

--- a/rust/hel/src/queue.rs
+++ b/rust/hel/src/queue.rs
@@ -364,7 +364,13 @@ impl Queue {
                     .get_chunk(self.retrieve_chunk)
                     .progress_futex()
                     .load(Ordering::Acquire);
-                assert!(progress & !(hel_sys::kHelProgressMask | hel_sys::kHelProgressFull | hel_sys::kHelProgressDone) == 0);
+                assert!(
+                    progress
+                        & !(hel_sys::kHelProgressMask
+                            | hel_sys::kHelProgressFull
+                            | hel_sys::kHelProgressDone)
+                        == 0
+                );
                 if progress & hel_sys::kHelProgressFull != 0 {
                     assert!(self.retrieve_chunk != self.tail_chunk);
                 }
@@ -385,7 +391,11 @@ impl Queue {
                 assert!(self.pending_notify & !masked_notify == 0);
 
                 let res = hel_check(unsafe {
-                    hel_sys::helDriveQueue(self.handle.handle(), hel_sys::kHelDriveWait, masked_notify as u32)
+                    hel_sys::helDriveQueue(
+                        self.handle.handle(),
+                        hel_sys::kHelDriveWait,
+                        masked_notify as u32,
+                    )
                 });
                 match res {
                     Err(crate::Error::Cancelled) => {}
@@ -396,7 +406,9 @@ impl Queue {
             } else {
                 // Note that we will check all cleared notifications again in the next iteration.
                 // This RMW happens before the next progressFutex wait due to the load-acquire here.
-                notify = self.user_notify().fetch_and(!notify_to_clear, Ordering::Acquire);
+                notify = self
+                    .user_notify()
+                    .fetch_and(!notify_to_clear, Ordering::Acquire);
             }
         }
     }
@@ -512,9 +524,7 @@ impl Queue {
                 }
                 let notify = self.user_notify().load(Ordering::Relaxed);
                 if (notify & hel_sys::kHelUserNotifySupplySqChunks) == 0 {
-                    hel_check(unsafe {
-                        hel_sys::helDriveQueue(self.handle.handle(), 0, 0)
-                    })?;
+                    hel_check(unsafe { hel_sys::helDriveQueue(self.handle.handle(), 0, 0) })?;
                 } else {
                     self.user_notify()
                         .fetch_and(!hel_sys::kHelUserNotifySupplySqChunks, Ordering::Acquire);

--- a/rust/hel/src/submission/action.rs
+++ b/rust/hel/src/submission/action.rs
@@ -9,9 +9,9 @@ const fn default_hel_action() -> hel_sys::HelAction {
     hel_sys::HelAction {
         type_: hel_sys::kHelActionNone as std::ffi::c_int,
         flags: 0,
-        buffer: std::ptr::null_mut(),
-        length: 0,
-        handle: hel_sys::kHelNullHandle as hel_sys::HelHandle,
+        __bindgen_anon_1: hel_sys::HelAction__bindgen_ty_1 { word0: 0 },
+        __bindgen_anon_2: hel_sys::HelAction__bindgen_ty_2 { word1: 0 },
+        __bindgen_anon_3: hel_sys::HelAction__bindgen_ty_3 { word2: 0 },
     }
 }
 
@@ -178,8 +178,8 @@ impl Action for SendBuffer<'_> {
         let mut action = default_hel_action();
 
         action.type_ = hel_sys::kHelActionSendFromBuffer as _;
-        action.buffer = self.data.as_ptr() as *mut _;
-        action.length = self.data.len();
+        action.__bindgen_anon_1.buffer = self.data.as_ptr() as *mut _;
+        action.__bindgen_anon_2.length = self.data.len();
 
         if has_next {
             action.flags = hel_sys::kHelItemChain;
@@ -208,8 +208,8 @@ impl Action for ReceiveBuffer<'_> {
         let mut action = default_hel_action();
 
         action.type_ = hel_sys::kHelActionRecvToBuffer as _;
-        action.buffer = self.data.as_ptr() as *mut _;
-        action.length = self.data.len();
+        action.__bindgen_anon_1.buffer = self.data.as_ptr() as *mut _;
+        action.__bindgen_anon_2.length = self.data.len();
 
         if has_next {
             action.flags = hel_sys::kHelItemChain;
@@ -279,7 +279,15 @@ impl Action for Dismiss {
     }
 }
 
-pub struct PullDescriptor;
+pub struct PullDescriptor {
+    required_rights: u32,
+}
+
+impl PullDescriptor {
+    pub fn new(required_rights: u32) -> Self {
+        Self { required_rights }
+    }
+}
 
 impl Action for PullDescriptor {
     const ACTION_COUNT: usize = 1;
@@ -290,6 +298,7 @@ impl Action for PullDescriptor {
         let mut action = default_hel_action();
 
         action.type_ = hel_sys::kHelActionPullDescriptor as _;
+        action.__bindgen_anon_2.rights = self.required_rights;
 
         if has_next {
             action.flags = hel_sys::kHelItemChain;
@@ -301,11 +310,15 @@ impl Action for PullDescriptor {
 
 pub struct PushDescriptor<'a> {
     handle: &'a Handle,
+    exposed_rights: u32,
 }
 
 impl<'a> PushDescriptor<'a> {
-    pub fn new(handle: &'a Handle) -> Self {
-        Self { handle }
+    pub fn new(handle: &'a Handle, exposed_rights: u32) -> Self {
+        Self {
+            handle,
+            exposed_rights,
+        }
     }
 }
 
@@ -318,7 +331,8 @@ impl Action for PushDescriptor<'_> {
         let mut action = default_hel_action();
 
         action.type_ = hel_sys::kHelActionPushDescriptor as _;
-        action.handle = self.handle.handle();
+        action.__bindgen_anon_2.rights = self.exposed_rights;
+        action.__bindgen_anon_3.handle = self.handle.handle();
 
         if has_next {
             action.flags = hel_sys::kHelItemChain;

--- a/rust/hel/src/submission/result.rs
+++ b/rust/hel/src/submission/result.rs
@@ -123,11 +123,7 @@ impl FromQueueElement for CredentialsResult {
         // SAFETY: The data is guaranteed to contain enough bytes
         // to read a [`hel_sys::HelCredentialsResult`]` and that it is
         // correctly aligned.
-        let result = unsafe {
-            data.as_ptr()
-                .cast::<hel_sys::HelCredentialsResult>()
-                .read()
-        };
+        let result = unsafe { data.as_ptr().cast::<hel_sys::HelCredentialsResult>().read() };
 
         element.advance(size_of::<hel_sys::HelCredentialsResult>());
 

--- a/rust/managarm/src/hw/device.rs
+++ b/rust/managarm/src/hw/device.rs
@@ -56,7 +56,7 @@ impl Device {
             &conversation_lane,
             (
                 hel::ReceiveBuffer::new(&mut tail_buffer),
-                hel::PullDescriptor,
+                hel::PullDescriptor::new(hel_sys::kHelRightNull),
             ),
         )
         .await?;
@@ -87,7 +87,7 @@ impl Device {
             &conversation_lane,
             (
                 hel::ReceiveBuffer::new(&mut tail_buffer),
-                hel::PullDescriptor,
+                hel::PullDescriptor::new(hel_sys::kHelRightNull),
             ),
         )
         .await?;

--- a/rust/managarm/src/hw/device.rs
+++ b/rust/managarm/src/hw/device.rs
@@ -56,7 +56,9 @@ impl Device {
             &conversation_lane,
             (
                 hel::ReceiveBuffer::new(&mut tail_buffer),
-                hel::PullDescriptor::new(hel_sys::kHelRightNull),
+                hel::PullDescriptor::new(
+                    hel_sys::kHelRightRead | hel_sys::kHelRightWrite | hel_sys::kHelRightAssign,
+                ),
             ),
         )
         .await?;
@@ -87,7 +89,7 @@ impl Device {
             &conversation_lane,
             (
                 hel::ReceiveBuffer::new(&mut tail_buffer),
-                hel::PullDescriptor::new(hel_sys::kHelRightNull),
+                hel::PullDescriptor::new(hel_sys::kHelRightWait | hel_sys::kHelRightSignal),
             ),
         )
         .await?;

--- a/rust/managarm/src/mbus/entity.rs
+++ b/rust/managarm/src/mbus/entity.rs
@@ -17,7 +17,7 @@ impl Entity {
             hel::Offer::new((
                 hel::SendBuffer::new(&head),
                 hel::ReceiveInline,
-                hel::PullDescriptor,
+                hel::PullDescriptor::new(hel_sys::kHelRightNull),
             )),
         )
         .await?;

--- a/rust/managarm/src/mbus/entity.rs
+++ b/rust/managarm/src/mbus/entity.rs
@@ -17,7 +17,7 @@ impl Entity {
             hel::Offer::new((
                 hel::SendBuffer::new(&head),
                 hel::ReceiveInline,
-                hel::PullDescriptor::new(hel_sys::kHelRightNull),
+                hel::PullDescriptor::new(hel_sys::kHelRightInvoke | hel_sys::kHelRightManage),
             )),
         )
         .await?;

--- a/rust/managarm/src/mbus/manager.rs
+++ b/rust/managarm/src/mbus/manager.rs
@@ -22,7 +22,10 @@ impl EntityManager {
             &self.mgmt_lane,
             hel::Offer::new((
                 hel::SendBuffer::new(&head),
-                hel::PushDescriptor::new(&lane, hel_sys::kHelRightsMax),
+                hel::PushDescriptor::new(
+                    &lane,
+                    hel_sys::kHelRightInvoke | hel_sys::kHelRightManage,
+                ),
                 hel::ReceiveInline,
             )),
         )
@@ -56,7 +59,7 @@ pub async fn create_entity(name: &str, properties: &Properties) -> Result<Entity
             hel::SendBuffer::new(&head),
             hel::SendBuffer::new(&tail),
             hel::ReceiveInline,
-            hel::PullDescriptor::new(hel_sys::kHelRightNull),
+            hel::PullDescriptor::new(hel_sys::kHelRightInvoke | hel_sys::kHelRightManage),
         )),
     )
     .await?;

--- a/rust/managarm/src/mbus/manager.rs
+++ b/rust/managarm/src/mbus/manager.rs
@@ -22,7 +22,7 @@ impl EntityManager {
             &self.mgmt_lane,
             hel::Offer::new((
                 hel::SendBuffer::new(&head),
-                hel::PushDescriptor::new(&lane),
+                hel::PushDescriptor::new(&lane, hel_sys::kHelRightsMax),
                 hel::ReceiveInline,
             )),
         )
@@ -56,7 +56,7 @@ pub async fn create_entity(name: &str, properties: &Properties) -> Result<Entity
             hel::SendBuffer::new(&head),
             hel::SendBuffer::new(&tail),
             hel::ReceiveInline,
-            hel::PullDescriptor,
+            hel::PullDescriptor::new(hel_sys::kHelRightNull),
         )),
     )
     .await?;

--- a/servers/kernletcc/Cargo.toml
+++ b/servers/kernletcc/Cargo.toml
@@ -9,6 +9,7 @@ bragi = "0.3"
 indexmap = "2"
 object = { version = "0.37", default-features = false, features = ["write"] }
 hel.workspace = true
+hel-sys.workspace = true
 managarm.workspace = true
 cranelift-codegen = { version = "0.124", features = ["x86"] }
 cranelift-frontend = "0.124"

--- a/servers/kernletcc/src/fafnir.rs
+++ b/servers/kernletcc/src/fafnir.rs
@@ -512,10 +512,7 @@ pub fn compile(code: &[u8], bind_types: &[BindType]) -> Result<Compiled> {
                 // Check operand types against the kernel-side signature.
                 let mut csig = Signature::new(CallConv::SystemV);
                 for (&a, &ty) in args.iter().zip(param_types) {
-                    ensure!(
-                        a.ty == ty,
-                        "operand of wrong type for intrinsic {name}"
-                    );
+                    ensure!(a.ty == ty, "operand of wrong type for intrinsic {name}");
                     csig.params.push(AbiParam::new(ty.clif()));
                 }
                 for &ty in result_types {
@@ -576,10 +573,7 @@ pub fn compile(code: &[u8], bind_types: &[BindType]) -> Result<Compiled> {
     }
 
     let ret = compiler.return_value()?;
-    ensure!(
-        ret.ty == FnrType::I32,
-        "kernlet must return a 32-bit value"
-    );
+    ensure!(ret.ty == FnrType::I32, "kernlet must return a 32-bit value");
     builder.ins().return_(&[ret.val]);
 
     builder.seal_all_blocks();

--- a/servers/kernletcc/src/main.rs
+++ b/servers/kernletcc/src/main.rs
@@ -50,7 +50,7 @@ async fn upload(
             hel::SendBuffer::new(&tail),
             hel::SendBuffer::new(elf_bytes),
             hel::ReceiveInline,
-            hel::PullDescriptor,
+            hel::PullDescriptor::new(hel_sys::kHelRightNull),
         )),
     )
     .await?;
@@ -102,7 +102,7 @@ async fn handle_request(lane: &Handle, ctl: &Handle) -> Result<bool> {
         &conversation,
         (
             hel::SendBuffer::new(&resp_head),
-            hel::PushDescriptor::new(&kernlet),
+            hel::PushDescriptor::new(&kernlet, hel_sys::kHelRightsMax),
         ),
     )
     .await?;

--- a/servers/kernletcc/src/main.rs
+++ b/servers/kernletcc/src/main.rs
@@ -50,7 +50,7 @@ async fn upload(
             hel::SendBuffer::new(&tail),
             hel::SendBuffer::new(elf_bytes),
             hel::ReceiveInline,
-            hel::PullDescriptor::new(hel_sys::kHelRightNull),
+            hel::PullDescriptor::new(hel_sys::kHelRightAssign),
         )),
     )
     .await?;
@@ -102,7 +102,7 @@ async fn handle_request(lane: &Handle, ctl: &Handle) -> Result<bool> {
         &conversation,
         (
             hel::SendBuffer::new(&resp_head),
-            hel::PushDescriptor::new(&kernlet, hel_sys::kHelRightsMax),
+            hel::PushDescriptor::new(&kernlet, hel_sys::kHelRightAssign),
         ),
     )
     .await?;

--- a/servers/netserver/src/main.cpp
+++ b/servers/netserver/src/main.cpp
@@ -677,8 +677,8 @@ struct HandleRequest {
 					conversation,
 					helix_ng::sendBuffer(
 						ser.data(), ser.size()),
-					helix_ng::pushDescriptor(remoteCtrl, kHelRightsMax),
-					helix_ng::pushDescriptor(remotePt, kHelRightsMax)
+					helix_ng::pushDescriptor(remoteCtrl, kHelRightInvoke | kHelRightManage),
+					helix_ng::pushDescriptor(remotePt, kHelRightInvoke | kHelRightManage)
 				);
 			HEL_CHECK(sendResp.error());
 			HEL_CHECK(pushCtrl.error());

--- a/servers/netserver/src/main.cpp
+++ b/servers/netserver/src/main.cpp
@@ -677,8 +677,8 @@ struct HandleRequest {
 					conversation,
 					helix_ng::sendBuffer(
 						ser.data(), ser.size()),
-					helix_ng::pushDescriptor(remoteCtrl),
-					helix_ng::pushDescriptor(remotePt)
+					helix_ng::pushDescriptor(remoteCtrl, kHelRightsMax),
+					helix_ng::pushDescriptor(remotePt, kHelRightsMax)
 				);
 			HEL_CHECK(sendResp.error());
 			HEL_CHECK(pushCtrl.error());

--- a/utils/runsvr/src/main.cpp
+++ b/utils/runsvr/src/main.cpp
@@ -103,7 +103,7 @@ async::result<helix::UniqueLane> runServer(const char *name) {
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor(kHelRightNull))
+			helix_ng::pullDescriptor(kHelRightInvoke))
 	);
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_req.error());

--- a/utils/runsvr/src/main.cpp
+++ b/utils/runsvr/src/main.cpp
@@ -103,7 +103,7 @@ async::result<helix::UniqueLane> runServer(const char *name) {
 		helix_ng::offer(
 			helix_ng::sendBragiHeadOnly(req, frg::stl_allocator{}),
 			helix_ng::recvInline(),
-			helix_ng::pullDescriptor())
+			helix_ng::pullDescriptor(kHelRightNull))
 	);
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_req.error());


### PR DESCRIPTION
Follow up on #1503. This PR updates `helTransferDescriptor()` and `pushDescriptor()` / `pullDescriptor()` to be aware of rights. This works as follows:
- `pushDescriptor()` gets a `exposedRights` mask that is AND-ed with the rights of the descriptor that is sent to a remote lane.
- `pullDescriptor()` gets a `requiredRights` mask of all rights that a program requires for a descriptor that it receives from a remote lane.
- `helTransferDescriptor()` gets both `exposedRights` and `requiredRights` (with the same semantics).

All userspace callers are updated (1) to provide a only minimal subset of rights to other servers and (2) to require the appropriate sets of rights when receiving capabilities from other servers.