### PR TITLE
thor: Fix bugs in thor's POSIX emulation

### DIFF
--- a/kernel/thor/arch/arm/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/cpu.hpp
@@ -248,6 +248,7 @@ public:
 	Word *arg1() { return &general()->x[2]; }
 	Word *result0() { return &general()->x[0]; }
 	Word *result1() { return &general()->x[1]; }
+	Word *result2() { return &general()->x[2]; }
 
 	ExecutorState *state() {
 		return reinterpret_cast<ExecutorState *>(_pointer);

--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -215,6 +215,7 @@ public:
 	Word *arg1() { return &general()->a(2); }
 	Word *result0() { return &general()->a(0); }
 	Word *result1() { return &general()->a(1); }
+	Word *result2() { return &general()->a(2); }
 
 	Frame *general() { return reinterpret_cast<Frame *>(_pointer); }
 

--- a/kernel/thor/arch/x86/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/cpu.hpp
@@ -331,6 +331,7 @@ public:
 	Word *arg1() { return &general()->rdx; }
 	Word *result0() { return &general()->rdi; }
 	Word *result1() { return &general()->rsi; }
+	Word *result2() { return &general()->rdx; }
 
 private:
 	// note: this struct is accessed from assembly.

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -1178,11 +1178,20 @@ namespace posix {
 					panicLogger() << "thor: Failed to create thread" << frg::endlog;
 				auto new_thread = std::move(*threadOutcome);
 				new_thread->flags |= Thread::kFlagServer;
-				auto new_info = attachThread(new_thread);
 
 				// see helCreateThread for the reasoning here
 				new_thread.policy().increment();
 				new_thread.policy().increment();
+
+				LoadBalancer::singleton().connect(new_thread.get(), getCpuData());
+				Scheduler::associate(new_thread.get(), &localScheduler.get());
+				Scheduler::resume(new_thread.get());
+
+				if(auto e = Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(new_thread)); e != Error::success)
+					panicLogger() << "thor: Failed to resume server" << frg::endlog;
+
+				// Attach after resumeOther() to ensure that we do not see the initial interrupt.
+				auto new_info = attachThread(new_thread);
 
 				auto writeOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					*executor->result0() = kHelErrNone;
@@ -1191,12 +1200,6 @@ namespace posix {
 				if(!writeOutcome)
 					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
 
-				LoadBalancer::singleton().connect(new_thread.get(), getCpuData());
-				Scheduler::associate(new_thread.get(), &localScheduler.get());
-				Scheduler::resume(new_thread.get());
-
-				if(auto e = Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(new_thread)); e != Error::success)
-					panicLogger() << "thor: Failed to resume server" << frg::endlog;
 				if(auto e = Thread::resumeOther(smarter::rc_policy_downcast<smarter::default_rc_policy>(info.thread)); e != Error::success)
 					panicLogger() << "thor: Failed to resume server" << frg::endlog;
 			}else if(interrupt == kIntrSuperCall + ::posix::superExit) {

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -1195,7 +1195,9 @@ namespace posix {
 
 				auto writeOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					*executor->result0() = kHelErrNone;
-					*executor->result1() = new_info.tid;
+					// The POSIX error; zero is managarm::posix::Errors::SUCCESS.
+					*executor->result1() = 0;
+					*executor->result2() = new_info.tid;
 				});
 				if(!writeOutcome)
 					panicLogger() << "thor: Failed to access server registers" << frg::endlog;


### PR DESCRIPTION
Fix two issues that could only be exercised by creating multiple threads: a mismatch in the `superClone` ABI and an ordering issue of thread resumption vs. the thread observe loop.