### PR TITLE
posix: Refactor trailing slash handling in path resolver

### DIFF
--- a/posix/subsystem/src/coredump.cpp
+++ b/posix/subsystem/src/coredump.cpp
@@ -13,7 +13,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> creat
 	PathResolver resolver;
 	resolver.setup(proc->fsContext()->getRoot(), proc->fsContext()->getWorkingDirectory(), name, proc);
 	auto resolveResult = co_await resolver.resolve(
-		resolvePrefix | resolveNoTrailingSlash);
+		resolvePrefix | resolveOpenCreate);
 	if (!resolveResult)
 		co_return resolveResult.error() | toPosixError;
 

--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -115,6 +115,9 @@ enum class Error {
 
 	directoryNotEmpty,
 
+	// Corresponds with ENAMETOOLONG
+	nameTooLong,
+
 	// Failure of the underlying device, corresponds to EIO
 	ioError,
 
@@ -198,6 +201,7 @@ inline managarm::posix::Errors operator|(Error e, ToPosixProtoError) {
 		case Error::brokenPipe: return managarm::posix::Errors::BROKEN_PIPE;
 		case Error::accessDenied: return managarm::posix::Errors::ACCESS_DENIED;
 		case Error::notDirectory: return managarm::posix::Errors::NOT_A_DIRECTORY;
+		case Error::nameTooLong: return managarm::posix::Errors::NAME_TOO_LONG;
 		case Error::insufficientPermissions: return managarm::posix::Errors::INSUFFICIENT_PERMISSION;
 		case Error::alreadyExists: return managarm::posix::Errors::ALREADY_EXISTS;
 		case Error::illegalOperationTarget: return managarm::posix::Errors::ILLEGAL_OPERATION_TARGET;
@@ -252,6 +256,7 @@ inline Error operator|(protocols::fs::Error e, ToPosixError) {
 		case protocols::fs::Error::notTerminal: return Error::notTerminal;
 		case protocols::fs::Error::noBackingDevice: return Error::noBackingDevice;
 		case protocols::fs::Error::isDirectory: return Error::isDirectory;
+		case protocols::fs::Error::nameTooLong: return Error::nameTooLong;
 		case protocols::fs::Error::directoryNotEmpty: return Error::directoryNotEmpty;
 		case protocols::fs::Error::internalError: return Error::fileClosed;
 		case protocols::fs::Error::noSuchProcess: return Error::noSuchProcess;

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -309,7 +309,7 @@ HandleRequest::operator()(managarm::posix::MkfifoAtRequest &&req,
 	PathResolver resolver;
 	resolver.setup(self->fsContext()->getRoot(),
 			relative_to, req.path(), self.get());
-	auto resolveResult = co_await resolver.resolve(resolvePrefix | resolveNoTrailingSlash);
+	auto resolveResult = co_await resolver.resolve(resolvePrefix | resolveCreatesNonDirectory);
 	if(!resolveResult) {
 		co_await sendErrorResponse<managarm::posix::MkfifoAtResponse>(conversation,
 				resolveResult.error() | toPosixError | toPosixProtoError);
@@ -411,7 +411,7 @@ HandleRequest::operator()(managarm::posix::LinkAtRequest &&req,
 	new_resolver.setup(self->fsContext()->getRoot(),
 			relative_to, req.target_path(), self.get());
 	auto new_resolveResult = co_await new_resolver.resolve(
-			resolvePrefix | resolveNoTrailingSlash);
+			resolvePrefix | resolveCreatesNonDirectory);
 	if(!new_resolveResult) {
 		co_await sendErrorResponse<managarm::posix::LinkAtResponse>(conversation,
 				new_resolveResult.error() | toPosixError | toPosixProtoError);
@@ -466,7 +466,7 @@ HandleRequest::operator()(managarm::posix::SymlinkAtRequest &&req,
 	resolver.setup(self->fsContext()->getRoot(),
 			relativeTo, req.path(), self.get());
 	auto resolveResult = co_await resolver.resolve(
-			resolvePrefix | resolveNoTrailingSlash);
+			resolvePrefix | resolveCreatesNonDirectory);
 	if(!resolveResult) {
 		co_await sendErrorResponse<managarm::posix::SymlinkAtResponse>(conversation,
 				resolveResult.error() | toPosixError | toPosixProtoError);
@@ -1377,7 +1377,7 @@ HandleRequest::operator()(managarm::posix::OpenAtRequest &&req,
 			relative_to, req.path(), self.get());
 	if(req.flags() & managarm::posix::OpenFlags::OF_CREATE) {
 		auto resolveResult = co_await resolver.resolve(
-				resolvePrefix | resolveNoTrailingSlash);
+				resolvePrefix | resolveOpenCreate);
 		if(!resolveResult) {
 			co_await sendErrorResponse<managarm::posix::OpenAtResponse>(conversation,
 					resolveResult.error() | toPosixError | toPosixProtoError);
@@ -1572,11 +1572,11 @@ HandleRequest::operator()(managarm::posix::MknodAtRequest &&req,
 		relative_to = {file->associatedMount(), file->associatedLink()};
 	}
 
-	// TODO: Add resolveNoTrailingSlash if not making a directory?
+	// mknod never creates a directory, so a trailing slash suppresses creation.
 	PathResolver resolver;
 	resolver.setup(self->fsContext()->getRoot(),
 			relative_to, req.path(), self.get());
-	auto resolveResult = co_await resolver.resolve(resolvePrefix);
+	auto resolveResult = co_await resolver.resolve(resolvePrefix | resolveCreatesNonDirectory);
 	if(!resolveResult) {
 		co_await sendErrorResponse<managarm::posix::MknodAtResponse>(conversation,
 				resolveResult.error() | toPosixError | toPosixProtoError);

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -311,16 +311,9 @@ HandleRequest::operator()(managarm::posix::MkfifoAtRequest &&req,
 			relative_to, req.path(), self.get());
 	auto resolveResult = co_await resolver.resolve(resolvePrefix | resolveNoTrailingSlash);
 	if(!resolveResult) {
-		if(resolveResult.error() == protocols::fs::Error::fileNotFound) {
-			co_await sendErrorResponse<managarm::posix::MkfifoAtResponse>(conversation, managarm::posix::Errors::FILE_NOT_FOUND);
-			co_return {};
-		} else if(resolveResult.error() == protocols::fs::Error::notDirectory) {
-			co_await sendErrorResponse<managarm::posix::MkfifoAtResponse>(conversation, managarm::posix::Errors::NOT_A_DIRECTORY);
-			co_return {};
-		} else {
-			std::cout << "posix: Unexpected failure from resolve()" << std::endl;
-			co_return {};
-		}
+		co_await sendErrorResponse<managarm::posix::MkfifoAtResponse>(conversation,
+				resolveResult.error() | toPosixError | toPosixProtoError);
+		co_return {};
 	}
 
 	auto parent = resolver.currentLink()->getTarget();
@@ -420,19 +413,9 @@ HandleRequest::operator()(managarm::posix::LinkAtRequest &&req,
 	auto new_resolveResult = co_await new_resolver.resolve(
 			resolvePrefix | resolveNoTrailingSlash);
 	if(!new_resolveResult) {
-		if(new_resolveResult.error() == protocols::fs::Error::illegalOperationTarget) {
-			co_await sendErrorResponse<managarm::posix::LinkAtResponse>(conversation, managarm::posix::Errors::ILLEGAL_OPERATION_TARGET);
-			co_return {};
-		} else if(new_resolveResult.error() == protocols::fs::Error::fileNotFound) {
-			co_await sendErrorResponse<managarm::posix::LinkAtResponse>(conversation, managarm::posix::Errors::FILE_NOT_FOUND);
-			co_return {};
-		} else if(new_resolveResult.error() == protocols::fs::Error::notDirectory) {
-			co_await sendErrorResponse<managarm::posix::LinkAtResponse>(conversation, managarm::posix::Errors::NOT_A_DIRECTORY);
-			co_return {};
-		} else {
-			std::cout << "posix: Unexpected failure from resolve()" << std::endl;
-			co_return {};
-		}
+		co_await sendErrorResponse<managarm::posix::LinkAtResponse>(conversation,
+				new_resolveResult.error() | toPosixError | toPosixProtoError);
+		co_return {};
 	}
 
 	auto target = resolver.currentLink()->getTarget();
@@ -485,16 +468,9 @@ HandleRequest::operator()(managarm::posix::SymlinkAtRequest &&req,
 	auto resolveResult = co_await resolver.resolve(
 			resolvePrefix | resolveNoTrailingSlash);
 	if(!resolveResult) {
-		if(resolveResult.error() == protocols::fs::Error::fileNotFound) {
-			co_await sendErrorResponse<managarm::posix::SymlinkAtResponse>(conversation, managarm::posix::Errors::FILE_NOT_FOUND);
-			co_return {};
-		} else if(resolveResult.error() == protocols::fs::Error::notDirectory) {
-			co_await sendErrorResponse<managarm::posix::SymlinkAtResponse>(conversation, managarm::posix::Errors::NOT_A_DIRECTORY);
-			co_return {};
-		} else {
-			std::cout << "posix: Unexpected failure from resolve()" << std::endl;
-			co_return {};
-		}
+		co_await sendErrorResponse<managarm::posix::SymlinkAtResponse>(conversation,
+				resolveResult.error() | toPosixError | toPosixProtoError);
+		co_return {};
 	}
 
 	logRequest(logRequests || logPaths, self, "SYMLINK", "'{}{}' -> '{}'",
@@ -1403,23 +1379,9 @@ HandleRequest::operator()(managarm::posix::OpenAtRequest &&req,
 		auto resolveResult = co_await resolver.resolve(
 				resolvePrefix | resolveNoTrailingSlash);
 		if(!resolveResult) {
-			if(resolveResult.error() == protocols::fs::Error::isDirectory) {
-				// TODO: Verify additional constraints for sending EISDIR.
-				co_await sendErrorResponse<managarm::posix::OpenAtResponse>(conversation, managarm::posix::Errors::IS_DIRECTORY);
-				co_return {};
-			} else if(resolveResult.error() == protocols::fs::Error::fileNotFound) {
-				co_await sendErrorResponse<managarm::posix::OpenAtResponse>(conversation, managarm::posix::Errors::FILE_NOT_FOUND);
-				co_return {};
-			} else if(resolveResult.error() == protocols::fs::Error::notDirectory) {
-				co_await sendErrorResponse<managarm::posix::OpenAtResponse>(conversation, managarm::posix::Errors::NOT_A_DIRECTORY);
-				co_return {};
-			} else if(resolveResult.error() == protocols::fs::Error::nameTooLong) {
-				co_await sendErrorResponse<managarm::posix::OpenAtResponse>(conversation, managarm::posix::Errors::NAME_TOO_LONG);
-				co_return {};
-			} else {
-				std::cout << "posix: Unexpected failure from resolve()" << std::endl;
-				co_return {};
-			}
+			co_await sendErrorResponse<managarm::posix::OpenAtResponse>(conversation,
+					resolveResult.error() | toPosixError | toPosixProtoError);
+			co_return {};
 		}
 
 		logRequest(logRequests || logPaths, self, "OPENAT", "create '{}'",
@@ -1616,16 +1578,9 @@ HandleRequest::operator()(managarm::posix::MknodAtRequest &&req,
 			relative_to, req.path(), self.get());
 	auto resolveResult = co_await resolver.resolve(resolvePrefix);
 	if(!resolveResult) {
-		if(resolveResult.error() == protocols::fs::Error::fileNotFound) {
-			co_await sendErrorResponse<managarm::posix::MknodAtResponse>(conversation, managarm::posix::Errors::FILE_NOT_FOUND);
-			co_return {};
-		} else if(resolveResult.error() == protocols::fs::Error::notDirectory) {
-			co_await sendErrorResponse<managarm::posix::MknodAtResponse>(conversation, managarm::posix::Errors::NOT_A_DIRECTORY);
-			co_return {};
-		} else {
-			std::cout << "posix: Unexpected failure from resolve()" << std::endl;
-			co_return {};
-		}
+		co_await sendErrorResponse<managarm::posix::MknodAtResponse>(conversation,
+				resolveResult.error() | toPosixError | toPosixProtoError);
+		co_return {};
 	}
 
 	auto parent = resolver.currentLink()->getTarget();

--- a/posix/subsystem/src/un-socket.cpp
+++ b/posix/subsystem/src/un-socket.cpp
@@ -579,7 +579,7 @@ public:
 			PathResolver resolver;
 			resolver.setup(process->fsContext()->getRoot(),
 					process->fsContext()->getWorkingDirectory(), std::move(path), process);
-			auto resolveResult = co_await resolver.resolve(resolvePrefix | resolveNoTrailingSlash);
+			auto resolveResult = co_await resolver.resolve(resolvePrefix | resolveCreatesNonDirectory);
 			if(!resolveResult) {
 				co_return resolveResult.error();
 			}

--- a/posix/subsystem/src/util.cpp
+++ b/posix/subsystem/src/util.cpp
@@ -25,6 +25,7 @@ std::ostream& operator<<(std::ostream& os, const Error& err) {
 		case Error::isDirectory: err_string = "isDirectory"; break;
 		case Error::noMemory: err_string = "noMemory"; break;
 		case Error::directoryNotEmpty: err_string = "directoryNotEmpty"; break;
+		case Error::nameTooLong: err_string = "nameTooLong"; break;
 		case Error::ioError: err_string = "ioError"; break;
 		case Error::noChildProcesses: err_string = "noChildProcesses"; break;
 		case Error::alreadyConnected: err_string = "alreadyConnected"; break;

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -241,6 +241,10 @@ void PathResolver::setup(ViewPath root, ViewPath workdir, std::string string, Pr
 }
 
 async::result<frg::expected<protocols::fs::Error, void>> PathResolver::resolve(ResolveFlags flags) {
+	// The trailing-slash policies only apply to prefix resolution (see vfs.hpp).
+	assert(!(flags & (resolveNoTrailingSlash | resolveOpenCreate | resolveCreatesNonDirectory))
+			|| (flags & resolvePrefix));
+
 	auto sn = StructName::get("path-resolve");
 	if(debugResolve) {
 		std::cout << "posix " << sn << ": Path resolution for '";
@@ -251,9 +255,6 @@ async::result<frg::expected<protocols::fs::Error, void>> PathResolver::resolve(R
 		}
 		std::cout << "'" << std::endl;
 	}
-
-	if((flags & resolveNoTrailingSlash) && _trailingSlash)
-		co_return protocols::fs::Error::isDirectory;
 
 	while(true) {
 		if(_components.empty()
@@ -457,6 +458,20 @@ async::result<frg::expected<protocols::fs::Error, void>> PathResolver::resolve(R
 
 		if (_components.front() == ".")
 			_components.pop_front();
+
+		// Enforce the caller's trailing-slash policy (see the flag definitions).
+		if(_trailingSlash) {
+			if(flags & resolveNoTrailingSlash)
+				co_return protocols::fs::Error::notDirectory;
+			if(flags & resolveOpenCreate)
+				co_return protocols::fs::Error::isDirectory;
+			if((flags & resolveCreatesNonDirectory) && !_components.empty()) {
+				auto childResult = co_await _currentPath.second->getTarget()->getLink(_components.front());
+				if(childResult && childResult.value())
+					co_return protocols::fs::Error::alreadyExists;
+				co_return protocols::fs::Error::fileNotFound;
+			}
+		}
 	}else{
 		assert(!_components.size());
 

--- a/posix/subsystem/src/vfs.hpp
+++ b/posix/subsystem/src/vfs.hpp
@@ -14,10 +14,31 @@
 #include "fs.hpp"
 
 using ResolveFlags = uint32_t;
-inline constexpr ResolveFlags resolvePrefix = (1 << 4);
-// The path must not refer to a directory (no trailing slash allowed).
-inline constexpr ResolveFlags resolveNoTrailingSlash = (1 << 2);
+
 inline constexpr ResolveFlags resolveDontFollow = (1 << 1);
+
+// Resolution stops before resolving the last component, ignoring trailing slashes.
+// In particular, both for a/b/c and for a/b/c/, resolution stops before c.
+// If a trailing slash is present, the behavior depends on the mutually exclusive flags
+// resolveNoTrailingSlash, resolveOpenCreate and resolveCreatesNonDirectory (see below).
+// Without any of these flags (mkdir, rename of a directory):
+// a trailing slash after successful prefix resolution returns success.
+// Note that the trailing slash handling is modelled after Linux, not POSIX.
+inline constexpr ResolveFlags resolvePrefix = (1 << 4);
+
+// The caller operates on an existing non-directory (rename with a non-directory source).
+// Requires resolvePrefix.
+// A trailing slash after successful prefix resolution fails with ENOTDIR.
+inline constexpr ResolveFlags resolveNoTrailingSlash = (1 << 2);
+// The caller is open() with O_CREAT.
+// Requires resolvePrefix.
+// A trailing slash after successful prefix resolution fails with EISDIR.
+inline constexpr ResolveFlags resolveOpenCreate = (1 << 5);
+// The caller creates a non-directory leaf (mkfifo, mknod, link, symlink, bind).
+// Requires resolvePrefix.
+// A trailing slash after successful prefix resolution checks the last component (without resolving symlinks) and then fails.
+// If the last component does not exist, resolution fails with ENOENT. Otherwise, it fails with EEXIST.
+inline constexpr ResolveFlags resolveCreatesNonDirectory = (1 << 6);
 
 using ViewPathPair = std::pair<std::shared_ptr<MountView>, std::shared_ptr<FsLink>>;
 

--- a/testsuites/posix-tests/meson.build
+++ b/testsuites/posix-tests/meson.build
@@ -23,6 +23,7 @@ src = [
 	'src/procfs.cpp',
 	'src/path-resolution.cpp',
 	'src/rename.cpp',
+	'src/trailing-slash-create.cpp',
 	'src/pthread-fork-wait.cpp',
 	'src/thread.cpp',
 	'src/poll.cpp',

--- a/testsuites/posix-tests/src/trailing-slash-create.cpp
+++ b/testsuites/posix-tests/src/trailing-slash-create.cpp
@@ -1,0 +1,165 @@
+#include <cassert>
+#include <cerrno>
+#include <cstdlib>
+#include <fcntl.h>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <frg/scope_exit.hpp>
+
+#include "testsuite.hpp"
+
+namespace {
+
+// Per-test scratch directory: the ext2 root on Managarm (to exercise libblockfs,
+// which /tmp as tmpfs would bypass), /tmp on hosts where the root is not writable.
+std::string make_scratch() {
+#if defined(__managarm__)
+	std::string tmpl = "/posix-tests-tscreate-XXXXXX";
+#else
+	std::string tmpl = "/tmp/posix-tests-tscreate-XXXXXX";
+#endif
+	std::string path(tmpl);
+	if(!mkdtemp(path.data()))
+		assert(!"mkdtemp() failed");
+	return path;
+}
+
+void create_file(const std::string &path) {
+	int fd = creat(path.c_str(), 0644);
+	assert(fd >= 0);
+	close(fd);
+}
+
+} // namespace
+
+// Each test drives the trailing-slash code paths in the resolver: a missing
+// leaf, an existing non-directory leaf and an existing directory leaf. These
+// expectations match Linux: for a non-directory creator a trailing slash
+// suppresses creation (ENOENT on a missing leaf, EEXIST on any existing one,
+// symlinks included); for open(O_CREAT) a trailing slash is always EISDIR.
+
+DEFINE_TEST(mkfifo_trailing_slash, ([] {
+	auto dir = make_scratch();
+	auto missing = dir + "/missing";
+	auto file = dir + "/file";
+	auto subdir = dir + "/subdir";
+	auto dangling = dir + "/dangling";
+	frg::scope_exit cleanup{[&] {
+		unlink(file.c_str());
+		unlink(dangling.c_str());
+		rmdir(subdir.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	create_file(file);
+	assert(mkdir(subdir.c_str(), 0755) == 0);
+	assert(symlink("nowhere", dangling.c_str()) == 0);
+
+	errno = 0;
+	assert(mkfifo((missing + "/").c_str(), 0644) == -1);
+	assert(errno == ENOENT);
+
+	errno = 0;
+	assert(mkfifo((file + "/").c_str(), 0644) == -1);
+	assert(errno == EEXIST);
+
+	errno = 0;
+	assert(mkfifo((subdir + "/").c_str(), 0644) == -1);
+	assert(errno == EEXIST);
+
+	// The leaf symlink counts as existing without being followed.
+	errno = 0;
+	assert(mkfifo((dangling + "/").c_str(), 0644) == -1);
+	assert(errno == EEXIST);
+}))
+
+DEFINE_TEST(link_trailing_slash, ([] {
+	auto dir = make_scratch();
+	auto src = dir + "/src";
+	auto missing = dir + "/missing";
+	auto file = dir + "/file";
+	auto subdir = dir + "/subdir";
+	frg::scope_exit cleanup{[&] {
+		unlink(src.c_str());
+		unlink(file.c_str());
+		rmdir(subdir.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	create_file(src);
+	create_file(file);
+	assert(mkdir(subdir.c_str(), 0755) == 0);
+
+	errno = 0;
+	assert(link(src.c_str(), (missing + "/").c_str()) == -1);
+	assert(errno == ENOENT);
+
+	errno = 0;
+	assert(link(src.c_str(), (file + "/").c_str()) == -1);
+	assert(errno == EEXIST);
+
+	errno = 0;
+	assert(link(src.c_str(), (subdir + "/").c_str()) == -1);
+	assert(errno == EEXIST);
+}))
+
+DEFINE_TEST(symlink_trailing_slash, ([] {
+	auto dir = make_scratch();
+	auto missing = dir + "/missing";
+	auto file = dir + "/file";
+	auto subdir = dir + "/subdir";
+	frg::scope_exit cleanup{[&] {
+		unlink(file.c_str());
+		rmdir(subdir.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	create_file(file);
+	assert(mkdir(subdir.c_str(), 0755) == 0);
+
+	errno = 0;
+	assert(symlink("target", (missing + "/").c_str()) == -1);
+	assert(errno == ENOENT);
+
+	errno = 0;
+	assert(symlink("target", (file + "/").c_str()) == -1);
+	assert(errno == EEXIST);
+
+	errno = 0;
+	assert(symlink("target", (subdir + "/").c_str()) == -1);
+	assert(errno == EEXIST);
+}))
+
+DEFINE_TEST(open_creat_trailing_slash, ([] {
+	auto dir = make_scratch();
+	auto missing = dir + "/missing";
+	auto file = dir + "/file";
+	auto subdir = dir + "/subdir";
+	frg::scope_exit cleanup{[&] {
+		unlink(file.c_str());
+		rmdir(subdir.c_str());
+		rmdir(dir.c_str());
+	}};
+
+	create_file(file);
+	assert(mkdir(subdir.c_str(), 0755) == 0);
+
+	errno = 0;
+	assert(open((missing + "/").c_str(), O_WRONLY | O_CREAT, 0644) == -1);
+	assert(errno == EISDIR);
+
+	errno = 0;
+	assert(open((file + "/").c_str(), O_WRONLY | O_CREAT, 0644) == -1);
+	assert(errno == EISDIR);
+
+	errno = 0;
+	assert(open((subdir + "/").c_str(), O_WRONLY | O_CREAT, 0644) == -1);
+	assert(errno == EISDIR);
+
+	// Errors on the prefix take precedence over the trailing-slash policy.
+	errno = 0;
+	assert(open((missing + "/x/").c_str(), O_WRONLY | O_CREAT, 0644) == -1);
+	assert(errno == ENOENT);
+}))


### PR DESCRIPTION
Our handling of trailing slashes diverged from Linux's handling in some cases. Add appropriate flags to the path resolver to fix this. Add `posix-tests` to ensure that our behavior matches Linux.