### PR TITLE
eir, thor: Pass firmware memory map to thor and use it to determine ACPI caching mode

### DIFF
--- a/kernel/eir/boot/limine/entry.cpp
+++ b/kernel/eir/boot/limine/entry.cpp
@@ -111,6 +111,57 @@ initgraph::Task setupMemoryRegions{
 		    eir::infoLogger() << "    Type " << map->type << " mapping."
 		                      << " Base: 0x" << frg::hex_fmt{map->base} << ", length: 0x"
 		                      << frg::hex_fmt{map->length} << frg::endlog;
+
+		    // Limine guarantees that all RAM-like entry types are actual memory.
+		    switch (map->type) {
+			    case LIMINE_MEMMAP_USABLE:
+			    case LIMINE_MEMMAP_BOOTLOADER_RECLAIMABLE:
+				    // Eir is responsible for dealing with bootloader reclaimable memory.
+				    // Hence, we map it to usableRam.
+				    reportFirmwareMemory(
+				        map->base, map->length, EirMemoryType::usableRam, eir_memory_attrs::wb
+				    );
+				    break;
+			    case LIMINE_MEMMAP_ACPI_RECLAIMABLE:
+				    reportFirmwareMemory(
+				        map->base, map->length, EirMemoryType::acpiReclaimable, eir_memory_attrs::wb
+				    );
+				    break;
+			    case LIMINE_MEMMAP_ACPI_NVS:
+				    reportFirmwareMemory(
+				        map->base, map->length, EirMemoryType::acpiNvs, eir_memory_attrs::wb
+				    );
+				    break;
+			    case LIMINE_MEMMAP_EXECUTABLE_AND_MODULES:
+				    reportFirmwareMemory(
+				        map->base, map->length, EirMemoryType::reserved, eir_memory_attrs::wb
+				    );
+				    break;
+			    case LIMINE_MEMMAP_FRAMEBUFFER:
+				    reportFirmwareMemory(
+				        map->base,
+				        map->length,
+				        EirMemoryType::framebuffer,
+				        eir_memory_attrs::wc | eir_memory_attrs::uc
+				    );
+				    break;
+			    case LIMINE_MEMMAP_RESERVED_MAPPED:
+				    // Limine uses this type for ACPI tables that live outside of ACPI
+				    // reclaimable memory (and for EFI runtime services).
+				    reportFirmwareMemory(
+				        map->base, map->length, EirMemoryType::reserved, eir_memory_attrs::wb
+				    );
+				    break;
+			    case LIMINE_MEMMAP_RESERVED:
+			    case LIMINE_MEMMAP_BAD_MEMORY:
+				    reportFirmwareMemory(map->base, map->length, EirMemoryType::reserved, 0);
+				    break;
+			    default:
+				    eir::infoLogger()
+				        << "eir: Unknown Limine memory map type " << map->type << frg::endlog;
+				    reportFirmwareMemory(map->base, map->length, EirMemoryType::reserved, 0);
+		    }
+
 		    if (map->type == LIMINE_MEMMAP_USABLE
 		        || map->type == LIMINE_MEMMAP_BOOTLOADER_RECLAIMABLE)
 			    createInitialRegions(

--- a/kernel/eir/boot/multiboot2/multiboot2.cpp
+++ b/kernel/eir/boot/multiboot2/multiboot2.cpp
@@ -59,6 +59,34 @@ initgraph::Task setupMemoryRegions{
 		    eir::infoLogger() << "    Type " << map->type << " mapping."
 		                      << " Base: 0x" << frg::hex_fmt{map->base} << ", length: 0x"
 		                      << frg::hex_fmt{map->length} << frg::endlog;
+
+		    // The entry types are the E820 memory types.
+		    switch (map->type) {
+			    case 1: // Available RAM.
+				    reportFirmwareMemory(
+				        map->base, map->length, EirMemoryType::usableRam, eir_memory_attrs::wb
+				    );
+				    break;
+			    case 3: // ACPI reclaimable.
+				    reportFirmwareMemory(
+				        map->base, map->length, EirMemoryType::acpiReclaimable, eir_memory_attrs::wb
+				    );
+				    break;
+			    case 4: // ACPI NVS.
+				    reportFirmwareMemory(
+				        map->base, map->length, EirMemoryType::acpiNvs, eir_memory_attrs::wb
+				    );
+				    break;
+			    case 2: // Reserved.
+			    case 5: // Defective RAM.
+				    reportFirmwareMemory(map->base, map->length, EirMemoryType::reserved, 0);
+				    break;
+			    default:
+				    eir::infoLogger()
+				        << "eir: Unknown E820 memory type " << map->type << frg::endlog;
+				    reportFirmwareMemory(map->base, map->length, EirMemoryType::reserved, 0);
+		    }
+
 		    if (map->type == 1)
 			    createInitialRegions(
 			        {map->base, map->length}, {reservedRegions.data(), nReservedRegions}

--- a/kernel/eir/boot/uefi/efi.hpp
+++ b/kernel/eir/boot/uefi/efi.hpp
@@ -94,6 +94,11 @@ using efi_physical_addr = uint64_t;
 
 using efi_virtual_addr = uint64_t;
 
+constexpr uint64_t EFI_MEMORY_UC = 0x1;
+constexpr uint64_t EFI_MEMORY_WC = 0x2;
+constexpr uint64_t EFI_MEMORY_WT = 0x4;
+constexpr uint64_t EFI_MEMORY_WB = 0x8;
+
 struct efi_memory_descriptor {
 	uint32_t type;
 	efi_physical_addr physical_start;

--- a/kernel/eir/boot/uefi/entry.cpp
+++ b/kernel/eir/boot/uefi/entry.cpp
@@ -624,6 +624,63 @@ initgraph::Task setupMemoryMap{
 		    }
 	    };
 
+	    for (size_t i = 0; i < entries; i++) {
+		    auto e = reinterpret_cast<const efi_memory_descriptor *>(
+		        uintptr_t(memMap) + (i * descriptorSize)
+		    );
+
+		    EirMemoryType type;
+		    switch (e->type) {
+			    case EfiConventionalMemory:
+			    case EfiLoaderCode:
+			    case EfiLoaderData:
+			    case EfiBootServicesCode:
+			    case EfiBootServicesData:
+				    // Eir is responsible for dealing with bootloader reclaimable memory.
+				    // Hence, we map it to usableRam.
+				    type = EirMemoryType::usableRam;
+				    break;
+			    case EfiRuntimeServicesCode:
+			    case EfiRuntimeServicesData:
+				    type = EirMemoryType::runtimeServices;
+				    break;
+			    case EfiACPIReclaimMemory:
+				    type = EirMemoryType::acpiReclaimable;
+				    break;
+			    case EfiACPIMemoryNVS:
+				    type = EirMemoryType::acpiNvs;
+				    break;
+			    case EfiMemoryMappedIO:
+			    case EfiMemoryMappedIOPortSpace:
+				    type = EirMemoryType::mmio;
+				    break;
+			    case EfiReservedMemoryType:
+			    case EfiUnusableMemory:
+			    case EfiPalCode:
+			    case EfiPersistentMemory:
+			    case EfiUnacceptedMemoryType:
+				    type = EirMemoryType::reserved;
+				    break;
+			    default:
+				    eir::infoLogger() << "eir: Unknown EFI memory type " << e->type << frg::endlog;
+				    type = EirMemoryType::reserved;
+		    }
+
+		    uint32_t attrs = 0;
+		    if (e->attribute & EFI_MEMORY_UC)
+			    attrs |= eir_memory_attrs::uc;
+		    if (e->attribute & EFI_MEMORY_WC)
+			    attrs |= eir_memory_attrs::wc;
+		    if (e->attribute & EFI_MEMORY_WT)
+			    attrs |= eir_memory_attrs::wt;
+		    if (e->attribute & EFI_MEMORY_WB)
+			    attrs |= eir_memory_attrs::wb;
+
+		    reportFirmwareMemory(
+		        e->physical_start, e->number_of_pages * eir::pageSize, type, attrs
+		    );
+	    }
+
 	    eir::infoLogger() << "Memory map:" << frg::endlog;
 	    auto entry = nextEntry(0);
 

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -61,6 +61,10 @@ void allocLogRingBuffer();
 void setupRegionStructs();
 void createInitialRegion(address_t base, address_t size);
 
+void
+reportFirmwareMemory(address_t address, address_t size, EirMemoryType type, uint32_t attributes);
+void serializeFirmwareMemoryMap();
+
 struct InitialRegion {
 	address_t base;
 	address_t size;

--- a/kernel/eir/generic/eir-internal/generic.hpp
+++ b/kernel/eir/generic/eir-internal/generic.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <cstddef>
 #include <eir-internal/arch/types.hpp>
 #include <eir/interface.hpp>
 #include <frg/span.hpp>
 #include <frg/string.hpp>
+#include <span>
 #include <stddef.h>
 #include <stdint.h>
+#include <type_traits>
 
 namespace eir {
 
@@ -75,7 +78,39 @@ physaddr_t virtToPhys(T *virt) {
 	return reinterpret_cast<physaddr_t>(virt) - physOffset;
 }
 
-address_t mapBootstrapData(void *p);
+// Data that eir passes to thor. A placement is virtually contiguous in thor's address space
+// but not in eir's; the write functions take care of crossing page boundaries.
+struct BootstrapData {
+	// Reserves size bytes of bootstrap data. The data is filled in by the write functions.
+	static BootstrapData place(size_t size, size_t alignment);
+
+	void writeBytes(std::span<const std::byte> bytes);
+
+	template <typename T>
+	    requires std::is_trivially_copyable_v<T>
+	void write(const T &object) {
+		writeBytes(std::as_bytes(std::span{&object, 1}));
+	}
+
+	template <typename T>
+	    requires std::is_trivially_copyable_v<T>
+	void writeArray(std::span<T> array) {
+		writeBytes(std::as_bytes(array));
+	}
+
+	// Address of the placement in thor's address space.
+	address_t kernelAddress() { return address_; }
+
+private:
+	BootstrapData(address_t address, size_t size) : address_{address}, size_{size} {}
+
+	address_t address_;
+	size_t size_;
+	size_t offset_{0};
+	// eir's view of the page that offset_ points into.
+	std::byte *window_{nullptr};
+};
+
 void mapKasanShadow(uint64_t address, size_t size);
 void unpoisonKasanShadow(uint64_t address, size_t size);
 void mapRegionsAndStructs();

--- a/kernel/eir/generic/eir-internal/memory-layout.hpp
+++ b/kernel/eir/generic/eir-internal/memory-layout.hpp
@@ -5,6 +5,9 @@
 
 namespace eir {
 
+// Size of the region that holds the data that eir passes to thor.
+constexpr uint64_t bootstrapDataSize = 0x200000; // 2 MiB should be enough.
+
 // Kernel stack and kernel stack size.
 // TODO: This does not need to be global if we move stack allocation into memory-layout.cpp.
 extern uint64_t kernelStack;

--- a/kernel/eir/generic/main-function.cpp
+++ b/kernel/eir/generic/main-function.cpp
@@ -130,20 +130,20 @@ static initgraph::Task mapRegions{
 		    if (regions[i].regionType == RegionType::allocatable)
 			    n++;
 	    }
-	    auto regionInfos = bootAlloc<EirRegion>(n);
-	    int j = 0;
+	    auto bootstrapData = BootstrapData::place(n * sizeof(EirRegion), alignof(EirRegion));
 	    for (size_t i = 0; i < eirMaxMemoryRegions; ++i) {
 		    if (regions[i].regionType != RegionType::allocatable)
 			    continue;
-		    regionInfos[j].address = regions[i].address;
-		    regionInfos[j].length = regions[i].size;
-		    regionInfos[j].order = regions[i].order;
-		    regionInfos[j].numRoots = regions[i].numRoots;
-		    regionInfos[j].buddyTree = regions[i].buddyMap;
-		    j++;
+		    EirRegion regionInfo{};
+		    regionInfo.address = regions[i].address;
+		    regionInfo.length = regions[i].size;
+		    regionInfo.order = regions[i].order;
+		    regionInfo.numRoots = regions[i].numRoots;
+		    regionInfo.buddyTree = regions[i].buddyMap;
+		    bootstrapData.write(regionInfo);
 	    }
 	    physicalMemoryNote.numRegions = n;
-	    physicalMemoryNote.regionInfo = mapBootstrapData(regionInfos);
+	    physicalMemoryNote.regionInfo = bootstrapData.kernelAddress();
     }
 };
 

--- a/kernel/eir/generic/main-function.cpp
+++ b/kernel/eir/generic/main-function.cpp
@@ -144,6 +144,8 @@ static initgraph::Task mapRegions{
 	    }
 	    physicalMemoryNote.numRegions = n;
 	    physicalMemoryNote.regionInfo = bootstrapData.kernelAddress();
+
+	    serializeFirmwareMemoryMap();
     }
 };
 

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -384,16 +384,39 @@ void allocLogRingBuffer() {
 
 address_t bootstrapDataPointer = 0;
 
-address_t mapBootstrapData(void *p) {
+BootstrapData BootstrapData::place(size_t size, size_t alignment) {
+	// Placements always start at a page boundary.
+	assert(alignment <= pageSize);
+
 	if (!bootstrapDataPointer)
 		bootstrapDataPointer = getMemoryLayout().bootstrapData;
 
-	auto pointer = bootstrapDataPointer;
-	bootstrapDataPointer += pageSize;
-	mapSingle4kPage(pointer, virtToPhys(p), 0);
-	mapKasanShadow(pointer, pageSize);
-	unpoisonKasanShadow(pointer, pageSize);
-	return pointer;
+	auto address = bootstrapDataPointer;
+	bootstrapDataPointer += (size + pageSize - 1) & ~(pageSize - 1);
+	if (bootstrapDataPointer > getMemoryLayout().bootstrapData + bootstrapDataSize)
+		panicLogger() << "eir: Bootstrap data region is exhausted" << frg::endlog;
+	return BootstrapData{address, size};
+}
+
+void BootstrapData::writeBytes(std::span<const std::byte> bytes) {
+	assert(offset_ + bytes.size() <= size_);
+
+	while (!bytes.empty()) {
+		auto misalign = offset_ & (pageSize - 1);
+		// Map a new page whenever the placement crosses a page boundary.
+		if (!misalign) {
+			auto physical = allocPage();
+			mapSingle4kPage(address_ + offset_, physical, 0);
+			mapKasanShadow(address_ + offset_, pageSize);
+			unpoisonKasanShadow(address_ + offset_, pageSize);
+			window_ = physToVirt<std::byte>(physical);
+		}
+
+		auto chunk = frg::min(bytes.size(), pageSize - misalign);
+		memcpy(window_ + misalign, bytes.data(), chunk);
+		offset_ += chunk;
+		bytes = bytes.subspan(chunk);
+	}
 }
 
 // ----------------------------------------------------------------------------
@@ -708,28 +731,31 @@ static initgraph::Task composeCommandLine{
 	    auto cmdlineChunks = getCmdline();
 
 	    // For each chunk: we either have a trailing space or null terminator.
-	    auto cmdlineLength = cmdlineChunks.size();
+	    // Without any chunks, we still write the null terminator.
+	    auto cmdlineLength = frg::max(cmdlineChunks.size(), size_t{1});
 	    for (auto chunk : cmdlineChunks)
 		    cmdlineLength += chunk.size();
 
-	    if (cmdlineLength > pageSize)
-		    panicLogger() << "eir: Command line exceeds page size" << frg::endlog;
-	    auto cmdlineBuffer = bootAlloc<char>(cmdlineLength);
+	    auto bootstrapData = BootstrapData::place(cmdlineLength, alignof(char));
 
-	    char *cmdlinePtr = cmdlineBuffer;
+	    auto logger = infoLogger();
+	    logger << "eir: Kernel command line: '";
+	    bool first = true;
 	    for (auto chunk : cmdlineChunks) {
 		    if (!chunk.size())
 			    continue;
-		    if (cmdlinePtr != cmdlineBuffer)
-			    *(cmdlinePtr++) = ' ';
-		    memcpy(cmdlinePtr, chunk.data(), chunk.size());
-		    cmdlinePtr += chunk.size();
+		    if (!first) {
+			    bootstrapData.write(' ');
+			    logger << ' ';
+		    }
+		    bootstrapData.writeArray(std::span{chunk.data(), chunk.size()});
+		    logger << chunk;
+		    first = false;
 	    }
-	    *cmdlinePtr = '\0';
+	    bootstrapData.write('\0');
+	    logger << "'" << frg::endlog;
 
-	    infoLogger() << "eir: Kernel command line: '" << cmdlineBuffer << "'" << frg::endlog;
-
-	    commandLineNote.ptr = mapBootstrapData(cmdlineBuffer);
+	    commandLineNote.ptr = bootstrapData.kernelAddress();
     }
 };
 

--- a/kernel/eir/generic/main.cpp
+++ b/kernel/eir/generic/main.cpp
@@ -9,6 +9,7 @@
 #include <eir-internal/uart/uart.hpp>
 
 #include <elf.h>
+#include <frg/algorithm.hpp>
 #include <frg/array.hpp>
 #include <frg/manual_box.hpp>
 #include <frg/utility.hpp>
@@ -197,6 +198,97 @@ void setupRegionStructs() {
 		auto tablePtr = physToVirt<int8_t>(regions[i].buddyTree);
 		BuddyAccessor::initialize(tablePtr, numRoots, order);
 	}
+}
+
+// ----------------------------------------------------------------------------
+// Firmware memory map handling.
+// ----------------------------------------------------------------------------
+
+namespace {
+
+constexpr size_t maxFirmwareMemoryEntries = 512;
+
+EirFirmwareMemory firmwareMemoryEntries[maxFirmwareMemoryEntries];
+size_t numFirmwareMemoryEntries = 0;
+
+// Complains about type/attribute combinations that thor would map in a surprising way,
+// either because the firmware lied to us or because we misclassified the entry.
+void checkFirmwareMemoryAttrs(address_t address, EirMemoryType type, uint32_t attributes) {
+	auto complain = [&](const char *what) {
+		eir::infoLogger() << "eir: Firmware memory at 0x" << frg::hex_fmt{address} << " " << what
+		                  << " (attributes: 0x" << frg::hex_fmt{attributes} << ")" << frg::endlog;
+	};
+
+	switch (type) {
+		case EirMemoryType::usableRam:
+		case EirMemoryType::acpiReclaimable:
+		case EirMemoryType::acpiNvs:
+			if (!(attributes & eir_memory_attrs::wb))
+				complain("is RAM but does not support write-back caching");
+			break;
+		case EirMemoryType::mmio:
+			if (attributes & eir_memory_attrs::wb)
+				complain("is MMIO but advertises write-back caching");
+			break;
+		default:
+			break;
+	}
+}
+
+} // namespace
+
+void
+reportFirmwareMemory(address_t address, address_t size, EirMemoryType type, uint32_t attributes) {
+	if (!size)
+		return;
+
+	checkFirmwareMemoryAttrs(address, type, attributes);
+
+	// Merge with the previous entry if possible; firmware maps are usually sorted.
+	if (numFirmwareMemoryEntries) {
+		auto &last = firmwareMemoryEntries[numFirmwareMemoryEntries - 1];
+		if (last.type == type && last.attributes == attributes
+		    && last.address + last.size == address) {
+			last.size += size;
+			return;
+		}
+	}
+
+	if (numFirmwareMemoryEntries >= maxFirmwareMemoryEntries)
+		eir::panicLogger() << "Eir: Firmware memory map entry limit exhausted" << frg::endlog;
+	firmwareMemoryEntries[numFirmwareMemoryEntries++] = {address, size, type, attributes};
+}
+
+void serializeFirmwareMemoryMap() {
+	// Note that frg::insertion_sort() swaps whenever the comparator returns true,
+	// i.e., this sorts by ascending address.
+	frg::insertion_sort(
+	    firmwareMemoryEntries,
+	    firmwareMemoryEntries + numFirmwareMemoryEntries,
+	    [](const EirFirmwareMemory &a, const EirFirmwareMemory &b) { return a.address > b.address; }
+	);
+
+	// Coalesce contiguous entries of the same type and attributes.
+	size_t n = 0;
+	for (size_t i = 0; i < numFirmwareMemoryEntries; ++i) {
+		auto &entry = firmwareMemoryEntries[i];
+		if (n && firmwareMemoryEntries[n - 1].type == entry.type
+		    && firmwareMemoryEntries[n - 1].attributes == entry.attributes
+		    && firmwareMemoryEntries[n - 1].address + firmwareMemoryEntries[n - 1].size
+		           == entry.address) {
+			firmwareMemoryEntries[n - 1].size += entry.size;
+			continue;
+		}
+		firmwareMemoryEntries[n++] = entry;
+	}
+	numFirmwareMemoryEntries = n;
+
+	auto bootstrapData =
+	    BootstrapData::place(n * sizeof(EirFirmwareMemory), alignof(EirFirmwareMemory));
+	bootstrapData.writeArray(std::span{firmwareMemoryEntries, n});
+
+	physicalMemoryNote.numFirmwareEntries = n;
+	physicalMemoryNote.firmwareEntriesPtr = bootstrapData.kernelAddress();
 }
 
 // ----------------------------------------------------------------------------

--- a/kernel/eir/generic/memory-layout.cpp
+++ b/kernel/eir/generic/memory-layout.cpp
@@ -58,7 +58,7 @@ void doDetermineMemoryLayout() {
 	ml.directPhysical = assignLayout(UINT64_C(1) << (s - 2));
 	ml.kernelVirtual = assignLayout(ml.kernelVirtualSize);
 	ml.allocLog = assignLayout(ml.allocLogSize);
-	ml.bootstrapData = assignLayout(0x200000);     // 2 MiB should be enough.
+	ml.bootstrapData = assignLayout(bootstrapDataSize);
 	kernelFrameBuffer = assignLayout(0x4000'0000); // 1 GiB.
 	kernelStack = assignLayout(kernelStackSize);
 	if (earlyMmioSize)

--- a/kernel/eir/system/dtb/discovery.cpp
+++ b/kernel/eir/system/dtb/discovery.cpp
@@ -228,6 +228,7 @@ void discoverMemoryFromDtb() {
 			auto size = reg->asPropArrayEntry(sizeCells, j);
 			j += sizeCells * 4;
 
+			reportFirmwareMemory(base, size, EirMemoryType::usableRam, eir_memory_attrs::wb);
 			createInitialRegions({base, size}, {reservedRegions, nReservedRegions});
 		}
 	}

--- a/kernel/klibc/eir/interface.hpp
+++ b/kernel/klibc/eir/interface.hpp
@@ -21,6 +21,33 @@ struct EirRegion {
 	EirPtr buddyTree;
 };
 
+enum class EirMemoryType : uint32_t {
+	null,
+	usableRam,
+	acpiReclaimable,
+	acpiNvs,
+	runtimeServices,
+	mmio,
+	framebuffer,
+	reserved,
+};
+
+// Caching modes that a memory region supports (derived from EFI_MEMORY_{UC,WC,WT,WB}).
+// Note that these are not mutually exclusive.
+namespace eir_memory_attrs {
+constexpr uint32_t uc = UINT32_C(1) << 0;
+constexpr uint32_t wc = UINT32_C(1) << 1;
+constexpr uint32_t wt = UINT32_C(1) << 2;
+constexpr uint32_t wb = UINT32_C(1) << 3;
+} // namespace eir_memory_attrs
+
+struct EirFirmwareMemory {
+	EirPtr address = 0;
+	EirSize size = 0;
+	EirMemoryType type = EirMemoryType::null;
+	uint32_t attributes = 0;
+};
+
 struct EirFramebuffer {
 	EirPtr fbAddress;
 	EirPtr fbEarlyWindow;
@@ -268,6 +295,14 @@ struct PhysicalMemory {
 	uint64_t numRegions = 0;
 	// Virtual address of an EirRegion[numRegions] array in the bootstrap data area.
 	uint64_t regionInfo = 0;
+
+	// Number of entries in the array pointed to by firmwarePtr.
+	uint64_t numFirmwareEntries = 0;
+	// Virtual address of an EirFirmwareMemory[numFirmwareEntries] array in the bootstrap data area.
+	// In contrast to regionInfo, this array describes the entire firmware memory map
+	// (e.g., as obtained from UEFI) and not only the memory that is usable by the kernel.
+	// The entries are sorted by address.
+	uint64_t firmwareEntriesPtr = 0;
 };
 
 struct CommandLine {

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -639,7 +639,13 @@ HelError helAccessPhysical(uintptr_t physical, size_t size, uint32_t cachingMode
 
 	CachingMode caching;
 	switch(cachingMode) {
-	case kHelCachingDefault: caching = CachingMode::null; break;
+	case kHelCachingDefault: {
+		// Derive the caching mode from the firmware memory map.
+		auto firmwareMode = determineFirmwareCachingMode(physical, size);
+		if(!firmwareMode)
+			return kHelErrIllegalArgs;
+		caching = *firmwareMode;
+	} break;
 	case kHelCachingUncached: caching = CachingMode::uncached; break;
 	case kHelCachingWriteCombine: caching = CachingMode::writeCombine; break;
 	case kHelCachingWriteThrough: caching = CachingMode::writeThrough; break;

--- a/kernel/thor/generic/physical.cpp
+++ b/kernel/thor/generic/physical.cpp
@@ -11,6 +11,40 @@ static bool logPhysicalAllocs = false;
 THOR_DEFINE_ELF_NOTE(memoryLayoutNote){elf_note_type::memoryLayout, {}};
 THOR_DEFINE_ELF_NOTE(physicalMemoryNote){elf_note_type::physicalMemory, {}};
 
+frg::optional<CachingMode> determineFirmwareCachingMode(PhysicalAddr physical, size_t size) {
+	auto *entries = reinterpret_cast<const EirFirmwareMemory *>(physicalMemoryNote->firmwareEntriesPtr);
+	size_t numEntries = physicalMemoryNote->numFirmwareEntries;
+
+	// Find the entry that contains the start of the range.
+	const EirFirmwareMemory *foundEntry = nullptr;
+	for(size_t i = 0; i < numEntries; i++) {
+		if(entries[i].address <= physical && physical < entries[i].address + entries[i].size) {
+			foundEntry = &entries[i];
+			break;
+		}
+	}
+
+	// Treat ranges outside of the firmware memory map as device memory.
+	if(!foundEntry)
+		return CachingMode::mmioNonPosted;
+	auto &entry = *foundEntry;
+
+	if(physical + size > entry.address + entry.size) {
+		warningLogger() << "thor: Physical range 0x" << frg::hex_fmt{physical}
+				<< " - 0x" << frg::hex_fmt{physical + size}
+				<< " straddles multiple firmware memory map entries" << frg::endlog;
+		return frg::null_opt;
+	}
+
+	if(entry.attributes & eir_memory_attrs::wb)
+		return CachingMode::writeBack;
+	// We do not have a CachingMode to represent WT, treat it like WC.
+	if(entry.attributes & (eir_memory_attrs::wc | eir_memory_attrs::wt))
+		return CachingMode::writeCombine;
+	// If neither WB nor WC is supported, treat it as device memory.
+	return CachingMode::mmioNonPosted;
+}
+
 void poisonPhysicalAccess(PhysicalAddr physical) {
 	auto address = directPhysicalOffset() + physical;
 	KernelPageSpace::global().unmapSingle4k(address);

--- a/kernel/thor/generic/thor-internal/physical.hpp
+++ b/kernel/thor/generic/thor-internal/physical.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 
 #include <eir/interface.hpp>
+#include <frg/optional.hpp>
 #include <frg/spinlock.hpp>
 #include <frg/manual_box.hpp>
 #include <physical-buddy.hpp>
@@ -27,6 +28,12 @@ inline void *mapDirectPhysical(PhysicalAddr physical) {
 inline PhysicalAddr reverseDirectPhysical(void *pointer) {
 	return reinterpret_cast<uintptr_t>(pointer) - directPhysicalOffset();
 }
+
+// Determines the caching mode with which the given physical range may be mapped,
+// based on the firmware memory map. Ranges that the firmware memory map does not
+// describe are assumed to be device memory. Returns null if the range straddles
+// multiple entries (mixing distinct memory types in one mapping is not meaningful).
+frg::optional<CachingMode> determineFirmwareCachingMode(PhysicalAddr physical, size_t size);
 
 struct PageAccessor {
 	friend void swap(PageAccessor &a, PageAccessor &b) {

--- a/kernel/thor/system/acpi/glue.cpp
+++ b/kernel/thor/system/acpi/glue.cpp
@@ -18,6 +18,7 @@
 #include <thor-internal/kernel-heap.hpp>
 #include <thor-internal/main.hpp>
 #include <thor-internal/pci/pci.hpp>
+#include <thor-internal/physical.hpp>
 #include <thor-internal/timer.hpp>
 #include <thor-internal/work-queue.hpp>
 
@@ -207,10 +208,14 @@ void *uacpi_kernel_map(uacpi_phys_addr physical, uacpi_size length) {
 	auto vsize = length + (physical & (kPageSize - 1));
 	size_t msize = pow2ceil(frg::max(vsize, static_cast<size_t>(0x10000)));
 
+	auto caching = determineFirmwareCachingMode(physical, length);
+	if (!caching)
+		return nullptr;
+
 	auto ptr = KernelVirtualMemory::global().allocate(msize);
 	for (size_t pg = 0; pg < vsize; pg += kPageSize)
 		KernelPageSpace::global().mapSingle4k(
-		    (VirtualAddr)ptr + pg, paddr + pg, page_access::write, CachingMode::null
+		    (VirtualAddr)ptr + pg, paddr + pg, page_access::write, *caching
 		);
 	return reinterpret_cast<char *>(ptr) + (physical & (kPageSize - 1));
 }
@@ -234,6 +239,8 @@ void uacpi_kernel_unmap(void *ptr, uacpi_size length) {
 uacpi_status
 uacpi_kernel_raw_memory_read(uacpi_phys_addr address, uacpi_u8 byte_width, uacpi_u64 *out) {
 	auto *ptr = uacpi_kernel_map(address, byte_width);
+	if (!ptr)
+		return UACPI_STATUS_MAPPING_FAILED;
 
 	switch (byte_width) {
 		case 1:
@@ -260,6 +267,8 @@ uacpi_kernel_raw_memory_read(uacpi_phys_addr address, uacpi_u8 byte_width, uacpi
 uacpi_status
 uacpi_kernel_raw_memory_write(uacpi_phys_addr address, uacpi_u8 byte_width, uacpi_u64 in) {
 	auto *ptr = uacpi_kernel_map(address, byte_width);
+	if (!ptr)
+		return UACPI_STATUS_MAPPING_FAILED;
 
 	switch (byte_width) {
 		case 1:


### PR DESCRIPTION
This allows thor to correctly determine the caching mode of memory regions that AML wants to access.