### PR TITLE
libblockfs, virtio-block: Make multi-threaded

### DIFF
--- a/core/virtio/src/core.cpp
+++ b/core/virtio/src/core.cpp
@@ -1,5 +1,6 @@
 
 #include <assert.h>
+#include <atomic>
 #include <iostream>
 #include <unordered_map>
 #include <optional>
@@ -82,7 +83,8 @@ struct LegacyPciTransport : Transport {
 	friend struct LegacyPciQueue;
 
 	LegacyPciTransport(protocols::hw::Device hw_device,
-			arch::io_space legacy_space, helix::UniqueDescriptor irq, helix::UniqueDescriptor dmaSpace);
+			arch::io_space legacy_space, helix::UniqueDescriptor bar,
+			helix::UniqueDescriptor irq, helix::UniqueDescriptor dmaSpace);
 
 	bool isLegacy() override {
 		return true;
@@ -106,11 +108,17 @@ struct LegacyPciTransport : Transport {
 	void runDevice() override;
 
 private:
+	// Returns the I/O space, after enabling it on the current thread if necessary.
+	arch::io_space _io();
+
 	async::detached _processIrqs();
 
 	protocols::hw::Device _hwDevice;
 	arch::io_space _legacySpace;
+	helix::UniqueDescriptor _bar;
 	helix::UniqueDescriptor _irq;
+	// Identifies this device within the per-thread table of enabled devices.
+	unsigned int _ioIndex;
 
 	std::vector<std::unique_ptr<LegacyPciQueue>> _queues;
 };
@@ -131,24 +139,42 @@ private:
 	LegacyPciTransport *_transport;
 };
 
+std::atomic<unsigned int> nextIoIndex{0};
+
 LegacyPciTransport::LegacyPciTransport(
-    protocols::hw::Device hw_device, arch::io_space legacy_space, helix::UniqueDescriptor irq, helix::UniqueDescriptor dmaSpace
+    protocols::hw::Device hw_device, arch::io_space legacy_space, helix::UniqueDescriptor bar,
+    helix::UniqueDescriptor irq, helix::UniqueDescriptor dmaSpace
 )
 : Transport(std::move(dmaSpace), false),
   _hwDevice{std::move(hw_device)},
   _legacySpace{legacy_space},
-  _irq{std::move(irq)} {}
+  _bar{std::move(bar)},
+  _irq{std::move(irq)},
+  _ioIndex{nextIoIndex.fetch_add(1, std::memory_order_relaxed)} {}
+
+// Thor enables port I/O per-thread, hence every thread has to call helEnableIo() itself.
+arch::io_space LegacyPciTransport::_io() {
+	thread_local std::vector<bool> enabled;
+
+	if(enabled.size() <= _ioIndex)
+		enabled.resize(_ioIndex + 1);
+	if(!enabled[_ioIndex]) {
+		HEL_CHECK(helEnableIo(_bar.getHandle()));
+		enabled[_ioIndex] = true;
+	}
+	return _legacySpace;
+}
 
 uint8_t LegacyPciTransport::loadConfig8(size_t offset) {
-	return _legacySpace.subspace(20).load(arch::scalar_register<uint8_t>(offset));
+	return _io().subspace(20).load(arch::scalar_register<uint8_t>(offset));
 }
 
 uint16_t LegacyPciTransport::loadConfig16(size_t offset) {
-	return _legacySpace.subspace(20).load(arch::scalar_register<uint16_t>(offset));
+	return _io().subspace(20).load(arch::scalar_register<uint16_t>(offset));
 }
 
 uint32_t LegacyPciTransport::loadConfig32(size_t offset) {
-	return _legacySpace.subspace(20).load(arch::scalar_register<uint32_t>(offset));
+	return _io().subspace(20).load(arch::scalar_register<uint32_t>(offset));
 }
 
 bool LegacyPciTransport::checkDeviceFeature(unsigned int feature) {
@@ -157,13 +183,13 @@ bool LegacyPciTransport::checkDeviceFeature(unsigned int feature) {
 				" on legacy device" << std::endl;
 		return false;
 	}
-	return _legacySpace.load(PCI_L_DEVICE_FEATURES) & (1 << feature);
+	return _io().load(PCI_L_DEVICE_FEATURES) & (1 << feature);
 }
 
 void LegacyPciTransport::acknowledgeDriverFeature(unsigned int feature) {
 	assert(feature < 32);
-	auto current = _legacySpace.load(PCI_L_DRIVER_FEATURES);
-	_legacySpace.store(PCI_L_DRIVER_FEATURES, current | (1 << feature));
+	auto current = _io().load(PCI_L_DRIVER_FEATURES);
+	_io().store(PCI_L_DRIVER_FEATURES, current | (1 << feature));
 }
 
 void LegacyPciTransport::finalizeFeatures() {
@@ -178,8 +204,8 @@ async::result<Queue *> LegacyPciTransport::setupQueue(unsigned int queue_index) 
 	assert(queue_index < _queues.size());
 	assert(!_queues[queue_index]);
 
-	_legacySpace.store(PCI_L_QUEUE_SELECT, queue_index);
-	auto queue_size = _legacySpace.load(PCI_L_QUEUE_SIZE);
+	_io().store(PCI_L_QUEUE_SELECT, queue_index);
+	auto queue_size = _io().load(PCI_L_QUEUE_SIZE);
 	assert(queue_size);
 
 	// TODO: Ensure that the queue size is indeed a power of 2.
@@ -219,14 +245,14 @@ async::result<Queue *> LegacyPciTransport::setupQueue(unsigned int queue_index) 
 	// Hand the queue to the device.
 	uintptr_t table_physical;
 	HEL_CHECK(helPointerPhysical(kHelNullHandle, table, &table_physical));
-	_legacySpace.store(PCI_L_QUEUE_ADDRESS, table_physical >> 12);
+	_io().store(PCI_L_QUEUE_ADDRESS, table_physical >> 12);
 
 	co_return _queues[queue_index].get();
 }
 
 void LegacyPciTransport::runDevice() {
 	// Set the DRIVER_OK bit to finish the configuration.
-	_legacySpace.store(PCI_L_DEVICE_STATUS, _legacySpace.load(PCI_L_DEVICE_STATUS) | DRIVER_OK);
+	_io().store(PCI_L_DEVICE_STATUS, _io().load(PCI_L_DEVICE_STATUS) | DRIVER_OK);
 
 	_processIrqs();
 }
@@ -243,7 +269,7 @@ async::detached LegacyPciTransport::_processIrqs() {
 		HEL_CHECK(await.error());
 		sequence = await.sequence();
 
-		auto isr = _legacySpace.load(PCI_L_ISR_STATUS);
+		auto isr = _io().load(PCI_L_ISR_STATUS);
 
 		if(!(isr & 3)) {
 			HEL_CHECK(helAcknowledgeIrq(_irq.getHandle(), kHelAckNack, sequence));
@@ -254,7 +280,7 @@ async::detached LegacyPciTransport::_processIrqs() {
 
 		if(isr & 2) {
 			std::cout << "core-virtio: Configuration change" << std::endl;
-			auto status = _legacySpace.load(PCI_L_DEVICE_STATUS);
+			auto status = _io().load(PCI_L_DEVICE_STATUS);
 			assert(!(status & DEVICE_NEEDS_RESET));
 		}
 		if(isr & 1)
@@ -269,7 +295,7 @@ LegacyPciQueue::LegacyPciQueue(LegacyPciTransport *transport,
 : Queue{queue_index, queue_size, {}, table, available, used}, _transport{transport} { }
 
 void LegacyPciQueue::notifyTransport() {
-	_transport->_legacySpace.store(PCI_L_QUEUE_NOTIFY, queueIndex());
+	_transport->_io().store(PCI_L_QUEUE_NOTIFY, queueIndex());
 }
 
 } // anonymous namespace
@@ -773,7 +799,7 @@ discover(protocols::hw::Device hw_device, DiscoverMode mode) {
 
 			std::cout << "virtio: Using legacy PCI transport" << std::endl;
 			co_return std::make_unique<LegacyPciTransport>(std::move(hw_device),
-					legacy_space, std::move(irq), std::move(dmaSpace));
+					legacy_space, std::move(bar), std::move(irq), std::move(dmaSpace));
 		}
 #else
 		throw std::runtime_error("Legacy transports are unsupported on this architecture");

--- a/drivers/block/ahci/src/main.cpp
+++ b/drivers/block/ahci/src/main.cpp
@@ -4,6 +4,7 @@
 #include <protocols/mbus/client.hpp>
 #include <protocols/hw/client.hpp>
 
+#include <helix/dispatcher-pool.hpp>
 #include <helix/timer.hpp>
 
 #include "controller.hpp"
@@ -73,5 +74,8 @@ int main() {
 	std::cout << "block/ahci: Starting driver\n";
 
 	observeControllers();
-	async::run_forever(helix::currentDispatcher);
+	// This driver is not thread-safe yet; run the pool single threaded.
+	helix::DispatcherPool::global().setThreadCount(1);
+	helix::DispatcherPool::global().blockOn(
+			async::suspend_indefinitely(async::cancellation_token{}));
 }

--- a/drivers/block/ata/src/main.cpp
+++ b/drivers/block/ata/src/main.cpp
@@ -10,6 +10,7 @@
 #include <async/oneshot-event.hpp>
 #include <arch/io_space.hpp>
 #include <arch/register.hpp>
+#include <helix/dispatcher-pool.hpp>
 #include <helix/ipc.hpp>
 #include <helix/timer.hpp>
 #include <protocols/hw/client.hpp>
@@ -436,5 +437,8 @@ int main() {
 	printf("block/ata: Starting driver\n");
 
 	observeControllers();
-	async::run_forever(helix::currentDispatcher);
+	// This driver is not thread-safe yet; run the pool single threaded.
+	helix::DispatcherPool::global().setThreadCount(1);
+	helix::DispatcherPool::global().blockOn(
+			async::suspend_indefinitely(async::cancellation_token{}));
 }

--- a/drivers/block/nvme/src/main.cpp
+++ b/drivers/block/nvme/src/main.cpp
@@ -3,6 +3,7 @@
 
 #include <core/cmdline.hpp>
 #include <frg/cmdline.hpp>
+#include <helix/dispatcher-pool.hpp>
 #include <map>
 #include <protocols/mbus/client.hpp>
 #include <protocols/hw/client.hpp>
@@ -120,5 +121,8 @@ int main() {
 	std::cout << "block/nvme: Starting driver\n";
 
 	async::detach(protocols::svrctl::serveControl(&controlOps));
-	async::run_forever(helix::currentDispatcher);
+	// This driver is not thread-safe yet; run the pool single threaded.
+	helix::DispatcherPool::global().setThreadCount(1);
+	helix::DispatcherPool::global().blockOn(
+			async::suspend_indefinitely(async::cancellation_token{}));
 }

--- a/drivers/block/virtio-blk/src/main.cpp
+++ b/drivers/block/virtio-blk/src/main.cpp
@@ -12,6 +12,7 @@
 #include <async/result.hpp>
 #include <hel.h>
 #include <hel-syscalls.h>
+#include <helix/dispatcher-pool.hpp>
 #include <helix/ipc.hpp>
 #include <protocols/mbus/client.hpp>
 #include <protocols/hw/client.hpp>
@@ -75,6 +76,7 @@ int main() {
 //	HEL_CHECK(helSetPriority(kHelThisThread, 3));
 
 	observeDevices();
-	async::run_forever(helix::currentDispatcher);
+	helix::DispatcherPool::global().blockOn(
+			async::suspend_indefinitely(async::cancellation_token{}));
 }
 

--- a/drivers/libblockfs/src/common-ops.hpp
+++ b/drivers/libblockfs/src/common-ops.hpp
@@ -5,6 +5,7 @@
 #include <async/algorithm.hpp>
 #include <core/clock.hpp>
 #include <frg/scope_exit.hpp>
+#include <helix/dispatcher-pool.hpp>
 #include "fs.hpp"
 #include "trace.hpp"
 
@@ -403,8 +404,8 @@ doOpen(std::shared_ptr<void> object, bool write, bool read, bool append) {
 		co_await self->updateTimes(clk::getRealtime(), std::nullopt, std::nullopt);
 	}
 
-	[] (smarter::shared_ptr<File> file, BaseFileSystem &fs, helix::UniqueLane localCtrl,
-			helix::UniqueLane localPt) -> async::detached {
+	helix::DispatcherPool::global().detach([] (smarter::shared_ptr<File> file, BaseFileSystem &fs,
+			helix::UniqueLane localCtrl, helix::UniqueLane localPt) -> async::result<void> {
 		auto fileOps = fs.fileOps();
 
 		co_await async::race_and_cancel(
@@ -417,7 +418,7 @@ doOpen(std::shared_ptr<void> object, bool write, bool read, bool append) {
 						file, fileOps, ct);
 			}
 		);
-	}(file, self->fs, std::move(localCtrl), std::move(localPt));
+	}(file, self->fs, std::move(localCtrl), std::move(localPt)));
 
 	co_return protocols::fs::OpenResult{std::move(remoteCtrl), std::move(remotePt)};
 }

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -13,6 +13,7 @@
 #include <core/align.hpp>
 #include <core/clock.hpp>
 #include <core/logging.hpp>
+#include <helix/dispatcher-pool.hpp>
 #include <helix/ipc.hpp>
 #include <helix/memory.hpp>
 
@@ -965,7 +966,7 @@ auto FileSystem::accessInode(uint32_t number) -> std::shared_ptr<BaseInode> {
 		inode_slot = std::weak_ptr<Inode>(new_inode);
 	}
 
-	initiateInode(new_inode);
+	helix::DispatcherPool::global().detach(initiateInode(new_inode));
 
 	return new_inode;
 }
@@ -1103,7 +1104,7 @@ std::pair<uint64_t, size_t> FileSystem::locateDiskInode(uint32_t number) {
 			static_cast<size_t>(byteOffset & (blockSize - 1))};
 }
 
-async::detached FileSystem::initiateInode(std::shared_ptr<Inode> inode) {
+async::result<void> FileSystem::initiateInode(std::shared_ptr<Inode> inode) {
 	auto [inodeBlock, inodeOffset] = locateDiskInode(inode->number);
 	inode->diskInodeWindow = co_await metadataCache->access(inodeBlock, true);
 	inode->diskInodeOffset = inodeOffset;
@@ -1138,12 +1139,13 @@ async::detached FileSystem::initiateInode(std::shared_ptr<Inode> inode) {
 	if(disk_inode->flags & EXT4_EXTENTS_FL)
 		inode->usesExtents = true;
 
-	manageFileData(inode);
+	// Keep the servicer on the pool member that this inode was initiated on.
+	async::detach_on(helix::Dispatcher::global().runQueue(), manageFileData(inode));
 
 	inode->readyEvent.raise();
 }
 
-async::detached FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
+async::result<void> FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 	while(true) {
 		helix::ManageMemory manage;
 		auto &&submit = helix::submitManageMemory(helix::BorrowedDescriptor(inode->backingMemory),

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -494,8 +494,8 @@ struct FileSystem final : BaseFileSystem {
 	// Returns the block containing the given on-disk inode and the offset within that block.
 	std::pair<uint64_t, size_t> locateDiskInode(uint32_t number);
 
-	async::detached initiateInode(std::shared_ptr<Inode> inode);
-	async::detached manageFileData(std::shared_ptr<Inode> inode);
+	async::result<void> initiateInode(std::shared_ptr<Inode> inode);
+	async::result<void> manageFileData(std::shared_ptr<Inode> inode);
 
 	// Allocate up to num blocks for the given inode.
 	// This function does not write back the BGDT, this is the caller's responsibility.

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -12,6 +12,7 @@
 #include <core/clock.hpp>
 #include <core/dispatch.hpp>
 #include <frg/scope_exit.hpp>
+#include <helix/dispatcher-pool.hpp>
 #include <helix/ipc.hpp>
 #include <protocols/fs/server.hpp>
 #include <protocols/mbus/client.hpp>
@@ -69,7 +70,7 @@ struct HandlePartition {
 			helix::UniqueLane local_lane, remote_lane;
 			std::tie(local_lane, remote_lane) = helix::createStream();
 			auto file = smarter::make_shared<raw::OpenFile>(rawFs);
-			async::detach(protocols::fs::servePassthrough(std::move(local_lane),
+			helix::DispatcherPool::global().detach(protocols::fs::servePassthrough(std::move(local_lane),
 							file,
 							&raw::rawOperations));
 
@@ -529,7 +530,7 @@ struct HandleDevice {
 			helix::UniqueLane local_lane, remote_lane;
 			std::tie(local_lane, remote_lane) = helix::createStream();
 			auto file = smarter::make_shared<raw::OpenFile>(rawFs);
-			async::detach(protocols::fs::servePassthrough(std::move(local_lane),
+			helix::DispatcherPool::global().detach(protocols::fs::servePassthrough(std::move(local_lane),
 							file,
 							&raw::rawOperations));
 

--- a/drivers/libblockfs/src/metadata-cache.cpp
+++ b/drivers/libblockfs/src/metadata-cache.cpp
@@ -1,6 +1,8 @@
 #include <bit>
 #include <string.h>
 
+#include <helix/dispatcher-pool.hpp>
+
 #include "metadata-cache.hpp"
 
 namespace blockfs {
@@ -61,11 +63,12 @@ async::detached MetadataCache::manage_(helix::UniqueDescriptor backing) {
 		co_await submitManage.async_wait();
 		HEL_CHECK(manage.error());
 
-		serviceRequest_(backing, manage.type(), manage.offset(), manage.length());
+		helix::DispatcherPool::global().detach(
+				serviceRequest_(backing, manage.type(), manage.offset(), manage.length()));
 	}
 }
 
-async::detached MetadataCache::serviceRequest_(helix::BorrowedDescriptor backing,
+async::result<void> MetadataCache::serviceRequest_(helix::BorrowedDescriptor backing,
 		int type, uintptr_t offset, size_t length) {
 	auto frameSize = size_t{1} << blockPagesShift_;
 	assert(!(offset & (frameSize - 1)));

--- a/drivers/libblockfs/src/metadata-cache.hpp
+++ b/drivers/libblockfs/src/metadata-cache.hpp
@@ -50,7 +50,7 @@ struct MetadataCache {
 
 private:
 	async::detached manage_(helix::UniqueDescriptor backing);
-	async::detached serviceRequest_(helix::BorrowedDescriptor backing,
+	async::result<void> serviceRequest_(helix::BorrowedDescriptor backing,
 			int type, uintptr_t offset, size_t length);
 
 	BlockDevice *device_;

--- a/drivers/libblockfs/src/raw.cpp
+++ b/drivers/libblockfs/src/raw.cpp
@@ -4,6 +4,7 @@
 
 #include <bragi/helpers-std.hpp>
 #include <core/dispatch.hpp>
+#include <helix/dispatcher-pool.hpp>
 #include "fs.bragi.hpp"
 
 namespace blockfs {
@@ -18,11 +19,11 @@ async::result<void> RawFs::init() {
 	HEL_CHECK(helCreateManagedMemory(cache_size, 0,
 				&backingMemory, &frontalMemory));
 
-	manageMapping();
+	helix::DispatcherPool::global().detach(manageMapping());
 	co_return;
 }
 
-async::detached RawFs::manageMapping() {
+async::result<void> RawFs::manageMapping() {
 	while(true) {
 		helix::ManageMemory manage;
 		auto &&submit = helix::submitManageMemory(helix::BorrowedDescriptor{backingMemory},

--- a/drivers/libblockfs/src/raw.hpp
+++ b/drivers/libblockfs/src/raw.hpp
@@ -18,7 +18,7 @@ struct RawFs {
 
 	async::result<void> init();
 
-	async::detached manageMapping();
+	async::result<void> manageMapping();
 
 	BlockDevice *device;
 	HelHandle backingMemory;

--- a/drivers/usb/devices/storage/src/main.cpp
+++ b/drivers/usb/devices/storage/src/main.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 
 #include <async/result.hpp>
+#include <helix/dispatcher-pool.hpp>
 #include <protocols/mbus/client.hpp>
 #include <protocols/usb/usb.hpp>
 #include <protocols/usb/api.hpp>
@@ -205,7 +206,10 @@ int main() {
 	std::cout << "block-usb: Starting driver" << std::endl;
 
 	observeDevices();
-	async::run_forever(helix::currentDispatcher);
+	// This driver is not thread-safe yet; run the pool single threaded.
+	helix::DispatcherPool::global().setThreadCount(1);
+	helix::DispatcherPool::global().blockOn(
+			async::suspend_indefinitely(async::cancellation_token{}));
 
 	return 0;
 }

--- a/hel/include/helix/dispatcher-pool.hpp
+++ b/hel/include/helix/dispatcher-pool.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <atomic>
+#include <concepts>
+#include <vector>
+
+#include <async/algorithm.hpp>
+#include <async/basic.hpp>
+#include <async/result.hpp>
+#include <async/run-queue.hpp>
+#include <frg/scope_exit.hpp>
+#include <helix/ipc.hpp>
+
+namespace helix {
+
+// Pool of threads that each drive a thread-local helix::Dispatcher.
+// The DispatcherPool is owned by the thread that creates it.
+// The owner of the DispatcherPool is adopted as its first pool member.
+struct DispatcherPool {
+	static DispatcherPool &global();
+
+	DispatcherPool(const DispatcherPool &) = delete;
+
+	DispatcherPool &operator= (const DispatcherPool &) = delete;
+
+	// Fixes the number of pool threads.
+	// Must be called before the pool is brought up.
+	void setThreadCount(size_t count) {
+		assert(async::current_run_queue_context() == ownerContext_
+				&& "setThreadCount() must be called from the owner thread");
+		assert(!live_.load(std::memory_order_relaxed)
+				&& "setThreadCount() must be called before bring-up");
+		assert(count > 0);
+		threadCount_ = count;
+	}
+
+	// Drives the calling thread's helix::Dispatcher until the sender completes and returns the sender's value.
+	// Brings up the pool on first call.
+	// Must not be called from a worker thread and must not be nested.
+	template<async::Sender S>
+	typename S::value_type blockOn(S sender) {
+		enter_();
+		inBlockOn_ = true;
+		frg::scope_exit leaveOnExit{[&] {
+			inBlockOn_ = false;
+		}};
+		return async::run(std::move(sender), currentDispatcher);
+	}
+
+	// Detaches a sender into the pool.
+	// The pool must have been brought up before.
+	template<async::Sender S>
+	requires std::same_as<typename S::value_type, void>
+	void detach(S sender) {
+		// There is no run queue to detach to before bring-up.
+		if(!live_.load(std::memory_order_acquire))
+			abort();
+		auto index = next_.fetch_add(1, std::memory_order_relaxed) % members_.size();
+		async::detach_on(members_[index], onRunQueue_(std::move(sender)));
+	}
+
+private:
+	DispatcherPool();
+
+	// Workaround for detach_on() since coroutines still start inline right now.
+	// TODO: Remove this when libasync also moves initial suspend to the queue.
+	template<async::Sender S>
+	static async::result<void> onRunQueue_(S sender) {
+		co_await async::invocable([] { });
+		co_await std::move(sender);
+	}
+
+	void enter_();
+
+	// Context of the owner thread.
+	async::run_queue_context *ownerContext_{nullptr};
+	// Number of threads that the pool uses.
+	size_t threadCount_{0};
+	// Member run queues. Immutable after bring-up.
+	std::vector<async::run_queue *> members_;
+	// Index of the thread that detach() targets next.
+	std::atomic<size_t> next_{0};
+	// True after bring-up.
+	std::atomic<bool> live_{false};
+	// Whether we are currently in blockOn() or not.
+	bool inBlockOn_{false};
+};
+
+} // namespace helix

--- a/hel/meson.build
+++ b/hel/meson.build
@@ -6,6 +6,7 @@ headers = [
 ]
 
 helix_headers = [
+	'include/helix/dispatcher-pool.hpp',
 	'include/helix/ipc-structs.hpp',
 	'include/helix/ipc.hpp',
 	'include/helix/memory.hpp',
@@ -14,6 +15,7 @@ helix_headers = [
 ]
 
 src = files(
+	'src/dispatcher-pool.cpp',
 	'src/globals.cpp',
 	'src/passthrough-fd.cpp',
 )

--- a/hel/src/dispatcher-pool.cpp
+++ b/hel/src/dispatcher-pool.cpp
@@ -1,0 +1,74 @@
+#include <stdlib.h>
+#include <bit>
+#include <future>
+#include <iostream>
+#include <thread>
+
+#include <hel.h>
+#include <hel-syscalls.h>
+#include <helix/dispatcher-pool.hpp>
+
+namespace helix {
+
+namespace {
+
+// Number of CPUs that we have access to.
+size_t queryCpuCount() {
+	uint8_t mask[64];
+	size_t actualSize;
+	HEL_CHECK(helGetAffinity(kHelThisThread, mask, sizeof(mask), &actualSize));
+
+	size_t count = 0;
+	for(size_t i = 0; i < actualSize; ++i)
+		count += std::popcount(mask[i]);
+	return count;
+}
+
+void workerMain(std::promise<async::run_queue *> promise) {
+	promise.set_value(Dispatcher::global().runQueue());
+	async::run_forever(currentDispatcher);
+	abort(); // We should never get here.
+}
+
+} // anonymous namespace
+
+DispatcherPool &DispatcherPool::global() {
+	static DispatcherPool singleton;
+	return singleton;
+}
+
+DispatcherPool::DispatcherPool() {
+	ownerContext_ = async::current_run_queue_context();
+
+	// Adopt the owner as the first member of this pool.
+	members_.push_back(Dispatcher::global().runQueue());
+}
+
+void DispatcherPool::enter_() {
+	assert(!inBlockOn_ && "blockOn() must not be nested");
+	assert(async::current_run_queue_context() == ownerContext_
+			&& "blockOn() must be called from the owner thread");
+
+	if(live_.load(std::memory_order_relaxed))
+		return;
+
+	auto numThreads = threadCount_ ? threadCount_ : queryCpuCount();
+	std::cout << "helix: Running dispatcher pool on " << numThreads
+			<< " threads" << std::endl;
+
+	assert(members_.size() == 1); // The owner is the first member.
+	for(size_t i = 1; i < numThreads; ++i) {
+		std::promise<async::run_queue *> promise;
+		auto future = promise.get_future();
+
+		// The workers are never joined for now to prevent UAF
+		// when there are still coroutines pointing to the helix::Dispatchers.
+		std::thread{workerMain, std::move(promise)}.detach();
+
+		members_.push_back(future.get());
+	}
+
+	live_.store(true, std::memory_order_release);
+}
+
+} // namespace helix


### PR DESCRIPTION
Add `helix::DispatcherPool` to dispatch coroutines to a thread pool. Change libblockfs to use this thread pool for most of its detached coroutines.