### PR TITLE
thor: Render framebuffer log directly from log ring

### DIFF
--- a/kernel/thor/generic/debug.cpp
+++ b/kernel/thor/generic/debug.cpp
@@ -43,8 +43,13 @@ void LogHandler::emitUrgent(frg::string_view record) {
 }
 
 void enableLogHandler(LogHandler *sink) {
-	auto lock = frg::guard(&listMutex);
-	globalLogList.push_back(sink);
+	{
+		auto lock = frg::guard(&listMutex);
+		globalLogList.push_back(sink);
+	}
+
+	// Handlers that render from the log ring need this to display the pre-existing records.
+	flushLogHandler(sink);
 }
 
 void disableLogHandler(LogHandler *sink) {

--- a/kernel/thor/generic/kernel-log.cpp
+++ b/kernel/thor/generic/kernel-log.cpp
@@ -210,6 +210,13 @@ void postLogRecord(frg::string_view record, bool expedited) {
 	}
 }
 
+void flushLogHandler(LogHandler *handler) {
+	StatelessIrqLock irqLock;
+	auto emitLock = frg::guard(&emitMutex);
+
+	handler->flush();
+}
+
 coroutine<void> waitForLog(uint64_t deqPtr) {
 	// TODO: Since we simply wait for drainEvent, log records may become available earlier
 	//       to consumers of the asynchronous waitForLog() / retrieveLogRecord() API

--- a/kernel/thor/generic/thor-internal/kernel-log.hpp
+++ b/kernel/thor/generic/thor-internal/kernel-log.hpp
@@ -7,6 +7,7 @@
 namespace thor {
 
 void postLogRecord(frg::string_view record, bool expedited);
+void flushLogHandler(LogHandler *handler);
 coroutine<void> waitForLog(uint64_t deqPtr);
 frg::tuple<bool, uint64_t, uint64_t, size_t> retrieveLogRecord(uint64_t deqPtr, void *data, size_t maxSize);
 

--- a/kernel/thor/system/framebuffer/boot-screen.cpp
+++ b/kernel/thor/system/framebuffer/boot-screen.cpp
@@ -1,5 +1,6 @@
 
 #include <thor-internal/framebuffer/boot-screen.hpp>
+#include <thor-internal/kernel-log.hpp>
 
 namespace thor {
 
@@ -96,15 +97,8 @@ BootScreen::BootScreen(TextDisplay *display)
 	_height = _display->getHeight();
 }
 
-void BootScreen::emit(frg::string_view record) {
-	auto [md, msg] = destructureLogRecord(record);
-	size_t idx = _displaySeq & (NUM_LINES - 1);
-	auto *line = &_displayLines[idx];
-
-	line->severity = md.severity;
-	line->length = msg.size();
-	memcpy(line->msg, msg.data(), msg.size());
-	++_displaySeq;
+void BootScreen::emit(frg::string_view) {
+	// postLogRecord() posted the record to the log ring already; redraw() renders from there.
 }
 
 void BootScreen::flush() {
@@ -112,42 +106,87 @@ void BootScreen::flush() {
 }
 
 void BootScreen::redraw() {
-	// Redraw up to _height lines.
-	for(size_t i = 0; i < _height - 1; i++) {
-		if(i >= _displaySeq)
+	char buffer[logLineLength];
+
+	// The last row is always left blank.
+	auto numRows = _height - 1;
+
+	// Drop records until the tail of the log ring fits onto the screen.
+	auto numRecords = countRecords();
+	while(numRecords > numRows) {
+		auto [success, recordPtr, nextPtr, size] = retrieveLogRecord(_topPtr, buffer, 0);
+		if(!success)
 			break;
-		auto seq = _displaySeq - i - 1;
-		size_t idx = seq & (NUM_LINES - 1);
-		auto *line = &_displayLines[idx];
-
-		Formatter fmt{this, 0, _height - i - 2};
-
-		switch(line->severity) {
-			case Severity::emergency:
-			case Severity::alert:
-			case Severity::critical:
-			case Severity::error:
-				fmt.print("\e[31m");
-				break;
-			case Severity::warning:
-				fmt.print("\e[33m");
-				break;
-			case Severity::notice:
-			case Severity::info:
-				fmt.print("\e[37m");
-				break;
-			case Severity::debug:
-				fmt.print("\e[35m");
-				break;
-			default:
-				fmt.print("\e[39m");
-		}
-
-		fmt.print(line->msg, line->length);
+		_topPtr = nextPtr;
+		numRecords--;
 	}
 
-	// Clear the last line.
-	_display->setBlanks(0, _height - 1, frg::min(logLineLength, _width), -1);
+	// Render the records. Producers may append to the ring while we do so; those records
+	// are picked up by the next redraw().
+	size_t y = 0;
+	auto ptr = _topPtr;
+	while(y < numRows) {
+		auto [success, recordPtr, nextPtr, size] = retrieveLogRecord(ptr, buffer, logLineLength);
+		if(!success)
+			break;
+
+		renderLine(y, {buffer, size});
+		ptr = nextPtr;
+		y++;
+	}
+
+	// Clear the rows that no record is rendered to.
+	for(; y < _height; y++)
+		_display->setBlanks(0, y, _width, -1);
+}
+
+size_t BootScreen::countRecords() {
+	// Only the record boundaries are of interest here; a maximal size of zero avoids copying.
+	char dummy;
+
+	size_t n = 0;
+	auto ptr = _topPtr;
+	while(true) {
+		auto [success, recordPtr, nextPtr, size] = retrieveLogRecord(ptr, &dummy, 0);
+		if(!success)
+			break;
+
+		// The ring may have invalidated the records that _topPtr points to.
+		if(!n)
+			_topPtr = recordPtr;
+		ptr = nextPtr;
+		n++;
+	}
+	return n;
+}
+
+void BootScreen::renderLine(size_t y, frg::string_view record) {
+	auto [md, msg] = destructureLogRecord(record);
+
+	Formatter fmt{this, 0, y};
+
+	switch(md.severity) {
+		case Severity::emergency:
+		case Severity::alert:
+		case Severity::critical:
+		case Severity::error:
+			fmt.print("\e[31m");
+			break;
+		case Severity::warning:
+			fmt.print("\e[33m");
+			break;
+		case Severity::notice:
+		case Severity::info:
+			fmt.print("\e[37m");
+			break;
+		case Severity::debug:
+			fmt.print("\e[35m");
+			break;
+		default:
+			fmt.print("\e[39m");
+	}
+
+	fmt.print(msg.data(), msg.size());
 }
 
 } //namespace thor

--- a/kernel/thor/system/framebuffer/fb.cpp
+++ b/kernel/thor/system/framebuffer/fb.cpp
@@ -111,6 +111,10 @@ void initializeBootFb(uint64_t address, uint64_t pitch, uint64_t width,
 	fb_info->bpp = bpp;
 	fb_info->type = type;
 
+	// Without a framebuffer, there is nothing to display the boot screen on.
+	if(!address)
+		return;
+
 	// Initialize the framebuffer with a lower-half window.
 	bootDisplay.initialize(early_window,
 			fb_info->width, fb_info->height, fb_info->pitch);

--- a/kernel/thor/system/framebuffer/thor-internal/framebuffer/boot-screen.hpp
+++ b/kernel/thor/system/framebuffer/thor-internal/framebuffer/boot-screen.hpp
@@ -42,23 +42,17 @@ struct BootScreen final : public LogHandler {
 	void emit(frg::string_view record) override;
 	void flush() override;
 
-	void redraw();
-
 private:
-	struct Line {
-		Severity severity;
-		size_t length{0};
-		char msg[logLineLength]{};
-	};
-
-	// Number of lines that are kept in memory. Must be power of 2.
-	static constexpr size_t NUM_LINES = 128;
+	void redraw();
+	size_t countRecords();
+	void renderLine(size_t y, frg::string_view record);
 
 	TextDisplay *_display;
 	size_t _width;
 	size_t _height;
-	Line _displayLines[NUM_LINES];
-	uint64_t _displaySeq{0};
+
+	// Ring pointer of the first record that is displayed on screen.
+	uint64_t _topPtr{0};
 };
 
 } // namespace thor


### PR DESCRIPTION
Prior to this PR, the framebuffer log handler emitted log records into an array of 128 lines and then rendered the lines to the screen. This caused log lines to wrap on screens with more than 128 lines.

Fix this by rendering directly from the log ring to the screen (using the same strategy that Eir also uses now).