### PR TITLE
eir: Fix eir-uefi on aarch64 and riscv64

### DIFF
--- a/kernel/eir/arch/arm/arch.cpp
+++ b/kernel/eir/arch/arm/arch.cpp
@@ -388,6 +388,8 @@ void initProcessorEarly() {
 static initgraph::Task earlyProcessorInit{
     &globalInitEngine,
     "arm.early-processor-init",
+    // The firmware handles its own interrupts, hence we must not steal VBAR before it is done.
+    initgraph::Requires{getFirmwareDoneStage()},
     initgraph::Entails{getMemoryLayoutReservedStage()},
     [] { initProcessorEarly(); }
 };

--- a/kernel/eir/arch/riscv/cpu.cpp
+++ b/kernel/eir/arch/riscv/cpu.cpp
@@ -273,6 +273,8 @@ void initProcessorEarly() {
 static initgraph::Task earlyProcessorInit{
     &globalInitEngine,
     "riscv.early-processor-init",
+    // The firmware handles its own interrupts, hence we must not steal stvec before it is done.
+    initgraph::Requires{getFirmwareDoneStage()},
     initgraph::Entails{getMemoryLayoutReservedStage()},
     [] {
 	    initProcessorEarly();

--- a/kernel/eir/boot/uefi/entry.cpp
+++ b/kernel/eir/boot/uefi/entry.cpp
@@ -499,7 +499,7 @@ initgraph::Task exitBootServices{
     &globalInitEngine,
     "uefi.exit-boot-services",
     initgraph::Requires{getBootservicesDoneStage()},
-    initgraph::Entails{getReservedRegionsKnownStage()},
+    initgraph::Entails{getFirmwareDoneStage(), getReservedRegionsKnownStage()},
     [] {
 	    disableLogHandler(&conOutLogHandler);
 

--- a/kernel/eir/generic/debug.cpp
+++ b/kernel/eir/generic/debug.cpp
@@ -83,6 +83,18 @@ void enableLogHandler(LogHandler *handler) {
 	if (handler->active)
 		return;
 
+	// Handlers that become available late would otherwise miss the entire early boot log.
+	if (handler->wantsBacklog) {
+		auto &ring = bootLogRing();
+		char buffer[maxLogLine];
+
+		uint64_t ptr = 0;
+		while (auto record = ring.dequeueAt(ptr, buffer, maxLogLine)) {
+			handler->emit({buffer, record->size});
+			ptr = record->nextPtr;
+		}
+	}
+
 	auto &handlerList = accessHandlerList();
 	handlerList.push_back(handler);
 	handler->active = true;

--- a/kernel/eir/generic/eir-internal/debug.hpp
+++ b/kernel/eir/generic/eir-internal/debug.hpp
@@ -30,6 +30,8 @@ struct LogHandler {
 
 	frg::default_list_hook<LogHandler> hook;
 	bool active{false};
+	// Whether enableLogHandler() replays the lines that were logged before.
+	bool wantsBacklog{false};
 };
 
 void enableLogHandler(LogHandler *handler);

--- a/kernel/eir/generic/eir-internal/main.hpp
+++ b/kernel/eir/generic/eir-internal/main.hpp
@@ -27,6 +27,10 @@ extern "C" void eirRunConstructors();
 initgraph::Stage *getInitrdAvailableStage();
 initgraph::Stage *getCmdlineAvailableStage();
 
+// After this stage, the boot protocol does not call into firmware anymore.
+// Boot protocols that never invoke firmware services reach this stage immediately.
+initgraph::Stage *getFirmwareDoneStage();
+
 // Before this stage, all reserved regions must be available.
 initgraph::Stage *getReservedRegionsKnownStage();
 

--- a/kernel/eir/generic/main-function.cpp
+++ b/kernel/eir/generic/main-function.cpp
@@ -51,6 +51,11 @@ initgraph::Stage *getCmdlineAvailableStage() {
 	return &s;
 }
 
+initgraph::Stage *getFirmwareDoneStage() {
+	static initgraph::Stage s{&globalInitEngine, "generic.firmware-done"};
+	return &s;
+}
+
 initgraph::Stage *getKernelMappableStage() {
 	static initgraph::Stage s{&globalInitEngine, "generic.kernel-mappable"};
 	return &s;

--- a/kernel/eir/system/uart/uart.cpp
+++ b/kernel/eir/system/uart/uart.cpp
@@ -95,7 +95,7 @@ static initgraph::Task setupBootUartMmio{
 
 BootUartConfig bootUartConfig;
 
-UartLogHandler::UartLogHandler(common::uart::AnyUart *uart) : uart_{uart} {}
+UartLogHandler::UartLogHandler(common::uart::AnyUart *uart) : uart_{uart} { wantsBacklog = true; }
 
 void UartLogHandler::emit(frg::string_view line) {
 	std::visit(


### PR DESCRIPTION
We were missing an initgraph dependency that caused us to install exception handlers before `ExitBootServices()`.