### PR TITLE
posix: Truncate oversized affinity masks to the kernel mask size

### DIFF
--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3954,6 +3954,11 @@ HelError helSetAffinity(HelHandle handle, uint8_t *mask, size_t size) {
 	if (!readUserArray(mask, buf.data(), size))
 		return kHelErrFault;
 
+	// Reject the padding bits of the last byte; they do not correspond to any CPU.
+	auto numCpus = getCpuCount();
+	if (numCpus % 8 && (buf[maskSize - 1] >> (numCpus % 8)))
+		return kHelErrIllegalArgs;
+
 	size_t n = 0;
 	for (auto i : buf) {
 		n += __builtin_popcount(i);

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -103,6 +103,7 @@ async::result<void> serve(std::shared_ptr<Process> self, std::shared_ptr<Generat
 namespace {
 	helix::UniqueLane kerncfgLane;
 	helix::UniqueLane pmLane;
+	size_t affinityMaskSize = 0;
 };
 
 helix::UniqueLane &getKerncfgLane() {
@@ -111,6 +112,11 @@ helix::UniqueLane &getKerncfgLane() {
 
 helix::UniqueLane &getPmLane() {
 	return pmLane;
+}
+
+size_t getAffinityMaskSize() {
+	assert(affinityMaskSize);
+	return affinityMaskSize;
 }
 
 struct CmdlineNode final : public procfs::RegularNode {
@@ -162,6 +168,22 @@ async::result<void> enumerateKerncfg() {
 
 	auto entity = co_await mbus_ng::Instance::global().getEntity(events[0].id);
 	kerncfgLane = (co_await entity.getRemoteLane()).unwrap();
+
+	// Determine the size of the affinity masks that thor accepts, i.e., one bit per CPU.
+	managarm::kerncfg::GetNumCpuRequest numCpuReq;
+	auto [offer, sendReq, recvResp] = co_await helix_ng::exchangeMsgs(
+		kerncfgLane,
+		helix_ng::offer(
+			helix_ng::sendBragiHeadOnly(numCpuReq, frg::stl_allocator{}),
+			helix_ng::recvInline()
+		)
+	);
+	HEL_CHECK(offer.error());
+	HEL_CHECK(sendReq.error());
+	HEL_CHECK(recvResp.error());
+
+	auto numCpuResp = bragi::parse_head_only<managarm::kerncfg::GetNumCpuResponse>(recvResp);
+	affinityMaskSize = (numCpuResp->num_cpu() + 7) / 8;
 
 	auto procfsRoot = std::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
 	procfsRoot->directMkregular("cmdline", std::make_shared<CmdlineNode>());

--- a/posix/subsystem/src/requests.hpp
+++ b/posix/subsystem/src/requests.hpp
@@ -7,3 +7,5 @@ async::result<void> serveRequests(std::shared_ptr<Process> self,
 
 helix::UniqueLane &getKerncfgLane();
 helix::UniqueLane &getPmLane();
+
+size_t getAffinityMaskSize();

--- a/posix/subsystem/src/requests/process.cpp
+++ b/posix/subsystem/src/requests/process.cpp
@@ -1,4 +1,5 @@
 #include "common.hpp"
+#include "../requests.hpp"
 #include <sys/wait.h>
 #include <sys/resource.h>
 #include <iostream>
@@ -196,7 +197,11 @@ HandleRequest::operator()(managarm::posix::SetAffinityRequest &&req,
 		handle = target->threadDescriptor().getHandle();
 	}
 
-	HelError e = helSetAffinity(handle, req.mask().data(), req.mask().size());
+	// Applications may pass masks that are larger than what thor accepts (e.g., sizeof(cpu_set_t)).
+	// Like Linux, ignore the bits beyond the last CPU instead of rejecting the oversized mask.
+	auto maskSize = std::min(req.mask().size(), getAffinityMaskSize());
+
+	HelError e = helSetAffinity(handle, req.mask().data(), maskSize);
 
 	if(e == kHelErrIllegalArgs) {
 		co_await sendErrorResponse<managarm::posix::SetAffinityResponse>(conversation, managarm::posix::Errors::ILLEGAL_ARGUMENTS);


### PR DESCRIPTION
This is a simple fix: Thor rejects affinity masks that a larger than ceil(N/8) bytes. Let posix-subsystem clamp to that size in case a caller passes a larger mask.