### PR TITLE
drivers/virtio-block: Coalesce physically contiguous descriptors

### DIFF
--- a/core/virtio/include/core/virtio/core.hpp
+++ b/core/virtio/include/core/virtio/core.hpp
@@ -235,6 +235,13 @@ struct DeviceToHostType { };
 inline constexpr HostToDeviceType hostToDevice;
 inline constexpr DeviceToHostType deviceToHost;
 
+// A DMA-contiguous piece of a buffer together with its resolved DMA address,
+// as produced by Queue::splitContiguous().
+struct DmaChunk {
+	arch::dma_buffer_view view;
+	uintptr_t address;
+};
+
 // Handle to a virtq descriptor.
 struct Handle {
 	Handle()
@@ -250,10 +257,14 @@ struct Handle {
 		return _tableIndex;
 	}
 
-	// setupBuffer() assumes that the buffer is contiguous in physical memory.
-	// Use scatterGather() for a more convenient API.
+	// setupBuffer() assumes that the buffer is contiguous in DMA space.
+	// Use Queue::splitContiguous() or scatterGather() to handle arbitrary buffers.
 	async::result<void> setupBuffer(HostToDeviceType, arch::dma_buffer_view view);
 	async::result<void> setupBuffer(DeviceToHostType, arch::dma_buffer_view view);
+
+	// These overloads take a chunk with an already resolved DMA address.
+	void setupBuffer(HostToDeviceType, DmaChunk chunk);
+	void setupBuffer(DeviceToHostType, DmaChunk chunk);
 
 	void setupLink(Handle other);
 
@@ -290,6 +301,13 @@ struct Chain {
 	}
 	async::result<void> setupBuffer(DeviceToHostType, arch::dma_buffer_view view) {
 		return _back.setupBuffer(deviceToHost, view);
+	}
+
+	void setupBuffer(HostToDeviceType, DmaChunk chunk) {
+		_back.setupBuffer(hostToDevice, chunk);
+	}
+	void setupBuffer(DeviceToHostType, DmaChunk chunk) {
+		_back.setupBuffer(deviceToHost, chunk);
 	}
 
 private:
@@ -330,6 +348,11 @@ public:
 	size_t numDescriptors() {
 		return _queueSize;
 	}
+
+	// Splits the view into a minimal sequence of chunks that are each contiguous
+	// in DMA space, i.e., that satisfy the requirement of Handle::setupBuffer().
+	// The returned chunks carry their resolved DMA addresses.
+	async::result<std::vector<DmaChunk>> splitContiguous(arch::dma_buffer_view view);
 
 	// Allocates a single descriptor. Special case of obtainDescriptors(), see below.
 	async::result<Handle> obtainDescriptor();

--- a/core/virtio/src/core.cpp
+++ b/core/virtio/src/core.cpp
@@ -811,6 +811,23 @@ async::result<void>Handle::setupBuffer(DeviceToHostType, arch::dma_buffer_view v
 	descriptor->flags.store(descriptor->flags.load() | VIRTQ_DESC_F_WRITE);
 }
 
+void Handle::setupBuffer(HostToDeviceType, DmaChunk chunk) {
+	assert(chunk.view.size());
+
+	auto descriptor = _queue->_table + _tableIndex;
+	descriptor->address.store(chunk.address);
+	descriptor->length.store(chunk.view.size());
+}
+
+void Handle::setupBuffer(DeviceToHostType, DmaChunk chunk) {
+	assert(chunk.view.size());
+
+	auto descriptor = _queue->_table + _tableIndex;
+	descriptor->address.store(chunk.address);
+	descriptor->length.store(chunk.view.size());
+	descriptor->flags.store(descriptor->flags.load() | VIRTQ_DESC_F_WRITE);
+}
+
 void Handle::setupLink(Handle other) {
 	auto descriptor = _queue->_table + _tableIndex;
 	descriptor->next.store(other._tableIndex);
@@ -819,27 +836,19 @@ void Handle::setupLink(Handle other) {
 
 async::result<void> scatterGather(HostToDeviceType, Chain &chain, Queue *queue,
 		arch::dma_buffer_view view) {
-	constexpr size_t page_size = 0x1000;
-	size_t offset = 0;
-	while(offset < view.size()) {
-		auto address = reinterpret_cast<uintptr_t>(view.data()) + offset;
-		auto chunk = std::min(view.size() - offset, page_size - (address & (page_size - 1)));
+	auto chunks = co_await queue->splitContiguous(view);
+	for(auto &chunk : chunks) {
 		chain.append(co_await queue->obtainDescriptor());
-		co_await chain.setupBuffer(hostToDevice, view.subview(offset, chunk));
-		offset += chunk;
+		chain.setupBuffer(hostToDevice, chunk);
 	}
 }
 
 async::result<void> scatterGather(DeviceToHostType, Chain &chain, Queue *queue,
 		arch::dma_buffer_view view) {
-	constexpr size_t page_size = 0x1000;
-	size_t offset = 0;
-	while(offset < view.size()) {
-		auto address = reinterpret_cast<uintptr_t>(view.data()) + offset;
-		auto chunk = std::min(view.size() - offset, page_size - (address & (page_size - 1)));
+	auto chunks = co_await queue->splitContiguous(view);
+	for(auto &chunk : chunks) {
 		chain.append(co_await queue->obtainDescriptor());
-		co_await chain.setupBuffer(deviceToHost, view.subview(offset, chunk));
-		offset += chunk;
+		chain.setupBuffer(deviceToHost, chunk);
 	}
 }
 
@@ -887,6 +896,52 @@ Queue::Queue(
 		_descriptorStack.push_back(i);
 	_descriptorSemaphore.release(_queueSize);
 	_activeRequests.resize(_queueSize);
+}
+
+async::result<std::vector<DmaChunk>> Queue::splitContiguous(arch::dma_buffer_view view) {
+	constexpr size_t pageSize = 0x1000;
+	// The descriptor length field is only 32 bits wide.
+	constexpr size_t maxChunkSize = 0xFFFFF000;
+
+	std::vector<DmaChunk> chunks;
+
+	// With an IOMMU, iova_of() maps the view's entire backing region contiguously
+	// into DMA space, hence the whole view fits into a single descriptor.
+	if(dmaSpace().iommuActive()) {
+		size_t offset = 0;
+		while(offset < view.size()) {
+			auto chunkView = view.subview(offset, std::min(view.size() - offset, maxChunkSize));
+			auto address = co_await dmaSpace().iova_of(chunkView);
+			chunks.push_back({chunkView, address});
+			offset += chunkView.size();
+		}
+		co_return chunks;
+	}
+
+	// Without an IOMMU, only contiguity within a page is guaranteed;
+	// still, merge pages that happen to be physically contiguous.
+	size_t chunkOffset = 0;
+	size_t chunkSize = 0;
+	uintptr_t chunkAddress = 0;
+	size_t offset = 0;
+	while(offset < view.size()) {
+		auto va = reinterpret_cast<uintptr_t>(view.data()) + offset;
+		auto piece = std::min(view.size() - offset, pageSize - (va & (pageSize - 1)));
+		auto address = co_await dmaSpace().iova_of(view.subview(offset, piece));
+		if(chunkSize && address == chunkAddress + chunkSize && chunkSize + piece <= maxChunkSize) {
+			chunkSize += piece;
+		}else{
+			if(chunkSize)
+				chunks.push_back({view.subview(chunkOffset, chunkSize), chunkAddress});
+			chunkOffset = offset;
+			chunkSize = piece;
+			chunkAddress = address;
+		}
+		offset += piece;
+	}
+	if(chunkSize)
+		chunks.push_back({view.subview(chunkOffset, chunkSize), chunkAddress});
+	co_return chunks;
 }
 
 async::result<Handle> Queue::obtainDescriptor() {

--- a/drivers/block/virtio-blk/src/block.cpp
+++ b/drivers/block/virtio-blk/src/block.cpp
@@ -114,11 +114,14 @@ async::result<size_t> Device::getSize() {
 }
 
 async::result<void> Device::_issueRequest(UserRequest *request) {
-	auto numSectors = request->view.size() >> sectorShift;
-	assert(numSectors);
+	assert(request->view.size());
+
+	// Split the view into DMA-contiguous chunks (and not into individual sectors)
+	// since setupBuffer() only requires contiguity in DMA space per descriptor.
+	auto chunks = co_await _requestQueue->splitContiguous(request->view);
 
 	// Acquire all descriptors of the chain at once to avoid potential deadlocks.
-	std::vector<virtio_core::Handle> handles(2 + numSectors);
+	std::vector<virtio_core::Handle> handles(2 + chunks.size());
 	co_await _requestQueue->obtainDescriptors(handles);
 
 	for(size_t i = 1; i < handles.size(); i++)
@@ -136,18 +139,16 @@ async::result<void> Device::_issueRequest(UserRequest *request) {
 	co_await handles.front().setupBuffer(virtio_core::hostToDevice, request->header.view_buffer());
 
 	// Setup descriptors for the transfered data.
-	for(size_t i = 0; i < numSectors; i++) {
+	for(size_t i = 0; i < chunks.size(); i++) {
 		if(request->write) {
-			co_await handles[1 + i].setupBuffer(virtio_core::hostToDevice,
-					request->view.subview(i << sectorShift, sectorSize));
+			handles[1 + i].setupBuffer(virtio_core::hostToDevice, chunks[i]);
 		}else{
-			co_await handles[1 + i].setupBuffer(virtio_core::deviceToHost,
-					request->view.subview(i << sectorShift, sectorSize));
+			handles[1 + i].setupBuffer(virtio_core::deviceToHost, chunks[i]);
 		}
 	}
 
 	if(logInitiateRetire)
-		std::cout << "Submitting " << numSectors << " data descriptors" << std::endl;
+		std::cout << "Submitting " << chunks.size() << " data descriptors" << std::endl;
 
 	// Setup a descriptor for the status byte.
 	co_await handles.back().setupBuffer(
@@ -160,8 +161,8 @@ async::result<void> Device::_issueRequest(UserRequest *request) {
 			[] (virtio_core::Request *base_request) {
 		auto request = static_cast<UserRequest *>(base_request);
 		if(logInitiateRetire)
-			std::cout << "Retiring " << (request->view.size() / 512uz)
-					<< " data descriptors" << std::endl;
+			std::cout << "Retiring request of " << request->view.size()
+					<< " bytes" << std::endl;
 		request->event.raise();
 	});
 	_requestQueue->notify();


### PR DESCRIPTION
Instead of submitting one descriptor per 512-byte sector, submit one descriptor per physically contiguous run.