### PR TITLE
hel, thor: Add IrqPin capability and make it possible to access DT IRQs from userspace

### DIFF
--- a/drivers/uart/src/main.cpp
+++ b/drivers/uart/src/main.cpp
@@ -377,7 +377,7 @@ int main() {
 	std::cout << "uart: Starting driver" << std::endl;
 
 	HelHandle pin_handle;
-	HEL_CHECK(helAccessIrq(4, &pin_handle));
+	HEL_CHECK(helAccessIrq(kHelAccessIrqByGsi, 0, 4, &pin_handle));
 	helix::UniqueDescriptor pin{pin_handle};
 
 	HelHandle irq_handle;

--- a/drivers/uart/src/main.cpp
+++ b/drivers/uart/src/main.cpp
@@ -376,8 +376,12 @@ async::detached runTerminal() {
 int main() {
 	std::cout << "uart: Starting driver" << std::endl;
 
+	HelHandle pin_handle;
+	HEL_CHECK(helAccessIrq(4, &pin_handle));
+	helix::UniqueDescriptor pin{pin_handle};
+
 	HelHandle irq_handle;
-	HEL_CHECK(helAccessIrq(4, &irq_handle));
+	HEL_CHECK(helHandleIrq(pin.getHandle(), &irq_handle));
 	irq = helix::UniqueIrq(irq_handle);
 
 	uintptr_t ports[] = { COM1, COM1 + 1, COM1 + 2, COM1 + 3, COM1 + 4, COM1 + 5, COM1 + 6,

--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -367,9 +367,9 @@ extern inline __attribute__ (( always_inline )) HelError helHandleIrq(HelHandle 
 	return error;
 };
 
-extern inline __attribute__ (( always_inline )) HelError helConfigureIrq(int number,
+extern inline __attribute__ (( always_inline )) HelError helConfigureIrq(HelHandle pin_handle,
 		uint32_t trigger, uint32_t polarity) {
-	return helSyscall3(kHelCallConfigureIrq, (HelWord)number, (HelWord)trigger,
+	return helSyscall3(kHelCallConfigureIrq, (HelWord)pin_handle, (HelWord)trigger,
 			(HelWord)polarity);
 };
 

--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -351,10 +351,18 @@ extern inline __attribute__ (( always_inline )) HelError helRaiseEvent(HelHandle
 	return helSyscall1(kHelCallRaiseEvent, (HelWord)handle);
 };
 
-extern inline __attribute__ (( always_inline )) HelError helAccessIrq(int number, 
+extern inline __attribute__ (( always_inline )) HelError helAccessIrq(int number,
 		HelHandle *handle) {
 	HelWord handle_word;
 	HelError error = helSyscall1_1(kHelCallAccessIrq, number, &handle_word);
+	*handle = (HelHandle)handle_word;
+	return error;
+};
+
+extern inline __attribute__ (( always_inline )) HelError helHandleIrq(HelHandle pin_handle,
+		HelHandle *handle) {
+	HelWord handle_word;
+	HelError error = helSyscall1_1(kHelCallHandleIrq, (HelWord)pin_handle, &handle_word);
 	*handle = (HelHandle)handle_word;
 	return error;
 };

--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -351,10 +351,11 @@ extern inline __attribute__ (( always_inline )) HelError helRaiseEvent(HelHandle
 	return helSyscall1(kHelCallRaiseEvent, (HelWord)handle);
 };
 
-extern inline __attribute__ (( always_inline )) HelError helAccessIrq(int number,
-		HelHandle *handle) {
+extern inline __attribute__ (( always_inline )) HelError helAccessIrq(uint32_t mode,
+		uint64_t controller, uint64_t index, HelHandle *handle) {
 	HelWord handle_word;
-	HelError error = helSyscall1_1(kHelCallAccessIrq, number, &handle_word);
+	HelError error = helSyscall3_1(kHelCallAccessIrq, (HelWord)mode, (HelWord)controller,
+			(HelWord)index, &handle_word);
 	*handle = (HelHandle)handle_word;
 	return error;
 };

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -1059,6 +1059,10 @@ enum HelLogSeverity {
 };
 
 enum {
+	kHelAccessIrqByGsi = 1,
+};
+
+enum {
 	kHelIrqTriggerNull = 0,
 	kHelIrqTriggerEdge = 1,
 	kHelIrqTriggerLevel = 2
@@ -1525,12 +1529,19 @@ HEL_C_LINKAGE HelError helCreateBitsetEvent(HelHandle *handle);
 //!     Handle to the event that will be raised.
 HEL_C_LINKAGE HelError helRaiseEvent(HelHandle handle);
 
-//! Access the IRQ pin that a global system interrupt is attached to.
-//! @param[in] number
-//!     Global system interrupt number.
+//! Access the IRQ pin that an IRQ is attached to.
+//! @param[in] mode
+//!     Determines how the IRQ is identified (e.g., ::kHelAccessIrqByGsi).
+//! @param[in] controller
+//!     Identifies the interrupt controller that the IRQ belongs to.
+//!     Unused for ::kHelAccessIrqByGsi.
+//! @param[in] index
+//!     Identifies the IRQ within the interrupt controller.
+//!     For ::kHelAccessIrqByGsi, this is the global system interrupt number.
 //! @param[out] handle
 //!     Handle to the IRQ pin.
-HEL_C_LINKAGE HelError helAccessIrq(int number, HelHandle *handle);
+HEL_C_LINKAGE HelError helAccessIrq(uint32_t mode, uint64_t controller, uint64_t index,
+		HelHandle *handle);
 
 //! Install an IRQ handler on an IRQ pin.
 //! @param[in] pinHandle

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -263,6 +263,7 @@ static const HelRights kHelRightSignal = UINT32_C(1) << 12;
 // - Thread: required to set priority.
 // - Thread: required to resume.
 // - Thread: required to kill.
+// - IRQ pin: required to configure the IRQ.
 static const HelRights kHelRightManage = UINT32_C(1) << 13;
 // All rights (even unspecified ones). Easier to recognize in code than a literal.
 static const HelRights kHelRightsMax = ~UINT32_C(0);
@@ -1538,7 +1539,14 @@ HEL_C_LINKAGE HelError helAccessIrq(int number, HelHandle *handle);
 //!     Handle to the new IRQ object.
 HEL_C_LINKAGE HelError helHandleIrq(HelHandle pinHandle, HelHandle *handle);
 
-HEL_C_LINKAGE HelError helConfigureIrq(int number, uint32_t trigger, uint32_t polarity);
+//! Configure the trigger mode and polarity of an IRQ pin.
+//! @param[in] pinHandle
+//!     Handle to the IRQ pin that is configured.
+//! @param[in] trigger
+//!     Trigger mode of the IRQ (see ::kHelIrqTriggerEdge and ::kHelIrqTriggerLevel).
+//! @param[in] polarity
+//!     Polarity of the IRQ (see ::kHelIrqPolarityHigh and ::kHelIrqPolarityLow).
+HEL_C_LINKAGE HelError helConfigureIrq(HelHandle pinHandle, uint32_t trigger, uint32_t polarity);
 
 HEL_C_LINKAGE HelError helAcknowledgeIrq(HelHandle handle, uint32_t flags, uint64_t sequence);
 

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -96,6 +96,7 @@ enum {
 	kHelCallCreateBitsetEvent = 97,
 	kHelCallRaiseEvent = 98,
 	kHelCallAccessIrq = 14,
+	kHelCallHandleIrq = 5,
 	kHelCallAcknowledgeIrq = 81,
 	kHelCallSubmitAwaitEvent = 82,
 	kHelCallAutomateIrq = 94,
@@ -214,6 +215,7 @@ static const HelRights kHelRightInvoke = UINT32_C(1) << 5;
 // - Memory view: required to map into indirect memory.
 // - Memory view: required to create slice.
 // - Memory view: required to bind to kernlet.
+// - IRQ pin: required to install an IRQ handler.
 // - Memory slice: required to map.
 // - Memory slice: required to map into indirect memory.
 // - Virtualized space: required to create virtualized CPU.
@@ -1522,7 +1524,19 @@ HEL_C_LINKAGE HelError helCreateBitsetEvent(HelHandle *handle);
 //!     Handle to the event that will be raised.
 HEL_C_LINKAGE HelError helRaiseEvent(HelHandle handle);
 
+//! Access the IRQ pin that a global system interrupt is attached to.
+//! @param[in] number
+//!     Global system interrupt number.
+//! @param[out] handle
+//!     Handle to the IRQ pin.
 HEL_C_LINKAGE HelError helAccessIrq(int number, HelHandle *handle);
+
+//! Install an IRQ handler on an IRQ pin.
+//! @param[in] pinHandle
+//!     Handle to the IRQ pin that the handler is installed on.
+//! @param[out] handle
+//!     Handle to the new IRQ object.
+HEL_C_LINKAGE HelError helHandleIrq(HelHandle pinHandle, HelHandle *handle);
 
 HEL_C_LINKAGE HelError helConfigureIrq(int number, uint32_t trigger, uint32_t polarity);
 

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -1060,6 +1060,7 @@ enum HelLogSeverity {
 
 enum {
 	kHelAccessIrqByGsi = 1,
+	kHelAccessIrqByPhandle = 2,
 };
 
 enum {
@@ -1535,9 +1536,11 @@ HEL_C_LINKAGE HelError helRaiseEvent(HelHandle handle);
 //! @param[in] controller
 //!     Identifies the interrupt controller that the IRQ belongs to.
 //!     Unused for ::kHelAccessIrqByGsi.
+//!     For ::kHelAccessIrqByPhandle, this is the device tree phandle of the controller.
 //! @param[in] index
 //!     Identifies the IRQ within the interrupt controller.
 //!     For ::kHelAccessIrqByGsi, this is the global system interrupt number.
+//!     For ::kHelAccessIrqByPhandle, this is a controller-specific IRQ index.
 //! @param[out] handle
 //!     Handle to the IRQ pin.
 HEL_C_LINKAGE HelError helAccessIrq(uint32_t mode, uint64_t controller, uint64_t index,

--- a/kernel/thor/arch/arm/thor-internal/arch/gic.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/gic.hpp
@@ -95,6 +95,12 @@ struct Gic : dt::IrqController {
 		auto pin = setupIrq(irq, trigger);
 		return pin;
 	}
+
+	smarter::shared_ptr<IrqPin> resolveIrqIndex(uint64_t index) override {
+		if (index >= irqCount())
+			return nullptr;
+		return getPin(index);
+	}
 };
 
 void initGicOnThisCpu();

--- a/kernel/thor/arch/riscv/aplic.cpp
+++ b/kernel/thor/arch/riscv/aplic.cpp
@@ -357,6 +357,12 @@ struct Aplic : dt::IrqController {
 		return pin;
 	}
 
+	smarter::shared_ptr<IrqPin> resolveIrqIndex(uint64_t index) override {
+		if (!index || index >= irqs_.size())
+			return nullptr;
+		return getIrq(index);
+	}
+
 	// TODO: Move this to a per-CPU AplicContext class.
 	uint32_t claim(size_t idx) {
 		assert(!imsic_); // claim() is only valid for direct routing.

--- a/kernel/thor/arch/riscv/plic.cpp
+++ b/kernel/thor/arch/riscv/plic.cpp
@@ -123,6 +123,12 @@ struct Plic : dt::IrqController {
 		return pin;
 	}
 
+	smarter::shared_ptr<IrqPin> resolveIrqIndex(uint64_t index) override {
+		if (!index || index >= irqs_.size())
+			return nullptr;
+		return getIrq(index);
+	}
+
 	// Claim the highest priority interrupt.
 	uint32_t claim(size_t ctx) { return space_.load(plicClaimCompleteRegister(ctx)); }
 	// Complete IRQ handling. Called at EOI.

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3461,12 +3461,27 @@ HelError helAccessIrq(int number, HelHandle *handle) {
 	if (!pin)
 		return kHelErrOutOfBounds;
 
+	*handle = this_universe->attachDescriptor(
+			AnyDescriptor::make<DescriptorType::irqPin>(std::move(pin), kHelRightAssign));
+
+	return kHelErrNone;
+}
+
+HelError helHandleIrq(HelHandle pinHandle, HelHandle *handle) {
+	auto this_thread = getCurrentThread();
+	auto this_universe = this_thread->getUniverse();
+
+	auto pinOutcome = this_universe->resolveObject<DescriptorType::irqPin>(pinHandle,
+			kHelRightAssign);
+	if(!pinOutcome)
+		return translateError(pinOutcome.error());
+
 	auto irqOutcome = GenericIrqObject::create(
 			frg::string<KernelAlloc>{*kernelAlloc, "generic-irq-object"});
 	if(!irqOutcome)
 		return translateError(irqOutcome.error());
 	auto irq = std::move(*irqOutcome);
-	IrqPin::attachSink(pin, irq.get());
+	IrqPin::attachSink(std::move(*pinOutcome), irq.get());
 
 	*handle = this_universe->attachDescriptor(
 			AnyDescriptor::make<DescriptorType::irq>(std::move(irq), kHelRightWait | kHelRightSignal));

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -25,6 +25,9 @@
 #include <thor-internal/thread.hpp>
 #include <thor-internal/timer.hpp>
 #include <thor-internal/acpi/acpi.hpp>
+#ifdef THOR_HAS_DTB_SUPPORT
+#include <thor-internal/dtb/dtb.hpp>
+#endif
 #ifdef __x86_64__
 #include <thor-internal/arch/debug.hpp>
 #include <thor-internal/arch/ept.hpp>
@@ -3450,21 +3453,36 @@ HelError helRaiseEvent(HelHandle handle) {
 }
 
 HelError helAccessIrq(uint32_t mode, uint64_t controller, uint64_t index, HelHandle *handle) {
-	if(mode != kHelAccessIrqByGsi)
-		return kHelErrIllegalArgs;
-	// kHelAccessIrqByGsi does not take any controller argument.
-	if (controller)
-		return kHelErrIllegalArgs;
-
-	// This syscall only makes sense on ACPI systems.
-	if (!acpiRsdpNote->rsdp)
-		return kHelErrUnsupportedOperation;
-
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto pin = acpi::getGlobalSystemIrq(index);
-	if (!pin)
+	smarter::shared_ptr<IrqPin> pin;
+	if(mode == kHelAccessIrqByGsi) {
+		// kHelAccessIrqByGsi does not take any controller argument.
+		if (controller)
+			return kHelErrIllegalArgs;
+		// GSIs only make sense on ACPI systems.
+		if (!acpiRsdpNote->rsdp)
+			return kHelErrUnsupportedOperation;
+		pin = acpi::getGlobalSystemIrq(index);
+	}else if(mode == kHelAccessIrqByPhandle) {
+#ifdef THOR_HAS_DTB_SUPPORT
+		if(controller > UINT32_MAX)
+			return kHelErrOutOfBounds;
+		auto *node = getDeviceTreeNodeByPhandle(controller);
+		if(!node)
+			return kHelErrOutOfBounds;
+		auto *irqController = node->getAssociatedIrqController();
+		if(!irqController)
+			return kHelErrIllegalArgs;
+		pin = irqController->resolveIrqIndex(index);
+#else
+		return kHelErrUnsupportedOperation;
+#endif
+	}else{
+		return kHelErrIllegalArgs;
+	}
+	if(!pin)
 		return kHelErrOutOfBounds;
 
 	*handle = this_universe->attachDescriptor(

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3449,7 +3449,13 @@ HelError helRaiseEvent(HelHandle handle) {
 	return kHelErrNone;
 }
 
-HelError helAccessIrq(int number, HelHandle *handle) {
+HelError helAccessIrq(uint32_t mode, uint64_t controller, uint64_t index, HelHandle *handle) {
+	if(mode != kHelAccessIrqByGsi)
+		return kHelErrIllegalArgs;
+	// kHelAccessIrqByGsi does not take any controller argument.
+	if (controller)
+		return kHelErrIllegalArgs;
+
 	// This syscall only makes sense on ACPI systems.
 	if (!acpiRsdpNote->rsdp)
 		return kHelErrUnsupportedOperation;
@@ -3457,7 +3463,7 @@ HelError helAccessIrq(int number, HelHandle *handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	auto pin = acpi::getGlobalSystemIrq(number);
+	auto pin = acpi::getGlobalSystemIrq(index);
 	if (!pin)
 		return kHelErrOutOfBounds;
 

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3462,7 +3462,7 @@ HelError helAccessIrq(int number, HelHandle *handle) {
 		return kHelErrOutOfBounds;
 
 	*handle = this_universe->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::irqPin>(std::move(pin), kHelRightAssign));
+			AnyDescriptor::make<DescriptorType::irqPin>(std::move(pin), kHelRightAssign | kHelRightManage));
 
 	return kHelErrNone;
 }
@@ -3489,7 +3489,7 @@ HelError helHandleIrq(HelHandle pinHandle, HelHandle *handle) {
 	return kHelErrNone;
 }
 
-HelError helConfigureIrq(int number, uint32_t trigger, uint32_t polarity) {
+HelError helConfigureIrq(HelHandle pinHandle, uint32_t trigger, uint32_t polarity) {
 	TriggerMode triggerMode;
 	switch(trigger) {
 		case kHelIrqTriggerEdge: triggerMode = TriggerMode::edge; break;
@@ -3504,15 +3504,15 @@ HelError helConfigureIrq(int number, uint32_t trigger, uint32_t polarity) {
 		default: return kHelErrIllegalArgs;
 	}
 
-	// This syscall only makes sense on ACPI systems.
-	if (!acpiRsdpNote->rsdp)
-	    return kHelErrUnsupportedOperation;
+	auto this_thread = getCurrentThread();
+	auto this_universe = this_thread->getUniverse();
 
-	auto pin = acpi::getGlobalSystemIrq(number);
-	if(!pin)
-		return kHelErrOutOfBounds;
+	auto pinOutcome = this_universe->resolveObject<DescriptorType::irqPin>(pinHandle,
+			kHelRightManage);
+	if(!pinOutcome)
+		return translateError(pinOutcome.error());
 
-	pin->configure(IrqConfiguration{triggerMode, irqPolarity});
+	(*pinOutcome)->configure(IrqConfiguration{triggerMode, irqPolarity});
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -821,7 +821,7 @@ void handleSyscall(SyscallImageAccessor image) {
 	} break;
 	case kHelCallAccessIrq: {
 		HelHandle handle;
-		*image.error() = helAccessIrq((int)arg0, &handle);
+		*image.error() = helAccessIrq((uint32_t)arg0, (uint64_t)arg1, (uint64_t)arg2, &handle);
 		*image.out0() = handle;
 	} break;
 	case kHelCallHandleIrq: {

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -685,7 +685,7 @@ void handleSyscall(SyscallImageAccessor image) {
 		*image.out0() = handle;
 	} break;
 	case kHelCallConfigureIrq: {
-		*image.error() = helConfigureIrq((int)arg0, (uint32_t)arg1, (uint32_t)arg2);
+		*image.error() = helConfigureIrq((HelHandle)arg0, (uint32_t)arg1, (uint32_t)arg2);
 	} break;
 	case kHelCallMapMemory: {
 		void *actual_pointer;

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -824,6 +824,11 @@ void handleSyscall(SyscallImageAccessor image) {
 		*image.error() = helAccessIrq((int)arg0, &handle);
 		*image.out0() = handle;
 	} break;
+	case kHelCallHandleIrq: {
+		HelHandle handle;
+		*image.error() = helHandleIrq((HelHandle)arg0, &handle);
+		*image.out0() = handle;
+	} break;
 	case kHelCallAcknowledgeIrq: {
 		*image.error() = helAcknowledgeIrq((HelHandle)arg0, (uint32_t)arg1, (uint64_t)arg2);
 	} break;

--- a/kernel/thor/generic/thor-internal/universe.hpp
+++ b/kernel/thor/generic/thor-internal/universe.hpp
@@ -29,6 +29,7 @@ struct KernletObject;
 struct BoundKernlet;
 struct TokenObject;
 struct DmaSpace;
+struct IrqPin;
 struct IrqObject;
 struct OneshotEvent;
 struct BitsetEvent;
@@ -103,6 +104,7 @@ enum class DescriptorType : uint8_t {
 	memoryViewLock,
 	thread,
 	lane,
+	irqPin,
 	irq,
 	oneshotEvent,
 	bitsetEvent,
@@ -181,6 +183,12 @@ template<>
 struct DescriptorTraits<DescriptorType::lane> {
 	using Object = Stream;
 	using Policy = LanePolicy;
+};
+
+template<>
+struct DescriptorTraits<DescriptorType::irqPin> {
+	using Object = IrqPin;
+	using Policy = smarter::default_rc_policy;
 };
 
 template<>

--- a/kernel/thor/system/dtb/thor-internal/dtb/irq.hpp
+++ b/kernel/thor/system/dtb/thor-internal/dtb/irq.hpp
@@ -9,6 +9,9 @@ namespace thor::dt {
 struct IrqController {
 	// Resolve a DT interrupt specifier to an IRQ.
 	virtual smarter::shared_ptr<IrqPin> resolveDtIrq(dtb::Cells irq) = 0;
+
+	// Resolve a controller-specific IRQ index to an IRQ.
+	virtual smarter::shared_ptr<IrqPin> resolveIrqIndex(uint64_t index) = 0;
 };
 
 } // namespace thor::dt

--- a/rust/hel/src/lib.rs
+++ b/rust/hel/src/lib.rs
@@ -98,10 +98,17 @@ pub fn access_io(ports: &[usize]) -> Result<Handle> {
     Ok(unsafe { Handle::from_raw(handle) })
 }
 
-/// Returns an IRQ object for the given global system interrupt number.
+/// Returns the IRQ pin that the given global system interrupt is attached to.
 pub fn access_irq(number: i32) -> Result<Handle> {
     let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
     result::hel_check(unsafe { hel_sys::helAccessIrq(number, &mut handle) })?;
+    Ok(unsafe { Handle::from_raw(handle) })
+}
+
+/// Returns an IRQ object that handles interrupts of the given IRQ pin.
+pub fn handle_irq(pin: &Handle) -> Result<Handle> {
+    let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
+    result::hel_check(unsafe { hel_sys::helHandleIrq(pin.handle(), &mut handle) })?;
     Ok(unsafe { Handle::from_raw(handle) })
 }
 

--- a/rust/hel/src/lib.rs
+++ b/rust/hel/src/lib.rs
@@ -99,9 +99,11 @@ pub fn access_io(ports: &[usize]) -> Result<Handle> {
 }
 
 /// Returns the IRQ pin that the given global system interrupt is attached to.
-pub fn access_irq(number: i32) -> Result<Handle> {
+pub fn access_irq_by_gsi(gsi: u64) -> Result<Handle> {
     let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
-    result::hel_check(unsafe { hel_sys::helAccessIrq(number, &mut handle) })?;
+    result::hel_check(unsafe {
+        hel_sys::helAccessIrq(hel_sys::kHelAccessIrqByGsi as u32, 0, gsi, &mut handle)
+    })?;
     Ok(unsafe { Handle::from_raw(handle) })
 }
 

--- a/rust/hel/src/lib.rs
+++ b/rust/hel/src/lib.rs
@@ -126,8 +126,8 @@ pub enum IrqPolarity {
     Low,
 }
 
-/// Configures the trigger mode and polarity of a global system interrupt.
-pub fn configure_irq(number: i32, trigger: IrqTrigger, polarity: IrqPolarity) -> Result<()> {
+/// Configures the trigger mode and polarity of an IRQ pin.
+pub fn configure_irq(pin: &Handle, trigger: IrqTrigger, polarity: IrqPolarity) -> Result<()> {
     let trigger = match trigger {
         IrqTrigger::Edge => hel_sys::kHelIrqTriggerEdge,
         IrqTrigger::Level => hel_sys::kHelIrqTriggerLevel,
@@ -136,7 +136,9 @@ pub fn configure_irq(number: i32, trigger: IrqTrigger, polarity: IrqPolarity) ->
         IrqPolarity::High => hel_sys::kHelIrqPolarityHigh,
         IrqPolarity::Low => hel_sys::kHelIrqPolarityLow,
     };
-    result::hel_check(unsafe { hel_sys::helConfigureIrq(number, trigger as u32, polarity as u32) })
+    result::hel_check(unsafe {
+        hel_sys::helConfigureIrq(pin.handle(), trigger as u32, polarity as u32)
+    })
 }
 
 /// A time value in nanoseconds since boot.

--- a/rust/hel/src/lib.rs
+++ b/rust/hel/src/lib.rs
@@ -107,6 +107,20 @@ pub fn access_irq_by_gsi(gsi: u64) -> Result<Handle> {
     Ok(unsafe { Handle::from_raw(handle) })
 }
 
+/// Returns the IRQ pin identified by a device tree phandle and a controller-specific index.
+pub fn access_irq_by_phandle(phandle: u64, index: u64) -> Result<Handle> {
+    let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
+    result::hel_check(unsafe {
+        hel_sys::helAccessIrq(
+            hel_sys::kHelAccessIrqByPhandle as u32,
+            phandle,
+            index,
+            &mut handle,
+        )
+    })?;
+    Ok(unsafe { Handle::from_raw(handle) })
+}
+
 /// Returns an IRQ object that handles interrupts of the given IRQ pin.
 pub fn handle_irq(pin: &Handle) -> Result<Handle> {
     let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;

--- a/sif/src/isa.rs
+++ b/sif/src/isa.rs
@@ -100,7 +100,7 @@ pub fn configure_isa_irqs() {
     println!("sif: Configuring ISA IRQs");
     for irq in PRECONFIGURED_ISA_IRQS {
         let line = overrides[usize::from(irq)].unwrap_or_else(|| IsaIrq::identity(irq));
-        let pin = match hel::access_irq(line.gsi as i32) {
+        let pin = match hel::access_irq_by_gsi(line.gsi as u64) {
             Ok(pin) => pin,
             Err(err) => {
                 println!(

--- a/sif/src/isa.rs
+++ b/sif/src/isa.rs
@@ -100,7 +100,17 @@ pub fn configure_isa_irqs() {
     println!("sif: Configuring ISA IRQs");
     for irq in PRECONFIGURED_ISA_IRQS {
         let line = overrides[usize::from(irq)].unwrap_or_else(|| IsaIrq::identity(irq));
-        if let Err(err) = hel::configure_irq(line.gsi as i32, line.trigger, line.polarity) {
+        let pin = match hel::access_irq(line.gsi as i32) {
+            Ok(pin) => pin,
+            Err(err) => {
+                println!(
+                    "sif: Failed to access ISA IRQ {irq} (GSI {}): {err}",
+                    line.gsi
+                );
+                continue;
+            }
+        };
+        if let Err(err) = hel::configure_irq(&pin, line.trigger, line.polarity) {
             println!(
                 "sif: Failed to configure ISA IRQ {irq} (GSI {}): {err}",
                 line.gsi

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -21,6 +21,7 @@ pub(crate) const EXPECT_LOCK: &str = "sif: PCI tree mutex was poisoned";
 
 pub struct IrqPin {
     gsi: u32,
+    handle: hel::Handle,
     trigger: IrqTrigger,
     polarity: IrqPolarity,
 }
@@ -28,6 +29,10 @@ pub struct IrqPin {
 impl IrqPin {
     pub fn gsi(&self) -> u32 {
         self.gsi
+    }
+
+    pub fn handle(&self) -> &hel::Handle {
+        &self.handle
     }
 }
 
@@ -43,13 +48,21 @@ pub fn system_irq(gsi: u32, trigger: IrqTrigger, polarity: IrqPolarity) -> Optio
         return Some(*pin);
     }
 
-    if let Err(err) = hel::configure_irq(gsi as i32, trigger, polarity) {
+    let handle = match hel::access_irq(gsi as i32) {
+        Ok(handle) => handle,
+        Err(err) => {
+            println!("sif: Failed to access GSI {gsi}: {err}");
+            return None;
+        }
+    };
+    if let Err(err) = hel::configure_irq(&handle, trigger, polarity) {
         println!("sif: Failed to configure GSI {gsi}: {err}");
         return None;
     }
 
     let pin = leak(IrqPin {
         gsi,
+        handle,
         trigger,
         polarity,
     });

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -48,7 +48,7 @@ pub fn system_irq(gsi: u32, trigger: IrqTrigger, polarity: IrqPolarity) -> Optio
         return Some(*pin);
     }
 
-    let handle = match hel::access_irq(gsi as i32) {
+    let handle = match hel::access_irq_by_gsi(gsi as u64) {
         Ok(handle) => handle,
         Err(err) => {
             println!("sif: Failed to access GSI {gsi}: {err}");

--- a/sif/src/pci/serve.rs
+++ b/sif/src/pci/serve.rs
@@ -174,7 +174,10 @@ impl managarm::hw::server::PciDevice for ServedEntity {
             return Ok(None);
         }
         match device.interrupt.get() {
-            Some(pin) => Ok(Some(hel::access_irq(pin.gsi() as i32)?)),
+            Some(pin) => {
+                let pin_handle = hel::access_irq(pin.gsi() as i32)?;
+                Ok(Some(hel::handle_irq(&pin_handle)?))
+            }
             None => Ok(None),
         }
     }

--- a/sif/src/pci/serve.rs
+++ b/sif/src/pci/serve.rs
@@ -174,10 +174,7 @@ impl managarm::hw::server::PciDevice for ServedEntity {
             return Ok(None);
         }
         match device.interrupt.get() {
-            Some(pin) => {
-                let pin_handle = hel::access_irq(pin.gsi() as i32)?;
-                Ok(Some(hel::handle_irq(&pin_handle)?))
-            }
+            Some(pin) => Ok(Some(hel::handle_irq(pin.handle())?)),
             None => Ok(None),
         }
     }


### PR DESCRIPTION
This is a prerequisite for adding device tree support to `sif`.
- We split `helAccessIrq()` into a new `helAccessIrq()` that returns the `IrqPin` as a capability and a `helHandleIrq()` that installs an IRQ handler.
- We change `helConfigureIrq()` to take an `IrqPin` capability instead of a GSI number.
- We add both DT and ACPI modes for `helAccessIrq()`.