### PR TITLE
hel, thor: Remove helEnableFullIo()

### DIFF
--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -376,10 +376,6 @@ extern inline __attribute__ (( always_inline )) HelError helEnableIo(HelHandle h
 	return helSyscall1(kHelCallEnableIo, (HelWord)handle);
 };
 
-extern inline __attribute__ (( always_inline )) HelError helEnableFullIo() {
-	return helSyscall0(kHelCallEnableFullIo);
-};
-
 extern inline __attribute__ (( always_inline )) HelError helBindKernlet(HelHandle handle,
 		const union HelKernletData *data, size_t num_data, HelHandle *bound_handle) {
 	HelWord handle_word;

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -100,7 +100,6 @@ enum {
 
 	kHelCallAccessIo = 11,
 	kHelCallEnableIo = 12,
-	kHelCallEnableFullIo = 35,
 
 	kHelCallBindKernlet = 93,
 
@@ -1509,8 +1508,6 @@ HEL_C_LINKAGE HelError helAccessIo(uintptr_t *port_array, size_t num_ports,
 //! @param[in] handle
 //!     Handle to the hardware I/O resource.
 HEL_C_LINKAGE HelError helEnableIo(HelHandle handle);
-
-HEL_C_LINKAGE HelError helEnableFullIo();
 
 //! @}
 //! @name Kernlet Management

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3625,19 +3625,6 @@ HelError helEnableIo(HelHandle handle) {
 #endif
 }
 
-HelError helEnableFullIo() {
-#ifdef THOR_ARCH_SUPPORTS_PIO
-	auto this_thread = getCurrentThread();
-
-	for(uintptr_t port = 0; port < 0x10000; port++)
-		this_thread->getContext().enableIoPort(port);
-
-	return kHelErrNone;
-#else
-	return kHelErrUnsupportedOperation;
-#endif
-}
-
 HelError helBindKernlet(HelHandle handle, const HelKernletData *data, size_t num_data,
 		HelHandle *bound_handle) {
 	auto this_thread = getCurrentThread();

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -836,9 +836,6 @@ void handleSyscall(SyscallImageAccessor image) {
 	case kHelCallEnableIo: {
 		*image.error() = helEnableIo((HelHandle)arg0);
 	} break;
-	case kHelCallEnableFullIo: {
-		*image.error() = helEnableFullIo();
-	} break;
 
 	case kHelCallBindKernlet: {
 		HelHandle bound_handle;


### PR DESCRIPTION
Instead of relying on `helEnableFullIo()`, drivers should use `helAccessIo()` + `helEnableIo()`. In fact, `helEnableFullIo()` has no callers anymore.