### PR TITLE
posix: Clarify delayedSignal design

### DIFF
--- a/posix/subsystem/src/observations.cpp
+++ b/posix/subsystem/src/observations.cpp
@@ -47,41 +47,50 @@ async::result<bool> handlePendingSignalsFromObservation(Process *self) {
 	if constexpr (logSignals)
 		std::println("posix: checking if we should raise pending signals; delayedSignal={}", bool(self->delayedSignal));
 
-	if (!self->delayedSignal) {
+	if (self->delayedSignal) {
+		// A delayedSignal is handled by superSigRaise before calling into this function.
+		// For other observations, if there is a delayedSignal, we cannot accept other signals
+		// until the delayedSignal has been handled.
+		co_return true;
+	}
+
+	while (true) {
 		auto active =
 		    co_await self->fetchSignal(~self->signalMask(), true);
 		if constexpr (logSignals)
 			std::println("posix: active SignalItem={}", bool(active));
 
-		if (active) {
-			auto handling = self->threadGroup()->signalContext()->determineHandling(active, self);
-			if constexpr (logSignals)
-				std::println("posix: signal={} handling={}", active->signalNumber, handling);
+		if (!active)
+			co_return true;
 
-			if (handling.ignored) {
-				co_await self->threadGroup()->signalContext()->raiseContext(active, self, handling);
-			} else {
-				self->accessThreadPage()->cancellationRequested = true;
-				alertRemoteQueue(self);
-				if (self->checkOrRequestSignalRaise()) {
-					if constexpr (logSignals)
-						std::println("posix: raising signal");
-					co_await self->threadGroup()->signalContext()->raiseContext(
-					    active, self, handling
-					);
-					if (handling.killed)
-						co_return false;
-				} else {
-					if constexpr (logSignals)
-						std::println("posix: making signal delayed");
-					self->delayedSignal = active;
-					self->delayedSignalHandling = handling;
-				}
-			}
+		auto handling = self->threadGroup()->signalContext()->determineHandling(active, self);
+		if constexpr (logSignals)
+			std::println("posix: signal={} handling={}", active->signalNumber, handling);
+
+		if (handling.ignored) {
+			co_await self->threadGroup()->signalContext()->raiseContext(active, self, handling);
+			continue;
+		}
+
+		self->accessThreadPage()->cancellationRequested = true;
+		alertRemoteQueue(self);
+		if (self->checkOrRequestSignalRaise()) {
+			if constexpr (logSignals)
+				std::println("posix: raising signal");
+			co_await self->threadGroup()->signalContext()->raiseContext(
+			    active, self, handling
+			);
+			if (handling.killed)
+				co_return false;
+			// Continue dequeuing signals here until only blocked signals remain.
+		} else {
+			if constexpr (logSignals)
+				std::println("posix: making signal delayed");
+			self->delayedSignal = active;
+			self->delayedSignalHandling = handling;
+			co_return true;
 		}
 	}
-
-	co_return true;
 }
 
 } // namespace
@@ -370,6 +379,11 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 			} else {
 				std::println("posix: userspace misbehavior, superSigRaise called without available signal");
 			}
+
+			// After raising delayedSignal, drain the signal queue so that signals that arrived
+			// during the SignalGuard (including fatal ones) are handled at this dispatch point.
+			if(!killed && !co_await handlePendingSignalsFromObservation(self.get()))
+				killed = true;
 
 			if(killed)
 				break;

--- a/posix/subsystem/src/observations.cpp
+++ b/posix/subsystem/src/observations.cpp
@@ -63,7 +63,7 @@ async::result<bool> handlePendingSignalsFromObservation(Process *self) {
 		if (!active)
 			co_return true;
 
-		auto handling = self->threadGroup()->signalContext()->determineHandling(active, self);
+		auto handling = self->threadGroup()->signalContext()->acceptSignal(active, self);
 		if constexpr (logSignals)
 			std::println("posix: signal={} handling={}", active->signalNumber, handling);
 
@@ -716,7 +716,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 				std::cout << "\e[33m" "posix: Ignoring global signal flag "
 						"during synchronous user space panic" "\e[39m" << std::endl;
 			bool killed;
-			co_await self->threadGroup()->signalContext()->determineAndRaiseContext(item, self.get(), killed);
+			co_await self->threadGroup()->signalContext()->acceptSignalAndRaiseContext(item, self.get(), killed);
 			if(killed)
 				break;
 			HEL_CHECK(helResume(thread.getHandle()));
@@ -752,7 +752,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 				std::cout << "\e[33m" "posix: Ignoring global signal flag "
 						"during synchronous SIGSEGV" "\e[39m" << std::endl;
 			bool killed;
-			co_await self->threadGroup()->signalContext()->determineAndRaiseContext(item, self.get(), killed);
+			co_await self->threadGroup()->signalContext()->acceptSignalAndRaiseContext(item, self.get(), killed);
 			if(killed)
 				break;
 			HEL_CHECK(helResume(thread.getHandle()));
@@ -766,7 +766,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 				std::cout << "\e[33m" "posix: Ignoring global signal flag "
 						"during synchronous SIGSEGV" "\e[39m" << std::endl;
 			bool killed;
-			co_await self->threadGroup()->signalContext()->determineAndRaiseContext(item, self.get(), killed);
+			co_await self->threadGroup()->signalContext()->acceptSignalAndRaiseContext(item, self.get(), killed);
 			if(killed)
 				break;
 			HEL_CHECK(helResume(thread.getHandle()));
@@ -780,7 +780,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 				std::cout << "\e[33m" "posix: Ignoring global signal flag "
 						"during synchronous SIGILL" "\e[39m" << std::endl;
 			bool killed;
-			co_await self->threadGroup()->signalContext()->determineAndRaiseContext(item, self.get(), killed);
+			co_await self->threadGroup()->signalContext()->acceptSignalAndRaiseContext(item, self.get(), killed);
 			if(killed) {
 				if(debugFaults) {
 					launchGdbServer(self.get());
@@ -799,7 +799,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 				std::cout << "\e[33m" "posix: Ignoring global signal flag "
 						"during synchronous SIGFPE" "\e[39m" << std::endl;
 			bool killed;
-			co_await self->threadGroup()->signalContext()->determineAndRaiseContext(item, self.get(), killed);
+			co_await self->threadGroup()->signalContext()->acceptSignalAndRaiseContext(item, self.get(), killed);
 			if(killed)
 				break;
 			HEL_CHECK(helResume(thread.getHandle()));
@@ -813,7 +813,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 				std::cout << "\e[33m" "posix: Ignoring global signal flag "
 						"during synchronous SIGILL" "\e[39m" << std::endl;
 			bool killed;
-			co_await self->threadGroup()->signalContext()->determineAndRaiseContext(item, self.get(), killed);
+			co_await self->threadGroup()->signalContext()->acceptSignalAndRaiseContext(item, self.get(), killed);
 			if(killed)
 				break;
 			HEL_CHECK(helResume(thread.getHandle()));

--- a/posix/subsystem/src/observations.cpp
+++ b/posix/subsystem/src/observations.cpp
@@ -41,6 +41,8 @@ void alertRemoteQueue(Process *self) {
 	}
 }
 
+// Accept pending signals. Either handle them or park the accepted signal in delayedSignal.
+// See the delayedSignal's comment in the Process class for the rationale.
 async::result<bool> handlePendingSignalsFromObservation(Process *self) {
 	if constexpr (logSignals)
 		std::println("posix: checking if we should raise pending signals; delayedSignal={}", bool(self->delayedSignal));

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -791,7 +791,7 @@ static const auto simdStateSize = [] () -> size_t {
 	return regInfo.setSize;
 }();
 
-SignalContext::SignalHandling SignalContext::determineHandling(SignalItem *item, Process *process) {
+SignalContext::SignalHandling SignalContext::acceptSignal(SignalItem *item, Process *process) {
 	SignalHandler handler = _handlers[item->signalNumber - 1];
 
 	process->enterSignal();
@@ -987,9 +987,9 @@ async::result<void> SignalContext::raiseContext(SignalItem *item, Process *proce
 	delete item;
 }
 
-async::result<void> SignalContext::determineAndRaiseContext(SignalItem *item, Process *process,
+async::result<void> SignalContext::acceptSignalAndRaiseContext(SignalItem *item, Process *process,
 		bool &killed) {
-	auto handling = determineHandling(item, process);
+	auto handling = acceptSignal(item, process);
 	killed = handling.killed;
 	co_return co_await raiseContext(item, process, handling);
 }

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -420,13 +420,17 @@ struct SignalContext {
 		SignalHandler handler;
 	};
 
-	// As this function bumps the signal seq number, only call this exactly
-	// once per SignalItem!
-	SignalHandling determineHandling(SignalItem *item, Process *process);
+	// Accept a signal and determine the signal disposition.
+	// Checks whether a signal is blocked or not happen *before* this function.
+	// As this function bumps the signal seq number, only call this exactly once per SignalItem!
+	// In a SignalGuard, acceptance happens when a signal is parked in delayedSignal,
+	// while the signal handler invocation happens after exiting the SignalGuard.
+	SignalHandling acceptSignal(SignalItem *item, Process *process);
+
 	async::result<void> raiseContext(SignalItem *item, Process *process,
 			SignalHandling handling);
 
-	async::result<void> determineAndRaiseContext(SignalItem *item, Process *process,
+	async::result<void> acceptSignalAndRaiseContext(SignalItem *item, Process *process,
 			bool &killed);
 
 	async::result<void> restoreContext(helix::BorrowedDescriptor thread, Process *process);

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -784,6 +784,7 @@ struct ThreadGroup : std::enable_shared_from_this<ThreadGroup> {
 
 	SignalContext *signalContext() { return _signalContext.get(); }
 	SignalQueue &signalQueue() { return signalQueue_; }
+	const std::vector<std::shared_ptr<Process>> &threads() { return threads_; }
 
 	static std::shared_ptr<ThreadGroup> findThreadGroup(ProcessId pid);
 	std::shared_ptr<Process> findThread(pid_t tid);

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -690,6 +690,19 @@ public:
 	bool forceTermination = false;
 
 	SignalQueue signalQueue;
+
+	// A signal that was accepted for delivery while the thread was inside a SignalGuard.
+	// Signals acceptance must still be evaluated within SignalGuard since non-ignored signals cause
+	// in-flight operations to be cancelled with EINTR (even when a SignalGuard is active --
+	// SignalGuard regions are libc-internal and unobservable to applications).
+	//
+	// Conceptually the signal is *delivered* at acceptance time and also the disposition and handling is fixed.
+	// Thus, delayedSignal is exempt from SIG_IGN discarding and nothing may drop it
+	// (otherwise, we would cause spurious EINTRs).
+	//
+	// Storing one delayedSignal suffices:
+	// only the signal that triggered an EINTR in the current SignalGuard region needs to be buffered.
+	// All later signals are queued normally and are drained by the delivery loop at SignalGuard exit.
 	SignalItem *delayedSignal = nullptr;
 	std::optional<SignalContext::SignalHandling> delayedSignalHandling = std::nullopt;
 

--- a/posix/subsystem/src/requests/process.cpp
+++ b/posix/subsystem/src/requests/process.cpp
@@ -601,15 +601,12 @@ HandleRequest::operator()(managarm::posix::SigactionRequest &&req,
 		co_return {};
 	}
 
-	auto removePendingSignal = [&](int signo) -> async::result<void> {
-		if (self->delayedSignal && self->delayedSignal->signalNumber == static_cast<int>(signo)) {
-			// If there is a pending signal that is now being ignored, remove it.
-			delete self->delayedSignal;
-			self->delayedSignal = nullptr;
-			self->delayedSignalHandling = std::nullopt;
-		}
+	auto removePendingSignal = [&](int signo) {
+		// This function does *not* drop delayedSignals (if we did, we would cause spurious EINTR).
 
-		while (co_await self->fetchSignal(1 << (signo - 1), true) != nullptr);
+		for (auto &thread : self->threadGroup()->threads())
+			while (auto item = thread->tryFetchSignal(UINT64_C(1) << (signo - 1)))
+				delete item;
 	};
 
 	std::set<int> defaultIgnoredSignals = {SIGCHLD, SIGURG, SIGWINCH};
@@ -622,11 +619,11 @@ HandleRequest::operator()(managarm::posix::SigactionRequest &&req,
 			// POSIX requires discarding pending signals when setting SIG_DFL for signals,
 			// if their default action is to ignore (POSIX 2024, B.2.4.3 Signal Actions)
 			if (defaultIgnoredSignals.contains(req.sig_number()))
-				co_await removePendingSignal(req.sig_number());
+				removePendingSignal(req.sig_number());
 		}else if(req.sig_handler() == uintptr_t(SIG_IGN)) {
 			// POSIX requires discarding pending signals when setting SIG_IGN
 			handler.disposition = SignalDisposition::ignore;
-			co_await removePendingSignal(req.sig_number());
+			removePendingSignal(req.sig_number());
 		}else{
 			handler.disposition = SignalDisposition::handle;
 			handler.handlerIp = req.sig_handler();


### PR DESCRIPTION
After not dealing with it for a few months, it was not entirely clear to me anymore why `delayedSignal` is required. This PR adds a comment to clarify the design. Also:
- The second commit fixes `sigaction()` with `SIG_IGN` to *not* discard `delayedSignal`: the `delayedSignal` is conceptually already accepted and may have already caused a `EINTR`. Thus, it must not be discarded anymore; otherwise, we get spurious EINTR.
- The third commit turns `handlePendingSignalsFromObservation()` into a loop that handles *all* pending signals and not only the first one. This is an independent correctness fix.