### PR TITLE
libblockfs: Close remaining thread safety gaps

### DIFF
--- a/drivers/libblockfs/include/scsi.hpp
+++ b/drivers/libblockfs/include/scsi.hpp
@@ -3,8 +3,6 @@
 #include <blockfs.hpp>
 
 #include <arch/dma_structs.hpp>
-#include <async/recurring-event.hpp>
-#include <frg/list.hpp>
 
 #include <string>
 
@@ -41,6 +39,9 @@ Error statusToError(uint8_t status);
 
 struct Interface {
 	virtual ~Interface() = default;
+
+	// Implementations must accept concurrent calls, serializing or pipelining them as
+	// the transport allows.
 	virtual async::result<frg::expected<Error, size_t>> sendScsiCommand(const CommandInfo &info) = 0;
 
 	async::result<frg::expected<Error, std::vector<uint64_t>>> reportLuns();
@@ -51,8 +52,6 @@ struct Interface {
 struct StorageDevice : Interface, blockfs::BlockDevice {
 	StorageDevice(size_t sectorSize, int64_t parentId, arch::contiguous_pool *pool)
 	: blockfs::BlockDevice(sectorSize, parentId, pool) { }
-
-	async::detached runScsi();
 
 	async::result<void> readSectors(uint64_t sector,
 			arch::dma_buffer_view view) final;
@@ -65,23 +64,8 @@ struct StorageDevice : Interface, blockfs::BlockDevice {
 	size_t storageSize{};
 
 private:
-	struct Request {
-		Request(bool isWrite, uint64_t sector, arch::dma_buffer_view view)
-		: isWrite{isWrite}, sector{sector}, view{view} { }
-
-		bool isWrite;
-		uint64_t sector;
-		arch::dma_buffer_view view;
-		async::oneshot_primitive event;
-		frg::default_list_hook<Request> requestHook;
-	};
-
-	async::recurring_event doorbell_;
-
-	frg::intrusive_list<
-		Request,
-		frg::locate_member<Request, frg::default_list_hook<Request>, &Request::requestHook>
-	> queue_;
+	async::result<void> performIo(bool isWrite, uint64_t sector,
+			arch::dma_buffer_view view);
 };
 
 inline constexpr uint8_t WELL_KNOWN_REPORT_LUNS_LUN = 1;

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1122,15 +1122,19 @@ auto FileSystem::accessRoot() -> std::shared_ptr<BaseInode> {
 auto FileSystem::accessInode(uint32_t number) -> std::shared_ptr<BaseInode> {
 	assert(number > 0);
 
-	std::lock_guard activeInodesLock{activeInodesMutex};
+	std::shared_ptr<Inode> new_inode;
+	{
+		std::lock_guard activeInodesLock{activeInodesMutex};
 
-	std::weak_ptr<Inode> &inode_slot = activeInodes[number];
-	std::shared_ptr<Inode> active_inode = inode_slot.lock();
-	if(active_inode)
-		return active_inode;
+		std::weak_ptr<Inode> &inode_slot = activeInodes[number];
+		std::shared_ptr<Inode> active_inode = inode_slot.lock();
+		if(active_inode)
+			return active_inode;
 
-	auto new_inode = std::make_shared<Inode>(*this, number);
-	inode_slot = std::weak_ptr<Inode>(new_inode);
+		new_inode = std::make_shared<Inode>(*this, number);
+		inode_slot = std::weak_ptr<Inode>(new_inode);
+	}
+
 	initiateInode(new_inode);
 
 	return new_inode;

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -953,15 +953,29 @@ async::result<void> FileSystem::init() {
 }
 
 async::detached FileSystem::handleBgdtWriteback() {
+	// Snapshot of blockGroupDescriptorBuffer that we write out.
+	arch::dma_buffer writebackBuffer{pool, blockGroupDescriptorBuffer.size()};
+
+	uint64_t seenSeq = 0;
 	while(true) {
-		co_await bdgtWriteback.async_wait();
+		co_await bgdtWriteback.async_wait(seenSeq);
 
-		co_await allocationMutex.async_lock();
-		frg::unique_lock allocationLock{frg::adopt_lock, allocationMutex};
+		{
+			co_await allocationMutex.async_lock();
+			frg::unique_lock allocationLock{frg::adopt_lock, allocationMutex};
 
+			// Take the sequence together with the snapshot, so that no request is missed.
+			// TODO: Use async::sequenced_event::current_sequence() once it exists.
+			seenSeq = bgdtWriteback.next_sequence() - 1;
+			assert(writebackBuffer.size() == blockGroupDescriptorBuffer.size());
+			memcpy(writebackBuffer.data(), blockGroupDescriptorBuffer.data(),
+					blockGroupDescriptorBuffer.size());
+		}
+
+		// The device write happens outside of allocationMutex.
 		auto bgdt_offset = (2048 + blockSize - 1) & ~size_t(blockSize - 1);
 		co_await device->writeSectors((bgdt_offset >> blockShift) * sectorsPerBlock,
-				blockGroupDescriptorBuffer);
+				writebackBuffer);
 	}
 }
 
@@ -1567,7 +1581,7 @@ async::result<uint32_t> FileSystem::allocateInode(uint32_t parentIno, bool direc
 				updateInodeBitmapChecksum(*this, &bgdt[bg], words, blockSize);
 				updateBlockGroupChecksum(*this, &bgdt[bg], bg);
 
-				bdgtWriteback.raise();
+				bgdtWriteback.raise();
 
 				auto syncBitmap = co_await helix_ng::synchronizeSpace(
 						helix::BorrowedDescriptor{kHelNullHandle},
@@ -1936,7 +1950,7 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 
 	updateInodeChecksum(*this, diskInode, inode->number);
 
-	bdgtWriteback.raise();
+	bgdtWriteback.raise();
 	auto syncInode = co_await helix_ng::synchronizeSpace(
 			helix::BorrowedDescriptor{kHelNullHandle},
 			inode->diskInode(), inodeSize);
@@ -2162,7 +2176,7 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 
 	updateInodeChecksum(*this, inode->diskInode(), inode->number);
 
-	bdgtWriteback.raise();
+	bgdtWriteback.raise();
 	auto syncInode = co_await helix_ng::synchronizeSpace(
 			helix::BorrowedDescriptor{kHelNullHandle},
 			inode->diskInode(), inodeSize);

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -14,7 +14,7 @@
 #include <protocols/fs/file-locks.hpp>
 
 #include <async/oneshot-event.hpp>
-#include <async/recurring-event.hpp>
+#include <async/sequenced-event.hpp>
 #include <hel.h>
 
 #include <blockfs.hpp>
@@ -479,7 +479,6 @@ struct FileSystem final : BaseFileSystem {
 
 	async::result<void> init();
 
-	async::recurring_event bdgtWriteback;
 	async::detached handleBgdtWriteback();
 
 	async::detached manageBlockBitmap(helix::UniqueDescriptor memory);
@@ -582,6 +581,9 @@ struct FileSystem final : BaseFileSystem {
 
 	// Serializes block/inode allocation and BGDT modifications.
 	async::mutex allocationMutex;
+
+	// Raised to request a writeback of the block group descriptor table.
+	async::sequenced_event bgdtWriteback;
 
 	// Protected by activeInodesMutex.
 	std::unordered_map<uint32_t, std::weak_ptr<Inode>> activeInodes;

--- a/drivers/libblockfs/src/raw.cpp
+++ b/drivers/libblockfs/src/raw.cpp
@@ -96,19 +96,27 @@ async::result<protocols::fs::ReadResult> rawRead(void *object, helix_ng::Credent
 	HEL_CHECK(helGetClock(&start));
 
 	auto self = static_cast<raw::OpenFile *>(object);
-	// TODO(geert): pass cancellation token through here
-	auto file_size = co_await self->rawFs->device->getSize();
 
-	if(self->offset >= file_size)
-		co_return std::unexpected{protocols::fs::Error::endOfFile};
+	uint64_t chunk_offset;
+	size_t chunkSize;
+	{
+		co_await self->offsetMutex.async_lock();
+		frg::unique_lock offsetLock{frg::adopt_lock, self->offsetMutex};
 
-	auto remaining = file_size - self->offset;
-	auto chunkSize = std::min(length, remaining);
-	if(!chunkSize)
-		co_return std::unexpected{protocols::fs::Error::endOfFile};
+		// TODO(geert): pass cancellation token through here
+		auto file_size = co_await self->rawFs->device->getSize();
 
-	auto chunk_offset = self->offset;
-	self->offset += chunkSize;
+		if(self->offset >= file_size)
+			co_return std::unexpected{protocols::fs::Error::endOfFile};
+
+		auto remaining = file_size - self->offset;
+		chunkSize = std::min(length, remaining);
+		if(!chunkSize)
+			co_return std::unexpected{protocols::fs::Error::endOfFile};
+
+		chunk_offset = self->offset;
+		self->offset += chunkSize;
+	}
 
 	// TODO(geert): use cancellation token here
 	auto readMemory = co_await helix_ng::readMemory(
@@ -174,18 +182,30 @@ async::result<protocols::fs::Error> rawFlock(void *object, int flags) {
 
 async::result<protocols::fs::SeekResult> rawSeekAbs(void *object, int64_t offset) {
 	auto self = static_cast<raw::OpenFile*>(object);
+
+	co_await self->offsetMutex.async_lock();
+	frg::unique_lock offsetLock{frg::adopt_lock, self->offsetMutex};
+
 	self->offset = offset;
 	co_return static_cast<ssize_t>(self->offset);
 }
 
 async::result<protocols::fs::SeekResult> rawSeekRel(void *object, int64_t offset) {
 	auto self = static_cast<raw::OpenFile*>(object);
+
+	co_await self->offsetMutex.async_lock();
+	frg::unique_lock offsetLock{frg::adopt_lock, self->offsetMutex};
+
 	self->offset += offset;
 	co_return static_cast<ssize_t>(self->offset);
 }
 
 async::result<protocols::fs::SeekResult> rawSeekEof(void *object, int64_t offset) {
 	auto self = static_cast<raw::OpenFile *>(object);
+
+	co_await self->offsetMutex.async_lock();
+	frg::unique_lock offsetLock{frg::adopt_lock, self->offsetMutex};
+
 	auto size = co_await self->rawFs->device->getSize();
 	self->offset = offset + size;
 	co_return static_cast<ssize_t>(self->offset);

--- a/drivers/libblockfs/src/raw.hpp
+++ b/drivers/libblockfs/src/raw.hpp
@@ -1,5 +1,7 @@
 
 #include <hel.h>
+#include <async/mutex.hpp>
+#include <frg/mutex.hpp>
 #include <helix/ipc.hpp>
 #include <helix/memory.hpp>
 #include <protocols/fs/file-locks.hpp>
@@ -31,7 +33,9 @@ struct OpenFile {
 	struct HandleIoctl;
 
 	RawFs *rawFs;
-	uint64_t offset;
+	async::mutex offsetMutex;
+	// Protected by offsetMutex.
+	uint64_t offset = 0;
 	Flock flock;
 };
 

--- a/drivers/libblockfs/src/scsi.cpp
+++ b/drivers/libblockfs/src/scsi.cpp
@@ -180,103 +180,88 @@ async::result<frg::expected<Error, std::vector<uint64_t>>> Interface::reportLuns
 	co_return data;
 }
 
-async::detached StorageDevice::runScsi() {
-	while (true) {
-		if (queue_.empty()) {
-			co_await doorbell_.async_wait();
-			continue;
-		}
+async::result<void> StorageDevice::performIo(bool isWrite, uint64_t sector,
+		arch::dma_buffer_view view) {
+	auto numSectors = view.size() >> sectorShift;
 
-		auto req = queue_.pop_front();
-		auto numSectors = req->view.size() >> sectorShift;
+	if (logRequests)
+		std::println(std::cout, "block-scsi: Reading {} sectors", numSectors);
+	assert(numSectors);
+	assert(numSectors <= 0xffff);
 
-		if (logRequests)
-			std::println(std::cout, "block-scsi: Reading {} sectors", numSectors);
-		assert(numSectors);
-		assert(numSectors <= 0xffff);
+	uint8_t commandData[16];
+	uint8_t commandLength;
 
-		uint8_t commandData[16];
-		uint8_t commandLength;
+	if (!isWrite) {
+		if (enableRead6 && sector <= 0x1fffff && numSectors <= 0xff) {
+			Read6 command{};
+			command.opCode = 0x08;
+			command.lba[0] = sector >> 16;
+			command.lba[1] = (sector >> 8) & 0xff;
+			command.lba[2] = sector & 0xff;
+			command.transferLength = numSectors;
 
-		if (!req->isWrite) {
-			if (enableRead6 && req->sector <= 0x1fffff && numSectors <= 0xff) {
-				Read6 command{};
-				command.opCode = 0x08;
-				command.lba[0] = req->sector >> 16;
-				command.lba[1] = (req->sector >> 8) & 0xff;
-				command.lba[2] = req->sector & 0xff;
-				command.transferLength = numSectors;
+			commandLength = sizeof(Read6);
+			memcpy(commandData, &command, sizeof(Read6));
+		} else if (sector <= 0xffffffff) {
+			Read10 command{};
+			command.opCode = 0x28;
+			command.lba[0] = sector >> 24;
+			command.lba[1] = (sector >> 16) & 0xff;
+			command.lba[2] = (sector >> 8) & 0xff;
+			command.lba[3] = sector & 0xff;
+			command.transferLength[0] = numSectors >> 8;
+			command.transferLength[1] = numSectors & 0xff;
 
-				commandLength = sizeof(Read6);
-				memcpy(commandData, &command, sizeof(Read6));
-			} else if (req->sector <= 0xffffffff) {
-				Read10 command{};
-				command.opCode = 0x28;
-				command.lba[0] = req->sector >> 24;
-				command.lba[1] = (req->sector >> 16) & 0xff;
-				command.lba[2] = (req->sector >> 8) & 0xff;
-				command.lba[3] = req->sector & 0xff;
-				command.transferLength[0] = numSectors >> 8;
-				command.transferLength[1] = numSectors & 0xff;
-
-				commandLength = sizeof(Read10);
-				memcpy(commandData, &command, sizeof(Read10));
-			} else {
-				logPanic("block-scsi: High LBAs are not supported!");
-			}
+			commandLength = sizeof(Read10);
+			memcpy(commandData, &command, sizeof(Read10));
 		} else {
-			if (req->sector <= 0xffffffff) {
-				Write10 command{};
-				command.opCode = 0x2a;
-				command.lba[0] = req->sector >> 24;
-				command.lba[1] = (req->sector >> 16) & 0xff;
-				command.lba[2] = (req->sector >> 8) & 0xff;
-				command.lba[3] = req->sector & 0xff;
-				command.transferLength[0] = numSectors >> 8;
-				command.transferLength[1] = numSectors & 0xff;
-
-				commandLength = sizeof(Write10);
-				memcpy(commandData, &command, sizeof(Write10));
-			} else {
-				logPanic("block-scsi: High LBAs are not supported!");
-			}
+			logPanic("block-scsi: High LBAs are not supported!");
 		}
+	} else {
+		if (sector <= 0xffffffff) {
+			Write10 command{};
+			command.opCode = 0x2a;
+			command.lba[0] = sector >> 24;
+			command.lba[1] = (sector >> 16) & 0xff;
+			command.lba[2] = (sector >> 8) & 0xff;
+			command.lba[3] = sector & 0xff;
+			command.transferLength[0] = numSectors >> 8;
+			command.transferLength[1] = numSectors & 0xff;
 
-		if (logSteps)
-			std::println(std::cout, "block-scsi: Sending command");
-
-		CommandInfo info{
-			.command{nullptr, commandData, commandLength},
-			.data = req->view,
-			.isWrite = req->isWrite
-		};
-		auto result = co_await sendScsiCommand(info);
-		if (!result) {
-			logPanic("block-scsi: Request failed with error {}",
-					result.error().toString());
+			commandLength = sizeof(Write10);
+			memcpy(commandData, &command, sizeof(Write10));
+		} else {
+			logPanic("block-scsi: High LBAs are not supported!");
 		}
-
-		if (logSteps)
-			std::println(std::cout, "block-scsi: Request complete");
-
-		req->event.raise();
 	}
+
+	if (logSteps)
+		std::println(std::cout, "block-scsi: Sending command");
+
+	CommandInfo info{
+		.command{nullptr, commandData, commandLength},
+		.data = view,
+		.isWrite = isWrite
+	};
+	auto result = co_await sendScsiCommand(info);
+	if (!result) {
+		logPanic("block-scsi: Request failed with error {}",
+				result.error().toString());
+	}
+
+	if (logSteps)
+		std::println(std::cout, "block-scsi: Request complete");
 }
 
 async::result<void> StorageDevice::readSectors(uint64_t sector,
 		arch::dma_buffer_view view) {
-	Request req{false, sector, view};
-	queue_.push_back(&req);
-	doorbell_.raise();
-	co_await req.event.wait();
+	co_await performIo(false, sector, view);
 }
 
 async::result<void> StorageDevice::writeSectors(uint64_t sector,
 		arch::dma_buffer_view view) {
-	Request req{true, sector, view};
-	queue_.push_back(&req);
-	doorbell_.raise();
-	co_await req.event.wait();
+	co_await performIo(true, sector, view);
 }
 
 async::result<size_t> StorageDevice::getSize() {

--- a/drivers/usb/devices/storage/src/main.cpp
+++ b/drivers/usb/devices/storage/src/main.cpp
@@ -22,7 +22,7 @@ namespace {
 
 namespace proto = protocols::usb;
 
-async::detached StorageDevice::run(int config_num, int intf_num) {
+async::result<void> StorageDevice::initialize(int config_num, int intf_num) {
 	// I own a USB key that does not support the READ6 command. ~AvdG
 	enableRead6 = false;
 
@@ -55,11 +55,12 @@ async::detached StorageDevice::run(int config_num, int intf_num) {
 
 	if(logSteps)
 		std::cout << "block-usb: Device is ready" << std::endl;
-
-	runScsi();
 }
 
 async::result<frg::expected<scsi::Error, size_t>> StorageDevice::sendScsiCommand(const scsi::CommandInfo &info) {
+	co_await transportMutex_.async_lock();
+	frg::unique_lock transportLock{frg::adopt_lock, transportMutex_};
+
 	CommandBlockWrapper cbw{};
 	cbw.signature = Signatures::kSignCbw;
 	cbw.tag = 1;
@@ -172,7 +173,7 @@ async::detached bindDevice(mbus_ng::Entity entity) {
 		std::cout << "block-usb: Detected USB device" << std::endl;
 
 	auto storage_device = new StorageDevice(device, entity.id());
-	storage_device->run(config_number.value(), intf_number.value());
+	co_await storage_device->initialize(config_number.value(), intf_number.value());
 	blockfs::runDevice(storage_device);
 }
 

--- a/drivers/usb/devices/storage/src/storage.hpp
+++ b/drivers/usb/devices/storage/src/storage.hpp
@@ -1,6 +1,6 @@
-#include <async/recurring-event.hpp>
-#include <async/oneshot-event.hpp>
+#include <async/mutex.hpp>
 #include <async/result.hpp>
+#include <frg/mutex.hpp>
 #include <blockfs.hpp>
 #include <scsi.hpp>
 
@@ -37,12 +37,15 @@ struct StorageDevice : scsi::StorageDevice {
 	  endp_in_{nullptr},
 	  endp_out_{nullptr} {}
 
-	async::detached run(int config_num, int intf_num);
+	async::result<void> initialize(int config_num, int intf_num);
 
 	async::result<frg::expected<scsi::Error, size_t>> sendScsiCommand(const scsi::CommandInfo &info) override;
 
 private:
 	arch::contiguous_pool pool_{{.addressBits = 64}};
+
+	// Bulk-only transport allows only one command at a time.
+	async::mutex transportMutex_;
 
 	protocols::usb::Device usbDevice_;
 	protocols::usb::Endpoint endp_in_;


### PR DESCRIPTION
We already have mutexes for most libblockfs data. This closes some final gaps.