### PR TITLE
drivers/xhci: Fix issues related to scratchpad buffers

### DIFF
--- a/core/arch/include/arch/os/dma_pool.hpp
+++ b/core/arch/include/arch/os/dma_pool.hpp
@@ -235,7 +235,7 @@ struct dma_space {
 
 		// Ensure that the backing pages of the view are already present, or faulted in.
 		auto populateResult = co_await helix_ng::populateSpace(
-		    space_, iova_base + dp.offset(), view.size()
+		    space_, iova_base + dp.offset(), view.size_bytes()
 		);
 		HEL_CHECK(populateResult.error());
 

--- a/drivers/usb/hcds/xhci/src/main.cpp
+++ b/drivers/usb/hcds/xhci/src/main.cpp
@@ -35,6 +35,20 @@ namespace proto = protocols::usb;
 
 std::vector<std::shared_ptr<Controller>> globalControllers;
 
+namespace {
+
+// Number of address bits that the controller can use for DMA.
+size_t dmaAddressBits([[maybe_unused]] arch::mem_space space) {
+#ifdef __aarch64__
+	// TODO: When we have a way to query the platform this could be restricted to RPI4 only.
+	return 31;
+#else
+	return (space.load(cap_regs::hccparams1) & hccparams1::ac64) ? 64 : 32;
+#endif
+}
+
+} // namespace
+
 Controller::Controller(
     protocols::hw::Device hw_device,
     mbus_ng::Entity entity,
@@ -51,14 +65,7 @@ Controller::Controller(
   _irq{std::move(irq)},
   _space{_mapping.get()},
   _name{name},
-#ifdef __aarch64__
-// TODO: When we have a way to query the platform this could be restricted to RPI4 only.
-		_memoryPool{{.addressBits = 31}},
-#else
-// TODO: It is theoretically possible that there could be controllers that don't support 64-bit
-// addresses, to support those this would have to be conditional.
-		_memoryPool{{.addressBits = 64}},
-#endif
+  _memoryPool{{.addressBits = dmaAddressBits(_space)}},
   _dmaSpaceHandle{std::move(dmaSpaceHandle)},
   _dmaSpace{_memoryPool.attachDmaSpace(_dmaSpaceHandle, iommuActive)},
   _dcbaa{&_memoryPool, 256},

--- a/drivers/usb/hcds/xhci/src/main.cpp
+++ b/drivers/usb/hcds/xhci/src/main.cpp
@@ -238,11 +238,15 @@ async::detached Controller::initialize() {
 	barrier.writeback(_dcbaa.view_buffer());
 
 	// Tell the controller about our device context pointer array
-	operational.store(op_regs::dcbaap, co_await _dmaSpace.iova_of(_dcbaa));
+	auto dcbaaPtr = co_await _dmaSpace.iova_of(_dcbaa);
+	operational.store(op_regs::dcbaapLow, dcbaaPtr & 0xFFFFFFFF);
+	operational.store(op_regs::dcbaapHi, dcbaaPtr >> 32);
 
 	// Tell the controller about our command ring
 	co_await _cmdRing.initialize();
-	operational.store(op_regs::crcr, _cmdRing.getPtr() | 1);
+	auto cmdRingPtr = _cmdRing.getPtr() | 1;
+	operational.store(op_regs::crcrLow, cmdRingPtr & 0xFFFFFFFF);
+	operational.store(op_regs::crcrHi, cmdRingPtr >> 32);
 
 	// Set up interrupters
 	// TODO(qookie): MSIs let us use multiple interrupters to

--- a/drivers/usb/hcds/xhci/src/main.cpp
+++ b/drivers/usb/hcds/xhci/src/main.cpp
@@ -1,6 +1,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 #include <optional>
 #include <memory>
@@ -220,16 +221,21 @@ async::detached Controller::initialize() {
 	auto pageSize = 1u << ((std::countr_zero(operational.load(op_regs::pagesize))) + 12);
 	std::println("{} Controller's minimum page size is {}", this, pageSize);
 
+	// We need to force a cache flush even on cache coherent platforms since
+	// the scratchpad buffer array and the scratchpad buffers use no-snoop transactions.
+	arch::dma_barrier forcedBarrier{false};
+
 	// Allocate the scratchpad buffers
-	_scratchpadBufArray = arch::dma_array<uint64_t>{&_memoryPool, nScratchpadBufs};
+	_scratchpadBufArray = arch::dma_array<uint64_t, 64>{&_memoryPool, nScratchpadBufs};
 	for (size_t i = 0; i < nScratchpadBufs; i++) {
 		_scratchpadBufs.push_back(arch::dma_buffer(&_memoryPool,
-					pageSize));
+					pageSize, pageSize));
+		memset(_scratchpadBufs.back().data(), 0, pageSize);
 
-		barrier.writeback(_scratchpadBufs.back());
+		forcedBarrier.writeback(_scratchpadBufs.back());
 		_scratchpadBufArray[i] = co_await _dmaSpace.iova_of(_scratchpadBufs.back());
 	}
-	barrier.writeback(_scratchpadBufArray.view_buffer());
+	forcedBarrier.writeback(_scratchpadBufArray.view_buffer());
 
 	// Initialize the device context pointer array
 	for (size_t i = 0; i < 256; i++)

--- a/drivers/usb/hcds/xhci/src/spec.hpp
+++ b/drivers/usb/hcds/xhci/src/spec.hpp
@@ -81,6 +81,7 @@ namespace hccparams1 {
 
 inline constexpr arch::field<uint32_t, uint16_t> extCapPtr(16, 16);
 inline constexpr arch::field<uint32_t, bool> contextSize(2, 1);
+inline constexpr arch::field<uint32_t, bool> ac64(0, 1);
 
 } // namespace hccparams1
 

--- a/drivers/usb/hcds/xhci/src/spec.hpp
+++ b/drivers/usb/hcds/xhci/src/spec.hpp
@@ -17,8 +17,10 @@ inline constexpr arch::bit_register<uint32_t> usbcmd(0);
 inline constexpr arch::bit_register<uint32_t> usbsts(0x04);
 inline constexpr arch::scalar_register<uint32_t> pagesize(0x8);
 inline constexpr arch::scalar_register<uint32_t> dnctrl(0x14);
-inline constexpr arch::scalar_register<uint64_t> crcr(0x18);
-inline constexpr arch::scalar_register<uint64_t> dcbaap(0x30);
+inline constexpr arch::scalar_register<uint32_t> crcrLow(0x18);
+inline constexpr arch::scalar_register<uint32_t> crcrHi(0x1C);
+inline constexpr arch::scalar_register<uint32_t> dcbaapLow(0x30);
+inline constexpr arch::scalar_register<uint32_t> dcbaapHi(0x34);
 inline constexpr arch::bit_register<uint32_t> config(0x38);
 
 } // namespace op_regs

--- a/drivers/usb/hcds/xhci/src/xhci.hpp
+++ b/drivers/usb/hcds/xhci/src/xhci.hpp
@@ -420,7 +420,8 @@ private:
 	arch::dma_space _dmaSpace;
 
 	arch::dma_array<uint64_t> _dcbaa;
-	arch::dma_array<uint64_t> _scratchpadBufArray;
+	// The scratchpad buffer array is required to be 64-byte aligned.
+	arch::dma_array<uint64_t, 64> _scratchpadBufArray;
 	std::vector<arch::dma_buffer> _scratchpadBufs;
 
 	std::vector<std::unique_ptr<Interrupter>> _interrupters;


### PR DESCRIPTION
Align / zero / flush scratchpad buffers explicitly. Also fix `crcr` and `dcbaap` setup to use 32-bit writes.