### PR TITLE
hel, thor: Add a hardware access token that is required for helAccess*() syscalls

### DIFF
--- a/drivers/gfx/bochs/meson.build
+++ b/drivers/gfx/bochs/meson.build
@@ -3,7 +3,7 @@ if host_machine.cpu_family() != 'x86_64'
 endif
 
 executable('gfx_bochs', 'src/main.cpp',
-	dependencies : drm_core_dep,
+	dependencies : [drm_core_dep, svrctl_proto_dep],
 	install : true
 )
 

--- a/drivers/gfx/bochs/src/main.cpp
+++ b/drivers/gfx/bochs/src/main.cpp
@@ -16,6 +16,7 @@
 #include <protocols/fs/server.hpp>
 #include <protocols/hw/client.hpp>
 #include <protocols/mbus/client.hpp>
+#include <protocols/svrctl/server.hpp>
 #include <core/drm/core.hpp>
 
 #include <libdrm/drm.h>
@@ -37,9 +38,11 @@ GfxDevice::GfxDevice(protocols::hw::Device hw_device,
 		helix::UniqueDescriptor video_ram, void *)
 : _videoRam{std::move(video_ram)}, _hwDevice{std::move(hw_device)},
 		_vramAllocator{24, 10}, _claimedDevice{false} {
+	auto sd = protocols::svrctl::getServerData();
+
 	uintptr_t ports[] = { 0x01CE, 0x01CF, 0x01D0 };
 	HelHandle handle;
-	HEL_CHECK(helAccessIo(ports, 3, &handle));
+	HEL_CHECK(helAccessIo(sd.hardwareAccess, ports, 3, &handle));
 	HEL_CHECK(helEnableIo(handle));
 
 	_operational = arch::global_io;

--- a/drivers/uart/meson.build
+++ b/drivers/uart/meson.build
@@ -3,6 +3,6 @@ if host_machine.cpu_family() != 'x86_64'
 endif
 
 executable('uart', 'src/main.cpp',
-	dependencies : [ libarch, fs_proto_dep, hw_proto_dep, mbus_proto_dep ],
+	dependencies : [ libarch, fs_proto_dep, hw_proto_dep, mbus_proto_dep, svrctl_proto_dep ],
 	install : true
 )

--- a/drivers/uart/src/main.cpp
+++ b/drivers/uart/src/main.cpp
@@ -18,6 +18,7 @@
 #include <helix/ipc.hpp>
 #include <protocols/fs/server.hpp>
 #include <protocols/mbus/client.hpp>
+#include <protocols/svrctl/server.hpp>
 
 #include "spec.hpp"
 #include "fs.bragi.hpp"
@@ -376,8 +377,10 @@ async::detached runTerminal() {
 int main() {
 	std::cout << "uart: Starting driver" << std::endl;
 
+	auto sd = protocols::svrctl::getServerData();
+
 	HelHandle pin_handle;
-	HEL_CHECK(helAccessIrq(kHelAccessIrqByGsi, 0, 4, &pin_handle));
+	HEL_CHECK(helAccessIrq(sd.hardwareAccess, kHelAccessIrqByGsi, 0, 4, &pin_handle));
 	helix::UniqueDescriptor pin{pin_handle};
 
 	HelHandle irq_handle;
@@ -387,7 +390,7 @@ int main() {
 	uintptr_t ports[] = { COM1, COM1 + 1, COM1 + 2, COM1 + 3, COM1 + 4, COM1 + 5, COM1 + 6,
 			COM1 + 7 };
 	HelHandle handle;
-	HEL_CHECK(helAccessIo(ports, 8, &handle));
+	HEL_CHECK(helAccessIo(sd.hardwareAccess, ports, 8, &handle));
 	HEL_CHECK(helEnableIo(handle));
 
 	base = arch::global_io.subspace(COM1);

--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -106,12 +106,14 @@ extern inline __attribute__ (( always_inline )) HelError helCopyOnWrite(HelHandl
 	return error;
 };
 
-extern inline __attribute__ (( always_inline )) HelError helAccessPhysical(uintptr_t physical,
-		size_t size, uint32_t cachingMode, HelHandle *handle) {
-	HelWord hel_handle;
-	HelError error = helSyscall3_1(kHelCallAccessPhysical, (HelWord)physical, (HelWord)size,
-			(HelWord)cachingMode, &hel_handle);
-	*handle = (HelHandle)hel_handle;
+extern inline __attribute__ (( always_inline )) HelError helAccessPhysical(
+	HelHandle accessHandle, uintptr_t physical, size_t size, uint32_t cachingMode, HelHandle *handle
+) {
+	HelWord outHandle;
+	HelError error = helSyscall4_1(
+		kHelCallAccessPhysical, (HelWord)accessHandle, (HelWord)physical, (HelWord)size, (HelWord)cachingMode, &outHandle
+	);
+	*handle = (HelHandle)outHandle;
 	return error;
 };
 
@@ -351,12 +353,14 @@ extern inline __attribute__ (( always_inline )) HelError helRaiseEvent(HelHandle
 	return helSyscall1(kHelCallRaiseEvent, (HelWord)handle);
 };
 
-extern inline __attribute__ (( always_inline )) HelError helAccessIrq(uint32_t mode,
-		uint64_t controller, uint64_t index, HelHandle *handle) {
-	HelWord handle_word;
-	HelError error = helSyscall3_1(kHelCallAccessIrq, (HelWord)mode, (HelWord)controller,
-			(HelWord)index, &handle_word);
-	*handle = (HelHandle)handle_word;
+extern inline __attribute__ (( always_inline )) HelError helAccessIrq(
+	HelHandle accessHandle, uint32_t mode, uint64_t controller, uint64_t index, HelHandle *handle
+) {
+	HelWord outHandle;
+	HelError error = helSyscall4_1(
+		kHelCallAccessIrq, (HelWord)accessHandle, (HelWord)mode, (HelWord)controller, (HelWord)index, &outHandle
+	);
+	*handle = (HelHandle)outHandle;
 	return error;
 };
 
@@ -386,12 +390,14 @@ extern inline __attribute__ (( always_inline )) HelError helAutomateIrq(HelHandl
 			(HelWord)kernlet);
 };
 
-extern inline __attribute__ (( always_inline )) HelError helAccessIo(const uintptr_t *port_array,
-		size_t num_ports, HelHandle *handle) {
-	HelWord out_handle;
-	HelError error = helSyscall2_1(kHelCallAccessIo, (HelWord)port_array,
-			(HelWord) num_ports, &out_handle);
-	*handle = (HelHandle)out_handle;
+extern inline __attribute__ (( always_inline )) HelError helAccessIo(
+	HelHandle accessHandle, const uintptr_t *portArray, size_t numPorts, HelHandle *handle
+) {
+	HelWord outHandle;
+	HelError error = helSyscall3_1(
+		kHelCallAccessIo, (HelWord)accessHandle, (HelWord)portArray, (HelWord) numPorts, &outHandle
+	);
+	*handle = (HelHandle)outHandle;
 	return error;
 };
 

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -1228,8 +1228,9 @@ HEL_C_LINKAGE HelError helCreateManagedMemory(size_t size, uint32_t flags,
 HEL_C_LINKAGE HelError helCopyOnWrite(HelHandle memory,
 		uintptr_t offset, size_t size, HelHandle *handle);
 
-HEL_C_LINKAGE HelError helAccessPhysical(uintptr_t physical,
-		size_t size, uint32_t cachingMode, HelHandle *handle);
+HEL_C_LINKAGE HelError helAccessPhysical(
+	HelHandle accessToken, uintptr_t physical, size_t size, uint32_t cachingMode, HelHandle *handle
+);
 
 //! Creates a memory object that obtains its memory by delegating to other memory objects.
 //! @param[in] numSlots
@@ -1543,8 +1544,9 @@ HEL_C_LINKAGE HelError helRaiseEvent(HelHandle handle);
 //!     For ::kHelAccessIrqByPhandle, this is a controller-specific IRQ index.
 //! @param[out] handle
 //!     Handle to the IRQ pin.
-HEL_C_LINKAGE HelError helAccessIrq(uint32_t mode, uint64_t controller, uint64_t index,
-		HelHandle *handle);
+HEL_C_LINKAGE HelError helAccessIrq(
+	HelHandle accessHandle, uint32_t mode, uint64_t controller, uint64_t index, HelHandle *handle
+);
 
 //! Install an IRQ handler on an IRQ pin.
 //! @param[in] pinHandle
@@ -1570,8 +1572,9 @@ HEL_C_LINKAGE HelError helAutomateIrq(HelHandle handle, uint32_t flags, HelHandl
 //! @name Input/Output
 //! @{
 
-HEL_C_LINKAGE HelError helAccessIo(const uintptr_t *port_array, size_t num_ports,
-		HelHandle *handle);
+HEL_C_LINKAGE HelError helAccessIo(
+	HelHandle accessToken, const uintptr_t *portArray, size_t numPorts, HelHandle *handle
+);
 
 //! Enable userspace access to hardware I/O resources.
 //! @param[in] handle

--- a/kernel/thor/generic/credentials.cpp
+++ b/kernel/thor/generic/credentials.cpp
@@ -1,6 +1,7 @@
 #include <stdint.h>
 
 #include <thor-internal/credentials.hpp>
+#include <thor-internal/debug.hpp>
 #include <thor-internal/kernel-heap.hpp>
 #include <thor-internal/random.hpp>
 
@@ -30,6 +31,16 @@ Credentials::Credentials() {
 	// ... and variant 1.
 	_credentials[8] &= 0x3f;
 	_credentials[8] |= 0x80;
+}
+
+smarter::shared_ptr<TokenObject> hardwareAccessToken() {
+	static frg::eternal<smarter::shared_ptr<TokenObject>> singleton{[] {
+		auto outcome = TokenObject::create();
+		if (!outcome)
+			panicLogger() << "thor: Failed to create global hardwareAccessToken" << frg::endlog;
+		return *outcome;
+	}()};
+	return *singleton;
 }
 
 } // namespace thor

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -633,8 +633,9 @@ HelError helCopyOnWrite(HelHandle memoryHandle,
 	return kHelErrNone;
 }
 
-HelError helAccessPhysical(uintptr_t physical, size_t size, uint32_t cachingMode,
-		HelHandle *handle) {
+HelError helAccessPhysical(
+	HelHandle accessHandle, uintptr_t physical, size_t size, uint32_t cachingMode, HelHandle *handle
+) {
 	if (physical & (kPageSize - 1))
 		return kHelErrIllegalArgs;
 	if (size & (kPageSize - 1))
@@ -661,6 +662,13 @@ HelError helAccessPhysical(uintptr_t physical, size_t size, uint32_t cachingMode
 
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
+
+	// Require the hardware access token to proceed.
+	auto accessOutcome = this_universe->resolveObject<DescriptorType::token>(accessHandle, kHelRightInvoke);
+	if(!accessOutcome)
+		return translateError(accessOutcome.error());
+	if (accessOutcome->get() != hardwareAccessToken().get())
+		return kHelErrIllegalObject;
 
 	auto memoryOutcome = HardwareMemory::create(physical, size, caching);
 	if(!memoryOutcome)
@@ -3452,9 +3460,18 @@ HelError helRaiseEvent(HelHandle handle) {
 	return kHelErrNone;
 }
 
-HelError helAccessIrq(uint32_t mode, uint64_t controller, uint64_t index, HelHandle *handle) {
+HelError helAccessIrq(
+	HelHandle accessHandle, uint32_t mode, uint64_t controller, uint64_t index, HelHandle *handle
+) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
+
+	// Require the hardware access token to proceed.
+	auto accessOutcome = this_universe->resolveObject<DescriptorType::token>(accessHandle, kHelRightInvoke);
+	if(!accessOutcome)
+		return translateError(accessOutcome.error());
+	if (accessOutcome->get() != hardwareAccessToken().get())
+		return kHelErrIllegalObject;
 
 	smarter::shared_ptr<IrqPin> pin;
 	if(mode == kHelAccessIrqByGsi) {
@@ -3690,18 +3707,26 @@ HelError helAutomateIrq(HelHandle handle, uint32_t flags, HelHandle kernlet_hand
 	return kHelErrNone;
 }
 
-HelError helAccessIo(const uintptr_t *port_array, size_t num_ports,
-		HelHandle *handle) {
+HelError helAccessIo(
+	HelHandle accessHandle, const uintptr_t *portArray, size_t numPorts, HelHandle *handle
+) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
+
+	// Require the hardware access token to proceed.
+	auto accessOutcome = this_universe->resolveObject<DescriptorType::token>(accessHandle, kHelRightInvoke);
+	if(!accessOutcome)
+		return translateError(accessOutcome.error());
+	if (accessOutcome->get() != hardwareAccessToken().get())
+		return kHelErrIllegalObject;
 
 	auto ioSpaceOutcome = IoSpace::create();
 	if(!ioSpaceOutcome)
 		return translateError(ioSpaceOutcome.error());
 	auto io_space = std::move(*ioSpaceOutcome);
-	for(size_t i = 0; i < num_ports; i++) {
+	for(size_t i = 0; i < numPorts; i++) {
 		uintptr_t port;
-		if(!readUserObject<uintptr_t>(port_array + i, port))
+		if(!readUserObject<uintptr_t>(portArray + i, port))
 			return kHelErrFault;
 		if (auto outcome = io_space->addPort(port); !outcome)
 			return translateError(outcome.error());

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -656,7 +656,7 @@ void handleSyscall(SyscallImageAccessor image) {
 	} break;
 	case kHelCallAccessPhysical: {
 		HelHandle handle;
-		*image.error() = helAccessPhysical((uintptr_t)arg0, (size_t)arg1, (uint32_t)arg2, &handle);
+		*image.error() = helAccessPhysical((HelHandle)arg0, (uintptr_t)arg1, (size_t)arg2, (uint32_t)arg3, &handle);
 		*image.out0() = handle;
 	} break;
 	case kHelCallCreateIndirectMemory: {
@@ -821,7 +821,7 @@ void handleSyscall(SyscallImageAccessor image) {
 	} break;
 	case kHelCallAccessIrq: {
 		HelHandle handle;
-		*image.error() = helAccessIrq((uint32_t)arg0, (uint64_t)arg1, (uint64_t)arg2, &handle);
+		*image.error() = helAccessIrq((HelHandle)arg0, (uint32_t)arg1, (uint64_t)arg2, (uint64_t)arg3, &handle);
 		*image.out0() = handle;
 	} break;
 	case kHelCallHandleIrq: {
@@ -838,7 +838,7 @@ void handleSyscall(SyscallImageAccessor image) {
 
 	case kHelCallAccessIo: {
 		HelHandle handle;
-		*image.error() = helAccessIo((uintptr_t *)arg0, (size_t)arg1, &handle);
+		*image.error() = helAccessIo((HelHandle)arg0, (uintptr_t *)arg1, (size_t)arg2, &handle);
 		*image.out0() = handle;
 	} break;
 	case kHelCallEnableIo: {

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -530,6 +530,7 @@ namespace posix {
 
 		uint64_t nextTid_ = 1;
 
+		Handle hardwareAccessHandle;
 		Handle mbusHandle;
 		Handle controlHandle;
 		frg::vector<OpenFile *, KernelAlloc> openFiles;
@@ -1110,18 +1111,24 @@ namespace posix {
 					panicLogger() << "thor: Failed to resume server" << frg::endlog;
 			}else if(interrupt == kIntrSuperCall + ::protocols::svrctl::superGetServerData) {
 				uintptr_t dataAddr;
+				size_t dataSize;
 				auto readOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					dataAddr = *executor->arg0();
+					dataSize = *executor->arg1();
 				});
 				if(!readOutcome)
 					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 
 				::protocols::svrctl::ManagarmServerData data = {
-					controlHandle
+					.hardwareAccess = hardwareAccessHandle,
+					.controlLane = controlHandle,
 				};
 
 				auto outcome = co_await info.thread->getAddressSpace()->writeSpace(
-						dataAddr, &data, sizeof(::protocols::svrctl::ManagarmServerData));
+					dataAddr,
+					&data,
+					frg::min(dataSize, sizeof(::protocols::svrctl::ManagarmServerData))
+				);
 				auto writeOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					if(!outcome) {
 						*executor->result0() = kHelErrFault;
@@ -1226,6 +1233,9 @@ void runService(frg::string<KernelAlloc> name, smarter::shared_ptr<Stream, LaneP
 
 		auto process = frg::construct<posix::Process>(*kernelAlloc, std::move(name));
 		KernelFiber::asyncBlockCurrent(process->setupAddressSpace(thread));
+		process->hardwareAccessHandle = thread->getUniverse()->attachDescriptor(
+			AnyDescriptor::make<DescriptorType::token>(hardwareAccessToken(), kHelRightInvoke)
+		);
 		process->attachControl(thread, std::move(controlLane));
 		process->attachMbus(thread);
 		KernelFiber::asyncBlockCurrent(process->attachFile(thread, stdioFile));

--- a/kernel/thor/generic/thor-internal/credentials.hpp
+++ b/kernel/thor/generic/thor-internal/credentials.hpp
@@ -28,4 +28,6 @@ public:
 	TokenObject(CtorToken) { }
 };
 
+smarter::shared_ptr<TokenObject> hardwareAccessToken();
+
 }

--- a/protocols/svrctl/include/protocols/svrctl/server.hpp
+++ b/protocols/svrctl/include/protocols/svrctl/server.hpp
@@ -9,6 +9,7 @@
 #include <async/result.hpp>
 #include <helix/ipc.hpp>
 #include <helix/memory.hpp>
+#include <protocols/svrctl/supercalls.hpp>
 #include <smarter.hpp>
 
 namespace protocols {
@@ -24,6 +25,8 @@ struct ControlOperations {
 	// Returns Error::deviceNotSupported if the operation is not possible.
 	async::result<Error> (*bind)(int64_t base_id);
 };
+
+ManagarmServerData getServerData();
 
 async::result<void>
 serveControl(const ControlOperations *ops);

--- a/protocols/svrctl/include/protocols/svrctl/supercalls.hpp
+++ b/protocols/svrctl/include/protocols/svrctl/supercalls.hpp
@@ -9,6 +9,7 @@ namespace svrctl {
 inline constexpr uint32_t superGetServerData = 64;
 
 struct ManagarmServerData {
+	HelHandle hardwareAccess;
 	HelHandle controlLane;
 };
 

--- a/protocols/svrctl/src/server.cpp
+++ b/protocols/svrctl/src/server.cpp
@@ -10,7 +10,6 @@
 #include <helix/ipc.hpp>
 
 #include <protocols/svrctl/server.hpp>
-#include <protocols/svrctl/supercalls.hpp>
 #include "svrctl.bragi.hpp"
 
 namespace protocols {
@@ -45,10 +44,19 @@ struct HandleBind {
 
 } // namespace anonymous
 
+ManagarmServerData getServerData() {
+	ManagarmServerData sd{};
+	HEL_CHECK(helSyscall2(
+		kHelCallSuper + superGetServerData,
+		reinterpret_cast<HelWord>(&sd),
+		sizeof(ManagarmServerData)
+	));
+	return sd;
+}
+
 async::result<void>
 serveControl(const ControlOperations *ops) {
-	ManagarmServerData sd;
-	HEL_CHECK(helSyscall1(kHelCallSuper + superGetServerData, reinterpret_cast<HelWord>(&sd)));
+	auto sd = getServerData();
 	helix::UniqueLane lane{sd.controlLane};
 
 	while(true) {

--- a/rust/hel/src/lib.rs
+++ b/rust/hel/src/lib.rs
@@ -78,10 +78,21 @@ impl CachingMode {
 }
 
 /// Returns a memory object backing the given physical memory range.
-pub fn access_physical(physical: usize, size: usize, caching: CachingMode) -> Result<Handle> {
+pub fn access_physical(
+    access_handle: &Handle,
+    physical: usize,
+    size: usize,
+    caching: CachingMode,
+) -> Result<Handle> {
     let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
     result::hel_check(unsafe {
-        hel_sys::helAccessPhysical(physical, size, caching.to_raw(), &mut handle)
+        hel_sys::helAccessPhysical(
+            access_handle.handle(),
+            physical,
+            size,
+            caching.to_raw(),
+            &mut handle,
+        )
     })?;
     Ok(unsafe { Handle::from_raw(handle) })
 }
@@ -92,26 +103,40 @@ pub fn enable_io(handle: Handle) -> Result<()> {
 }
 
 /// Returns an IO-space object granting access to the given set of IO ports.
-pub fn access_io(ports: &[usize]) -> Result<Handle> {
+pub fn access_io(access_handle: &Handle, ports: &[usize]) -> Result<Handle> {
     let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
-    result::hel_check(unsafe { hel_sys::helAccessIo(ports.as_ptr(), ports.len(), &mut handle) })?;
+    result::hel_check(unsafe {
+        hel_sys::helAccessIo(
+            access_handle.handle(),
+            ports.as_ptr(),
+            ports.len(),
+            &mut handle,
+        )
+    })?;
     Ok(unsafe { Handle::from_raw(handle) })
 }
 
 /// Returns the IRQ pin that the given global system interrupt is attached to.
-pub fn access_irq_by_gsi(gsi: u64) -> Result<Handle> {
+pub fn access_irq_by_gsi(access_handle: &Handle, gsi: u64) -> Result<Handle> {
     let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
     result::hel_check(unsafe {
-        hel_sys::helAccessIrq(hel_sys::kHelAccessIrqByGsi as u32, 0, gsi, &mut handle)
+        hel_sys::helAccessIrq(
+            access_handle.handle(),
+            hel_sys::kHelAccessIrqByGsi as u32,
+            0,
+            gsi,
+            &mut handle,
+        )
     })?;
     Ok(unsafe { Handle::from_raw(handle) })
 }
 
 /// Returns the IRQ pin identified by a device tree phandle and a controller-specific index.
-pub fn access_irq_by_phandle(phandle: u64, index: u64) -> Result<Handle> {
+pub fn access_irq_by_phandle(access_handle: &Handle, phandle: u64, index: u64) -> Result<Handle> {
     let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
     result::hel_check(unsafe {
         hel_sys::helAccessIrq(
+            access_handle.handle(),
             hel_sys::kHelAccessIrqByPhandle as u32,
             phandle,
             index,

--- a/rust/managarm/src/lib.rs
+++ b/rust/managarm/src/lib.rs
@@ -6,3 +6,4 @@ pub mod hw;
 pub mod kerncfg;
 pub mod mbus;
 pub mod posix;
+pub mod svrctl;

--- a/rust/managarm/src/posix.rs
+++ b/rust/managarm/src/posix.rs
@@ -25,7 +25,6 @@ pub enum PosixSupercall {
     SigSuspend = 13,
     GetTid = 14,
     SigGetPending = 15,
-    GetServerData = 64,
 }
 
 #[repr(C)]

--- a/rust/managarm/src/svrctl.rs
+++ b/rust/managarm/src/svrctl.rs
@@ -1,0 +1,43 @@
+use hel::Handle;
+use std::mem::ManuallyDrop;
+use std::sync::LazyLock;
+
+#[repr(i32)]
+pub enum SvrctlSupercall {
+    GetServerData = 64,
+}
+
+#[derive(Default)]
+#[repr(C)]
+struct ManagarmServerData {
+    hardware_access: hel_sys::HelHandle,
+    control_lane: hel_sys::HelHandle,
+}
+
+static SERVER_DATA: LazyLock<ManagarmServerData> = LazyLock::new(|| {
+    let mut server_data = ManagarmServerData::default();
+    let result = unsafe {
+        hel_sys::helSyscall2(
+            hel_sys::kHelCallSuper as i32 + SvrctlSupercall::GetServerData as i32,
+            (&raw mut server_data).addr() as u64,
+            std::mem::size_of::<ManagarmServerData>() as u64,
+        )
+    };
+
+    if result != hel_sys::kHelErrNone as i32 {
+        let error_string = unsafe { hel_sys::_helErrorString(result) };
+        let error_cstr = unsafe { std::ffi::CStr::from_ptr(error_string) };
+
+        panic!("Failed to get server data: {error_cstr:?}");
+    }
+
+    server_data
+});
+
+pub fn hardware_access_handle() -> &'static Handle {
+    static HANDLE: LazyLock<ManuallyDrop<Handle>> = LazyLock::new(|| unsafe {
+        ManuallyDrop::new(Handle::from_raw(SERVER_DATA.hardware_access))
+    });
+
+    &HANDLE
+}

--- a/sif/src/acpi/glue.rs
+++ b/sif/src/acpi/glue.rs
@@ -1,3 +1,4 @@
+use managarm::svrctl::hardware_access_handle;
 use std::collections::{BTreeMap, VecDeque};
 use std::ffi::{CStr, c_void};
 use std::sync::atomic::Ordering;
@@ -66,7 +67,12 @@ pub unsafe extern "C" fn uacpi_kernel_map(addr: uacpi_phys_addr, len: uacpi_size
     let aligned = (addr as usize) & !PAGE_MASK;
     let span = (len + page_off + PAGE_MASK) & !PAGE_MASK;
 
-    let handle = match hel::access_physical(aligned, span, hel::CachingMode::Default) {
+    let handle = match hel::access_physical(
+        hardware_access_handle(),
+        aligned,
+        span,
+        hel::CachingMode::Default,
+    ) {
         Ok(handle) => handle,
         Err(_) => return UACPI_MAP_FAILED,
     };
@@ -295,7 +301,7 @@ pub unsafe extern "C" fn uacpi_kernel_io_map(
             ports.push(base as usize + i);
         }
 
-        let Ok(handle) = hel::access_io(&ports) else {
+        let Ok(handle) = hel::access_io(hardware_access_handle(), &ports) else {
             return uacpi_sys::UACPI_STATUS_INVALID_ARGUMENT;
         };
         let Ok(()) = hel::enable_io(handle) else {

--- a/sif/src/isa.rs
+++ b/sif/src/isa.rs
@@ -1,4 +1,5 @@
 use hel::{IrqPolarity, IrqTrigger};
+use managarm::svrctl::hardware_access_handle;
 use uacpi_sys::acpi_madt_interrupt_source_override;
 use zerocopy::FromBytes;
 
@@ -100,7 +101,7 @@ pub fn configure_isa_irqs() {
     println!("sif: Configuring ISA IRQs");
     for irq in PRECONFIGURED_ISA_IRQS {
         let line = overrides[usize::from(irq)].unwrap_or_else(|| IsaIrq::identity(irq));
-        let pin = match hel::access_irq_by_gsi(line.gsi as u64) {
+        let pin = match hel::access_irq_by_gsi(hardware_access_handle(), line.gsi as u64) {
             Ok(pin) => pin,
             Err(err) => {
                 println!(

--- a/sif/src/pci/config/ecam.rs
+++ b/sif/src/pci/config/ecam.rs
@@ -1,3 +1,4 @@
+use managarm::svrctl::hardware_access_handle;
 use std::collections::BTreeMap;
 use std::sync::Mutex;
 
@@ -55,6 +56,7 @@ impl EcamPcieConfigIo {
         let offset = ((bus - self.bus_start) as u64) << 20;
 
         let handle = hel::access_physical(
+            hardware_access_handle(),
             (self.mmio_base + offset) as usize,
             SIZE,
             hel::CachingMode::Mmio,

--- a/sif/src/pci/config/mod.rs
+++ b/sif/src/pci/config/mod.rs
@@ -1,6 +1,7 @@
 pub mod ecam;
 pub mod legacy;
 
+use managarm::svrctl::hardware_access_handle;
 use std::collections::BTreeMap;
 use std::ptr::addr_of;
 use std::sync::Mutex;
@@ -247,7 +248,7 @@ pub unsafe fn write_config_word(
 fn add_legacy_config_io() -> anyhow::Result<()> {
     // Unlike thor, we need to be granted access to the config window ports.
     let ports: Vec<usize> = (0xCF8..=0xCFF).collect();
-    hel::access_io(&ports)
+    hel::access_io(hardware_access_handle(), &ports)
         .and_then(hel::enable_io)
         .context("failed to enable the legacy PCI config I/O ports")?;
 

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod discover;
 pub mod serve;
 
+use managarm::svrctl::hardware_access_handle;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU8};
 use std::sync::{Mutex, OnceLock};
@@ -48,7 +49,7 @@ pub fn system_irq(gsi: u32, trigger: IrqTrigger, polarity: IrqPolarity) -> Optio
         return Some(*pin);
     }
 
-    let handle = match hel::access_irq_by_gsi(gsi as u64) {
+    let handle = match hel::access_irq_by_gsi(hardware_access_handle(), gsi as u64) {
         Ok(handle) => handle,
         Err(err) => {
             println!("sif: Failed to access GSI {gsi}: {err}");

--- a/sif/src/pci/serve.rs
+++ b/sif/src/pci/serve.rs
@@ -1,3 +1,4 @@
+use managarm::svrctl::hardware_access_handle;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
@@ -154,13 +155,18 @@ impl managarm::hw::server::PciDevice for ServedEntity {
                 let aligned = (bar.host_address as usize) & !PAGE_MASK;
                 let page_off = (bar.host_address as usize) & PAGE_MASK;
                 let span = ((bar.length as usize) + page_off + PAGE_MASK) & !PAGE_MASK;
-                hel::access_physical(aligned, span.max(PAGE_SIZE), hel::CachingMode::Mmio)
+                hel::access_physical(
+                    hardware_access_handle(),
+                    aligned,
+                    span.max(PAGE_SIZE),
+                    hel::CachingMode::Mmio,
+                )
             }
             BarType::Io => {
                 let ports: Vec<usize> = (bar.address..bar.address + bar.length)
                     .map(|p| p as usize)
                     .collect();
-                hel::access_io(&ports)
+                hel::access_io(hardware_access_handle(), &ports)
             }
             BarType::None => Err(hel::Error::IllegalArgs),
         }


### PR DESCRIPTION
Prior to this PR, all programs could simply call `helAccessPhysical()`, `helAccessIo()` or `helAccessIrq()` to obtain direct access to hardware. This PR fixes this gap:
- `helAccess*()` syscalls now takes a token handle and fail if this token does not match a kernel-defined hardware access token.
- The hardware access token is only handed out to servers (e.g., not to POSIX applications). In a follow up, we can restrict it to specific servers only. The long term plan is to hand it only to `sif` but right now, we also need it in the Bochs VGA driver and in the x86 UART driver as these drivers do not obtain their resources over the `hw` protocol yet.