### PR TITLE
thor, kernletcc, drivers: Support kernlets on all architectures

### DIFF
--- a/core/virtio/src/core.cpp
+++ b/core/virtio/src/core.cpp
@@ -322,6 +322,7 @@ private:
 	arch::mem_space _deviceSpace() { return arch::mem_space{_deviceMapping.get()}; }
 
 	async::detached _processIrqs();
+	async::result<void> _processIrqsWithoutKernlet();
 	async::detached _processQueueMsi();
 
 	protocols::hw::Device _hwDevice;
@@ -506,7 +507,6 @@ void StandardPciTransport::runDevice() {
 }
 
 async::detached StandardPciTransport::_processIrqs() {
-#ifdef __x86_64__ // TODO: implement kernlet compilation for aarch64
 	co_await connectKernletCompiler();
 
 	std::vector<uint8_t> kernlet_program;
@@ -539,6 +539,12 @@ async::detached StandardPciTransport::_processIrqs() {
 	auto kernlet_object = co_await compile(kernlet_program.data(),
 			kernlet_program.size(), {BindType::memoryView, BindType::offset,
 			BindType::bitsetEvent});
+	if(!kernlet_object) {
+		std::cout << "core-virtio: Kernlets are unavailable,"
+				" acknowledging IRQs from user space" << std::endl;
+		co_await _processIrqsWithoutKernlet();
+		co_return;
+	}
 
 	HelHandle event_handle;
 	HEL_CHECK(helCreateBitsetEvent(&event_handle));
@@ -549,7 +555,7 @@ async::detached StandardPciTransport::_processIrqs() {
 	data[1].handle = _isrMapping.offset();
 	data[2].handle = event.getHandle();
 	HelHandle bound_handle;
-	HEL_CHECK(helBindKernlet(kernlet_object.getHandle(), data, 3, &bound_handle));
+	HEL_CHECK(helBindKernlet(kernlet_object->getHandle(), data, 3, &bound_handle));
 	HEL_CHECK(helAutomateIrq(_irq.getHandle(), 0, bound_handle));
 
 	co_await _hwDevice.enableBusIrq();
@@ -576,7 +582,9 @@ async::detached StandardPciTransport::_processIrqs() {
 			for(auto &queue : _queues)
 				queue->processInterrupt();
 	}
-#else
+}
+
+async::result<void> StandardPciTransport::_processIrqsWithoutKernlet() {
 	co_await _hwDevice.enableBusIrq();
 
 	// TODO: The kick here should not be required.
@@ -608,7 +616,6 @@ async::detached StandardPciTransport::_processIrqs() {
 			for(auto &queue : _queues)
 				queue->processInterrupt();
 	}
-#endif
 }
 
 async::detached StandardPciTransport::_processQueueMsi() {

--- a/drivers/usb/hcds/ehci/meson.build
+++ b/drivers/usb/hcds/ehci/meson.build
@@ -1,4 +1,4 @@
 executable('ehci', 'src/main.cpp',
-	dependencies : [ libarch, hw_proto_dep, mbus_proto_dep, usb_proto_dep, kernlet_proto_dep ],
+	dependencies : [ libarch, core_dep, hw_proto_dep, mbus_proto_dep, usb_proto_dep, kernlet_proto_dep ],
 	install : true
 )

--- a/drivers/usb/hcds/ehci/src/main.cpp
+++ b/drivers/usb/hcds/ehci/src/main.cpp
@@ -9,6 +9,7 @@
 
 #include <arch/dma_pool.hpp>
 #include <async/result.hpp>
+#include <core/logging.hpp>
 #include <fafnir/dsl.hpp>
 #include <helix/ipc.hpp>
 #include <protocols/hw/client.hpp>
@@ -466,6 +467,8 @@ async::detached Controller::handleIrqs() {
 	auto kernlet_object = co_await compile(kernlet_program.data(),
 			kernlet_program.size(), {BindType::memoryView, BindType::offset,
 			BindType::bitsetEvent});
+	if(!kernlet_object)
+		logPanic("ehci: Failed to compile the IRQ kernlet");
 
 	HelHandle event_handle;
 	HEL_CHECK(helCreateBitsetEvent(&event_handle));
@@ -476,7 +479,7 @@ async::detached Controller::handleIrqs() {
 	data[1].handle = _mapping.offset() + _space.load(cap_regs::caplength);
 	data[2].handle = event.getHandle();
 	HelHandle bound_handle;
-	HEL_CHECK(helBindKernlet(kernlet_object.getHandle(), data, 3, &bound_handle));
+	HEL_CHECK(helBindKernlet(kernlet_object->getHandle(), data, 3, &bound_handle));
 	HEL_CHECK(helAutomateIrq(_irq.getHandle(), 0, bound_handle));
 
 	co_await _hwDevice.enableBusIrq();

--- a/drivers/usb/hcds/uhci/meson.build
+++ b/drivers/usb/hcds/uhci/meson.build
@@ -3,6 +3,6 @@ if host_machine.cpu_family() != 'x86_64'
 endif
 
 executable('uhci', 'src/main.cpp',
-	dependencies : [ libarch, hw_proto_dep, kernlet_proto_dep, mbus_proto_dep, usb_proto_dep ],
+	dependencies : [ libarch, core_dep, hw_proto_dep, kernlet_proto_dep, mbus_proto_dep, usb_proto_dep ],
 	install : true
 )

--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -12,6 +12,7 @@
 #include <arch/io_space.hpp>
 #include <arch/dma_pool.hpp>
 #include <async/result.hpp>
+#include <core/logging.hpp>
 #include <fafnir/dsl.hpp>
 #include <frg/list.hpp>
 #include <helix/ipc.hpp>
@@ -223,6 +224,8 @@ async::detached Controller::_handleIrqs() {
 
 	auto kernlet_object = co_await compile(kernlet_program.data(),
 			kernlet_program.size(), {BindType::offset, BindType::bitsetEvent});
+	if(!kernlet_object)
+		logPanic("uhci: Failed to compile the IRQ kernlet");
 
 	HelHandle event_handle;
 	HEL_CHECK(helCreateBitsetEvent(&event_handle));
@@ -232,7 +235,7 @@ async::detached Controller::_handleIrqs() {
 	data[0].handle = _ioBase;
 	data[1].handle = event.getHandle();
 	HelHandle bound_handle;
-	HEL_CHECK(helBindKernlet(kernlet_object.getHandle(), data, 2, &bound_handle));
+	HEL_CHECK(helBindKernlet(kernlet_object->getHandle(), data, 2, &bound_handle));
 	HEL_CHECK(helAutomateIrq(_irq.getHandle(), 0, bound_handle));
 
 	co_await _hwDevice.enableBusIrq();

--- a/kernel/klibc/elf.h
+++ b/kernel/klibc/elf.h
@@ -34,6 +34,12 @@ enum {
 };
 
 enum {
+	EM_X86_64 = 62,
+	EM_AARCH64 = 183,
+	EM_RISCV = 243
+};
+
+enum {
 	SHN_UNDEF = 0,
 	SHN_ABS = 0xFFF1
 };
@@ -77,11 +83,13 @@ enum {
 };
 
 enum {
+	R_AARCH64_JUMP_SLOT = 1026,
 	R_AARCH64_RELATIVE = 1027
 };
 
 enum {
-	R_RISCV_RELATIVE = 3
+	R_RISCV_RELATIVE = 3,
+	R_RISCV_JUMP_SLOT = 5
 };
 
 struct Elf64_Rela {

--- a/kernel/thor/arch/arm/thor-internal/arch/paging.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/paging.hpp
@@ -42,14 +42,14 @@ inline size_t icacheLineSize() {
 	uint64_t ctr;
 	asm ("mrs %0, ctr_el0" : "=r"(ctr));
 
-	return (ctr & 0b1111) << 4;
+	return size_t{4} << (ctr & 0b1111);
 }
 
 inline size_t dcacheLineSize() {
 	uint64_t ctr;
 	asm ("mrs %0, ctr_el0" : "=r"(ctr));
 
-	return ((ctr >> 16) & 0b1111) << 4;
+	return size_t{4} << ((ctr >> 16) & 0b1111);
 }
 
 inline size_t isICachePIPT() {

--- a/kernel/thor/arch/arm/thor-internal/arch/paging.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/paging.hpp
@@ -59,6 +59,26 @@ inline size_t isICachePIPT() {
 	return ((ctr >> 14) & 0b11) == 0b11;
 }
 
+inline void syncInstructionCache(void *pointer, size_t size) {
+	auto dsz = dcacheLineSize(), isz = icacheLineSize();
+	auto va = reinterpret_cast<uintptr_t>(pointer);
+
+	for (auto addr = va & ~(dsz - 1); addr < va + size; addr += dsz) {
+		asm volatile ("dc cvau, %0" :: "r"(addr) : "memory");
+	}
+	asm volatile ("dsb ish");
+
+	// ic ivau broadcasts to the inner shareable domain, hence no IPI is required.
+	if (isICachePIPT()) {
+		for (auto addr = va & ~(isz - 1); addr < va + size; addr += isz) {
+			asm volatile ("ic ivau, %0" :: "r"(addr) : "memory");
+		}
+	} else {
+		asm volatile ("ic ialluis" ::: "memory");
+	}
+	asm volatile ("dsb ish; isb");
+}
+
 
 template <bool Kernel>
 struct ARMCursorPolicy {

--- a/kernel/thor/arch/riscv/thor-internal/arch/paging.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/paging.hpp
@@ -27,6 +27,9 @@ constexpr uint64_t pteAgeMask = UINT64_C(3) << pteAgeShift;
 
 inline int getLowerHalfBits() { return 12 + 9 * riscvConfigNote->numPtLevels - 1; }
 
+// TODO: fence.i only affects the local hart; remote harts need an SBI RFENCE.
+inline void syncInstructionCache(void *, size_t) { asm volatile("fence.i" ::: "memory"); }
+
 template <bool Kernel>
 struct RiscvCursorPolicy {
 	static inline constexpr size_t maxLevels = 4;

--- a/kernel/thor/arch/x86/thor-internal/arch/paging.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/paging.hpp
@@ -32,6 +32,9 @@ inline int getLowerHalfBits() {
 	return 47;
 }
 
+// x86 keeps the instruction cache coherent with the data cache.
+inline void syncInstructionCache(void *, size_t) { }
+
 template <bool Kernel>
 struct X86CursorPolicy {
 	static inline constexpr size_t maxLevels = 4;

--- a/kernel/thor/generic/kernlet.cpp
+++ b/kernel/thor/generic/kernlet.cpp
@@ -8,6 +8,7 @@
 #include <frg/string.hpp>
 #include <elf.h>
 #include <thor-internal/universe.hpp>
+#include <thor-internal/arch-generic/paging.hpp>
 #include <thor-internal/coroutine.hpp>
 #include <thor-internal/fiber.hpp>
 #include <thor-internal/kernlet.hpp>
@@ -24,6 +25,20 @@ namespace thor {
 namespace {
 	constexpr bool logBinding = false;
 	constexpr bool logIo = false;
+
+	// ELF constants of the architecture that we load kernlets for.
+#if defined(__x86_64__)
+	constexpr Elf64_Half kernletMachine = EM_X86_64;
+	constexpr Elf64_Xword kernletJumpSlot = R_X86_64_JUMP_SLOT;
+#elif defined(__aarch64__)
+	constexpr Elf64_Half kernletMachine = EM_AARCH64;
+	constexpr Elf64_Xword kernletJumpSlot = R_AARCH64_JUMP_SLOT;
+#elif defined(__riscv) && __riscv_xlen == 64
+	constexpr Elf64_Half kernletMachine = EM_RISCV;
+	constexpr Elf64_Xword kernletJumpSlot = R_RISCV_JUMP_SLOT;
+#else
+#error Unknown architecture
+#endif
 }
 
 // ------------------------------------------------------------------------
@@ -135,9 +150,12 @@ smarter::shared_ptr<KernletObject> processElfDso(const char *buffer,
 			&& ehdr.e_ident[1] == 'E'
 			&& ehdr.e_ident[2] == 'L'
 			&& ehdr.e_ident[3] == 'F');
+	assert(ehdr.e_machine == kernletMachine);
 
 	// Load all PHDRs.
 	Elf64_Dyn *dynamic = nullptr;
+	char *execBase = nullptr;
+	size_t execSize = 0;
 
 	for(int i = 0; i < ehdr.e_phnum; i++) {
 		Elf64_Phdr phdr;
@@ -165,6 +183,12 @@ smarter::shared_ptr<KernletObject> processElfDso(const char *buffer,
 			// Fill the segment.
 			memset(base + phdr.p_vaddr, 0, phdr.p_memsz);
 			memcpy(base + phdr.p_vaddr, buffer + phdr.p_offset, phdr.p_filesz);
+
+			if(phdr.p_flags & PF_X) {
+				assert(!execBase);
+				execBase = base + phdr.p_vaddr;
+				execSize = phdr.p_memsz;
+			}
 		}else if(phdr.p_type == PT_DYNAMIC) {
 			dynamic = reinterpret_cast<Elf64_Dyn *>(base + phdr.p_vaddr);
 		}else if(phdr.p_type == PT_NOTE
@@ -313,13 +337,17 @@ smarter::shared_ptr<KernletObject> processElfDso(const char *buffer,
 
 	for(size_t off = 0; off < plt_rel_sectionsize; off += sizeof(Elf64_Rela)) {
 		auto reloc = reinterpret_cast<const Elf64_Rela *>(plt_rels + off);
-		assert(ELF64_R_TYPE(reloc->r_info) == R_X86_64_JUMP_SLOT);
+		assert(ELF64_R_TYPE(reloc->r_info) == kernletJumpSlot);
 
 		auto rp = reinterpret_cast<uint64_t *>(base + reloc->r_offset);
 		auto symbol = sym_tab + ELF64_R_SYM(reloc->r_info);
 		auto sym_name = frg::string_view{str_tab + symbol->st_name};
 		*rp = reinterpret_cast<uint64_t>(resolveExternal(sym_name));
 	}
+
+	// Only relocation can still modify the code, hence we sync the I-cache afterwards.
+	assert(execBase);
+	syncInstructionCache(execBase, execSize);
 
 	// Look up symbols.
 	auto elf64Hash = [] (frg::string_view string) -> uint32_t {

--- a/kernel/thor/generic/thor-internal/arch-generic/paging.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/paging.hpp
@@ -9,6 +9,9 @@ namespace thor {
 // Get the size of the lower half (= virtual memory available to user-space) in bits.
 int getLowerHalfBits();
 
+// Make instructions that were written to the given range visible to instruction fetch.
+void syncInstructionCache(void *pointer, size_t size);
+
 template <typename T>
 concept ValidCursor = requires (T t, uintptr_t va, PhysicalAddr pa,
 		PageFlags flags, CachingMode mode) {

--- a/protocols/kernlet/include/protocols/kernlet/compiler.hpp
+++ b/protocols/kernlet/include/protocols/kernlet/compiler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <async/result.hpp>
+#include <expected>
 #include <fafnir/dsl.hpp>
 #include <helix/ipc.hpp>
 #include <vector>
@@ -10,6 +11,11 @@ enum class BindType {
 	offset,
 	memoryView,
 	bitsetEvent
+};
+
+enum class CompileError {
+	illegalRequest,
+	architectureNotSupported
 };
 
 // Fafnir value types for the kernlet bindings, mirroring BindType.
@@ -56,5 +62,5 @@ namespace kernlet_intrin {
 }
 
 async::result<void> connectKernletCompiler();
-async::result<helix::UniqueDescriptor> compile(void *code, size_t size,
+async::result<std::expected<helix::UniqueDescriptor, CompileError>> compile(void *code, size_t size,
 		std::vector<BindType> bind_types);

--- a/protocols/kernlet/kernlet.bragi
+++ b/protocols/kernlet/kernlet.bragi
@@ -2,7 +2,8 @@ namespace "managarm::kernlet";
 
 enum Error {
 	SUCCESS = 0,
-	ILLEGAL_REQUEST
+	ILLEGAL_REQUEST,
+	ARCHITECTURE_NOT_SUPPORTED
 }
 
 enum ParameterType {

--- a/protocols/kernlet/src/compiler.cpp
+++ b/protocols/kernlet/src/compiler.cpp
@@ -36,7 +36,7 @@ async::result<void> connectKernletCompiler() {
 	}
 }
 
-async::result<helix::UniqueDescriptor> compile(void *code, size_t size,
+async::result<std::expected<helix::UniqueDescriptor, CompileError>> compile(void *code, size_t size,
 		std::vector<BindType> bind_types) {
 	// Compile the kernlet object.
 	managarm::kernlet::CompileRequest req;
@@ -68,13 +68,19 @@ async::result<helix::UniqueDescriptor> compile(void *code, size_t size,
 	HEL_CHECK(sendTail.error());
 	HEL_CHECK(sendCode.error());
 	HEL_CHECK(recvResp.error());
-	HEL_CHECK(pullKernlet.error());
 
 	auto resp = *bragi::parse_head_only<managarm::kernlet::SvrResponse>(recvResp);
 
 	recvResp.reset();
-	assert(resp.error() == managarm::kernlet::Error::SUCCESS);
 
+	// On failure the compiler does not push a descriptor, hence pullKernlet is only valid
+	// once we know that the compilation succeeded.
+	if(resp.error() == managarm::kernlet::Error::ARCHITECTURE_NOT_SUPPORTED)
+		co_return std::unexpected{CompileError::architectureNotSupported};
+	if(resp.error() != managarm::kernlet::Error::SUCCESS)
+		co_return std::unexpected{CompileError::illegalRequest};
+
+	HEL_CHECK(pullKernlet.error());
 	co_return pullKernlet.descriptor();
 }
 

--- a/servers/kernletcc/Cargo.toml
+++ b/servers/kernletcc/Cargo.toml
@@ -10,10 +10,20 @@ indexmap = "2"
 object = { version = "0.37", default-features = false, features = ["write"] }
 hel.workspace = true
 managarm.workspace = true
-cranelift-codegen = { version = "0.124", features = ["x86"] }
+cranelift-codegen = "0.124"
 cranelift-frontend = "0.124"
 cranelift-control = "0.124"
 target-lexicon = "0.13"
+
+# Only build the Cranelift backend that we actually target.
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+cranelift-codegen = { version = "0.124", features = ["x86"] }
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+cranelift-codegen = { version = "0.124", features = ["arm64"] }
+
+[target.'cfg(target_arch = "riscv64")'.dependencies]
+cranelift-codegen = { version = "0.124", features = ["riscv64"] }
 
 [build-dependencies]
 bragi-build = "0.1"

--- a/servers/kernletcc/src/elf.rs
+++ b/servers/kernletcc/src/elf.rs
@@ -6,7 +6,7 @@ use object::Endianness;
 use object::elf;
 use object::write::elf::{FileHeader, ProgramHeader, Rel, Sym, SymbolIndex, Writer};
 
-use crate::fafnir::Compiled;
+use crate::fafnir::{Arch, Compiled, GotReloc, GotRelocKind};
 
 const SYM_SIZE: usize = size_of::<elf::Sym64<Endianness>>();
 const RELA_SIZE: usize = size_of::<elf::Rela64<Endianness>>();
@@ -25,8 +25,83 @@ fn sysv_elf_hash(name: &str) -> u32 {
     h
 }
 
+/// The ELF machine and JUMP_SLOT relocation type of an architecture.
+/// Keep in sync with kernletMachine/kernletJumpSlot in kernel/thor/generic/kernlet.cpp.
+fn elf_arch(arch: Arch) -> (u16, u32) {
+    match arch {
+        Arch::X86_64 => (elf::EM_X86_64, elf::R_X86_64_JUMP_SLOT),
+        Arch::Aarch64 => (elf::EM_AARCH64, elf::R_AARCH64_JUMP_SLOT),
+        Arch::Riscv64 => (elf::EM_RISCV, elf::R_RISCV_JUMP_SLOT),
+    }
+}
+
+/// Rewrites the 4-byte instruction at `offset` in place.
+fn patch_insn(code: &mut [u8], offset: usize, f: impl FnOnce(u32) -> u32) {
+    let field = &mut code[offset..offset + 4];
+    let insn = u32::from_le_bytes(field.try_into().unwrap());
+    field.copy_from_slice(&f(insn).to_le_bytes());
+}
+
+/// Encodes the address of a GOT slot into the instruction field that references it.
+/// `got_vaddr` is the address of the slot, `text_off` the address of the code.
+fn patch_got_reference(
+    code: &mut [u8],
+    reloc: &GotReloc,
+    got_vaddr: usize,
+    text_off: usize,
+) -> Result<()> {
+    let slot = got_vaddr as i64 + reloc.addend;
+    let pc = (text_off + reloc.pc_offset as usize) as i64;
+    let field = reloc.offset as usize;
+
+    match reloc.kind {
+        GotRelocKind::X86Pcrel32 => {
+            let value = i32::try_from(slot - pc)
+                .map_err(|_| anyhow::anyhow!("GOT displacement out of range"))?;
+            code[field..field + 4].copy_from_slice(&value.to_le_bytes());
+        }
+        GotRelocKind::Aarch64AdrpPage => {
+            // The adrp immediate counts 4 KiB pages and is split into immlo and immhi.
+            let pages = (slot >> 12) - (pc >> 12);
+            ensure!(
+                (-(1 << 20)..(1 << 20)).contains(&pages),
+                "GOT page offset out of range"
+            );
+            let imm = pages as u32;
+            patch_insn(code, field, |insn| {
+                (insn & !((0x3 << 29) | (0x7FFFF << 5)))
+                    | ((imm & 0x3) << 29)
+                    | (((imm >> 2) & 0x7FFFF) << 5)
+            });
+        }
+        GotRelocKind::Aarch64LdrLo12 => {
+            // The 64-bit ldr immediate is scaled by the access size.
+            ensure!(slot % 8 == 0, "GOT slot is not 8-byte aligned");
+            let imm = ((slot as u32) & 0xFFF) >> 3;
+            patch_insn(code, field, |insn| (insn & !(0xFFF << 10)) | (imm << 10));
+        }
+        GotRelocKind::RiscvAuipcHi20 => {
+            // The auipc immediate is rounded such that the (sign-extended) low 12 bits of the
+            // paired ld cancel the rounding out again.
+            let offset = i32::try_from(slot - pc)
+                .map_err(|_| anyhow::anyhow!("GOT displacement out of range"))?;
+            let hi20 = ((offset as u32).wrapping_add(0x800) >> 12) & 0xFFFFF;
+            patch_insn(code, field, |insn| (insn & 0xFFF) | (hi20 << 12));
+        }
+        GotRelocKind::RiscvLoadLo12 => {
+            let offset = i32::try_from(slot - pc)
+                .map_err(|_| anyhow::anyhow!("GOT displacement out of range"))?;
+            let lo12 = (offset as u32) & 0xFFF;
+            patch_insn(code, field, |insn| (insn & 0x000F_FFFF) | (lo12 << 20));
+        }
+    }
+    Ok(())
+}
+
 /// Builds an ELF DSO from compiled kernlet code and its external relocations.
 pub fn build_dso(compiled: &Compiled) -> Result<Vec<u8>> {
+    let (machine, jump_slot) = elf_arch(compiled.arch);
+
     let mut buffer = Vec::new();
     let mut w = Writer::new(Endianness::Little, true, &mut buffer);
 
@@ -92,7 +167,7 @@ pub fn build_dso(compiled: &Compiled) -> Result<Vec<u8>> {
         os_abi: elf::ELFOSABI_NONE,
         abi_version: 0,
         e_type: elf::ET_DYN,
-        e_machine: elf::EM_X86_64,
+        e_machine: machine,
         e_entry: 0,
         e_flags: 0,
     })?;
@@ -120,16 +195,11 @@ pub fn build_dso(compiled: &Compiled) -> Result<Vec<u8>> {
         p_align: 8,
     });
 
-    // Code (.text); patch each GOT-relative field to its GOT slot via S + A - P.
+    // Code (.text); patch each GOT reference to point at its GOT slot.
     let mut code = compiled.code.clone();
     for reloc in &compiled.relocs {
-        let got_vaddr = (got_off + reloc.symbol as usize * 8) as i64;
-        let field_vaddr = (text_off + reloc.offset as usize) as i64;
-        let value = got_vaddr + reloc.addend - field_vaddr;
-        let value =
-            i32::try_from(value).map_err(|_| anyhow::anyhow!("GOT displacement out of range"))?;
-        code[reloc.offset as usize..reloc.offset as usize + 4]
-            .copy_from_slice(&value.to_le_bytes());
+        let got_vaddr = got_off + reloc.symbol as usize * 8;
+        patch_got_reference(&mut code, reloc, got_vaddr, text_off)?;
     }
     w.write_align(8);
     check_off(w.len(), text_off, ".text")?;
@@ -205,7 +275,7 @@ pub fn build_dso(compiled: &Compiled) -> Result<Vec<u8>> {
             &Rel {
                 r_offset: (got_off + i * 8) as u64,
                 r_sym: symidx.0,
-                r_type: elf::R_X86_64_JUMP_SLOT,
+                r_type: jump_slot,
                 r_addend: 0,
             },
         );

--- a/servers/kernletcc/src/fafnir.rs
+++ b/servers/kernletcc/src/fafnir.rs
@@ -15,6 +15,7 @@ use cranelift_codegen::{Context, FinalizedRelocTarget};
 use cranelift_control::ControlPlane;
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
 use indexmap::IndexSet;
+use std::collections::HashMap;
 
 // Fafnir opcodes, in the order defined by fafnir/language.h.
 const FNR_OP_NULL: u8 = 0;
@@ -86,15 +87,71 @@ struct TypedValue {
     ty: FnrType,
 }
 
-/// A relocation referencing an external (kernel-provided) symbol.
+/// The architecture that kernlets are compiled for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Arch {
+    X86_64,
+    Aarch64,
+    Riscv64,
+}
+
+impl Arch {
+    /// The architecture that kernletcc runs on, or `None` if we cannot compile Fafnir for it.
+    /// Drivers are told about the latter via ARCHITECTURE_NOT_SUPPORTED.
+    pub fn host() -> Option<Arch> {
+        if cfg!(target_arch = "x86_64") {
+            Some(Arch::X86_64)
+        } else if cfg!(target_arch = "aarch64") {
+            Some(Arch::Aarch64)
+        } else if cfg!(target_arch = "riscv64") {
+            Some(Arch::Riscv64)
+        } else {
+            None
+        }
+    }
+
+    fn triple(self) -> &'static str {
+        match self {
+            Arch::X86_64 => "x86_64-unknown-none-elf",
+            Arch::Aarch64 => "aarch64-unknown-none",
+            Arch::Riscv64 => "riscv64-unknown-none-elf",
+        }
+    }
+
+    /// Whether the architecture has port I/O, i.e. whether thor provides the `__pio_*` intrinsics.
+    fn has_pio(self) -> bool {
+        self == Arch::X86_64
+    }
+}
+
+/// The instruction field that a GOT reference is encoded in.
+#[derive(Debug, Clone, Copy)]
+pub enum GotRelocKind {
+    /// x86-64: the 4-byte RIP-relative displacement of a `movq sym@GOTPCREL(%rip), %reg`.
+    X86Pcrel32,
+    /// aarch64: the 21-bit page offset of an `adrp`.
+    Aarch64AdrpPage,
+    /// aarch64: the scaled 12-bit offset of the `ldr` that follows the `adrp`.
+    Aarch64LdrLo12,
+    /// riscv64: the high 20 bits of a PC-relative offset, held by an `auipc`.
+    RiscvAuipcHi20,
+    /// riscv64: the low 12 bits of the offset, held by the `ld` that follows the `auipc`.
+    RiscvLoadLo12,
+}
+
+/// A reference from the code to the GOT slot of an external (kernel-provided) symbol.
 #[derive(Debug, Clone)]
-pub struct ExternReloc {
-    /// Offset of the 4-byte PC-relative field within the code buffer.
+pub struct GotReloc {
+    /// Offset of the instruction field within the code buffer.
     pub offset: u32,
+    /// Code offset that the displacement is computed against. This is the field itself, except
+    /// for riscv64 low-12 relocations, which are relative to their `auipc`.
+    pub pc_offset: u32,
     /// Addend supplied by Cranelift.
     pub addend: i64,
     /// Index into `Compiled::externs`.
     pub symbol: u32,
+    pub kind: GotRelocKind,
 }
 
 /// A symbol exported (defined) by the kernlet, located at `offset` within `code`.
@@ -108,12 +165,13 @@ pub struct Export {
 /// The result of compiling a kernlet: machine code, the symbols it exports
 /// and its external relocations.
 pub struct Compiled {
+    pub arch: Arch,
     pub code: Vec<u8>,
     /// Exported symbols.
     pub exports: Vec<Export>,
-    /// External symbols. `ExternReloc::symbol` indexes into this vector.
+    /// External symbols. `GotReloc::symbol` indexes into this vector.
     pub externs: Vec<String>,
-    pub relocs: Vec<ExternReloc>,
+    pub relocs: Vec<GotReloc>,
 }
 
 struct Reader<'a> {
@@ -195,6 +253,11 @@ enum BlockKind {
         merge_block: cranelift_codegen::ir::Block,
         merge_vars: Vec<(Variable, FnrType)>,
     },
+}
+
+/// Whether an intrinsic requires port I/O, i.e. whether thor only provides it on x86.
+fn intrinsic_needs_pio(name: &str) -> bool {
+    matches!(name, "__pio_read16" | "__pio_write16")
 }
 
 /// Signatures of the kernel intrinsics from `resolveExternal` (kernel/thor/generic/kernlet.cpp):
@@ -289,31 +352,19 @@ impl Compiler {
     }
 }
 
-/// The Cranelift target triple for the architecture kernletcc runs on, or `None` if we cannot
-/// compile Fafnir for it. Drivers are told about the latter via ARCHITECTURE_NOT_SUPPORTED.
-pub fn target_triple() -> Option<&'static str> {
-    if cfg!(target_arch = "x86_64") {
-        Some("x86_64-unknown-none-elf")
-    } else {
-        None
-    }
-}
-
-/// Compiles Fafnir bytecode into machine code for the architecture kernletcc runs on.
-pub fn compile(code: &[u8], bind_types: &[BindType]) -> Result<Compiled> {
-    // Generate PIC code: Cranelift emits X86GOTPCRel4 relocations for external symbols
-    // (GOT-relative loads) that we later resolve to GOT slots the kernel fills via JUMP_SLOT.
+/// Compiles Fafnir bytecode into machine code for the given architecture.
+pub fn compile(arch: Arch, code: &[u8], bind_types: &[BindType]) -> Result<Compiled> {
+    // Generate PIC code: Cranelift references external symbols through the GOT, which we later
+    // resolve to GOT slots that the kernel fills in via JUMP_SLOT relocations.
     let mut flags = settings::builder();
     flags.set("opt_level", "speed").unwrap();
     flags.set("is_pic", "true").unwrap();
-    let Some(triple) = target_triple() else {
-        bail!("compiling Fafnir is not supported on this architecture");
-    };
-    let triple: target_lexicon::Triple = triple.parse().unwrap();
+    let triple: target_lexicon::Triple = arch.triple().parse().unwrap();
+    let call_conv = CallConv::triple_default(&triple);
     let isa = cranelift_codegen::isa::lookup(triple)?.finish(settings::Flags::new(flags))?;
 
     // Signature of the entry point: automate_irq(const void *instance) -> int
-    let mut sig = Signature::new(CallConv::SystemV);
+    let mut sig = Signature::new(call_conv);
     sig.params.push(AbiParam::new(types::I64));
     sig.returns.push(AbiParam::new(types::I32));
     let mut func = Function::with_name_signature(UserFuncName::user(0, 0), sig);
@@ -504,6 +555,10 @@ pub fn compile(code: &[u8], bind_types: &[BindType]) -> Result<Compiled> {
                 let (param_types, result_types) = intrinsic_signature(&name)
                     .ok_or_else(|| anyhow::anyhow!("unknown intrinsic: {name}"))?;
                 ensure!(
+                    arch.has_pio() || !intrinsic_needs_pio(&name),
+                    "intrinsic {name} requires port I/O, which this architecture lacks"
+                );
+                ensure!(
                     nargs == param_types.len(),
                     "wrong number of arguments for intrinsic {name}"
                 );
@@ -523,12 +578,9 @@ pub fn compile(code: &[u8], bind_types: &[BindType]) -> Result<Compiled> {
                 args.reverse();
 
                 // Check operand types against the kernel-side signature.
-                let mut csig = Signature::new(CallConv::SystemV);
+                let mut csig = Signature::new(call_conv);
                 for (&a, &ty) in args.iter().zip(param_types) {
-                    ensure!(
-                        a.ty == ty,
-                        "operand of wrong type for intrinsic {name}"
-                    );
+                    ensure!(a.ty == ty, "operand of wrong type for intrinsic {name}");
                     csig.params.push(AbiParam::new(ty.clif()));
                 }
                 for &ty in result_types {
@@ -589,10 +641,7 @@ pub fn compile(code: &[u8], bind_types: &[BindType]) -> Result<Compiled> {
     }
 
     let ret = compiler.return_value()?;
-    ensure!(
-        ret.ty == FnrType::I32,
-        "kernlet must return a 32-bit value"
-    );
+    ensure!(ret.ty == FnrType::I32, "kernlet must return a 32-bit value");
     builder.ins().return_(&[ret.val]);
 
     builder.seal_all_blocks();
@@ -617,29 +666,58 @@ pub fn compile(code: &[u8], bind_types: &[BindType]) -> Result<Compiled> {
         (code, raw)
     };
 
-    let mut relocs = Vec::new();
-    for (offset, addend, kind, target) in raw_relocs {
-        // We only emit calls to imported intrinsics, which in PIC mode become GOT-relative
-        // loads of the symbol address against external user symbols.
-        ensure!(
-            matches!(kind, Reloc::X86GOTPCRel4),
-            "unexpected relocation kind: {kind:?}"
-        );
-        let symbol = match target {
+    // We only emit calls to imported intrinsics, which in PIC mode become GOT-relative loads of
+    // the symbol address against external user symbols.
+    let symbol_of = |target: &FinalizedRelocTarget| -> Result<u32> {
+        match target {
             FinalizedRelocTarget::ExternalName(ExternalName::User(name_ref)) => {
-                let uen = &ctx.func.params.user_named_funcs()[name_ref];
+                let uen = &ctx.func.params.user_named_funcs()[*name_ref];
                 ensure!(
                     (uen.index as usize) < externs.len(),
                     "relocation references unknown intrinsic"
                 );
-                uen.index
+                Ok(uen.index)
             }
             other => bail!("unexpected relocation target: {other:?}"),
+        }
+    };
+
+    // riscv64 attaches the low-12 relocation to the label of its `auipc` rather than to the
+    // symbol, hence we remember which GOT slot each `auipc` refers to.
+    let mut auipc_symbols: HashMap<u32, u32> = HashMap::new();
+
+    let mut relocs = Vec::new();
+    for (offset, addend, kind, target) in raw_relocs {
+        let (symbol, kind, pc_offset) = match kind {
+            Reloc::X86GOTPCRel4 => (symbol_of(&target)?, GotRelocKind::X86Pcrel32, offset),
+            Reloc::Aarch64AdrGotPage21 => {
+                (symbol_of(&target)?, GotRelocKind::Aarch64AdrpPage, offset)
+            }
+            Reloc::Aarch64Ld64GotLo12Nc => {
+                (symbol_of(&target)?, GotRelocKind::Aarch64LdrLo12, offset)
+            }
+            Reloc::RiscvGotHi20 => {
+                let symbol = symbol_of(&target)?;
+                auipc_symbols.insert(offset, symbol);
+                (symbol, GotRelocKind::RiscvAuipcHi20, offset)
+            }
+            Reloc::RiscvPCRelLo12I => {
+                let FinalizedRelocTarget::Func(auipc) = target else {
+                    bail!("unexpected relocation target: {target:?}");
+                };
+                let symbol = *auipc_symbols
+                    .get(&auipc)
+                    .ok_or_else(|| anyhow::anyhow!("low-12 relocation without a GOT auipc"))?;
+                (symbol, GotRelocKind::RiscvLoadLo12, auipc)
+            }
+            other => bail!("unexpected relocation kind: {other:?}"),
         };
-        relocs.push(ExternReloc {
+        relocs.push(GotReloc {
             offset,
+            pc_offset,
             addend,
             symbol,
+            kind,
         });
     }
 
@@ -647,6 +725,7 @@ pub fn compile(code: &[u8], bind_types: &[BindType]) -> Result<Compiled> {
     // resolves by name (kernel/thor/generic/kernlet.cpp).
     let code_size = code_bytes.len() as u32;
     let compiled = Compiled {
+        arch,
         code: code_bytes,
         exports: vec![Export {
             name: "automate_irq".to_string(),

--- a/servers/kernletcc/src/fafnir.rs
+++ b/servers/kernletcc/src/fafnir.rs
@@ -289,14 +289,27 @@ impl Compiler {
     }
 }
 
-/// Compiles Fafnir bytecode into x86-64 machine code.
+/// The Cranelift target triple for the architecture kernletcc runs on, or `None` if we cannot
+/// compile Fafnir for it. Drivers are told about the latter via ARCHITECTURE_NOT_SUPPORTED.
+pub fn target_triple() -> Option<&'static str> {
+    if cfg!(target_arch = "x86_64") {
+        Some("x86_64-unknown-none-elf")
+    } else {
+        None
+    }
+}
+
+/// Compiles Fafnir bytecode into machine code for the architecture kernletcc runs on.
 pub fn compile(code: &[u8], bind_types: &[BindType]) -> Result<Compiled> {
     // Generate PIC code: Cranelift emits X86GOTPCRel4 relocations for external symbols
     // (GOT-relative loads) that we later resolve to GOT slots the kernel fills via JUMP_SLOT.
     let mut flags = settings::builder();
     flags.set("opt_level", "speed").unwrap();
     flags.set("is_pic", "true").unwrap();
-    let triple: target_lexicon::Triple = "x86_64-unknown-none-elf".parse().unwrap();
+    let Some(triple) = target_triple() else {
+        bail!("compiling Fafnir is not supported on this architecture");
+    };
+    let triple: target_lexicon::Triple = triple.parse().unwrap();
     let isa = cranelift_codegen::isa::lookup(triple)?.finish(settings::Flags::new(flags))?;
 
     // Signature of the entry point: automate_irq(const void *instance) -> int

--- a/servers/kernletcc/src/main.rs
+++ b/servers/kernletcc/src/main.rs
@@ -97,17 +97,17 @@ async fn handle_request(lane: &Handle, ctl: &Handle) -> Result<bool> {
     recv_tail?;
     let code = recv_code?;
 
-    if fafnir::target_triple().is_none() {
+    let Some(arch) = fafnir::Arch::host() else {
         reject(&conversation, kernlet::Error::ArchitectureNotSupported).await?;
         return Ok(true);
-    }
+    };
 
     let req: kernlet::CompileRequest = bragi::head_tail_from_bytes(&head, &tail)?;
     let proto: Vec<kernlet::ParameterType> = req.bind_types().to_vec();
     let bind_types: Vec<BindType> = proto.iter().map(|&p| bind_type_of(p)).collect();
 
     // Compilation fails on malformed bytecode, i.e. due to the request and not due to us.
-    let elf_bytes = match fafnir::compile(&code, &bind_types)
+    let elf_bytes = match fafnir::compile(arch, &code, &bind_types)
         .and_then(|compiled| elf::build_dso(&compiled))
     {
         Ok(elf_bytes) => elf_bytes,

--- a/servers/kernletcc/src/main.rs
+++ b/servers/kernletcc/src/main.rs
@@ -65,6 +65,15 @@ async fn upload(
     Ok(pull?.expect("kernletctl did not push a kernlet descriptor"))
 }
 
+/// Sends a head-only response without a kernlet descriptor, used to reject a request.
+async fn reject(conversation: &Handle, error: kernlet::Error) -> Result<()> {
+    let resp = kernlet::SvrResponse::new(error);
+    let resp_head = bragi::head_to_bytes(&resp)?;
+    let (send_resp,) = hel::submit_async(conversation, (hel::SendBuffer::new(&resp_head),)).await?;
+    send_resp?;
+    Ok(())
+}
+
 /// Handles a single request on the given lane. Returns `false` if the lane was shut down.
 async fn handle_request(lane: &Handle, ctl: &Handle) -> Result<bool> {
     let (conv, (head,)) = hel::submit_async(lane, hel::Accept::new((hel::ReceiveInline,))).await?;
@@ -88,12 +97,27 @@ async fn handle_request(lane: &Handle, ctl: &Handle) -> Result<bool> {
     recv_tail?;
     let code = recv_code?;
 
+    if fafnir::target_triple().is_none() {
+        reject(&conversation, kernlet::Error::ArchitectureNotSupported).await?;
+        return Ok(true);
+    }
+
     let req: kernlet::CompileRequest = bragi::head_tail_from_bytes(&head, &tail)?;
     let proto: Vec<kernlet::ParameterType> = req.bind_types().to_vec();
     let bind_types: Vec<BindType> = proto.iter().map(|&p| bind_type_of(p)).collect();
 
-    let compiled = fafnir::compile(&code, &bind_types)?;
-    let elf_bytes = elf::build_dso(&compiled)?;
+    // Compilation fails on malformed bytecode, i.e. due to the request and not due to us.
+    let elf_bytes = match fafnir::compile(&code, &bind_types)
+        .and_then(|compiled| elf::build_dso(&compiled))
+    {
+        Ok(elf_bytes) => elf_bytes,
+        Err(e) => {
+            eprintln!("kernletcc: Failed to compile a kernlet: {e:?}");
+            reject(&conversation, kernlet::Error::IllegalRequest).await?;
+            return Ok(true);
+        }
+    };
+
     let kernlet = upload(ctl, &elf_bytes, &proto).await?;
 
     let resp = kernlet::SvrResponse::new(kernlet::Error::Success);


### PR DESCRIPTION
This adds support to handle the relocation types needed for kernlets on all architectures. This makes the virtio and EHCI kernlets usable on all architectures (not UHCI though since that uses PIO).