### PR TITLE
protocols/fs: Fix missing reset after recvInline() on client side

### DIFF
--- a/drivers/libevbackend/src/libevbackend.cpp
+++ b/drivers/libevbackend/src/libevbackend.cpp
@@ -69,6 +69,9 @@ async::detached issueReset() {
 	auto preamble = bragi::read_preamble(hwResp);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(hwResp);
+	hwResp.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -77,8 +80,9 @@ async::detached issueReset() {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(hwResp, tailBuffer);
-	hwResp.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 	throw std::runtime_error("Return from PM_RESET request");

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -581,11 +581,16 @@ private:
 
 		auto preamble = bragi::read_preamble(recv_resp);
 		if (preamble.error()) {
+			recv_resp.reset();
 			std::cout << "posix: error decoding preamble" << std::endl;
 			auto [dismiss] = co_await helix_ng::exchangeMsgs(
 				conversation, helix_ng::dismiss());
 			HEL_CHECK(dismiss.error());
+			co_return Error::ioError;
 		}
+
+		auto resp = *bragi::parse_head_only<managarm::fs::NodeTraverseLinksResponse>(recv_resp);
+		recv_resp.reset();
 
 		std::vector<uint8_t> tail(preamble.tail_size());
 		auto [recv_tail, pull_desc] = co_await helix_ng::exchangeMsgs(
@@ -596,8 +601,11 @@ private:
 		);
 		HEL_CHECK(recv_tail.error());
 
-		auto resp = *bragi::parse_head_tail<managarm::fs::NodeTraverseLinksResponse>(recv_resp, tail);
-		recv_resp.reset();
+		bragi::limited_reader reader{tail.data(), tail.size()};
+		if(!resp.decode_tail(reader)) {
+			std::cout << "posix: error decoding tail" << std::endl;
+			co_return Error::ioError;
+		}
 
 		if(resp.error() != managarm::fs::Errors::SUCCESS)
 			co_return resp.error() | toPosixError;

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -123,11 +123,16 @@ async::result<void> populateRootView() {
 
 			auto preamble = bragi::read_preamble(recv_resp);
 			if (preamble.error()) {
+				recv_resp.reset();
 				std::cout << "posix: error decoding preamble" << std::endl;
 				auto [dismiss] = co_await helix_ng::exchangeMsgs(
 					conversation, helix_ng::dismiss());
 				HEL_CHECK(dismiss.error());
+				break;
 			}
+
+			auto resp = *bragi::parse_head_only<managarm::fs::ReadEntriesResponse>(recv_resp);
+			recv_resp.reset();
 
 			std::vector<uint8_t> tail(preamble.tail_size());
 			auto [recv_tail] = co_await helix_ng::exchangeMsgs(
@@ -136,8 +141,9 @@ async::result<void> populateRootView() {
 			);
 			HEL_CHECK(recv_tail.error());
 
-			auto resp = *bragi::parse_head_tail<managarm::fs::ReadEntriesResponse>(recv_resp, tail);
-			recv_resp.reset();
+			bragi::limited_reader reader{tail.data(), tail.size()};
+			auto ok = resp.decode_tail(reader);
+			assert(ok);
 
 			if(resp.error() == managarm::fs::Errors::END_OF_FILE)
 				break;

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -1,6 +1,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <unistd.h>
 #include <iostream>
 #include <print>
@@ -337,12 +338,28 @@ struct HandleFileRequest {
 			HEL_CHECK(send_resp.error());
 			logBragiSerializedReply(ser);
 		}else if(req.req_type() == managarm::fs::CntReqType::PT_BIND) {
+			struct sockaddr_storage addr_buf = {};
 			auto [extract_creds, recv_addr] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::extractCredentials(),
-				helix_ng::recvInline()
+				helix_ng::recvBuffer(&addr_buf, sizeof(addr_buf))
 			);
 			HEL_CHECK(extract_creds.error());
+
+			// The address length is picked by the client, hence do not trust it.
+			if(recv_addr.error() == kHelErrBufferTooSmall) {
+				managarm::fs::SvrResponse resp;
+				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size())
+				);
+				HEL_CHECK(send_resp.error());
+				logBragiSerializedReply(ser);
+				co_return {};
+			}
 			HEL_CHECK(recv_addr.error());
 
 			if(!file_ops->bind) {
@@ -361,8 +378,7 @@ struct HandleFileRequest {
 
 			auto error = co_await file_ops->bind(file.get(),
 				extract_creds.credentials(),
-				recv_addr.data(), recv_addr.length());
-			recv_addr.reset();
+				&addr_buf, recv_addr.actualLength());
 
 			managarm::fs::SvrResponse resp;
 			resp.set_error(error | toFsError);
@@ -375,12 +391,28 @@ struct HandleFileRequest {
 			HEL_CHECK(send_resp.error());
 			logBragiSerializedReply(ser);
 		}else if(req.req_type() == managarm::fs::CntReqType::PT_CONNECT) {
+			struct sockaddr_storage addr_buf = {};
 			auto [extract_creds, recv_addr] = co_await helix_ng::exchangeMsgs(
 				conversation,
 				helix_ng::extractCredentials(),
-				helix_ng::recvInline()
+				helix_ng::recvBuffer(&addr_buf, sizeof(addr_buf))
 			);
 			HEL_CHECK(extract_creds.error());
+
+			// The address length is picked by the client, hence do not trust it.
+			if(recv_addr.error() == kHelErrBufferTooSmall) {
+				managarm::fs::SvrResponse resp;
+				resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+
+				auto ser = resp.SerializeAsString();
+				auto [send_resp] = co_await helix_ng::exchangeMsgs(
+					conversation,
+					helix_ng::sendBuffer(ser.data(), ser.size())
+				);
+				HEL_CHECK(send_resp.error());
+				logBragiSerializedReply(ser);
+				co_return {};
+			}
 			HEL_CHECK(recv_addr.error());
 
 			if(!file_ops->connect) {
@@ -399,8 +431,7 @@ struct HandleFileRequest {
 
 			auto error = co_await file_ops->connect(file.get(),
 				extract_creds.credentials(),
-				recv_addr.data(), recv_addr.length());
-			recv_addr.reset();
+				&addr_buf, recv_addr.actualLength());
 
 			managarm::fs::SvrResponse resp;
 			resp.set_error(error | toFsError);
@@ -740,14 +771,29 @@ struct HandleFileRequest {
 		std::vector<uint8_t> buffer;
 		buffer.resize(req.size());
 
+		struct sockaddr_storage addr_buf = {};
 		auto [recv_data, extract_creds, recv_addr] = co_await helix_ng::exchangeMsgs(
 			conversation,
 			helix_ng::recvBuffer(buffer.data(), buffer.size()),
 			helix_ng::extractCredentials(),
-			helix_ng::recvInline()
+			helix_ng::recvBuffer(&addr_buf, sizeof(addr_buf))
 		);
 		HEL_CHECK(recv_data.error());
 		HEL_CHECK(extract_creds.error());
+
+		// The address length is picked by the client, hence do not trust it.
+		if(recv_addr.error() == kHelErrBufferTooSmall) {
+			managarm::fs::SendMsgReply resp;
+			resp.set_error(managarm::fs::Errors::ILLEGAL_ARGUMENT);
+
+			auto ser = resp.SerializeAsString();
+			auto [send_resp] = co_await helix_ng::exchangeMsgs(
+				conversation,
+				helix_ng::sendBuffer(ser.data(), ser.size())
+			);
+			HEL_CHECK(send_resp.error());
+			co_return {};
+		}
 		HEL_CHECK(recv_addr.error());
 
 		if(!file_ops->sendMsg) {
@@ -778,9 +824,8 @@ struct HandleFileRequest {
 		auto res = co_await file_ops->sendMsg(file.get(),
 			extract_creds.credentials(), req.flags(),
 			buffer.data(), recv_data.actualLength(),
-			recv_addr.data(), recv_addr.length(),
+			&addr_buf, recv_addr.actualLength(),
 			std::move(files), ucreds);
-		recv_addr.reset();
 
 		managarm::fs::SendMsgReply resp;
 

--- a/protocols/hw/src/client.cpp
+++ b/protocols/hw/src/client.cpp
@@ -32,6 +32,9 @@ async::result<PciInfo> Device::getPciInfo() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -40,8 +43,9 @@ async::result<PciInfo> Device::getPciInfo() {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -112,6 +116,9 @@ async::result<helix::UniqueDescriptor> Device::accessBar(int index) {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail, pull_bar] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -122,8 +129,9 @@ async::result<helix::UniqueDescriptor> Device::accessBar(int index) {
 	HEL_CHECK(recv_tail.error());
 	HEL_CHECK(pull_bar.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -150,6 +158,9 @@ async::result<helix::UniqueDescriptor> Device::accessExpansionRom() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail, pull_bar] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -160,8 +171,9 @@ async::result<helix::UniqueDescriptor> Device::accessExpansionRom() {
 	HEL_CHECK(recv_tail.error());
 	HEL_CHECK(pull_bar.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -189,6 +201,9 @@ async::result<helix::UniqueDescriptor> Device::accessIrq(size_t index) {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail, pull_irq] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -199,8 +214,9 @@ async::result<helix::UniqueDescriptor> Device::accessIrq(size_t index) {
 	HEL_CHECK(recv_tail.error());
 	HEL_CHECK(pull_irq.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -227,6 +243,9 @@ async::result<helix::UniqueDescriptor> Device::installMsi(int index) {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail, pull_msi] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -237,8 +256,9 @@ async::result<helix::UniqueDescriptor> Device::installMsi(int index) {
 	HEL_CHECK(recv_tail.error());
 	HEL_CHECK(pull_msi.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -264,6 +284,9 @@ async::result<void> Device::claimDevice() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -272,8 +295,9 @@ async::result<void> Device::claimDevice() {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 }
@@ -297,6 +321,9 @@ async::result<void> Device::enableBusIrq() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -305,8 +332,9 @@ async::result<void> Device::enableBusIrq() {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 }
@@ -330,6 +358,9 @@ async::result<void> Device::enableMsi() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -338,8 +369,9 @@ async::result<void> Device::enableMsi() {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 }
@@ -363,6 +395,9 @@ async::result<void> Device::enableBusmaster() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -371,8 +406,9 @@ async::result<void> Device::enableBusmaster() {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 }
@@ -398,6 +434,9 @@ async::result<uint32_t> Device::loadPciSpace(size_t offset, unsigned int size) {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -406,8 +445,9 @@ async::result<uint32_t> Device::loadPciSpace(size_t offset, unsigned int size) {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -436,6 +476,9 @@ async::result<void> Device::storePciSpace(size_t offset, unsigned int size, uint
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -444,8 +487,9 @@ async::result<void> Device::storePciSpace(size_t offset, unsigned int size, uint
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 }
@@ -472,6 +516,9 @@ async::result<uint32_t> Device::loadPciCapability(unsigned int index, size_t off
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -480,8 +527,9 @@ async::result<uint32_t> Device::loadPciCapability(unsigned int index, size_t off
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -507,6 +555,9 @@ async::result<FbInfo> Device::getFbInfo() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -515,8 +566,9 @@ async::result<FbInfo> Device::getFbInfo() {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -550,6 +602,9 @@ async::result<helix::UniqueDescriptor> Device::accessFbMemory() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail, pull_bar] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -560,8 +615,9 @@ async::result<helix::UniqueDescriptor> Device::accessFbMemory() {
 	HEL_CHECK(recv_tail.error());
 	HEL_CHECK(pull_bar.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -589,6 +645,9 @@ async::result<void> Device::getBatteryState(BatteryState &state, bool block) {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::BatteryStateReply>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 		offer.descriptor(),
@@ -597,8 +656,9 @@ async::result<void> Device::getBatteryState(BatteryState &state, bool block) {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::BatteryStateReply>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -640,6 +700,9 @@ async::result<std::shared_ptr<AcpiResources>> Device::getResources() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::AcpiGetResourcesReply>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 		offer.descriptor(),
@@ -648,8 +711,9 @@ async::result<std::shared_ptr<AcpiResources>> Device::getResources() {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::AcpiGetResourcesReply>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 	auto res = std::make_shared<AcpiResources>();
@@ -678,6 +742,9 @@ async::result<DtInfo> Device::getDtInfo() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -686,8 +753,9 @@ async::result<DtInfo> Device::getDtInfo() {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -726,6 +794,9 @@ async::result<std::string> Device::getDtPath() {
 	auto preamble = bragi::read_preamble(recvHead);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::GetDtPathResponse>(recvHead);
+	recvHead.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recvTail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -734,8 +805,9 @@ async::result<std::string> Device::getDtPath() {
 
 	HEL_CHECK(recvTail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::GetDtPathResponse>(recvHead, tailBuffer);
-	recvHead.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 	co_return resp.path();
@@ -761,6 +833,9 @@ async::result<std::optional<DtProperty>> Device::getDtProperty(std::string_view 
 	auto preamble = bragi::read_preamble(recvHead);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::GetDtPropertyResponse>(recvHead);
+	recvHead.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recvTail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -769,8 +844,9 @@ async::result<std::optional<DtProperty>> Device::getDtProperty(std::string_view 
 
 	HEL_CHECK(recvTail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::GetDtPropertyResponse>(recvHead, tailBuffer);
-	recvHead.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	if (resp.error() == managarm::hw::Errors::SUCCESS)
 		co_return DtProperty{std::move(resp.data())};
@@ -799,6 +875,9 @@ async::result<std::vector<std::pair<std::string, DtProperty>>> Device::getDtProp
 	auto preamble = bragi::read_preamble(recvHead);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::GetDtPropertiesResponse>(recvHead);
+	recvHead.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recvTail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -807,8 +886,9 @@ async::result<std::vector<std::pair<std::string, DtProperty>>> Device::getDtProp
 
 	HEL_CHECK(recvTail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::GetDtPropertiesResponse>(recvHead, tailBuffer);
-	recvHead.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -842,6 +922,9 @@ async::result<helix::UniqueDescriptor> Device::accessDtRegister(uint32_t index) 
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail, pull_reg] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -852,8 +935,9 @@ async::result<helix::UniqueDescriptor> Device::accessDtRegister(uint32_t index) 
 	HEL_CHECK(recv_tail.error());
 	HEL_CHECK(pull_reg.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -881,6 +965,9 @@ async::result<helix::UniqueDescriptor> Device::installDtIrq(uint32_t index) {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail, pull_irq] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -891,8 +978,9 @@ async::result<helix::UniqueDescriptor> Device::installDtIrq(uint32_t index) {
 	HEL_CHECK(recv_tail.error());
 	HEL_CHECK(pull_irq.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 
@@ -920,6 +1008,9 @@ async::result<void> Device::enableDma(bool passthrough) {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -928,8 +1019,9 @@ async::result<void> Device::enableDma(bool passthrough) {
 
 	HEL_CHECK(recv_tail.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 }
 
 async::result<std::vector<uint8_t>> Device::getSmbiosHeader() {
@@ -949,6 +1041,7 @@ async::result<std::vector<uint8_t>> Device::getSmbiosHeader() {
 	HEL_CHECK(recv_head.error());
 
 	auto resp = *bragi::parse_head_only<managarm::hw::GetSmbiosHeaderReply>(recv_head);
+	recv_head.reset();
 
 	std::vector<uint8_t> smbiosHeader(resp.size());
 	auto [recv_data] = co_await helix_ng::exchangeMsgs(
@@ -977,6 +1070,7 @@ async::result<std::vector<uint8_t>> Device::getSmbiosTable() {
 	HEL_CHECK(recv_head.error());
 
 	auto resp = *bragi::parse_head_only<managarm::hw::GetSmbiosTableReply>(recv_head);
+	recv_head.reset();
 
 	std::vector<uint8_t> smbiosTable(resp.size());
 	auto [recv_data] = co_await helix_ng::exchangeMsgs(
@@ -1007,6 +1101,9 @@ async::result<std::pair<helix::UniqueDescriptor, uint32_t>> Device::getVbt() {
 	auto preamble = bragi::read_preamble(recv_head);
 	assert(!preamble.error());
 
+	auto resp = *bragi::parse_head_only<managarm::hw::SvrResponse>(recv_head);
+	recv_head.reset();
+
 	std::vector<std::byte> tailBuffer(preamble.tail_size());
 	auto [recv_tail, pull_desc] = co_await helix_ng::exchangeMsgs(
 			offer.descriptor(),
@@ -1017,8 +1114,9 @@ async::result<std::pair<helix::UniqueDescriptor, uint32_t>> Device::getVbt() {
 	HEL_CHECK(recv_tail.error());
 	HEL_CHECK(pull_desc.error());
 
-	auto resp = *bragi::parse_head_tail<managarm::hw::SvrResponse>(recv_head, tailBuffer);
-	recv_head.reset();
+	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
+	auto ok = resp.decode_tail(reader);
+	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
 

--- a/protocols/mbus/src/client_ng.cpp
+++ b/protocols/mbus/src/client_ng.cpp
@@ -158,6 +158,13 @@ async::result<Result<Properties>> Entity::getProperties() const {
 	if (preamble.error() || preamble.id() != bragi::message_id<managarm::mbus::GetPropertiesResponse>)
 		co_return Error::protocolViolation;
 
+	auto maybeResp = bragi::parse_head_only<managarm::mbus::GetPropertiesResponse>(recvHead);
+	recvHead.reset();
+	if (!maybeResp)
+		co_return Error::protocolViolation;
+
+	auto &resp = *maybeResp;
+
 	std::vector<std::byte> tail(preamble.tail_size());
 	auto [recvTail] =
 		co_await helix_ng::exchangeMsgs(
@@ -166,12 +173,9 @@ async::result<Result<Properties>> Entity::getProperties() const {
 		);
 	HEL_CHECK(recvTail.error());
 
-	auto maybeResp = bragi::parse_head_tail<managarm::mbus::GetPropertiesResponse>(recvHead, tail);
-	recvHead.reset();
-	if (!maybeResp)
+	bragi::limited_reader reader{tail.data(), tail.size()};
+	if (!resp.decode_tail(reader))
 		co_return Error::protocolViolation;
-
-	auto &resp = *maybeResp;
 	if (resp.error() == managarm::mbus::Error::NO_SUCH_ENTITY)
 		co_return Error::noSuchEntity;
 
@@ -349,6 +353,13 @@ async::result<Result<EnumerationResult>> Enumerator::nextEvents() {
 	if (preamble.error() || preamble.id() != bragi::message_id<managarm::mbus::EnumerateResponse>)
 		co_return Error::protocolViolation;
 
+	auto maybeResp = bragi::parse_head_only<managarm::mbus::EnumerateResponse>(recvRespHead);
+	recvRespHead.reset();
+	if (!maybeResp)
+		co_return Error::protocolViolation;
+
+	auto &resp = *maybeResp;
+
 	std::vector<std::byte> tail(preamble.tail_size());
 	auto [recvRespTail] =
 		co_await helix_ng::exchangeMsgs(
@@ -357,12 +368,9 @@ async::result<Result<EnumerationResult>> Enumerator::nextEvents() {
 		);
 	HEL_CHECK(recvRespTail.error());
 
-	auto maybeResp = bragi::parse_head_tail<managarm::mbus::EnumerateResponse>(recvRespHead, tail);
-	recvRespHead.reset();
-	if (!maybeResp)
+	bragi::limited_reader reader{tail.data(), tail.size()};
+	if (!resp.decode_tail(reader))
 		co_return Error::protocolViolation;
-
-	auto &resp = *maybeResp;
 	if (resp.error() == managarm::mbus::Error::NO_SUCH_ENTITY)
 		co_return Error::noSuchEntity;
 


### PR DESCRIPTION
We fixed the server side by adding the request dispatcher; however, we do not have a request dispatcher on the client side. Fix the `.reset()` calls manually.