### PR TITLE
sif: Port thor's PCI structs over to sif

### DIFF
--- a/sif/src/pci/acpi.rs
+++ b/sif/src/pci/acpi.rs
@@ -1,0 +1,155 @@
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+use hel::{IrqPolarity, IrqTrigger};
+
+use uacpi_sys::{uacpi_iteration_decision, uacpi_namespace_node, uacpi_u32, uacpi_u64};
+
+#[derive(Clone, Copy)]
+pub struct RootBus {
+    pub seg: u16,
+    pub bus: u8,
+    node: *mut uacpi_namespace_node,
+}
+
+pub type Routes = HashMap<(u16, u8, u8), u32>;
+
+unsafe extern "C" fn root_bus_callback(
+    user: *mut c_void,
+    node: *mut uacpi_namespace_node,
+    _depth: uacpi_u32,
+) -> uacpi_iteration_decision {
+    let roots = unsafe { &mut *(user as *mut Vec<RootBus>) };
+
+    let mut segment: uacpi_u64 = 0;
+    unsafe { uacpi_sys::uacpi_eval_simple_integer(node, c"_SEG".as_ptr(), &mut segment) };
+    let mut base_bus: uacpi_u64 = 0;
+    unsafe { uacpi_sys::uacpi_eval_simple_integer(node, c"_BBN".as_ptr(), &mut base_bus) };
+
+    roots.push(RootBus {
+        seg: segment as u16,
+        bus: base_bus as u8,
+        node,
+    });
+    uacpi_sys::UACPI_ITERATION_DECISION_NEXT_PEER
+}
+
+pub fn find_root_buses() -> Vec<RootBus> {
+    let mut roots: Vec<RootBus> = Vec::new();
+    let user = &mut roots as *mut _ as *mut c_void;
+    unsafe {
+        uacpi_sys::uacpi_find_devices(c"PNP0A03".as_ptr(), Some(root_bus_callback), user);
+        uacpi_sys::uacpi_find_devices(c"PNP0A08".as_ptr(), Some(root_bus_callback), user);
+    }
+    roots.sort_by_key(|root| (root.seg, root.bus));
+    roots.dedup_by_key(|root| (root.seg, root.bus));
+    if roots.is_empty() {
+        roots.push(RootBus {
+            seg: 0,
+            bus: 0,
+            node: std::ptr::null_mut(),
+        });
+    }
+    roots
+}
+
+fn resolve_link(
+    source: *mut uacpi_namespace_node,
+    index: u32,
+) -> Option<(u32, IrqTrigger, IrqPolarity)> {
+    let mut raw_resources: *mut uacpi_sys::uacpi_resources = std::ptr::null_mut();
+    let status = unsafe { uacpi_sys::uacpi_get_current_resources(source, &raw mut raw_resources) };
+    if status != uacpi_sys::UACPI_STATUS_OK || raw_resources.is_null() {
+        return None;
+    }
+
+    let resources =
+        unsafe { std::slice::from_raw_parts((*raw_resources).entries, (*raw_resources).length) };
+
+    let mut route = None;
+
+    for cur in resources.iter() {
+        let ty = cur.type_;
+        if ty == uacpi_sys::UACPI_RESOURCE_TYPE_END_TAG as u32 {
+            break;
+        }
+        if ty == uacpi_sys::UACPI_RESOURCE_TYPE_IRQ as u32 {
+            let irq = unsafe { (*cur).__bindgen_anon_1.irq.as_ref() };
+            if (index as usize) < irq.num_irqs as usize {
+                let gsi = unsafe { *irq.irqs.as_ptr().add(index as usize) } as u32;
+                route = Some((gsi, trigger_of(irq.triggering), polarity_of(irq.polarity)));
+            }
+            break;
+        }
+        if ty == uacpi_sys::UACPI_RESOURCE_TYPE_EXTENDED_IRQ as u32 {
+            let irq = unsafe { (*cur).__bindgen_anon_1.extended_irq.as_ref() };
+            if (index as usize) < irq.num_irqs as usize {
+                let gsi = unsafe { *irq.irqs.as_ptr().add(index as usize) };
+                route = Some((gsi, trigger_of(irq.triggering), polarity_of(irq.polarity)));
+            }
+            break;
+        }
+        let len = cur.length as usize;
+        if len == 0 {
+            break;
+        }
+    }
+
+    unsafe { uacpi_sys::uacpi_free_resources(raw_resources) };
+    route
+}
+
+fn trigger_of(triggering: u8) -> IrqTrigger {
+    if triggering as u32 == uacpi_sys::UACPI_TRIGGERING_EDGE {
+        IrqTrigger::Edge
+    } else {
+        IrqTrigger::Level
+    }
+}
+
+fn polarity_of(polarity: u8) -> IrqPolarity {
+    if polarity as u32 == uacpi_sys::UACPI_POLARITY_ACTIVE_HIGH {
+        IrqPolarity::High
+    } else {
+        IrqPolarity::Low
+    }
+}
+
+pub fn build_routes(roots: &[RootBus]) -> Routes {
+    let mut routes = Routes::new();
+    for root in roots {
+        if root.node.is_null() {
+            continue;
+        }
+
+        let mut table: *mut uacpi_sys::uacpi_pci_routing_table = std::ptr::null_mut();
+        let status = unsafe { uacpi_sys::uacpi_get_pci_routing_table(root.node, &mut table) };
+        if status != uacpi_sys::UACPI_STATUS_OK || table.is_null() {
+            continue;
+        }
+
+        let num_entries = unsafe { (*table).num_entries };
+        let entries = unsafe { (*table).entries.as_ptr() };
+        for i in 0..num_entries {
+            let entry = unsafe { &*entries.add(i) };
+            let slot = (entry.address >> 16) as u8;
+            let (gsi, trigger, polarity) = if entry.source.is_null() {
+                (entry.index, IrqTrigger::Level, IrqPolarity::Low)
+            } else {
+                match resolve_link(entry.source, entry.index) {
+                    Some(route) => route,
+                    None => continue,
+                }
+            };
+
+            if let Err(err) = hel::configure_irq(gsi as i32, trigger, polarity) {
+                println!("sif: Failed to configure GSI {gsi}: {err}");
+                continue;
+            }
+            routes.insert((root.seg, slot, entry.pin), gsi);
+        }
+
+        unsafe { uacpi_sys::uacpi_free_pci_routing_table(table) };
+    }
+    routes
+}

--- a/sif/src/pci/acpi.rs
+++ b/sif/src/pci/acpi.rs
@@ -1,18 +1,24 @@
 use std::collections::HashMap;
 use std::ffi::c_void;
+use std::sync::OnceLock;
 
 use hel::{IrqPolarity, IrqTrigger};
 
 use uacpi_sys::{uacpi_iteration_decision, uacpi_namespace_node, uacpi_u32, uacpi_u64};
 
+use super::discover::add_root_bus;
+use super::{IrqIndex, PciBus, config};
+
 #[derive(Clone, Copy)]
-pub struct RootBus {
-    pub seg: u16,
-    pub bus: u8,
+struct RootBus {
+    seg: u16,
+    bus: u8,
     node: *mut uacpi_namespace_node,
 }
 
-pub type Routes = HashMap<(u16, u8, u8), u32>;
+type Routes = HashMap<(u16, u8, u8), u32>;
+
+static ROUTES: OnceLock<Routes> = OnceLock::new();
 
 unsafe extern "C" fn root_bus_callback(
     user: *mut c_void,
@@ -34,7 +40,7 @@ unsafe extern "C" fn root_bus_callback(
     uacpi_sys::UACPI_ITERATION_DECISION_NEXT_PEER
 }
 
-pub fn find_root_buses() -> Vec<RootBus> {
+fn find_root_buses() -> Vec<RootBus> {
     let mut roots: Vec<RootBus> = Vec::new();
     let user = &mut roots as *mut _ as *mut c_void;
     unsafe {
@@ -115,7 +121,7 @@ fn polarity_of(polarity: u8) -> IrqPolarity {
     }
 }
 
-pub fn build_routes(roots: &[RootBus]) -> Routes {
+fn build_routes(roots: &[RootBus]) -> Routes {
     let mut routes = Routes::new();
     for root in roots {
         if root.node.is_null() {
@@ -152,4 +158,36 @@ pub fn build_routes(roots: &[RootBus]) -> Routes {
         unsafe { uacpi_sys::uacpi_free_pci_routing_table(table) };
     }
     routes
+}
+
+pub fn resolve_irq(seg: u16, slot: u8, index: IrqIndex) -> Option<u32> {
+    ROUTES.get()?.get(&(seg, slot, index as u8 - 1)).copied()
+}
+
+pub fn discover_root_buses() {
+    let roots = find_root_buses();
+
+    let routes = build_routes(&roots);
+    println!("sif: Resolved {} PCI interrupt routes", routes.len());
+    ROUTES
+        .set(routes)
+        .expect("sif: PCI interrupt routes were already resolved");
+
+    for root in roots {
+        let Some(io) = config::get_config_io_for(root.seg, root.bus) else {
+            println!(
+                "sif: No config space for PCI host bridge {:04x}:{:02x}",
+                root.seg, root.bus
+            );
+            continue;
+        };
+
+        println!(
+            "sif: Found PCI host bridge {:04x}:{:02x}",
+            root.seg, root.bus
+        );
+
+        let root_bus = PciBus::new(io, root.seg, root.bus);
+        add_root_bus(root_bus);
+    }
 }

--- a/sif/src/pci/acpi.rs
+++ b/sif/src/pci/acpi.rs
@@ -187,7 +187,7 @@ pub fn discover_root_buses() {
             root.seg, root.bus
         );
 
-        let root_bus = PciBus::new(io, root.seg, root.bus);
+        let root_bus = PciBus::new(None, io, root.seg, root.bus);
         add_root_bus(root_bus);
     }
 }

--- a/sif/src/pci/config/mod.rs
+++ b/sif/src/pci/config/mod.rs
@@ -31,9 +31,6 @@ pub enum ConfigIoError {
     #[error("register {offset:#x} is not aligned to {size} bytes")]
     Misaligned { offset: u16, size: u8 },
 
-    #[error("{0} is not a valid configuration space access size")]
-    UnsupportedSize(u8),
-
     #[error("failed to map the ECAM window of {seg:04x}:{bus:02x}")]
     MappingFailed {
         seg: u16,

--- a/sif/src/pci/discover.rs
+++ b/sif/src/pci/discover.rs
@@ -1,7 +1,9 @@
 use std::sync::Mutex;
+use std::sync::atomic::Ordering;
 
-use super::{EXPECT_LOCK, PciBus};
+use super::{EXPECT_LOCK, PciBridge, PciBus, PciDevice};
 
+static ALL_DEVICES: Mutex<Vec<&'static PciDevice>> = Mutex::new(Vec::new());
 static ALL_ROOT_BUSES: Mutex<Vec<&'static PciBus>> = Mutex::new(Vec::new());
 
 pub fn all_root_buses() -> Vec<&'static PciBus> {
@@ -10,4 +12,138 @@ pub fn all_root_buses() -> Vec<&'static PciBus> {
 
 pub fn add_root_bus(bus: &'static PciBus) {
     ALL_ROOT_BUSES.lock().expect(EXPECT_LOCK).push(bus);
+}
+
+fn check_pci_function(
+    bus: &'static PciBus,
+    slot: u8,
+    function: u8,
+    enumerate_downstream: &mut dyn FnMut(&'static PciBus),
+) {
+    let vendor = bus.vendor(slot, function);
+    if vendor == 0xFFFF {
+        return;
+    }
+
+    let header_type = bus.header_type(slot, function);
+    if header_type & 0x7F == 0 {
+        println!("sif:   Function {function}: Device");
+    } else if header_type & 0x7F == 1 {
+        let downstream_id = unsafe { bus.secondary_bus(slot, function) };
+
+        if downstream_id == 0 {
+            println!("sif:   Function {function}: unconfigured PCI-to-PCI bridge");
+        } else {
+            println!("sif:   Function {function}: PCI-to-PCI bridge to bus {downstream_id}");
+        }
+    } else {
+        println!(
+            "sif:   Function {function}: Unexpected PCI header type {}",
+            header_type & 0x7F
+        );
+    }
+
+    let device_id = bus.device_id(slot, function);
+    let revision = bus.revision(slot, function);
+    let class_code = bus.class_code(slot, function);
+    let sub_class = bus.sub_class(slot, function);
+    let interface = bus.interface(slot, function);
+
+    println!(
+        "sif:     Vendor/device: {vendor:04x}.{device_id:04x}.{revision:02x}, \
+                class: {class_code:02x}.{sub_class:02x}.{interface:02x}"
+    );
+
+    if header_type & 0x7F == 0 {
+        let subsystem_vendor = unsafe { bus.subsystem_vendor(slot, function) };
+        let subsystem_device = unsafe { bus.subsystem_device(slot, function) };
+
+        let status = bus.status(slot, function);
+        if status & 0x08 != 0 {
+            println!("sif:       IRQ is asserted!");
+        }
+
+        let device = PciDevice::new(
+            bus,
+            slot,
+            function,
+            vendor,
+            device_id,
+            revision,
+            class_code,
+            sub_class,
+            interface,
+            subsystem_vendor,
+            subsystem_device,
+        );
+
+        ALL_DEVICES.lock().expect(EXPECT_LOCK).push(device);
+        bus.child_devices.lock().expect(EXPECT_LOCK).push(device);
+    } else if header_type & 0x7F == 1 {
+        let bridge = PciBridge::new(
+            bus, slot, function, vendor, device_id, revision, class_code, sub_class, interface,
+        );
+        bus.child_bridges.lock().expect(EXPECT_LOCK).push(bridge);
+
+        let downstream_id = unsafe { bus.secondary_bus(slot, function) };
+
+        if downstream_id != 0 {
+            bridge.downstream_id.store(downstream_id, Ordering::Relaxed);
+            bridge.subordinate_id.store(
+                unsafe { bus.subordinate_bus(slot, function) },
+                Ordering::Relaxed,
+            );
+
+            let downstream_bus = bus.make_downstream_bus(bridge, downstream_id);
+            assert!(
+                bridge.associated_bus.set(downstream_bus).is_ok(),
+                "sif: PCI bridge was already enumerated"
+            );
+            enumerate_downstream(downstream_bus);
+        } else {
+            println!("sif:     Deferring enumeration until the bridge is configured");
+        }
+    }
+}
+
+fn check_pci_device(
+    bus: &'static PciBus,
+    slot: u8,
+    enumerate_downstream: &mut dyn FnMut(&'static PciBus),
+) {
+    let vendor = bus.vendor(slot, 0);
+    if vendor == 0xFFFF {
+        return;
+    }
+
+    println!(
+        "sif: Segment: {}, bus: {}, slot {}",
+        bus.seg_id, bus.bus_id, slot
+    );
+
+    let header_type = bus.header_type(slot, 0);
+    if header_type & 0x80 != 0 {
+        for function in 0..8 {
+            check_pci_function(bus, slot, function, enumerate_downstream);
+        }
+    } else {
+        check_pci_function(bus, slot, 0, enumerate_downstream);
+    }
+}
+
+fn check_pci_bus(bus: &'static PciBus, enumerate_downstream: &mut dyn FnMut(&'static PciBus)) {
+    for slot in 0..32 {
+        check_pci_device(bus, slot, enumerate_downstream);
+    }
+}
+
+pub fn enumerate_all() {
+    // Downstream buses are appended as we go, hence this also covers buses behind bridges.
+    let mut queue = all_root_buses();
+    let mut i = 0;
+    while i < queue.len() {
+        let bus = queue[i];
+        check_pci_bus(bus, &mut |downstream| queue.push(downstream));
+        i += 1;
+    }
 }

--- a/sif/src/pci/discover.rs
+++ b/sif/src/pci/discover.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 use std::sync::atomic::Ordering;
 
-use super::{EXPECT_LOCK, PciBridge, PciBus, PciDevice};
+use super::{Capability, EXPECT_LOCK, PciBridge, PciBus, PciDevice, PciEntity, name_of_capability};
 
 static ALL_DEVICES: Mutex<Vec<&'static PciDevice>> = Mutex::new(Vec::new());
 static ALL_ROOT_BUSES: Mutex<Vec<&'static PciBus>> = Mutex::new(Vec::new());
@@ -12,6 +12,46 @@ pub fn all_root_buses() -> Vec<&'static PciBus> {
 
 pub fn add_root_bus(bus: &'static PciBus) {
     ALL_ROOT_BUSES.lock().expect(EXPECT_LOCK).push(bus);
+}
+
+fn find_pci_caps(entity: &PciEntity) {
+    let bus = entity.parent_bus;
+    let slot = entity.slot;
+    let function = entity.function;
+
+    let status = bus.status(slot, function);
+
+    // Find all capabilities.
+    if status & 0x10 != 0 {
+        // The bottom two bits of each capability offset must be masked!
+        let mut offset = (bus.capabilities_pointer(slot, function) & 0xFC) as u16;
+        while offset != 0 {
+            // Capability headers sit at device-defined offsets, hence we cannot use a
+            // safe accessor to read them.
+            let ent = unsafe { bus.read_config_half(slot, function, offset) };
+            let type_ = (ent & 0xFF) as u32;
+
+            if let Some(name) = name_of_capability(type_) {
+                println!("sif:     {name} capability");
+            } else {
+                println!("sif:     Capability of type {type_:#04x}");
+            }
+
+            let length = if type_ == 0x09 {
+                Some(unsafe { bus.read_config_byte(slot, function, offset + 2) } as u64)
+            } else {
+                None
+            };
+
+            entity.caps.lock().expect(EXPECT_LOCK).push(Capability {
+                type_,
+                offset,
+                length,
+            });
+
+            offset = ((ent >> 8) & 0xFC) as u16;
+        }
+    }
 }
 
 fn check_pci_function(
@@ -77,6 +117,8 @@ fn check_pci_function(
             subsystem_device,
         );
 
+        find_pci_caps(&device.entity);
+
         ALL_DEVICES.lock().expect(EXPECT_LOCK).push(device);
         bus.child_devices.lock().expect(EXPECT_LOCK).push(device);
     } else if header_type & 0x7F == 1 {
@@ -84,6 +126,8 @@ fn check_pci_function(
             bus, slot, function, vendor, device_id, revision, class_code, sub_class, interface,
         );
         bus.child_bridges.lock().expect(EXPECT_LOCK).push(bridge);
+
+        find_pci_caps(&bridge.entity);
 
         let downstream_id = unsafe { bus.secondary_bus(slot, function) };
 

--- a/sif/src/pci/discover.rs
+++ b/sif/src/pci/discover.rs
@@ -11,6 +11,10 @@ use crate::acpi::PAGE_MASK;
 static ALL_DEVICES: Mutex<Vec<&'static PciDevice>> = Mutex::new(Vec::new());
 static ALL_ROOT_BUSES: Mutex<Vec<&'static PciBus>> = Mutex::new(Vec::new());
 
+pub fn all_devices() -> Vec<&'static PciDevice> {
+    ALL_DEVICES.lock().expect(EXPECT_LOCK).clone()
+}
+
 pub fn all_root_buses() -> Vec<&'static PciBus> {
     ALL_ROOT_BUSES.lock().expect(EXPECT_LOCK).clone()
 }

--- a/sif/src/pci/discover.rs
+++ b/sif/src/pci/discover.rs
@@ -1,7 +1,12 @@
 use std::sync::Mutex;
 use std::sync::atomic::Ordering;
 
-use super::{Capability, EXPECT_LOCK, PciBridge, PciBus, PciDevice, PciEntity, name_of_capability};
+use super::{
+    BarType, Capability, EXPECT_LOCK, IrqIndex, PCI_REGULAR_BAR0, PciBridge, PciBus, PciDevice,
+    PciEntity, name_of_capability,
+};
+
+use crate::acpi::PAGE_MASK;
 
 static ALL_DEVICES: Mutex<Vec<&'static PciDevice>> = Mutex::new(Vec::new());
 static ALL_ROOT_BUSES: Mutex<Vec<&'static PciBus>> = Mutex::new(Vec::new());
@@ -12,6 +17,150 @@ pub fn all_root_buses() -> Vec<&'static PciBus> {
 
 pub fn add_root_bus(bus: &'static PciBus) {
     ALL_ROOT_BUSES.lock().expect(EXPECT_LOCK).push(bus);
+}
+
+fn compute_bar_length(mask: u64) -> u64 {
+    assert!(mask != 0);
+    1u64 << mask.trailing_zeros()
+}
+
+fn read_entity_bars(entity: &PciEntity, n_bars: usize) {
+    let bus = entity.parent_bus;
+    let slot = entity.slot;
+    let function = entity.function;
+
+    let mut bars = entity.bars.lock().expect(EXPECT_LOCK);
+
+    // The caller passes the number of BARs of the header type of the entity, hence all
+    // offsets that we compute below address BARs.
+    let size_bar = |offset: u16, restore: u32| -> u32 {
+        unsafe {
+            bus.set_bar(slot, function, offset, 0xFFFFFFFF);
+            let mask = bus.bar(slot, function, offset);
+            bus.set_bar(slot, function, offset, restore);
+
+            mask
+        }
+    };
+
+    let mut i = 0;
+    while i < n_bars {
+        let offset = PCI_REGULAR_BAR0 + (i as u16) * 4;
+        let bar = unsafe { bus.bar(slot, function, offset) };
+
+        if bar & 1 != 0 {
+            let address = (bar & 0xFFFFFFFC) as u64;
+            let mask = size_bar(offset, bar) & 0xFFFFFFFC;
+
+            // The device does not decode any address bits from this BAR.
+            if mask == 0 {
+                i += 1;
+                continue;
+            }
+
+            let length = compute_bar_length(mask as u64);
+
+            bars[i].type_ = BarType::Io;
+            bars[i].address = address;
+            bars[i].length = length;
+
+            if address == 0 {
+                println!("sif:     unallocated I/O space BAR #{i}, length: {length} ports");
+            } else {
+                bars[i].host_type = BarType::Io;
+                bars[i].host_address = address;
+                bars[i].offset = 0;
+
+                println!("sif:     I/O space BAR #{i} at {address:#x}, length: {length} ports");
+            }
+
+            i += 1;
+        } else if (bar >> 1) & 3 == 0 {
+            let address = (bar & 0xFFFFFFF0) as u64;
+            let mask = size_bar(offset, bar) & 0xFFFFFFF0;
+
+            // The device does not decode any address bits from this BAR.
+            if mask == 0 {
+                i += 1;
+                continue;
+            }
+
+            let length = compute_bar_length(mask as u64);
+            let prefetchable = bar & (1 << 3) != 0;
+
+            bars[i].type_ = BarType::Memory;
+            bars[i].address = address;
+            bars[i].length = length;
+            bars[i].prefetchable = prefetchable;
+
+            if address == 0 {
+                println!(
+                    "sif:     unallocated 32-bit memory BAR #{i}, length: {length} bytes{}",
+                    if prefetchable { " (prefetchable)" } else { "" }
+                );
+            } else {
+                bars[i].host_type = BarType::Memory;
+                bars[i].host_address = address;
+                bars[i].offset = (address as usize & PAGE_MASK) as u32;
+
+                println!(
+                    "sif:     32-bit memory BAR #{i} at {address:#x}, length: {length} bytes{}",
+                    if prefetchable { " (prefetchable)" } else { "" }
+                );
+            }
+
+            i += 1;
+        } else if (bar >> 1) & 3 == 2 {
+            assert!(i < n_bars - 1); // Otherwise there is no next BAR.
+            let high = unsafe { bus.bar(slot, function, offset + 4) };
+            let address = ((high as u64) << 32) | (bar & 0xFFFFFFF0) as u64;
+
+            let mask = unsafe {
+                bus.set_bar(slot, function, offset, 0xFFFFFFFF);
+                bus.set_bar(slot, function, offset + 4, 0xFFFFFFFF);
+                let mask = ((bus.bar(slot, function, offset + 4) as u64) << 32)
+                    | (bus.bar(slot, function, offset) & 0xFFFFFFF0) as u64;
+                bus.set_bar(slot, function, offset, bar);
+                bus.set_bar(slot, function, offset + 4, high);
+
+                mask
+            };
+
+            // The device does not decode any address bits from this BAR.
+            if mask == 0 {
+                i += 2;
+                continue;
+            }
+
+            let length = compute_bar_length(mask);
+            let prefetchable = bar & (1 << 3) != 0;
+
+            bars[i].type_ = BarType::Memory;
+            bars[i].address = address;
+            bars[i].length = length;
+            bars[i].prefetchable = prefetchable;
+
+            if address == 0 {
+                println!(
+                    "sif:     unallocated 64-bit memory BAR #{i}, length: {length} bytes{}",
+                    if prefetchable { " (prefetchable)" } else { "" }
+                );
+            } else {
+                bars[i].host_type = BarType::Memory;
+                bars[i].host_address = address;
+                bars[i].offset = (address as usize & PAGE_MASK) as u32;
+
+                println!(
+                    "sif:     64-bit memory BAR #{i} at {address:#x}, length: {length} bytes{}",
+                    if prefetchable { " (prefetchable)" } else { "" }
+                );
+            }
+
+            i += 2;
+        } else {
+            panic!("Unexpected BAR type");
+        }
+    }
 }
 
 fn find_pci_caps(entity: &PciEntity) {
@@ -119,6 +268,24 @@ fn check_pci_function(
 
         find_pci_caps(&device.entity);
 
+        read_entity_bars(&device.entity, 6);
+
+        let irq_index = IrqIndex::from_pin(bus.interrupt_pin(slot, function));
+        if irq_index != IrqIndex::Null {
+            if let Some(gsi) = super::acpi::resolve_irq(bus.seg_id, slot, irq_index) {
+                println!(
+                    "sif:     Interrupt: {} (routed to GSI {gsi})",
+                    irq_index.name()
+                );
+                device
+                    .interrupt
+                    .set(gsi)
+                    .expect("sif: PCI device was already enumerated");
+            } else {
+                println!("sif:     Interrupt routing not available!");
+            }
+        }
+
         ALL_DEVICES.lock().expect(EXPECT_LOCK).push(device);
         bus.child_devices.lock().expect(EXPECT_LOCK).push(device);
     } else if header_type & 0x7F == 1 {
@@ -128,6 +295,8 @@ fn check_pci_function(
         bus.child_bridges.lock().expect(EXPECT_LOCK).push(bridge);
 
         find_pci_caps(&bridge.entity);
+
+        read_entity_bars(&bridge.entity, 2);
 
         let downstream_id = unsafe { bus.secondary_bus(slot, function) };
 

--- a/sif/src/pci/discover.rs
+++ b/sif/src/pci/discover.rs
@@ -1,0 +1,13 @@
+use std::sync::Mutex;
+
+use super::{EXPECT_LOCK, PciBus};
+
+static ALL_ROOT_BUSES: Mutex<Vec<&'static PciBus>> = Mutex::new(Vec::new());
+
+pub fn all_root_buses() -> Vec<&'static PciBus> {
+    ALL_ROOT_BUSES.lock().expect(EXPECT_LOCK).clone()
+}
+
+pub fn add_root_bus(bus: &'static PciBus) {
+    ALL_ROOT_BUSES.lock().expect(EXPECT_LOCK).push(bus);
+}

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -1,5 +1,6 @@
 pub mod acpi;
 pub mod config;
+pub mod discover;
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -10,6 +11,50 @@ use anyhow::Result;
 use managarm::hw::pci::IoType;
 use managarm::hw::server::{BarDescriptor, CapDescriptor, PciDevice, serve_pci_device};
 use managarm::mbus::{EntityManager, Item, Properties, create_entity};
+
+use config::PciConfigIo;
+
+pub(crate) fn leak<T>(value: T) -> &'static T {
+    Box::leak(Box::new(value))
+}
+
+// The PCI tree is only locked for the duration of a single operation, none of which can panic.
+pub(crate) const EXPECT_LOCK: &str = "sif: PCI tree mutex was poisoned";
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum IrqIndex {
+    Null = 0,
+    IntA = 1,
+    IntB = 2,
+    IntC = 3,
+    IntD = 4,
+}
+
+impl IrqIndex {
+    pub fn from_pin(pin: u8) -> IrqIndex {
+        match pin {
+            1 => IrqIndex::IntA,
+            2 => IrqIndex::IntB,
+            3 => IrqIndex::IntC,
+            4 => IrqIndex::IntD,
+            _ => IrqIndex::Null,
+        }
+    }
+}
+
+pub struct PciBus {
+    #[allow(dead_code)]
+    pub io: &'static dyn PciConfigIo,
+
+    pub seg_id: u16,
+    pub bus_id: u8,
+}
+
+impl PciBus {
+    pub fn new(io: &'static dyn PciConfigIo, seg_id: u16, bus_id: u8) -> &'static PciBus {
+        leak(PciBus { io, seg_id, bus_id })
+    }
+}
 
 #[derive(Clone, Copy)]
 struct Address {
@@ -476,7 +521,6 @@ fn scan_bus<'a>(
     seg: u16,
     bus: u8,
     parent_id: i64,
-    routes: &'a acpi::Routes,
     out: &'a mut Vec<Publication>,
 ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
     Box::pin(async move {
@@ -510,7 +554,7 @@ fn scan_bus<'a>(
                 } else {
                     "pci-device"
                 };
-                let irq = resolve_irq(addr, routes);
+                let irq = resolve_irq(addr);
                 println!(
                     "sif: pci: {seg:04x}:{bus:02x}:{slot:02x}.{func} {name} vendor: {:04x} device: {:04x} irq: {:?}",
                     addr.vendor_id(),
@@ -532,7 +576,7 @@ fn scan_bus<'a>(
                 if is_bridge {
                     let secondary = addr.secondary_bus();
                     if secondary > bus {
-                        scan_bus(seg, secondary, id, routes, out).await?;
+                        scan_bus(seg, secondary, id, out).await?;
                     }
                 }
             }
@@ -541,24 +585,22 @@ fn scan_bus<'a>(
     })
 }
 
-fn resolve_irq(addr: Address, routes: &acpi::Routes) -> Option<u32> {
-    let pin = addr.interrupt_pin();
-    if pin == 0 || pin > 4 {
+fn resolve_irq(addr: Address) -> Option<u32> {
+    let index = IrqIndex::from_pin(addr.interrupt_pin());
+    if index == IrqIndex::Null {
         return None;
     }
-    routes.get(&(addr.seg, addr.slot, pin - 1)).copied()
+    acpi::resolve_irq(addr.seg, addr.slot, index)
 }
 
 pub async fn publish_devices() -> Result<()> {
-    let roots = acpi::find_root_buses();
-    let routes = acpi::build_routes(&roots);
-    println!("sif: Resolved {} PCI interrupt routes", routes.len());
+    acpi::discover_root_buses();
 
     let mut entities: Vec<Publication> = Vec::new();
 
-    for root in &roots {
-        let seg = root.seg;
-        let bus = root.bus;
+    for root_bus in discover::all_root_buses() {
+        let seg = root_bus.seg_id;
+        let bus = root_bus.bus_id;
 
         let mut props: Properties = HashMap::new();
         props.insert("unix.subsystem".into(), string("pci"));
@@ -571,7 +613,7 @@ pub async fn publish_devices() -> Result<()> {
         let root_id = manager.id();
         entities.push((manager, None));
 
-        scan_bus(seg, bus, root_id, &routes, &mut entities).await?;
+        scan_bus(seg, bus, root_id, &mut entities).await?;
     }
 
     println!("sif: Enumerated {} PCI objects", entities.len());

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -42,6 +42,16 @@ impl IrqIndex {
             _ => IrqIndex::Null,
         }
     }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            IrqIndex::IntA => "INTA",
+            IrqIndex::IntB => "INTB",
+            IrqIndex::IntC => "INTC",
+            IrqIndex::IntD => "INTD",
+            IrqIndex::Null => panic!("Illegal PCI interrupt pin"),
+        }
+    }
 }
 
 pub fn name_of_capability(type_: u32) -> Option<&'static str> {
@@ -203,6 +213,10 @@ impl PciBus {
     pub fn capabilities_pointer(&self, slot: u8, function: u8) -> u8 {
         unsafe { self.read_config_byte(slot, function, PCI_REGULAR_CAPABILITIES) }
     }
+
+    pub fn interrupt_pin(&self, slot: u8, function: u8) -> u8 {
+        unsafe { self.read_config_byte(slot, function, PCI_REGULAR_INTERRUPT_PIN) }
+    }
 }
 
 // Accessors for registers whose existence depends on the header type, hence they are unsafe.
@@ -234,6 +248,49 @@ impl PciBus {
     pub unsafe fn subsystem_device(&self, slot: u8, function: u8) -> u16 {
         unsafe { self.read_config_half(slot, function, PCI_REGULAR_SUBSYSTEM_DEVICE) }
     }
+
+    // Only the first two BARs exist in both header types.
+    fn check_bar(offset: u16) {
+        assert!(offset >= PCI_REGULAR_BAR0 && offset < PCI_REGULAR_BAR0 + 24);
+        assert!(offset % 4 == 0);
+    }
+
+    /// # Safety
+    ///
+    /// The offset must address a BAR of the header type of the function.
+    pub unsafe fn bar(&self, slot: u8, function: u8, offset: u16) -> u32 {
+        Self::check_bar(offset);
+        unsafe { self.read_config_word(slot, function, offset) }
+    }
+
+    /// # Safety
+    ///
+    /// The offset must address a BAR of the header type of the function.
+    pub unsafe fn set_bar(&self, slot: u8, function: u8, offset: u16, value: u32) {
+        Self::check_bar(offset);
+        unsafe { self.write_config_word(slot, function, offset, value) };
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
+pub enum BarType {
+    #[default]
+    None,
+    Io,
+    Memory,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Default)]
+pub struct PciBar {
+    pub type_: BarType,
+    pub address: u64,
+    pub length: u64,
+    pub prefetchable: bool,
+
+    pub host_type: BarType,
+    pub host_address: u64,
+    pub offset: u32,
 }
 
 #[allow(dead_code)]
@@ -265,6 +322,8 @@ pub struct PciEntity {
     pub interface: u8,
 
     pub caps: Mutex<Vec<Capability>>,
+
+    pub bars: Mutex<Vec<PciBar>>,
 }
 
 impl PciEntity {
@@ -279,6 +338,7 @@ impl PciEntity {
         class_code: u8,
         sub_class: u8,
         interface: u8,
+        n_bars: usize,
     ) -> PciEntity {
         PciEntity {
             parent_bus,
@@ -293,6 +353,7 @@ impl PciEntity {
             sub_class,
             interface,
             caps: Mutex::new(Vec::new()),
+            bars: Mutex::new(vec![PciBar::default(); n_bars]),
         }
     }
 }
@@ -322,7 +383,7 @@ impl PciBridge {
         leak(PciBridge {
             entity: PciEntity::new(
                 parent_bus, slot, function, vendor, device_id, revision, class_code, sub_class,
-                interface,
+                interface, 2,
             ),
             associated_bus: OnceLock::new(),
             downstream_id: AtomicU8::new(0),
@@ -337,6 +398,8 @@ pub struct PciDevice {
 
     pub subsystem_vendor: u16,
     pub subsystem_device: u16,
+
+    pub interrupt: OnceLock<u32>,
 }
 
 impl PciDevice {
@@ -357,10 +420,11 @@ impl PciDevice {
         leak(PciDevice {
             entity: PciEntity::new(
                 parent_bus, slot, function, vendor, device_id, revision, class_code, sub_class,
-                interface,
+                interface, 6,
             ),
             subsystem_vendor,
             subsystem_device,
+            interrupt: OnceLock::new(),
         })
     }
 }
@@ -376,9 +440,11 @@ pub const PCI_CLASS_CODE: u16 = 0x0B;
 pub const PCI_HEADER_TYPE: u16 = 0x0E;
 
 // usual device header fields
+pub const PCI_REGULAR_BAR0: u16 = 0x10;
 pub const PCI_REGULAR_SUBSYSTEM_VENDOR: u16 = 0x2C;
 pub const PCI_REGULAR_SUBSYSTEM_DEVICE: u16 = 0x2E;
 pub const PCI_REGULAR_CAPABILITIES: u16 = 0x34;
+pub const PCI_REGULAR_INTERRUPT_PIN: u16 = 0x3D;
 
 // PCI-to-PCI bridge header fields
 pub const PCI_BRIDGE_SECONDARY: u16 = 0x19;

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -1,18 +1,12 @@
 pub mod acpi;
 pub mod config;
 pub mod discover;
+pub mod serve;
 
-use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
-use std::rc::Rc;
-use std::sync::atomic::AtomicU8;
+use std::sync::atomic::{AtomicI64, AtomicU8};
 use std::sync::{Mutex, OnceLock};
 
 use anyhow::Result;
-use managarm::hw::pci::IoType;
-use managarm::hw::server::{BarDescriptor, CapDescriptor, serve_pci_device};
-use managarm::mbus::{EntityManager, Item, Properties, create_entity};
 
 use config::PciConfigIo;
 
@@ -73,7 +67,6 @@ pub fn name_of_capability(type_: u32) -> Option<&'static str> {
 }
 
 pub struct PciBus {
-    #[allow(dead_code)]
     pub associated_bridge: Option<&'static PciBridge>,
     pub io: &'static dyn PciConfigIo,
     pub child_devices: Mutex<Vec<&'static PciDevice>>,
@@ -81,9 +74,14 @@ pub struct PciBus {
 
     pub seg_id: u16,
     pub bus_id: u8,
+
+    pub mbus_id: AtomicI64,
 }
 
-#[allow(dead_code)]
+// Every address that we hand out belongs to a device that we enumerated, hence accesses to it
+// only fail if the caller picks a bad register.
+const EXPECT_ACCESS: &str = "sif: configuration space access to an enumerated device failed";
+
 impl PciBus {
     pub fn new(
         associated_bridge: Option<&'static PciBridge>,
@@ -98,6 +96,7 @@ impl PciBus {
             child_bridges: Mutex::new(Vec::new()),
             seg_id,
             bus_id,
+            mbus_id: AtomicI64::new(0),
         })
     }
 
@@ -184,6 +183,14 @@ impl PciBus {
 
     pub fn device_id(&self, slot: u8, function: u8) -> u16 {
         unsafe { self.read_config_half(slot, function, PCI_DEVICE) }
+    }
+
+    pub fn command(&self, slot: u8, function: u8) -> u16 {
+        unsafe { self.read_config_half(slot, function, PCI_COMMAND) }
+    }
+
+    pub fn set_command(&self, slot: u8, function: u8, value: u16) {
+        unsafe { self.write_config_half(slot, function, PCI_COMMAND, value) };
     }
 
     pub fn status(&self, slot: u8, function: u8) -> u16 {
@@ -280,7 +287,6 @@ pub enum BarType {
     Memory,
 }
 
-#[allow(dead_code)]
 #[derive(Clone, Copy, Default)]
 pub struct PciBar {
     pub type_: BarType,
@@ -293,7 +299,6 @@ pub struct PciBar {
     pub offset: u32,
 }
 
-#[allow(dead_code)]
 pub struct Capability {
     pub type_: u32,
     pub offset: u16,
@@ -301,7 +306,6 @@ pub struct Capability {
 }
 
 // Common part of devices and bridges.
-#[allow(dead_code)]
 pub struct PciEntity {
     pub parent_bus: &'static PciBus,
 
@@ -310,6 +314,9 @@ pub struct PciEntity {
     pub bus: u8,
     pub slot: u8,
     pub function: u8,
+
+    // mbus object ID of the entity.
+    pub mbus_id: AtomicI64,
 
     // vendor-specific device information
     pub vendor: u16,
@@ -346,6 +353,7 @@ impl PciEntity {
             bus: parent_bus.bus_id,
             slot,
             function,
+            mbus_id: AtomicI64::new(0),
             vendor,
             device_id,
             revision,
@@ -356,9 +364,15 @@ impl PciEntity {
             bars: Mutex::new(vec![PciBar::default(); n_bars]),
         }
     }
+
+    pub fn enable_busmaster(&self) {
+        let bus = self.parent_bus;
+
+        let cmd = bus.command(self.slot, self.function);
+        bus.set_command(self.slot, self.function, cmd | 0x0004);
+    }
 }
 
-#[allow(dead_code)]
 pub struct PciBridge {
     pub entity: PciEntity,
 
@@ -392,7 +406,6 @@ impl PciBridge {
     }
 }
 
-#[allow(dead_code)]
 pub struct PciDevice {
     pub entity: PciEntity,
 
@@ -427,11 +440,19 @@ impl PciDevice {
             interrupt: OnceLock::new(),
         })
     }
+
+    pub fn enable_irq(&self) {
+        let bus = self.entity.parent_bus;
+
+        let command = bus.command(self.entity.slot, self.entity.function);
+        bus.set_command(self.entity.slot, self.entity.function, command & !0x400);
+    }
 }
 
 // general PCI header fields
 pub const PCI_VENDOR: u16 = 0;
 pub const PCI_DEVICE: u16 = 2;
+pub const PCI_COMMAND: u16 = 4;
 pub const PCI_STATUS: u16 = 6;
 pub const PCI_REVISION: u16 = 0x08;
 pub const PCI_INTERFACE: u16 = 0x09;
@@ -450,575 +471,10 @@ pub const PCI_REGULAR_INTERRUPT_PIN: u16 = 0x3D;
 pub const PCI_BRIDGE_SECONDARY: u16 = 0x19;
 pub const PCI_BRIDGE_SUBORDINATE: u16 = 0x1A;
 
-#[derive(Clone, Copy)]
-struct Address {
-    seg: u16,
-    bus: u8,
-    slot: u8,
-    func: u8,
-}
-
-// Every address that we hand out belongs to a device that we enumerated, hence accesses to it
-// only fail if the caller picks a bad register.
-const EXPECT_ACCESS: &str = "sif: configuration space access to an enumerated device failed";
-
-impl Address {
-    /// Reads a register of `size` bytes.
-    ///
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn read(self, offset: u16, size: u8) -> config::Result<u32> {
-        match size {
-            1 => Ok(u32::from(unsafe { self.try_read8(offset) }?)),
-            2 => Ok(u32::from(unsafe { self.try_read16(offset) }?)),
-            4 => unsafe { self.try_read32(offset) },
-            _ => Err(config::ConfigIoError::UnsupportedSize(size)),
-        }
-    }
-
-    /// Writes a register of `size` bytes.
-    ///
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn write(self, offset: u16, size: u8, value: u32) -> config::Result<()> {
-        match size {
-            1 => unsafe { self.try_write8(offset, value as u8) },
-            2 => unsafe { self.try_write16(offset, value as u16) },
-            4 => unsafe { self.try_write32(offset, value) },
-            _ => Err(config::ConfigIoError::UnsupportedSize(size)),
-        }
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn try_read8(self, offset: u16) -> config::Result<u8> {
-        unsafe { config::read_config_byte(self.seg, self.bus, self.slot, self.func, offset) }
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn try_read16(self, offset: u16) -> config::Result<u16> {
-        unsafe { config::read_config_half(self.seg, self.bus, self.slot, self.func, offset) }
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn try_read32(self, offset: u16) -> config::Result<u32> {
-        unsafe { config::read_config_word(self.seg, self.bus, self.slot, self.func, offset) }
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn read8(self, offset: u16) -> u8 {
-        unsafe { self.try_read8(offset) }.expect(EXPECT_ACCESS)
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn read16(self, offset: u16) -> u16 {
-        unsafe { self.try_read16(offset) }.expect(EXPECT_ACCESS)
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn read32(self, offset: u16) -> u32 {
-        unsafe { self.try_read32(offset) }.expect(EXPECT_ACCESS)
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn try_write8(self, offset: u16, value: u8) -> config::Result<()> {
-        unsafe {
-            config::write_config_byte(self.seg, self.bus, self.slot, self.func, offset, value)
-        }
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn try_write16(self, offset: u16, value: u16) -> config::Result<()> {
-        unsafe {
-            config::write_config_half(self.seg, self.bus, self.slot, self.func, offset, value)
-        }
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn try_write32(self, offset: u16, value: u32) -> config::Result<()> {
-        unsafe {
-            config::write_config_word(self.seg, self.bus, self.slot, self.func, offset, value)
-        }
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn write16(self, offset: u16, value: u16) {
-        unsafe { self.try_write16(offset, value) }.expect(EXPECT_ACCESS)
-    }
-
-    /// # Safety
-    ///
-    /// See [`config::PciConfigIo`].
-    unsafe fn write32(self, offset: u16, value: u32) {
-        unsafe { self.try_write32(offset, value) }.expect(EXPECT_ACCESS)
-    }
-}
-
-// Accessors for the registers of the type 0/1 configuration space header. Their side effects
-// are known, hence they are safe.
-impl Address {
-    fn vendor_id(self) -> u16 {
-        unsafe { self.read16(0x00) }
-    }
-
-    fn device_id(self) -> u16 {
-        unsafe { self.read16(0x02) }
-    }
-
-    fn command(self) -> u16 {
-        unsafe { self.read16(0x04) }
-    }
-
-    fn set_command(self, value: u16) {
-        unsafe { self.write16(0x04, value) };
-    }
-
-    fn status(self) -> u16 {
-        unsafe { self.read16(0x06) }
-    }
-
-    fn revision(self) -> u8 {
-        unsafe { self.read8(0x08) }
-    }
-
-    fn interface(self) -> u8 {
-        unsafe { self.read8(0x09) }
-    }
-
-    fn subclass(self) -> u8 {
-        unsafe { self.read8(0x0A) }
-    }
-
-    fn class_code(self) -> u8 {
-        unsafe { self.read8(0x0B) }
-    }
-
-    fn header_type(self) -> u8 {
-        unsafe { self.read8(0x0E) }
-    }
-
-    fn bar(self, index: usize) -> u32 {
-        assert!(index < 6);
-        unsafe { self.read32(0x10 + 4 * index as u16) }
-    }
-
-    fn set_bar(self, index: usize, value: u32) {
-        assert!(index < 6);
-        unsafe { self.write32(0x10 + 4 * index as u16, value) };
-    }
-
-    fn secondary_bus(self) -> u8 {
-        unsafe { self.read8(0x19) }
-    }
-
-    fn subsystem_vendor(self) -> u16 {
-        unsafe { self.read16(0x2C) }
-    }
-
-    fn subsystem_device(self) -> u16 {
-        unsafe { self.read16(0x2E) }
-    }
-
-    fn capabilities_pointer(self) -> u8 {
-        unsafe { self.read8(0x34) }
-    }
-
-    fn interrupt_pin(self) -> u8 {
-        unsafe { self.read8(0x3D) }
-    }
-}
-
-fn size_from_mask(mask: u32) -> u64 {
-    if mask == 0 {
-        0
-    } else {
-        1u64 << mask.trailing_zeros()
-    }
-}
-
-fn size_from_mask64(mask: u64) -> u64 {
-    if mask == 0 {
-        0
-    } else {
-        1u64 << mask.trailing_zeros()
-    }
-}
-
-fn read_bars(addr: Address, count: usize) -> [BarDescriptor; 6] {
-    let mut bars = [BarDescriptor::default(); 6];
-    let mut i = 0;
-    while i < count {
-        let original = addr.bar(i);
-        addr.set_bar(i, 0xFFFFFFFF);
-        let mask = addr.bar(i);
-        addr.set_bar(i, original);
-
-        if mask == 0 {
-            i += 1;
-            continue;
-        }
-
-        if original & 1 != 0 {
-            let base = (original & 0xFFFFFFFC) as u64;
-            bars[i] = BarDescriptor {
-                io_type: IoType::Port,
-                host_type: IoType::Port,
-                address: base,
-                length: size_from_mask(mask & 0xFFFFFFFC),
-                offset: 0,
-            };
-            i += 1;
-        } else if (original >> 1) & 3 == 2 {
-            // The upper half of a 64-bit BAR must not extend past the last BAR of the header.
-            if i + 1 >= count {
-                break;
-            }
-
-            let high_original = addr.bar(i + 1);
-            addr.set_bar(i + 1, 0xFFFFFFFF);
-            let high_mask = addr.bar(i + 1);
-            addr.set_bar(i + 1, high_original);
-
-            let base = (((high_original as u64) << 32) | (original & 0xFFFFFFF0) as u64) as u64;
-            let full_mask = ((high_mask as u64) << 32) | (mask & 0xFFFFFFF0) as u64;
-            bars[i] = BarDescriptor {
-                io_type: IoType::Memory,
-                host_type: IoType::Memory,
-                address: base,
-                length: size_from_mask64(full_mask),
-                offset: (base & 0xFFF) as u32,
-            };
-            i += 2;
-        } else {
-            let base = (original & 0xFFFFFFF0) as u64;
-            bars[i] = BarDescriptor {
-                io_type: IoType::Memory,
-                host_type: IoType::Memory,
-                address: base,
-                length: size_from_mask(mask & 0xFFFFFFF0),
-                offset: (base & 0xFFF) as u32,
-            };
-            i += 1;
-        }
-    }
-    bars
-}
-
-fn read_capabilities(addr: Address) -> Vec<CapDescriptor> {
-    let mut caps = Vec::new();
-    if addr.status() & 0x10 == 0 {
-        return caps;
-    }
-
-    let mut pointer = (addr.capabilities_pointer() & 0xFC) as u16;
-    let mut seen = 0;
-    while pointer != 0 && seen < 64 {
-        // Capability headers sit at device-defined offsets, but reading them has no side effects.
-        let type_ = unsafe { addr.read8(pointer) };
-        let next = unsafe { addr.read8(pointer + 1) } & 0xFC;
-        let length = if type_ == 0x09 {
-            u64::from(unsafe { addr.read8(pointer + 2) })
-        } else {
-            0
-        };
-        caps.push(CapDescriptor {
-            type_: type_ as u32,
-            offset: pointer as u64,
-            length,
-        });
-        pointer = next as u16;
-        seen += 1;
-    }
-    caps
-}
-
-struct SifPciDevice {
-    addr: Address,
-    irq: Option<u32>,
-    bars: [BarDescriptor; 6],
-    caps: Vec<CapDescriptor>,
-    config_space_size: u32,
-}
-
-impl managarm::hw::server::PciDevice for SifPciDevice {
-    fn bars(&self) -> [BarDescriptor; 6] {
-        self.bars
-    }
-
-    fn capabilities(&self) -> Vec<CapDescriptor> {
-        self.caps.clone()
-    }
-
-    fn config_read(&self, offset: u32, size: u32) -> Option<u32> {
-        if offset as usize + size as usize > self.config_space_size as usize {
-            return None;
-        }
-        // The protocol hands out raw config space access; the client is responsible for it.
-        unsafe { self.addr.read(offset as u16, size as u8) }.ok()
-    }
-
-    fn config_write(&self, offset: u32, size: u32, word: u32) -> bool {
-        if offset as usize + size as usize > self.config_space_size as usize {
-            return false;
-        }
-        // The protocol hands out raw config space access; the client is responsible for it.
-        unsafe { self.addr.write(offset as u16, size as u8, word) }.is_ok()
-    }
-
-    fn capability_read(&self, index: i32, offset: u32, size: u32) -> Option<u32> {
-        let cap = self.caps.get(index as usize)?;
-        self.config_read(cap.offset as u32 + offset, size)
-    }
-
-    fn access_bar(&self, index: usize) -> hel::Result<hel::Handle> {
-        let bar = self.bars.get(index).ok_or(hel::Error::IllegalArgs)?;
-        match bar.host_type {
-            IoType::Memory => {
-                let aligned = (bar.address as usize) & !0xFFF;
-                let page_off = (bar.address as usize) & 0xFFF;
-                let span = ((bar.length as usize) + page_off + 0xFFF) & !0xFFF;
-                hel::access_physical(aligned, span.max(0x1000), hel::CachingMode::Mmio)
-            }
-            IoType::Port => {
-                let ports: Vec<usize> = (bar.address..bar.address + bar.length)
-                    .map(|p| p as usize)
-                    .collect();
-                hel::access_io(&ports)
-            }
-            IoType::None => Err(hel::Error::IllegalArgs),
-        }
-    }
-
-    fn access_irq(&self, _index: u64) -> hel::Result<Option<hel::Handle>> {
-        match self.irq {
-            Some(gsi) => Ok(Some(hel::access_irq(gsi as i32)?)),
-            None => Ok(None),
-        }
-    }
-
-    fn enable_busmaster(&self) {
-        self.addr.set_command(self.addr.command() | 0x4);
-    }
-
-    fn enable_irq(&self) {
-        self.addr.set_command(self.addr.command() & !0x400);
-    }
-}
-
-fn string(value: &str) -> Item {
-    Item::String(value.to_string())
-}
-
-fn hex(value: u32, width: usize) -> Item {
-    Item::String(format!("{value:0width$x}"))
-}
-
-fn decimal(value: i64) -> Item {
-    Item::String(format!("{value}"))
-}
-
-fn functions(seg: u16, bus: u8, slot: u8) -> Vec<u8> {
-    let addr = Address {
-        seg,
-        bus,
-        slot,
-        func: 0,
-    };
-    if addr.vendor_id() == 0xFFFF {
-        return Vec::new();
-    }
-    if addr.header_type() & 0x80 != 0 {
-        (0..8).collect()
-    } else {
-        vec![0]
-    }
-}
-
-async fn serve_entity(manager: &'static EntityManager, device: Rc<SifPciDevice>) {
-    let id = manager.id();
-
-    loop {
-        let (local, remote) = match hel::create_stream() {
-            Ok(pair) => pair,
-            Err(err) => {
-                println!("sif: entity {id}: create_stream failed: {err}");
-                return;
-            }
-        };
-        if let Err(err) = manager.serve_remote_lane(remote).await {
-            println!("sif: entity {id}: serve_remote_lane failed: {err}");
-            return;
-        }
-        hel::spawn(serve_pci_device(local, device.clone()));
-    }
-}
-
-fn device_properties(addr: Address, is_bridge: bool, parent_id: i64) -> Properties {
-    let mut props = HashMap::new();
-    props.insert("unix.subsystem".into(), string("pci"));
-    props.insert(
-        "pci-type".into(),
-        string(if is_bridge {
-            "pci-bridge"
-        } else {
-            "pci-device"
-        }),
-    );
-    props.insert("pci-segment".into(), hex(addr.seg as u32, 4));
-    props.insert("pci-bus".into(), hex(addr.bus as u32, 2));
-    props.insert("pci-slot".into(), hex(addr.slot as u32, 2));
-    props.insert("pci-function".into(), hex(addr.func as u32, 1));
-    props.insert("pci-vendor".into(), hex(addr.vendor_id() as u32, 4));
-    props.insert("pci-device".into(), hex(addr.device_id() as u32, 4));
-    props.insert("pci-revision".into(), hex(addr.revision() as u32, 2));
-    props.insert("pci-class".into(), hex(addr.class_code() as u32, 2));
-    props.insert("pci-subclass".into(), hex(addr.subclass() as u32, 2));
-    props.insert("pci-interface".into(), hex(addr.interface() as u32, 2));
-    if !is_bridge {
-        props.insert(
-            "pci-subsystem-vendor".into(),
-            hex(addr.subsystem_vendor() as u32, 2),
-        );
-        props.insert(
-            "pci-subsystem-device".into(),
-            hex(addr.subsystem_device() as u32, 2),
-        );
-    }
-    props.insert("drvcore.mbus-parent".into(), decimal(parent_id));
-    props
-}
-
-type Publication = (EntityManager, Option<Rc<SifPciDevice>>);
-
-fn scan_bus<'a>(
-    seg: u16,
-    bus: u8,
-    parent_id: i64,
-    out: &'a mut Vec<Publication>,
-) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
-    Box::pin(async move {
-        // Bridges can lead to buses that neither MCFG nor the legacy window covers.
-        let Some(io) = config::get_config_io_for(seg, bus) else {
-            println!("sif: Skipping bus {seg:04x}:{bus:02x} without configuration space");
-            return Ok(());
-        };
-        let config_space_size = if io.supports_4k_config_space() {
-            0x1000
-        } else {
-            0x100
-        };
-
-        for slot in 0..32 {
-            for func in functions(seg, bus, slot) {
-                let addr = Address {
-                    seg,
-                    bus,
-                    slot,
-                    func,
-                };
-                if addr.vendor_id() == 0xFFFF {
-                    continue;
-                }
-
-                let is_bridge = addr.header_type() & 0x7F == 1;
-                let props = device_properties(addr, is_bridge, parent_id);
-                let name = if is_bridge {
-                    "pci-bridge"
-                } else {
-                    "pci-device"
-                };
-                let irq = resolve_irq(addr);
-                println!(
-                    "sif: pci: {seg:04x}:{bus:02x}:{slot:02x}.{func} {name} vendor: {:04x} device: {:04x} irq: {:?}",
-                    addr.vendor_id(),
-                    addr.device_id(),
-                    irq,
-                );
-                let manager = create_entity(name, &props).await?;
-                let id = manager.id();
-
-                let device = Rc::new(SifPciDevice {
-                    addr,
-                    irq,
-                    bars: read_bars(addr, if is_bridge { 2 } else { 6 }),
-                    caps: read_capabilities(addr),
-                    config_space_size,
-                });
-                out.push((manager, Some(device)));
-
-                if is_bridge {
-                    let secondary = addr.secondary_bus();
-                    if secondary > bus {
-                        scan_bus(seg, secondary, id, out).await?;
-                    }
-                }
-            }
-        }
-        Ok(())
-    })
-}
-
-fn resolve_irq(addr: Address) -> Option<u32> {
-    let index = IrqIndex::from_pin(addr.interrupt_pin());
-    if index == IrqIndex::Null {
-        return None;
-    }
-    acpi::resolve_irq(addr.seg, addr.slot, index)
-}
-
 pub async fn publish_devices() -> Result<()> {
     acpi::discover_root_buses();
     discover::enumerate_all();
-
-    let mut entities: Vec<Publication> = Vec::new();
-
-    for root_bus in discover::all_root_buses() {
-        let seg = root_bus.seg_id;
-        let bus = root_bus.bus_id;
-
-        let mut props: Properties = HashMap::new();
-        props.insert("unix.subsystem".into(), string("pci"));
-        props.insert("pci-type".into(), string("pci-root-bus"));
-        props.insert("pci-segment".into(), hex(seg as u32, 4));
-        props.insert("pci-bus".into(), hex(bus as u32, 2));
-
-        println!("sif: PCI root bus {seg:04x}:{bus:02x}");
-        let manager = create_entity("pci-root-bus", &props).await?;
-        let root_id = manager.id();
-        entities.push((manager, None));
-
-        scan_bus(seg, bus, root_id, &mut entities).await?;
-    }
-
-    println!("sif: Enumerated {} PCI objects", entities.len());
-
-    for (manager, device) in entities {
-        let manager: &'static EntityManager = Box::leak(Box::new(manager));
-        if let Some(device) = device {
-            hel::spawn(serve_entity(manager, device));
-        }
-    }
+    serve::publish_all().await?;
 
     Ok(())
 }

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -6,10 +6,12 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::sync::atomic::AtomicU8;
+use std::sync::{Mutex, OnceLock};
 
 use anyhow::Result;
 use managarm::hw::pci::IoType;
-use managarm::hw::server::{BarDescriptor, CapDescriptor, PciDevice, serve_pci_device};
+use managarm::hw::server::{BarDescriptor, CapDescriptor, serve_pci_device};
 use managarm::mbus::{EntityManager, Item, Properties, create_entity};
 
 use config::PciConfigIo;
@@ -44,17 +46,310 @@ impl IrqIndex {
 
 pub struct PciBus {
     #[allow(dead_code)]
+    pub associated_bridge: Option<&'static PciBridge>,
     pub io: &'static dyn PciConfigIo,
+    pub child_devices: Mutex<Vec<&'static PciDevice>>,
+    pub child_bridges: Mutex<Vec<&'static PciBridge>>,
 
     pub seg_id: u16,
     pub bus_id: u8,
 }
 
+#[allow(dead_code)]
 impl PciBus {
-    pub fn new(io: &'static dyn PciConfigIo, seg_id: u16, bus_id: u8) -> &'static PciBus {
-        leak(PciBus { io, seg_id, bus_id })
+    pub fn new(
+        associated_bridge: Option<&'static PciBridge>,
+        io: &'static dyn PciConfigIo,
+        seg_id: u16,
+        bus_id: u8,
+    ) -> &'static PciBus {
+        leak(PciBus {
+            associated_bridge,
+            io,
+            child_devices: Mutex::new(Vec::new()),
+            child_bridges: Mutex::new(Vec::new()),
+            seg_id,
+            bus_id,
+        })
+    }
+
+    pub fn make_downstream_bus(
+        &'static self,
+        bridge: &'static PciBridge,
+        downstream_id: u8,
+    ) -> &'static PciBus {
+        PciBus::new(Some(bridge), self.io, self.seg_id, downstream_id)
+    }
+
+    /// # Safety
+    ///
+    /// See [`config::PciConfigIo`].
+    pub unsafe fn read_config_byte(&self, slot: u8, function: u8, offset: u16) -> u8 {
+        unsafe {
+            self.io
+                .read_config_byte(self.seg_id, self.bus_id, slot, function, offset)
+        }
+        .expect(EXPECT_ACCESS)
+    }
+
+    /// # Safety
+    ///
+    /// See [`config::PciConfigIo`].
+    pub unsafe fn read_config_half(&self, slot: u8, function: u8, offset: u16) -> u16 {
+        unsafe {
+            self.io
+                .read_config_half(self.seg_id, self.bus_id, slot, function, offset)
+        }
+        .expect(EXPECT_ACCESS)
+    }
+
+    /// # Safety
+    ///
+    /// See [`config::PciConfigIo`].
+    pub unsafe fn read_config_word(&self, slot: u8, function: u8, offset: u16) -> u32 {
+        unsafe {
+            self.io
+                .read_config_word(self.seg_id, self.bus_id, slot, function, offset)
+        }
+        .expect(EXPECT_ACCESS)
+    }
+
+    /// # Safety
+    ///
+    /// See [`config::PciConfigIo`].
+    pub unsafe fn write_config_byte(&self, slot: u8, function: u8, offset: u16, value: u8) {
+        unsafe {
+            self.io
+                .write_config_byte(self.seg_id, self.bus_id, slot, function, offset, value)
+        }
+        .expect(EXPECT_ACCESS)
+    }
+
+    /// # Safety
+    ///
+    /// See [`config::PciConfigIo`].
+    pub unsafe fn write_config_half(&self, slot: u8, function: u8, offset: u16, value: u16) {
+        unsafe {
+            self.io
+                .write_config_half(self.seg_id, self.bus_id, slot, function, offset, value)
+        }
+        .expect(EXPECT_ACCESS)
+    }
+
+    /// # Safety
+    ///
+    /// See [`config::PciConfigIo`].
+    pub unsafe fn write_config_word(&self, slot: u8, function: u8, offset: u16, value: u32) {
+        unsafe {
+            self.io
+                .write_config_word(self.seg_id, self.bus_id, slot, function, offset, value)
+        }
+        .expect(EXPECT_ACCESS)
     }
 }
+
+// Accessors for registers whose side effects are known, hence they are safe.
+impl PciBus {
+    pub fn vendor(&self, slot: u8, function: u8) -> u16 {
+        unsafe { self.read_config_half(slot, function, PCI_VENDOR) }
+    }
+
+    pub fn device_id(&self, slot: u8, function: u8) -> u16 {
+        unsafe { self.read_config_half(slot, function, PCI_DEVICE) }
+    }
+
+    pub fn status(&self, slot: u8, function: u8) -> u16 {
+        unsafe { self.read_config_half(slot, function, PCI_STATUS) }
+    }
+
+    pub fn revision(&self, slot: u8, function: u8) -> u8 {
+        unsafe { self.read_config_byte(slot, function, PCI_REVISION) }
+    }
+
+    pub fn interface(&self, slot: u8, function: u8) -> u8 {
+        unsafe { self.read_config_byte(slot, function, PCI_INTERFACE) }
+    }
+
+    pub fn sub_class(&self, slot: u8, function: u8) -> u8 {
+        unsafe { self.read_config_byte(slot, function, PCI_SUB_CLASS) }
+    }
+
+    pub fn class_code(&self, slot: u8, function: u8) -> u8 {
+        unsafe { self.read_config_byte(slot, function, PCI_CLASS_CODE) }
+    }
+
+    pub fn header_type(&self, slot: u8, function: u8) -> u8 {
+        unsafe { self.read_config_byte(slot, function, PCI_HEADER_TYPE) }
+    }
+}
+
+// Accessors for registers whose existence depends on the header type, hence they are unsafe.
+impl PciBus {
+    /// # Safety
+    ///
+    /// The function must have a PCI-to-PCI bridge header.
+    pub unsafe fn secondary_bus(&self, slot: u8, function: u8) -> u8 {
+        unsafe { self.read_config_byte(slot, function, PCI_BRIDGE_SECONDARY) }
+    }
+
+    /// # Safety
+    ///
+    /// The function must have a PCI-to-PCI bridge header.
+    pub unsafe fn subordinate_bus(&self, slot: u8, function: u8) -> u8 {
+        unsafe { self.read_config_byte(slot, function, PCI_BRIDGE_SUBORDINATE) }
+    }
+
+    /// # Safety
+    ///
+    /// The function must have a regular header.
+    pub unsafe fn subsystem_vendor(&self, slot: u8, function: u8) -> u16 {
+        unsafe { self.read_config_half(slot, function, PCI_REGULAR_SUBSYSTEM_VENDOR) }
+    }
+
+    /// # Safety
+    ///
+    /// The function must have a regular header.
+    pub unsafe fn subsystem_device(&self, slot: u8, function: u8) -> u16 {
+        unsafe { self.read_config_half(slot, function, PCI_REGULAR_SUBSYSTEM_DEVICE) }
+    }
+}
+
+// Common part of devices and bridges.
+#[allow(dead_code)]
+pub struct PciEntity {
+    pub parent_bus: &'static PciBus,
+
+    // Location of the entity on the PCI bus.
+    pub seg: u16,
+    pub bus: u8,
+    pub slot: u8,
+    pub function: u8,
+
+    // vendor-specific device information
+    pub vendor: u16,
+    pub device_id: u16,
+    pub revision: u8,
+
+    // generic device information
+    pub class_code: u8,
+    pub sub_class: u8,
+    pub interface: u8,
+}
+
+impl PciEntity {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        parent_bus: &'static PciBus,
+        slot: u8,
+        function: u8,
+        vendor: u16,
+        device_id: u16,
+        revision: u8,
+        class_code: u8,
+        sub_class: u8,
+        interface: u8,
+    ) -> PciEntity {
+        PciEntity {
+            parent_bus,
+            seg: parent_bus.seg_id,
+            bus: parent_bus.bus_id,
+            slot,
+            function,
+            vendor,
+            device_id,
+            revision,
+            class_code,
+            sub_class,
+            interface,
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub struct PciBridge {
+    pub entity: PciEntity,
+
+    pub associated_bus: OnceLock<&'static PciBus>,
+    pub downstream_id: AtomicU8,
+    pub subordinate_id: AtomicU8,
+}
+
+impl PciBridge {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        parent_bus: &'static PciBus,
+        slot: u8,
+        function: u8,
+        vendor: u16,
+        device_id: u16,
+        revision: u8,
+        class_code: u8,
+        sub_class: u8,
+        interface: u8,
+    ) -> &'static PciBridge {
+        leak(PciBridge {
+            entity: PciEntity::new(
+                parent_bus, slot, function, vendor, device_id, revision, class_code, sub_class,
+                interface,
+            ),
+            associated_bus: OnceLock::new(),
+            downstream_id: AtomicU8::new(0),
+            subordinate_id: AtomicU8::new(0),
+        })
+    }
+}
+
+#[allow(dead_code)]
+pub struct PciDevice {
+    pub entity: PciEntity,
+
+    pub subsystem_vendor: u16,
+    pub subsystem_device: u16,
+}
+
+impl PciDevice {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        parent_bus: &'static PciBus,
+        slot: u8,
+        function: u8,
+        vendor: u16,
+        device_id: u16,
+        revision: u8,
+        class_code: u8,
+        sub_class: u8,
+        interface: u8,
+        subsystem_vendor: u16,
+        subsystem_device: u16,
+    ) -> &'static PciDevice {
+        leak(PciDevice {
+            entity: PciEntity::new(
+                parent_bus, slot, function, vendor, device_id, revision, class_code, sub_class,
+                interface,
+            ),
+            subsystem_vendor,
+            subsystem_device,
+        })
+    }
+}
+
+// general PCI header fields
+pub const PCI_VENDOR: u16 = 0;
+pub const PCI_DEVICE: u16 = 2;
+pub const PCI_STATUS: u16 = 6;
+pub const PCI_REVISION: u16 = 0x08;
+pub const PCI_INTERFACE: u16 = 0x09;
+pub const PCI_SUB_CLASS: u16 = 0x0A;
+pub const PCI_CLASS_CODE: u16 = 0x0B;
+pub const PCI_HEADER_TYPE: u16 = 0x0E;
+
+// usual device header fields
+pub const PCI_REGULAR_SUBSYSTEM_VENDOR: u16 = 0x2C;
+pub const PCI_REGULAR_SUBSYSTEM_DEVICE: u16 = 0x2E;
+
+// PCI-to-PCI bridge header fields
+pub const PCI_BRIDGE_SECONDARY: u16 = 0x19;
+pub const PCI_BRIDGE_SUBORDINATE: u16 = 0x1A;
 
 #[derive(Clone, Copy)]
 struct Address {
@@ -367,7 +662,7 @@ struct SifPciDevice {
     config_space_size: u32,
 }
 
-impl PciDevice for SifPciDevice {
+impl managarm::hw::server::PciDevice for SifPciDevice {
     fn bars(&self) -> [BarDescriptor; 6] {
         self.bars
     }
@@ -595,6 +890,7 @@ fn resolve_irq(addr: Address) -> Option<u32> {
 
 pub async fn publish_devices() -> Result<()> {
     acpi::discover_root_buses();
+    discover::enumerate_all();
 
     let mut entities: Vec<Publication> = Vec::new();
 

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -44,6 +44,24 @@ impl IrqIndex {
     }
 }
 
+pub fn name_of_capability(type_: u32) -> Option<&'static str> {
+    match type_ {
+        0x01 => Some("PCI Power Management Interface"),
+        0x02 => Some("AGP"),
+        0x03 => Some("VPD"),
+        0x04 => Some("Slot-identification"),
+        0x05 => Some("MSI"),
+        0x09 => Some("Vendor-specific"),
+        0x0A => Some("Debug-port"),
+        0x0C => Some("PCI Hot Plug"),
+        0x0D => Some("PCI Bridge Subsystem ID"),
+        0x10 => Some("PCIe"),
+        0x11 => Some("MSI-X"),
+        0x12 => Some("Serial ATA DATA/Index Configuration"),
+        _ => None,
+    }
+}
+
 pub struct PciBus {
     #[allow(dead_code)]
     pub associated_bridge: Option<&'static PciBridge>,
@@ -181,6 +199,10 @@ impl PciBus {
     pub fn header_type(&self, slot: u8, function: u8) -> u8 {
         unsafe { self.read_config_byte(slot, function, PCI_HEADER_TYPE) }
     }
+
+    pub fn capabilities_pointer(&self, slot: u8, function: u8) -> u8 {
+        unsafe { self.read_config_byte(slot, function, PCI_REGULAR_CAPABILITIES) }
+    }
 }
 
 // Accessors for registers whose existence depends on the header type, hence they are unsafe.
@@ -214,6 +236,13 @@ impl PciBus {
     }
 }
 
+#[allow(dead_code)]
+pub struct Capability {
+    pub type_: u32,
+    pub offset: u16,
+    pub length: Option<u64>,
+}
+
 // Common part of devices and bridges.
 #[allow(dead_code)]
 pub struct PciEntity {
@@ -234,6 +263,8 @@ pub struct PciEntity {
     pub class_code: u8,
     pub sub_class: u8,
     pub interface: u8,
+
+    pub caps: Mutex<Vec<Capability>>,
 }
 
 impl PciEntity {
@@ -261,6 +292,7 @@ impl PciEntity {
             class_code,
             sub_class,
             interface,
+            caps: Mutex::new(Vec::new()),
         }
     }
 }
@@ -346,6 +378,7 @@ pub const PCI_HEADER_TYPE: u16 = 0x0E;
 // usual device header fields
 pub const PCI_REGULAR_SUBSYSTEM_VENDOR: u16 = 0x2C;
 pub const PCI_REGULAR_SUBSYSTEM_DEVICE: u16 = 0x2E;
+pub const PCI_REGULAR_CAPABILITIES: u16 = 0x34;
 
 // PCI-to-PCI bridge header fields
 pub const PCI_BRIDGE_SECONDARY: u16 = 0x19;

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -1,18 +1,15 @@
+pub mod acpi;
 pub mod config;
 
 use std::collections::HashMap;
-use std::ffi::c_void;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 
 use anyhow::Result;
-use hel::{IrqPolarity, IrqTrigger};
 use managarm::hw::pci::IoType;
 use managarm::hw::server::{BarDescriptor, CapDescriptor, PciDevice, serve_pci_device};
 use managarm::mbus::{EntityManager, Item, Properties, create_entity};
-
-use uacpi_sys::{uacpi_iteration_decision, uacpi_namespace_node, uacpi_u32, uacpi_u64};
 
 #[derive(Clone, Copy)]
 struct Address {
@@ -479,7 +476,7 @@ fn scan_bus<'a>(
     seg: u16,
     bus: u8,
     parent_id: i64,
-    routes: &'a Routes,
+    routes: &'a acpi::Routes,
     out: &'a mut Vec<Publication>,
 ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
     Box::pin(async move {
@@ -544,156 +541,7 @@ fn scan_bus<'a>(
     })
 }
 
-#[derive(Clone, Copy)]
-struct RootBus {
-    seg: u16,
-    bus: u8,
-    node: *mut uacpi_namespace_node,
-}
-
-type Routes = HashMap<(u16, u8, u8), u32>;
-
-unsafe extern "C" fn root_bus_callback(
-    user: *mut c_void,
-    node: *mut uacpi_namespace_node,
-    _depth: uacpi_u32,
-) -> uacpi_iteration_decision {
-    let roots = unsafe { &mut *(user as *mut Vec<RootBus>) };
-
-    let mut segment: uacpi_u64 = 0;
-    unsafe { uacpi_sys::uacpi_eval_simple_integer(node, c"_SEG".as_ptr(), &mut segment) };
-    let mut base_bus: uacpi_u64 = 0;
-    unsafe { uacpi_sys::uacpi_eval_simple_integer(node, c"_BBN".as_ptr(), &mut base_bus) };
-
-    roots.push(RootBus {
-        seg: segment as u16,
-        bus: base_bus as u8,
-        node,
-    });
-    uacpi_sys::UACPI_ITERATION_DECISION_NEXT_PEER
-}
-
-fn find_root_buses() -> Vec<RootBus> {
-    let mut roots: Vec<RootBus> = Vec::new();
-    let user = &mut roots as *mut _ as *mut c_void;
-    unsafe {
-        uacpi_sys::uacpi_find_devices(c"PNP0A03".as_ptr(), Some(root_bus_callback), user);
-        uacpi_sys::uacpi_find_devices(c"PNP0A08".as_ptr(), Some(root_bus_callback), user);
-    }
-    roots.sort_by_key(|root| (root.seg, root.bus));
-    roots.dedup_by_key(|root| (root.seg, root.bus));
-    if roots.is_empty() {
-        roots.push(RootBus {
-            seg: 0,
-            bus: 0,
-            node: std::ptr::null_mut(),
-        });
-    }
-    roots
-}
-
-fn resolve_link(
-    source: *mut uacpi_namespace_node,
-    index: u32,
-) -> Option<(u32, IrqTrigger, IrqPolarity)> {
-    let mut raw_resources: *mut uacpi_sys::uacpi_resources = std::ptr::null_mut();
-    let status = unsafe { uacpi_sys::uacpi_get_current_resources(source, &raw mut raw_resources) };
-    if status != uacpi_sys::UACPI_STATUS_OK || raw_resources.is_null() {
-        return None;
-    }
-
-    let resources =
-        unsafe { std::slice::from_raw_parts((*raw_resources).entries, (*raw_resources).length) };
-
-    let mut route = None;
-
-    for cur in resources.iter() {
-        let ty = cur.type_;
-        if ty == uacpi_sys::UACPI_RESOURCE_TYPE_END_TAG as u32 {
-            break;
-        }
-        if ty == uacpi_sys::UACPI_RESOURCE_TYPE_IRQ as u32 {
-            let irq = unsafe { (*cur).__bindgen_anon_1.irq.as_ref() };
-            if (index as usize) < irq.num_irqs as usize {
-                let gsi = unsafe { *irq.irqs.as_ptr().add(index as usize) } as u32;
-                route = Some((gsi, trigger_of(irq.triggering), polarity_of(irq.polarity)));
-            }
-            break;
-        }
-        if ty == uacpi_sys::UACPI_RESOURCE_TYPE_EXTENDED_IRQ as u32 {
-            let irq = unsafe { (*cur).__bindgen_anon_1.extended_irq.as_ref() };
-            if (index as usize) < irq.num_irqs as usize {
-                let gsi = unsafe { *irq.irqs.as_ptr().add(index as usize) };
-                route = Some((gsi, trigger_of(irq.triggering), polarity_of(irq.polarity)));
-            }
-            break;
-        }
-        let len = cur.length as usize;
-        if len == 0 {
-            break;
-        }
-    }
-
-    unsafe { uacpi_sys::uacpi_free_resources(raw_resources) };
-    route
-}
-
-fn trigger_of(triggering: u8) -> IrqTrigger {
-    if triggering as u32 == uacpi_sys::UACPI_TRIGGERING_EDGE {
-        IrqTrigger::Edge
-    } else {
-        IrqTrigger::Level
-    }
-}
-
-fn polarity_of(polarity: u8) -> IrqPolarity {
-    if polarity as u32 == uacpi_sys::UACPI_POLARITY_ACTIVE_HIGH {
-        IrqPolarity::High
-    } else {
-        IrqPolarity::Low
-    }
-}
-
-fn build_routes(roots: &[RootBus]) -> Routes {
-    let mut routes = Routes::new();
-    for root in roots {
-        if root.node.is_null() {
-            continue;
-        }
-
-        let mut table: *mut uacpi_sys::uacpi_pci_routing_table = std::ptr::null_mut();
-        let status = unsafe { uacpi_sys::uacpi_get_pci_routing_table(root.node, &mut table) };
-        if status != uacpi_sys::UACPI_STATUS_OK || table.is_null() {
-            continue;
-        }
-
-        let num_entries = unsafe { (*table).num_entries };
-        let entries = unsafe { (*table).entries.as_ptr() };
-        for i in 0..num_entries {
-            let entry = unsafe { &*entries.add(i) };
-            let slot = (entry.address >> 16) as u8;
-            let (gsi, trigger, polarity) = if entry.source.is_null() {
-                (entry.index, IrqTrigger::Level, IrqPolarity::Low)
-            } else {
-                match resolve_link(entry.source, entry.index) {
-                    Some(route) => route,
-                    None => continue,
-                }
-            };
-
-            if let Err(err) = hel::configure_irq(gsi as i32, trigger, polarity) {
-                println!("sif: Failed to configure GSI {gsi}: {err}");
-                continue;
-            }
-            routes.insert((root.seg, slot, entry.pin), gsi);
-        }
-
-        unsafe { uacpi_sys::uacpi_free_pci_routing_table(table) };
-    }
-    routes
-}
-
-fn resolve_irq(addr: Address, routes: &Routes) -> Option<u32> {
+fn resolve_irq(addr: Address, routes: &acpi::Routes) -> Option<u32> {
     let pin = addr.interrupt_pin();
     if pin == 0 || pin > 4 {
         return None;
@@ -702,8 +550,8 @@ fn resolve_irq(addr: Address, routes: &Routes) -> Option<u32> {
 }
 
 pub async fn publish_devices() -> Result<()> {
-    let roots = find_root_buses();
-    let routes = build_routes(&roots);
+    let roots = acpi::find_root_buses();
+    let routes = acpi::build_routes(&roots);
     println!("sif: Resolved {} PCI interrupt routes", routes.len());
 
     let mut entities: Vec<Publication> = Vec::new();

--- a/sif/src/pci/serve.rs
+++ b/sif/src/pci/serve.rs
@@ -1,0 +1,292 @@
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::atomic::Ordering;
+
+use anyhow::Result;
+use managarm::hw::pci::IoType;
+use managarm::hw::server::{BarDescriptor, CapDescriptor, serve_pci_device};
+use managarm::mbus::{EntityManager, Item, Properties, create_entity};
+
+use super::discover::{all_devices, all_root_buses};
+use super::{BarType, EXPECT_LOCK, PciBridge, PciBus, PciDevice, PciEntity, leak};
+
+use crate::acpi::{PAGE_MASK, PAGE_SIZE};
+
+fn string(value: &str) -> Item {
+    Item::String(value.to_string())
+}
+
+fn hex(value: u32, width: usize) -> Item {
+    Item::String(format!("{value:0width$x}"))
+}
+
+fn decimal(value: i64) -> Item {
+    Item::String(format!("{value}"))
+}
+
+#[derive(Clone, Copy)]
+enum ServedEntity {
+    Device(&'static PciDevice),
+    Bridge(&'static PciBridge),
+}
+
+impl ServedEntity {
+    fn entity(&self) -> &'static PciEntity {
+        match self {
+            ServedEntity::Device(device) => &device.entity,
+            ServedEntity::Bridge(bridge) => &bridge.entity,
+        }
+    }
+}
+
+fn io_type_of(type_: BarType) -> IoType {
+    match type_ {
+        BarType::None => IoType::None,
+        BarType::Io => IoType::Port,
+        BarType::Memory => IoType::Memory,
+    }
+}
+
+impl managarm::hw::server::PciDevice for ServedEntity {
+    fn bars(&self) -> [BarDescriptor; 6] {
+        let mut out = [BarDescriptor::default(); 6];
+        for (i, bar) in self
+            .entity()
+            .bars
+            .lock()
+            .expect(EXPECT_LOCK)
+            .iter()
+            .enumerate()
+        {
+            out[i] = BarDescriptor {
+                io_type: io_type_of(bar.type_),
+                host_type: io_type_of(bar.host_type),
+                address: bar.address,
+                length: bar.length,
+                offset: bar.offset,
+            };
+        }
+        out
+    }
+
+    fn capabilities(&self) -> Vec<CapDescriptor> {
+        self.entity()
+            .caps
+            .lock()
+            .expect(EXPECT_LOCK)
+            .iter()
+            .map(|cap| CapDescriptor {
+                type_: cap.type_,
+                offset: cap.offset as u64,
+                length: cap.length.unwrap_or(!0),
+            })
+            .collect()
+    }
+
+    fn config_read(&self, offset: u32, size: u32) -> Option<u32> {
+        let entity = self.entity();
+        let bus = entity.parent_bus;
+
+        if offset as usize + size as usize > 0x1000 {
+            return None;
+        }
+
+        let offset = offset as u16;
+        // The protocol hands out raw config space access; the client is responsible for it.
+        Some(match size {
+            1 => (unsafe { bus.read_config_byte(entity.slot, entity.function, offset) }) as u32,
+            2 => (unsafe { bus.read_config_half(entity.slot, entity.function, offset) }) as u32,
+            4 => unsafe { bus.read_config_word(entity.slot, entity.function, offset) },
+            _ => 0xFFFFFFFF,
+        })
+    }
+
+    fn config_write(&self, offset: u32, size: u32, word: u32) -> bool {
+        let entity = self.entity();
+        let bus = entity.parent_bus;
+
+        if offset as usize + size as usize > 0x1000 {
+            return false;
+        }
+
+        let offset = offset as u16;
+        // The protocol hands out raw config space access; the client is responsible for it.
+        match size {
+            1 => unsafe { bus.write_config_byte(entity.slot, entity.function, offset, word as u8) },
+            2 => unsafe {
+                bus.write_config_half(entity.slot, entity.function, offset, word as u16)
+            },
+            4 => unsafe { bus.write_config_word(entity.slot, entity.function, offset, word) },
+            _ => {}
+        }
+        true
+    }
+
+    fn capability_read(&self, index: i32, offset: u32, size: u32) -> Option<u32> {
+        let cap_offset = {
+            let caps = self.entity().caps.lock().expect(EXPECT_LOCK);
+            caps.get(usize::try_from(index).ok()?)?.offset
+        };
+        self.config_read(cap_offset as u32 + offset, size)
+    }
+
+    fn access_bar(&self, index: usize) -> hel::Result<hel::Handle> {
+        let bars = self.entity().bars.lock().expect(EXPECT_LOCK);
+        let bar = bars.get(index).ok_or(hel::Error::IllegalArgs)?;
+        match bar.host_type {
+            BarType::Memory => {
+                let aligned = (bar.host_address as usize) & !PAGE_MASK;
+                let page_off = (bar.host_address as usize) & PAGE_MASK;
+                let span = ((bar.length as usize) + page_off + PAGE_MASK) & !PAGE_MASK;
+                hel::access_physical(aligned, span.max(PAGE_SIZE), hel::CachingMode::Mmio)
+            }
+            BarType::Io => {
+                let ports: Vec<usize> = (bar.address..bar.address + bar.length)
+                    .map(|p| p as usize)
+                    .collect();
+                hel::access_io(&ports)
+            }
+            BarType::None => Err(hel::Error::IllegalArgs),
+        }
+    }
+
+    fn access_irq(&self, index: u64) -> hel::Result<Option<hel::Handle>> {
+        let ServedEntity::Device(device) = self else {
+            return Ok(None);
+        };
+        if index != 0 {
+            return Ok(None);
+        }
+        match device.interrupt.get() {
+            Some(&gsi) => Ok(Some(hel::access_irq(gsi as i32)?)),
+            None => Ok(None),
+        }
+    }
+
+    fn enable_busmaster(&self) {
+        self.entity().enable_busmaster();
+    }
+
+    fn enable_irq(&self) {
+        if let ServedEntity::Device(device) = self {
+            device.enable_irq();
+        }
+    }
+}
+
+async fn serve_entity(manager: &'static EntityManager, served: ServedEntity) {
+    let id = manager.id();
+    let device = Rc::new(served);
+
+    loop {
+        let (local, remote) = match hel::create_stream() {
+            Ok(pair) => pair,
+            Err(err) => {
+                println!("sif: entity {id}: create_stream failed: {err}");
+                return;
+            }
+        };
+        if let Err(err) = manager.serve_remote_lane(remote).await {
+            println!("sif: entity {id}: serve_remote_lane failed: {err}");
+            return;
+        }
+        hel::spawn(serve_pci_device(local, device.clone()));
+    }
+}
+
+fn entity_properties(entity: &PciEntity, pci_type: &str) -> Properties {
+    let mut props = HashMap::new();
+    props.insert("unix.subsystem".into(), string("pci"));
+    props.insert("pci-type".into(), string(pci_type));
+    props.insert("pci-segment".into(), hex(entity.seg as u32, 4));
+    props.insert("pci-bus".into(), hex(entity.bus as u32, 2));
+    props.insert("pci-slot".into(), hex(entity.slot as u32, 2));
+    props.insert("pci-function".into(), hex(entity.function as u32, 1));
+    props.insert("pci-vendor".into(), hex(entity.vendor as u32, 4));
+    props.insert("pci-device".into(), hex(entity.device_id as u32, 4));
+    props.insert("pci-revision".into(), hex(entity.revision as u32, 2));
+    props.insert("pci-class".into(), hex(entity.class_code as u32, 2));
+    props.insert("pci-subclass".into(), hex(entity.sub_class as u32, 2));
+    props.insert("pci-interface".into(), hex(entity.interface as u32, 2));
+
+    let parent = entity
+        .parent_bus
+        .associated_bridge
+        .map(|bridge| bridge.entity.mbus_id.load(Ordering::Relaxed))
+        .unwrap_or(entity.parent_bus.mbus_id.load(Ordering::Relaxed));
+    props.insert("drvcore.mbus-parent".into(), decimal(parent));
+
+    props
+}
+
+async fn publish_entity(served: ServedEntity, pci_type: &str) -> Result<()> {
+    let entity = served.entity();
+
+    let mut props = entity_properties(entity, pci_type);
+    if let ServedEntity::Device(device) = served {
+        props.insert(
+            "pci-subsystem-vendor".into(),
+            hex(device.subsystem_vendor as u32, 2),
+        );
+        props.insert(
+            "pci-subsystem-device".into(),
+            hex(device.subsystem_device as u32, 2),
+        );
+    }
+
+    println!(
+        "sif: pci: {:04x}:{:02x}:{:02x}.{} {} vendor: {:04x} device: {:04x}",
+        entity.seg,
+        entity.bus,
+        entity.slot,
+        entity.function,
+        pci_type,
+        entity.vendor,
+        entity.device_id,
+    );
+
+    let manager: &'static EntityManager = leak(create_entity(pci_type, &props).await?);
+    entity.mbus_id.store(manager.id(), Ordering::Relaxed);
+    hel::spawn(serve_entity(manager, served));
+
+    Ok(())
+}
+
+fn bridges_in_publish_order(bus: &'static PciBus, out: &mut Vec<&'static PciBridge>) {
+    for bridge in bus.child_bridges.lock().expect(EXPECT_LOCK).iter() {
+        out.push(bridge);
+        if let Some(&downstream) = bridge.associated_bus.get() {
+            bridges_in_publish_order(downstream, out);
+        }
+    }
+}
+
+pub async fn publish_all() -> Result<()> {
+    for root_bus in all_root_buses() {
+        let mut props: Properties = HashMap::new();
+        props.insert("unix.subsystem".into(), string("pci"));
+        props.insert("pci-type".into(), string("pci-root-bus"));
+        props.insert("pci-segment".into(), hex(root_bus.seg_id as u32, 4));
+        props.insert("pci-bus".into(), hex(root_bus.bus_id as u32, 2));
+
+        println!(
+            "sif: PCI root bus {:04x}:{:02x}",
+            root_bus.seg_id, root_bus.bus_id
+        );
+        let manager: &'static EntityManager = leak(create_entity("pci-root-bus", &props).await?);
+        root_bus.mbus_id.store(manager.id(), Ordering::Relaxed);
+
+        // Publish bridges in pre-order so that every bridge finds its parent's mbus ID set.
+        let mut bridges = Vec::new();
+        bridges_in_publish_order(root_bus, &mut bridges);
+        for bridge in bridges {
+            publish_entity(ServedEntity::Bridge(bridge), "pci-bridge").await?;
+        }
+    }
+
+    for device in all_devices() {
+        publish_entity(ServedEntity::Device(device), "pci-device").await?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This ports the `PciBus` / `PciEntity` / `PciBridge` / `PciDevice` structs over to sif such that sif stores the full PCI hierarchy including bus <-> bridge relations etc.