### PR TITLE
virtio-block: Negotiate VIRTIO_BLK_F_FLUSH and add flush()

### DIFF
--- a/drivers/block/virtio-blk/src/block.cpp
+++ b/drivers/block/virtio-blk/src/block.cpp
@@ -31,6 +31,12 @@ Device::Device(std::unique_ptr<virtio_core::Transport> transport, int64_t parent
   _size{0} {}
 
 async::result<void> Device::runDevice() {
+	// Without VIRTIO_BLK_F_FLUSH, qemu disables its write cache and fdatasync()s on every write.
+	// Negotiate it to get writeback caching on the host side.
+	if(_transport->checkDeviceFeature(VIRTIO_BLK_F_FLUSH)) {
+		_transport->acknowledgeDriverFeature(VIRTIO_BLK_F_FLUSH);
+		_hasFlush = true;
+	}
 	_transport->finalizeFeatures();
 	_transport->claimQueues(1);
 	_requestQueue = co_await _transport->setupQueue(0);

--- a/drivers/block/virtio-blk/src/block.cpp
+++ b/drivers/block/virtio-blk/src/block.cpp
@@ -115,6 +115,38 @@ async::result<void> Device::writeSectors(uint64_t sector, arch::dma_buffer_view 
 	}
 }
 
+async::result<void> Device::flush() {
+	if(!_hasFlush)
+		co_return;
+
+	UserRequest request{false, 0, {}, pagePool};
+
+	std::array<virtio_core::Handle, 2> handles;
+	co_await _requestQueue->obtainDescriptors(handles);
+	handles[0].setupLink(handles[1]);
+
+	request.header->type = VIRTIO_BLK_T_FLUSH;
+	request.header->reserved = 0;
+	request.header->sector = 0;
+
+	co_await handles[0].setupBuffer(virtio_core::hostToDevice, request.header.view_buffer());
+	co_await handles[1].setupBuffer(virtio_core::deviceToHost, request.status.view_buffer());
+
+	_requestQueue->postDescriptor(handles.front(), &request,
+			[] (virtio_core::Request *base_request) {
+		auto request = static_cast<UserRequest *>(base_request);
+		request->event.raise();
+	});
+	_requestQueue->notify();
+
+	co_await request.event.wait();
+	if(*request.status != VIRTIO_BLK_S_OK) {
+		std::cout << "virtio: Device signaled an error for flush, status "
+				<< static_cast<unsigned int>(*request.status) << std::endl;
+		abort();
+	}
+}
+
 async::result<size_t> Device::getSize() {
 	co_return _size * 512;
 }

--- a/drivers/block/virtio-blk/src/block.hpp
+++ b/drivers/block/virtio-blk/src/block.hpp
@@ -26,6 +26,10 @@ enum {
 };
 
 enum {
+	VIRTIO_BLK_F_FLUSH = 9
+};
+
+enum {
 	VIRTIO_BLK_S_OK = 0,
 	VIRTIO_BLK_S_IOERR = 1,
 	VIRTIO_BLK_S_UNSUPP = 2
@@ -84,6 +88,9 @@ private:
 
 	// The size of the disk
 	size_t _size;
+
+	// Whether the device supports VIRTIO_BLK_T_FLUSH.
+	bool _hasFlush = false;
 };
 
 } } // namespace block::virtio

--- a/drivers/block/virtio-blk/src/block.hpp
+++ b/drivers/block/virtio-blk/src/block.hpp
@@ -22,7 +22,8 @@ static_assert(sizeof(VirtRequest) == 16, "Bad sizeof(VirtRequest)");
 
 enum {
 	VIRTIO_BLK_T_IN = 0,
-	VIRTIO_BLK_T_OUT = 1
+	VIRTIO_BLK_T_OUT = 1,
+	VIRTIO_BLK_T_FLUSH = 4,
 };
 
 enum {
@@ -73,6 +74,8 @@ struct Device : blockfs::BlockDevice {
 
 	async::result<void> readSectors(uint64_t sector, arch::dma_buffer_view view) override;
 	async::result<void> writeSectors(uint64_t sector, arch::dma_buffer_view view) override;
+
+	async::result<void> flush() override;
 
 	async::result<size_t> getSize() override;
 

--- a/drivers/libblockfs/include/blockfs.hpp
+++ b/drivers/libblockfs/include/blockfs.hpp
@@ -20,6 +20,13 @@ struct BlockDevice {
 		throw std::runtime_error("BlockDevice does not support writeSectors()");
 	}
 
+	// Flushes the device's write cache.
+	// flush() affects all write requests that have completed before flush() starts.
+	// When flush() returns, all these write requests will have made it to durable storage.
+	virtual async::result<void> flush() {
+		co_return;
+	}
+
 	virtual async::result<size_t> getSize() = 0;
 
 	virtual async::result<void> handleIoctl(managarm::fs::GenericIoctlRequest &req, helix::BorrowedDescriptor conversation) {


### PR DESCRIPTION
Negotiating `VIRTIO_BLK_F_FLUSH` gives a massive performance boost for writes on cached storage since it prevents qemu from doing an `fdatasync()` after each write.

Also add a `flush()` function to do the sync. This is not called anywhere yet, but we will need it to implement `sync()` in the future.