### PR TITLE
thor: Let backing memory report a static 2^62 size

### DIFF
--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -1871,11 +1871,6 @@ HelError doSubmitManageMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> qu
 
 HelError helUpdateMemory(HelHandle handle, int type,
 		uintptr_t offset, size_t length) {
-	if (offset & (kPageSize - 1))
-		return kHelErrIllegalArgs;
-	if (length & (kPageSize - 1))
-		return kHelErrIllegalArgs;
-
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -925,6 +925,8 @@ size_t AllocatedMemory::getLength() {
 
 std::expected<smarter::shared_ptr<ManagedSpace>, Error> ManagedSpace::create(
 		size_t length, bool readahead) {
+	if(length > backingMemoryLength)
+		return std::unexpected{Error::illegalArgs};
 	auto self = smarter::allocate_shared<ManagedSpace>(*kernelAlloc, length, readahead);
 	self->selfPtr = self;
 	spawnOnWorkQueue(*kernelAlloc, WorkQueue::generalQueue().lock(), self->_runReclaimLoop());
@@ -1336,8 +1338,6 @@ ManagedSpace::~ManagedSpace() {
 Error ManagedSpace::lockPages(uintptr_t offset, size_t size) {
 	auto irq_lock = frg::guard(&irqMutex());
 	auto lock = frg::guard(&mutex);
-	if((offset + size) / kPageSize > numPages)
-		return Error::bufferTooSmall;
 
 	for(size_t pg = 0; pg < size; pg += kPageSize) {
 		size_t index = (offset + pg) / kPageSize;
@@ -1363,7 +1363,6 @@ void ManagedSpace::unlockPages(uintptr_t offset, size_t size) {
 	{
 		auto irq_lock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&mutex);
-		assert((offset + size) / kPageSize <= numPages);
 
 		for(size_t pg = 0; pg < size; pg += kPageSize) {
 			size_t index = (offset + pg) / kPageSize;
@@ -1578,10 +1577,13 @@ std::expected<smarter::shared_ptr<BackingMemory>, Error> BackingMemory::create(
 	return ptr;
 }
 
+// Note: This resizes the ManagedSpace but it does not affect BackingMemory::getLength().
 coroutine<frg::expected<Error>> BackingMemory::resize(size_t newSize) {
 	assert(currentIpl() == ipl::exceptionalWork);
 	if(_managed->isSwapSpace)
 		co_return Error::illegalObject;
+	if(newSize > backingMemoryLength)
+		co_return Error::illegalArgs;
 	assert(!(newSize & (kPageSize - 1)));
 	auto newPages = newSize >> kPageShift;
 
@@ -1606,6 +1608,8 @@ coroutine<frg::expected<Error>> BackingMemory::resize(size_t newSize) {
 }
 
 Error BackingMemory::lockRange(uintptr_t offset, size_t size) {
+	if(offset > backingMemoryLength || size > backingMemoryLength - offset)
+		return Error::bufferTooSmall;
 	return _managed->lockPages(offset, size);
 }
 
@@ -1617,11 +1621,12 @@ PhysicalRange BackingMemory::peekRange(uintptr_t offset, FetchFlags) {
 	auto index = offset >> kPageShift;
 	auto misalign = offset & (kPageSize - 1);
 
+	if(offset >= backingMemoryLength)
+		return PhysicalRange{};
+
 	auto irqLock = frg::guard(&irqMutex());
 	auto lock = frg::guard(&_managed->mutex);
 
-	if(index >= _managed->numPages)
-		return PhysicalRange{};
 	auto pit = _managed->pages.find(index);
 	if(!pit)
 		return PhysicalRange{};
@@ -1641,11 +1646,12 @@ BackingMemory::touchRange(uintptr_t offset, size_t, FetchFlags) {
 	auto index = offset >> kPageShift;
 	auto misalign = offset & (kPageSize - 1);
 
+	if(offset >= backingMemoryLength)
+		co_return Error::fault;
+
 	auto irqLock = frg::guard(&irqMutex());
 	auto lock = frg::guard(&_managed->mutex);
 
-	if(index >= _managed->numPages)
-		co_return Error::fault;
 	auto [pit, wasInserted] = _managed->pages.find_or_insert(index, _managed.get(), index);
 	assert(pit);
 
@@ -1664,8 +1670,7 @@ BackingMemory::touchRange(uintptr_t offset, size_t, FetchFlags) {
 }
 
 size_t BackingMemory::getLength() {
-	// Size is constant so we do not need to lock.
-	return _managed->numPages << kPageShift;
+	return backingMemoryLength;
 }
 
 coroutine<frg::expected<Error, MemoryNotification>> BackingMemory::pollNotification() {
@@ -1694,16 +1699,6 @@ Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t lengt
 	{
 		auto irqLock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&_managed->mutex);
-
-		if ((offset + length) / kPageSize > _managed->numPages) {
-			infoLogger() << frg::fmt(
-				"thor: Requested {} of range {}-{} in BackingMemory of size {}",
-				type == ManageRequest::initialize ? "initialization" : "writeback",
-				offset, offset + length, _managed->numPages * kPageSize
-			) << frg::endlog;
-
-			return Error::illegalArgs;
-		}
 
 	/*	assert(length == kPageSize);
 		auto inspect = (unsigned char *)physicalToVirtual(_managed->physicalPages[offset / kPageSize]);
@@ -1947,10 +1942,23 @@ std::expected<smarter::shared_ptr<FrontalMemory>, Error> FrontalMemory::create(
 }
 
 Error FrontalMemory::lockRange(uintptr_t offset, size_t size) {
+	// We only check once against the ManagedSpace size.
+	// A concurrent shrink after this check is equivalent to locking before the shrink.
+	{
+		auto irqLock = frg::guard(&irqMutex());
+		auto lock = frg::guard(&_managed->mutex);
+
+		auto limit = _managed->numPages << kPageShift;
+		if(offset > limit || size > limit - offset)
+			return Error::bufferTooSmall;
+	}
+
 	return _managed->lockPages(offset, size);
 }
 
 void FrontalMemory::unlockRange(uintptr_t offset, size_t size) {
+	// Note that unlockPages() tolerates locks beyond the current size:
+	// unlocking a locked range must still be possible even after shrinking the file.
 	_managed->unlockPages(offset, size);
 }
 

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -1683,8 +1683,10 @@ coroutine<frg::expected<Error, MemoryNotification>> BackingMemory::pollNotificat
 }
 
 Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t length) {
-	assert((offset % kPageSize) == 0);
-	assert((length % kPageSize) == 0);
+	if (offset & (kPageSize - 1))
+		return Error::illegalArgs;
+	if (length & (kPageSize - 1))
+		return Error::illegalArgs;
 
 	frg::intrusive_list<
 		ManagedSpace::TransactionMonitor,
@@ -1700,23 +1702,26 @@ Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t lengt
 		auto irqLock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&_managed->mutex);
 
-	/*	assert(length == kPageSize);
-		auto inspect = (unsigned char *)physicalToVirtual(_managed->physicalPages[offset / kPageSize]);
-		auto log = infoLogger() << "dump";
-		for(size_t b = 0; b < kPageSize; b += 16) {
-			log << frg::hex_fmt(offset + b) << "   ";
-			for(size_t i = 0; i < 16; i++)
-				log << " " << frg::hex_fmt(inspect[b + i]);
-			log << "\n";
+		// Validate the whole range before updating any page such that failure is atomic.
+		ManagedSpace::TxState expectedState;
+		if (type == ManageRequest::initialize) {
+			expectedState = ManagedSpace::TxState::initialization;
+		} else if (type == ManageRequest::writeback) {
+			expectedState = ManagedSpace::TxState::writeback;
+		} else {
+			return Error::illegalArgs;
 		}
-		log << frg::endlog;*/
+		for(size_t pg = 0; pg < length; pg += kPageSize) {
+			size_t index = (offset + pg) / kPageSize;
+			auto pit = _managed->pages.find(index);
+			if(!pit || pit->transactionState != expectedState)
+				return Error::illegalArgs;
+		}
 
 		if(type == ManageRequest::initialize) {
 			for(size_t pg = 0; pg < length; pg += kPageSize) {
 				size_t index = (offset + pg) / kPageSize;
 				auto pit = _managed->pages.find(index);
-				assert(pit);
-				assert(pit->transactionState == ManagedSpace::TxState::initialization);
 				// Initialization implies an in-flight fetch, which holds a view
 				// reference; discardPage() thus never sees this state.
 				assert(!pit->discarded);
@@ -1735,9 +1740,7 @@ Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t lengt
 			for(size_t pg = 0; pg < length; pg += kPageSize) {
 				size_t index = (offset + pg) / kPageSize;
 				auto pit = _managed->pages.find(index);
-				assert(pit);
 
-				assert(pit->transactionState == ManagedSpace::TxState::writeback);
 				if(pit->discarded) {
 					// Raise the monitor as usual - writebackFence() waiters hold references to it.
 					ref_rc(pit->monitor.get());

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -1584,7 +1584,8 @@ coroutine<frg::expected<Error>> BackingMemory::resize(size_t newSize) {
 		co_return Error::illegalObject;
 	if(newSize > backingMemoryLength)
 		co_return Error::illegalArgs;
-	assert(!(newSize & (kPageSize - 1)));
+	if(newSize & (kPageSize - 1))
+		co_return Error::illegalArgs;
 	auto newPages = newSize >> kPageShift;
 
 	size_t oldPages;

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -872,6 +872,11 @@ private:
 	size_t _budgetClaimed = 0;
 };
 
+// Static size of BackingMemory views.
+// It also bounds the ManagedSpace size that is visible to FrontalMemory
+// (otherwise, some pages would be unreachable through the backing view).
+inline constexpr size_t backingMemoryLength = size_t{1} << 62;
+
 struct BackingMemory final : MemoryView {
 private:
 	struct CtorToken {};


### PR DESCRIPTION
`resize()` now only applies to the size of `FrontalMemory`. This way, manage requests can still be completed via `BackingMemory` even after `resize()` shrinks the `ManagedMemory`.