### PR TITLE
posix: Implement mmap()ing of /dev/zero

### DIFF
--- a/posix/subsystem/src/devices/zero.cpp
+++ b/posix/subsystem/src/devices/zero.cpp
@@ -41,7 +41,8 @@ public:
 	}
 
 	ZeroFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
-	: FileWithDefaults{FileKind::unknown,  StructName::get("zero-file"), std::move(mount), std::move(link)} { }
+	: FileWithDefaults{FileKind::unknown,  StructName::get("zero-file"), std::move(mount), std::move(link),
+			defaultMapsAnonymously} { }
 };
 
 struct ZeroDevice final : UnixDevice {

--- a/posix/subsystem/src/file.cpp
+++ b/posix/subsystem/src/file.cpp
@@ -286,6 +286,10 @@ bool File::isTerminal() {
 	return _defaultOps & defaultIsTerminal;
 }
 
+bool File::mapsAnonymously() {
+	return _defaultOps & defaultMapsAnonymously;
+}
+
 async::result<frg::expected<Error>> File::readExactly(Process *process,
 		void *data, size_t length) {
 	size_t offset = 0;

--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -330,6 +330,7 @@ public:
 	using DefaultOps = uint32_t;
 	static inline constexpr DefaultOps defaultIsTerminal = 1 << 1;
 	static inline constexpr DefaultOps defaultPipeLikeSeek = 1 << 2;
+	static inline constexpr DefaultOps defaultMapsAnonymously = 1 << 3;
 
 	// ------------------------------------------------------------------------
 	// File protocol adapters.
@@ -521,6 +522,9 @@ public:
 	}
 
 	bool isTerminal();
+
+	// Whether mappings of this file are backed by anonymous memory instead of accessMemory().
+	bool mapsAnonymously();
 
 	async::result<frg::expected<Error>> readExactly(Process *process, void *data, size_t length);
 

--- a/posix/subsystem/src/requests/memory.cpp
+++ b/posix/subsystem/src/requests/memory.cpp
@@ -26,6 +26,11 @@ HandleRequest::operator()(managarm::posix::VmMapRequest &&req,
 		co_return {};
 	}
 
+	if((req.flags() & MAP_ANONYMOUS) && req.rel_offset()) {
+		co_await sendErrorResponse<managarm::posix::VmMapResponse>(conversation, managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+		co_return {};
+	}
+
 	uint32_t nativeFlags = 0;
 
 	if(req.mode() & PROT_READ)
@@ -46,7 +51,8 @@ HandleRequest::operator()(managarm::posix::VmMapRequest &&req,
 	}else if((req.flags() & (MAP_PRIVATE | MAP_SHARED)) == MAP_SHARED) {
 		copyOnWrite = false;
 	}else{
-		throw std::runtime_error("posix: Handle illegal flags in VM_MAP");
+		co_await sendErrorResponse<managarm::posix::VmMapResponse>(conversation, managarm::posix::Errors::ILLEGAL_ARGUMENTS);
+		co_return {};
 	}
 
 	uintptr_t hint = req.address_hint();
@@ -54,9 +60,10 @@ HandleRequest::operator()(managarm::posix::VmMapRequest &&req,
 	smarter::shared_ptr<File, FileHandle> file;
 	if(!(req.flags() & MAP_ANONYMOUS)) {
 		file = self->fileContext()->getFile(req.fd());
-		assert(file && "Illegal FD for VM_MAP");
-	}else{
-		assert(!req.rel_offset());
+		if(!file) {
+			co_await sendErrorResponse<managarm::posix::VmMapResponse>(conversation, managarm::posix::Errors::NO_SUCH_FD);
+			co_return {};
+		}
 	}
 
 	// Files such as /dev/zero map like anonymous memory; their offset is ignored.

--- a/posix/subsystem/src/requests/memory.cpp
+++ b/posix/subsystem/src/requests/memory.cpp
@@ -51,10 +51,17 @@ HandleRequest::operator()(managarm::posix::VmMapRequest &&req,
 
 	uintptr_t hint = req.address_hint();
 
-	frg::expected<Error, void *> result;
-	if(req.flags() & MAP_ANONYMOUS) {
+	smarter::shared_ptr<File, FileHandle> file;
+	if(!(req.flags() & MAP_ANONYMOUS)) {
+		file = self->fileContext()->getFile(req.fd());
+		assert(file && "Illegal FD for VM_MAP");
+	}else{
 		assert(!req.rel_offset());
+	}
 
+	// Files such as /dev/zero map like anonymous memory; their offset is ignored.
+	frg::expected<Error, void *> result;
+	if((req.flags() & MAP_ANONYMOUS) || file->mapsAnonymously()) {
 		if(req.size() == 0) {
 			std::cout << "posix: VM_MAP with size 0 is not allowed" << std::endl;
 			co_await sendErrorResponse<managarm::posix::VmMapResponse>(conversation, managarm::posix::Errors::ILLEGAL_ARGUMENTS);
@@ -80,8 +87,6 @@ HandleRequest::operator()(managarm::posix::VmMapRequest &&req,
 					0, size, false, nativeFlags);
 		}
 	}else{
-		auto file = self->fileContext()->getFile(req.fd());
-		assert(file && "Illegal FD for VM_MAP");
 		auto memory = co_await file->accessMemory();
 		if(!memory) {
 			co_await sendErrorResponse<managarm::posix::VmMapResponse>(conversation, managarm::posix::Errors::ILLEGAL_ARGUMENTS);

--- a/posix/subsystem/src/requests/memory.cpp
+++ b/posix/subsystem/src/requests/memory.cpp
@@ -105,11 +105,8 @@ HandleRequest::operator()(managarm::posix::VmMapRequest &&req,
 	}
 
 	if(!result) {
-		assert(result.error() == Error::alreadyExists || result.error() == Error::noMemory);
-		if(result.error() == Error::alreadyExists)
-			co_await sendErrorResponse<managarm::posix::VmMapResponse>(conversation, managarm::posix::Errors::ALREADY_EXISTS);
-		else if(result.error() == Error::noMemory)
-			co_await sendErrorResponse<managarm::posix::VmMapResponse>(conversation, managarm::posix::Errors::NO_MEMORY);
+		co_await sendErrorResponse<managarm::posix::VmMapResponse>(conversation,
+				result.error() | toPosixProtoError);
 		co_return {};
 	}
 


### PR DESCRIPTION
Fix #1508 . Note that the semantics of mmap()ing /dev/zero differ from the semantics of all other files.