### PR TITLE
sif: Make sif work on Aarch64 and RISC-V

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ hel = { path = "rust/hel" }
 hel-sys = { path = "rust/hel-sys" }
 managarm = { path = "rust/managarm" }
 uacpi-sys = { path = "rust/uacpi-sys" }
+zerocopy = { version = "0.8", features = ["derive"] }

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3444,7 +3444,10 @@ HelError helRaiseEvent(HelHandle handle) {
 }
 
 HelError helAccessIrq(int number, HelHandle *handle) {
-#ifdef __x86_64__
+	// This syscall only makes sense on ACPI systems.
+	if (!acpiRsdpNote->rsdp)
+		return kHelErrUnsupportedOperation;
+
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
@@ -3463,11 +3466,6 @@ HelError helAccessIrq(int number, HelHandle *handle) {
 			AnyDescriptor::make<DescriptorType::irq>(std::move(irq), kHelRightWait | kHelRightSignal));
 
 	return kHelErrNone;
-#else
-	(void)number;
-	(void)handle;
-	return kHelErrUnsupportedOperation;
-#endif
 }
 
 HelError helConfigureIrq(int number, uint32_t trigger, uint32_t polarity) {

--- a/rust/uacpi-sys/Cargo.toml
+++ b/rust/uacpi-sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+zerocopy.workspace = true
 
 [build-dependencies]
 bindgen = "0.72.1"

--- a/rust/uacpi-sys/build.rs
+++ b/rust/uacpi-sys/build.rs
@@ -1,5 +1,33 @@
 use std::path::PathBuf;
 
+use bindgen::callbacks::{DeriveInfo, ParseCallbacks};
+
+/// ACPI structures that consumers parse out of raw table bytes.
+const ZEROCOPY_STRUCTS: &[&str] = &[
+    "acpi_entry_hdr",
+    "acpi_madt_interrupt_source_override",
+    "acpi_sdt_hdr",
+];
+
+/// Lets consumers read [`ZEROCOPY_STRUCTS`] from byte slices without unsafe code.
+///
+/// The derives cannot be applied to all of the bindings: zerocopy rejects the structures that
+/// contain pointers, unions or flexible array members.
+#[derive(Debug)]
+struct ZerocopyDerives;
+
+impl ParseCallbacks for ZerocopyDerives {
+    fn add_derives(&self, info: &DeriveInfo<'_>) -> Vec<String> {
+        if !ZEROCOPY_STRUCTS.contains(&info.name) {
+            return Vec::new();
+        }
+        ["FromBytes", "IntoBytes", "Immutable", "KnownLayout"]
+            .iter()
+            .map(|derive| format!("zerocopy::{derive}"))
+            .collect()
+    }
+}
+
 fn main() {
     let installdir = PathBuf::from(pkg_config::get_variable("uacpi", "installdir").unwrap());
     let includedir = pkg_config::get_variable("uacpi", "includedir").unwrap();
@@ -19,6 +47,7 @@ fn main() {
         .derive_default(true)
         .derive_debug(true)
         .prepend_enum_name(false)
+        .parse_callbacks(Box::new(ZerocopyDerives))
         .header("src/wrapper.h")
         .clang_arg(format!("-I{includedir}"))
         .formatter(bindgen::Formatter::Rustfmt)

--- a/sif/Cargo.toml
+++ b/sif/Cargo.toml
@@ -12,3 +12,4 @@ managarm.workspace = true
 parking_lot = "0.12"
 thiserror = "2.0"
 uacpi-sys.workspace = true
+zerocopy.workspace = true

--- a/sif/src/acpi/mod.rs
+++ b/sif/src/acpi/mod.rs
@@ -11,6 +11,13 @@ pub(crate) const PAGE_MASK: usize = PAGE_SIZE - 1;
 
 pub(crate) static RSDP: AtomicU64 = AtomicU64::new(0);
 
+#[cfg(target_arch = "x86_64")]
+const INTERRUPT_MODEL: uacpi_sys::uacpi_interrupt_model = uacpi_sys::UACPI_INTERRUPT_MODEL_IOAPIC;
+#[cfg(target_arch = "aarch64")]
+const INTERRUPT_MODEL: uacpi_sys::uacpi_interrupt_model = uacpi_sys::UACPI_INTERRUPT_MODEL_GIC;
+#[cfg(target_arch = "riscv64")]
+const INTERRUPT_MODEL: uacpi_sys::uacpi_interrupt_model = uacpi_sys::UACPI_INTERRUPT_MODEL_RINTC;
+
 pub fn set_rsdp(addr: u64) {
     RSDP.store(addr, Ordering::Relaxed);
 }
@@ -29,7 +36,7 @@ pub fn uacpi_init() -> Result<()> {
         crate::pci::config::discover_config_spaces()?;
         check(uacpi_sys::uacpi_namespace_load(), "uacpi_namespace_load")?;
         check(
-            uacpi_sys::uacpi_set_interrupt_model(uacpi_sys::UACPI_INTERRUPT_MODEL_IOAPIC),
+            uacpi_sys::uacpi_set_interrupt_model(INTERRUPT_MODEL),
             "uacpi_set_interrupt_model",
         )?;
         check(

--- a/sif/src/isa.rs
+++ b/sif/src/isa.rs
@@ -1,0 +1,110 @@
+use hel::{IrqPolarity, IrqTrigger};
+use uacpi_sys::acpi_madt_interrupt_source_override;
+use zerocopy::FromBytes;
+
+use crate::uacpi::table::Table;
+
+/// Number of IRQs of the ISA bus.
+const NUM_ISA_IRQS: usize = 16;
+
+/// ISA IRQs that we configure upfront, i.e., before any driver claims them.
+///
+/// TODO: This is a hack. We assume that HPET will use legacy replacement.
+const PRECONFIGURED_ISA_IRQS: [u8; 5] = [0, 1, 4, 12, 14];
+
+/// The GSI that an ISA IRQ is wired to, and how the interrupt controller drives it.
+#[derive(Clone, Copy)]
+struct IsaIrq {
+    gsi: u32,
+    trigger: IrqTrigger,
+    polarity: IrqPolarity,
+}
+
+impl IsaIrq {
+    /// Without an override, ISA IRQs are identity mapped to GSIs and use the ISA bus defaults.
+    fn identity(irq: u8) -> IsaIrq {
+        IsaIrq {
+            gsi: irq.into(),
+            trigger: IrqTrigger::Edge,
+            polarity: IrqPolarity::High,
+        }
+    }
+}
+
+/// Interrupt source overrides of the MADT, indexed by ISA IRQ.
+type IsaOverrides = [Option<IsaIrq>; NUM_ISA_IRQS];
+
+/// Collects the interrupt source overrides of the MADT.
+fn read_isa_overrides() -> IsaOverrides {
+    let mut overrides: IsaOverrides = [None; NUM_ISA_IRQS];
+
+    let madt = match Table::find_by_signature(c"APIC") {
+        Ok(Some(madt)) => madt,
+        Ok(None) => {
+            println!("sif: No MADT table, assuming that no ISA IRQs are overridden");
+            return overrides;
+        }
+        Err(err) => {
+            println!("sif: Failed to find the MADT: {err}");
+            return overrides;
+        }
+    };
+
+    for (entry_type, subtable) in madt.subtables(size_of::<uacpi_sys::acpi_madt>()) {
+        if u32::from(entry_type) != uacpi_sys::ACPI_MADT_ENTRY_TYPE_INTERRUPT_SOURCE_OVERRIDE {
+            continue;
+        }
+        let Ok((entry, _)) = acpi_madt_interrupt_source_override::read_from_prefix(subtable) else {
+            println!("sif: Ignoring truncated MADT interrupt source override");
+            continue;
+        };
+        let bus = entry.bus;
+        let source = entry.source;
+        let gsi = entry.gsi;
+        let flags = u32::from(entry.flags);
+
+        // ACPI only defines overrides for the ISA bus.
+        if bus != 0 || usize::from(source) >= NUM_ISA_IRQS {
+            println!("sif: Ignoring MADT override of bus {bus} IRQ {source}");
+            continue;
+        }
+        if overrides[usize::from(source)].is_some() {
+            println!("sif: Ignoring duplicate MADT override of ISA IRQ {source}");
+            continue;
+        }
+
+        // Interrupts that conform to the bus use the ISA defaults.
+        let trigger = match flags & uacpi_sys::ACPI_MADT_TRIGGERING_MASK {
+            uacpi_sys::ACPI_MADT_TRIGGERING_LEVEL => IrqTrigger::Level,
+            _ => IrqTrigger::Edge,
+        };
+        let polarity = match flags & uacpi_sys::ACPI_MADT_POLARITY_MASK {
+            uacpi_sys::ACPI_MADT_POLARITY_ACTIVE_LOW => IrqPolarity::Low,
+            _ => IrqPolarity::High,
+        };
+
+        overrides[usize::from(source)] = Some(IsaIrq {
+            gsi,
+            trigger,
+            polarity,
+        });
+    }
+
+    overrides
+}
+
+/// Configures the ISA IRQs of devices whose drivers cannot resolve them themselves.
+pub fn configure_isa_irqs() {
+    let overrides = read_isa_overrides();
+
+    println!("sif: Configuring ISA IRQs");
+    for irq in PRECONFIGURED_ISA_IRQS {
+        let line = overrides[usize::from(irq)].unwrap_or_else(|| IsaIrq::identity(irq));
+        if let Err(err) = hel::configure_irq(line.gsi as i32, line.trigger, line.polarity) {
+            println!(
+                "sif: Failed to configure ISA IRQ {irq} (GSI {}): {err}",
+                line.gsi
+            );
+        }
+    }
+}

--- a/sif/src/main.rs
+++ b/sif/src/main.rs
@@ -2,7 +2,11 @@ use anyhow::{Result, bail};
 
 mod acpi;
 mod io;
+// Only x86 has an ISA bus (and hence ISA IRQs).
+#[cfg(target_arch = "x86_64")]
+mod isa;
 mod pci;
+mod uacpi;
 
 fn main() -> Result<()> {
     hel::block_on(async {
@@ -21,6 +25,10 @@ fn main() -> Result<()> {
         acpi::uacpi_init()?;
 
         println!("sif: uACPI initialized");
+
+        // Configure the ISA IRQs before the PCI links to match thor's ordering.
+        #[cfg(target_arch = "x86_64")]
+        isa::configure_isa_irqs();
 
         pci::publish_devices().await?;
 

--- a/sif/src/uacpi/mod.rs
+++ b/sif/src/uacpi/mod.rs
@@ -1,0 +1,37 @@
+//! Safe wrappers around uACPI.
+//!
+//! Wrappers are named after the uacpi_*() functions that they wrap. To keep this module
+//! extractable into a crate of its own, it must not depend on the rest of sif.
+
+pub mod table;
+
+use std::borrow::Cow;
+use std::ffi::CStr;
+
+use thiserror::Error;
+
+use uacpi_sys::uacpi_status;
+
+/// A failure that a uACPI function reported through its status code.
+#[derive(Debug, Error)]
+#[error("{function}() failed: {}", status_to_string(*.status))]
+pub struct Error {
+    function: &'static str,
+    status: uacpi_status,
+}
+
+impl Error {
+    fn new(function: &'static str, status: uacpi_status) -> Error {
+        Error { function, status }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Wraps uacpi_status_to_string().
+fn status_to_string(status: uacpi_status) -> Cow<'static, str> {
+    // SAFETY: uACPI returns a string constant for every status code.
+    let string: &'static CStr =
+        unsafe { CStr::from_ptr(uacpi_sys::uacpi_status_to_string(status)) };
+    string.to_string_lossy()
+}

--- a/sif/src/uacpi/table.rs
+++ b/sif/src/uacpi/table.rs
@@ -1,0 +1,92 @@
+use std::ffi::CStr;
+use std::slice;
+
+use uacpi_sys::{acpi_entry_hdr, acpi_sdt_hdr};
+use zerocopy::FromBytes;
+
+use super::{Error, Result};
+
+/// A reference to an ACPI table, i.e., a table that uACPI keeps mapped for us.
+pub struct Table {
+    table: uacpi_sys::uacpi_table,
+}
+
+impl Table {
+    /// Wraps uacpi_table_find_by_signature().
+    pub fn find_by_signature(signature: &CStr) -> Result<Option<Table>> {
+        let mut table = uacpi_sys::uacpi_table::default();
+        // SAFETY: uACPI only reads the signature and only writes to the table.
+        let status =
+            unsafe { uacpi_sys::uacpi_table_find_by_signature(signature.as_ptr(), &mut table) };
+        match status {
+            uacpi_sys::UACPI_STATUS_OK => (),
+            uacpi_sys::UACPI_STATUS_NOT_FOUND => return Ok(None),
+            _ => return Err(Error::new("uacpi_table_find_by_signature", status)),
+        }
+
+        let table = Table { table };
+        // uACPI does not hand out tables that it failed to map.
+        if table.hdr().is_null() {
+            return Ok(None);
+        }
+        Ok(Some(table))
+    }
+
+    fn hdr(&self) -> *const acpi_sdt_hdr {
+        // SAFETY: the union only holds different representations of the same pointer.
+        unsafe { self.table.__bindgen_anon_1.hdr }
+    }
+
+    /// Returns the bytes of the table, header included.
+    fn bytes(&self) -> &[u8] {
+        // SAFETY: uACPI maps whole tables, hence at least the header is accessible.
+        let header =
+            unsafe { slice::from_raw_parts(self.hdr().cast::<u8>(), size_of::<acpi_sdt_hdr>()) };
+        let (hdr, _) = acpi_sdt_hdr::read_from_prefix(header)
+            .expect("sif: slice of an ACPI table header is too small");
+
+        // SAFETY: the table stays mapped for as long as we hold our reference to it.
+        unsafe { slice::from_raw_parts(self.hdr().cast::<u8>(), hdr.length as usize) }
+    }
+
+    /// Iterates the subtables that follow the first `header_size` bytes of the table,
+    /// like uacpi_for_each_subtable() does.
+    pub fn subtables(&self, header_size: usize) -> Subtables<'_> {
+        Subtables {
+            rest: self.bytes().get(header_size..).unwrap_or_default(),
+        }
+    }
+}
+
+impl Drop for Table {
+    /// Wraps uacpi_table_unref().
+    fn drop(&mut self) {
+        // SAFETY: we drop the only reference that we took in find_by_signature().
+        unsafe { uacpi_sys::uacpi_table_unref(&mut self.table) };
+    }
+}
+
+/// Iterator over the subtables of an ACPI table such as the MADT.
+pub struct Subtables<'a> {
+    rest: &'a [u8],
+}
+
+impl<'a> Iterator for Subtables<'a> {
+    /// The type of the subtable and its bytes, header included.
+    type Item = (u8, &'a [u8]);
+
+    fn next(&mut self) -> Option<(u8, &'a [u8])> {
+        let (hdr, _) = acpi_entry_hdr::read_from_prefix(self.rest).ok()?;
+
+        // Give up instead of spinning forever on a table that we cannot make sense of.
+        let length = usize::from(hdr.length);
+        if length < size_of::<acpi_entry_hdr>() {
+            println!("sif: Ignoring subtable with a length of {length} bytes");
+            return None;
+        }
+
+        let subtable = self.rest.get(..length)?;
+        self.rest = &self.rest[length..];
+        Some((hdr.type_, subtable))
+    }
+}


### PR DESCRIPTION
This is a short PR that enables sif on Aarch64 and RISC-V (ACPI only). The only thing that was missing is removing an `#ifdef` around `helAccessIrq()` and passing the right model to `_PIC`.

The `configureIsaIrqs()` change is a separate fix to make the UART IRQ work when running under sif on x86.