### PR TITLE
sif: Support MSIs

### DIFF
--- a/drivers/uart/src/main.cpp
+++ b/drivers/uart/src/main.cpp
@@ -380,7 +380,7 @@ int main() {
 	auto sd = protocols::svrctl::getServerData();
 
 	HelHandle pin_handle;
-	HEL_CHECK(helAccessIrq(sd.hardwareAccess, kHelAccessIrqByGsi, 0, 4, &pin_handle));
+	HEL_CHECK(helAccessIrq(sd.hardwareAccess, kHelAccessIrqByGsi, 0, 4, nullptr, &pin_handle));
 	helix::UniqueDescriptor pin{pin_handle};
 
 	HelHandle irq_handle;

--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -379,11 +379,13 @@ extern inline __attribute__ (( always_inline )) HelError helRaiseEvent(HelHandle
 };
 
 extern inline __attribute__ (( always_inline )) HelError helAccessIrq(
-	HelHandle accessHandle, uint32_t mode, uint64_t controller, uint64_t index, HelHandle *handle
+	HelHandle accessHandle, uint32_t mode, uint64_t controller, uint64_t index,
+	const char *name, HelHandle *handle
 ) {
 	HelWord outHandle;
-	HelError error = helSyscall4_1(
-		kHelCallAccessIrq, (HelWord)accessHandle, (HelWord)mode, (HelWord)controller, (HelWord)index, &outHandle
+	HelError error = helSyscall5_1(
+		kHelCallAccessIrq, (HelWord)accessHandle, (HelWord)mode, (HelWord)controller,
+		(HelWord)index, (HelWord)name, &outHandle
 	);
 	*handle = (HelHandle)outHandle;
 	return error;
@@ -401,6 +403,11 @@ extern inline __attribute__ (( always_inline )) HelError helConfigureIrq(HelHand
 		uint32_t trigger, uint32_t polarity) {
 	return helSyscall3(kHelCallConfigureIrq, (HelWord)pin_handle, (HelWord)trigger,
 			(HelWord)polarity);
+};
+
+extern inline __attribute__ (( always_inline )) HelError helQueryMsiInfo(HelHandle pin_handle,
+		struct HelMsiInfo *info) {
+	return helSyscall2(kHelCallQueryMsiInfo, (HelWord)pin_handle, (HelWord)info);
 };
 
 extern inline __attribute__ (( always_inline )) HelError helAcknowledgeIrq(HelHandle handle,

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -103,6 +103,7 @@ enum {
 	kHelCallAcknowledgeIrq = 81,
 	kHelCallSubmitAwaitEvent = 82,
 	kHelCallAutomateIrq = 94,
+	kHelCallQueryMsiInfo = 6,
 
 	kHelCallAccessIo = 11,
 	kHelCallEnableIo = 12,
@@ -269,6 +270,7 @@ static const HelRights kHelRightSignal = UINT32_C(1) << 12;
 // - Thread: required to resume.
 // - Thread: required to kill.
 // - IRQ pin: required to configure the IRQ.
+// - IRQ pin: required to obtain MSI address and data words.
 static const HelRights kHelRightManage = UINT32_C(1) << 13;
 // All rights (even unspecified ones). Easier to recognize in code than a literal.
 static const HelRights kHelRightsMax = ~UINT32_C(0);
@@ -1066,6 +1068,12 @@ enum HelLogSeverity {
 enum {
 	kHelAccessIrqByGsi = 1,
 	kHelAccessIrqByPhandle = 2,
+	kHelAccessIrqAllocateMsi = 3,
+};
+
+//! Size of the buffer that ::helAccessIrq reads an IRQ name from.
+enum {
+	kHelIrqNameSize = 32,
 };
 
 enum {
@@ -1078,6 +1086,12 @@ enum {
 	kHelIrqPolarityNull = 0,
 	kHelIrqPolarityHigh = 1,
 	kHelIrqPolarityLow = 2
+};
+
+//! Message address / data pair that raises an MSI (see ::helQueryMsiInfo).
+struct HelMsiInfo {
+	uint64_t address;
+	uint32_t data;
 };
 
 //! @name Logging
@@ -1574,20 +1588,28 @@ HEL_C_LINKAGE HelError helCreateBitsetEvent(HelHandle *handle);
 HEL_C_LINKAGE HelError helRaiseEvent(HelHandle handle);
 
 //! Access the IRQ pin that an IRQ is attached to.
+//! For ::kHelAccessIrqAllocateMsi, allocate a fresh MSI pin from the system's
+//! MSI controller instead of accessing an existing IRQ.
 //! @param[in] mode
 //!     Determines how the IRQ is identified (e.g., ::kHelAccessIrqByGsi).
 //! @param[in] controller
 //!     Identifies the interrupt controller that the IRQ belongs to.
-//!     Unused for ::kHelAccessIrqByGsi.
+//!     Unused for ::kHelAccessIrqByGsi and ::kHelAccessIrqAllocateMsi.
 //!     For ::kHelAccessIrqByPhandle, this is the device tree phandle of the controller.
 //! @param[in] index
 //!     Identifies the IRQ within the interrupt controller.
 //!     For ::kHelAccessIrqByGsi, this is the global system interrupt number.
 //!     For ::kHelAccessIrqByPhandle, this is a controller-specific IRQ index.
+//!     Unused for ::kHelAccessIrqAllocateMsi.
+//! @param[in] name
+//!     Names the pin in kernel diagnostics. The kernel reads ::kHelIrqNameSize bytes from
+//!     this buffer and stops at the first null byte, if any.
+//!     Only used for ::kHelAccessIrqAllocateMsi, which requires it to be non-null.
 //! @param[out] handle
 //!     Handle to the IRQ pin.
 HEL_C_LINKAGE HelError helAccessIrq(
-	HelHandle accessHandle, uint32_t mode, uint64_t controller, uint64_t index, HelHandle *handle
+	HelHandle accessHandle, uint32_t mode, uint64_t controller, uint64_t index,
+	const char *name, HelHandle *handle
 );
 
 //! Install an IRQ handler on an IRQ pin.
@@ -1609,6 +1631,14 @@ HEL_C_LINKAGE HelError helHandleIrq(HelHandle pinHandle, HelHandle *handle);
 //!     ::kHelIrqPolarityNull states that the interrupt controller has no configurable
 //!     polarity.
 HEL_C_LINKAGE HelError helConfigureIrq(HelHandle pinHandle, uint32_t trigger, uint32_t polarity);
+
+//! Retrieves the message address and data of an MSI pin.
+//! @param[in] pinHandle
+//!     Handle to the IRQ pin. The pin must be message-signaled
+//!     (e.g., allocated via ::kHelAccessIrqAllocateMsi).
+//! @param[out] info
+//!     Message address / data pair that raises the MSI.
+HEL_C_LINKAGE HelError helQueryMsiInfo(HelHandle pinHandle, struct HelMsiInfo *info);
 
 HEL_C_LINKAGE HelError helAcknowledgeIrq(HelHandle handle, uint32_t flags, uint64_t sequence);
 

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -3532,7 +3532,8 @@ HelError helRaiseEvent(HelHandle handle) {
 }
 
 HelError helAccessIrq(
-	HelHandle accessHandle, uint32_t mode, uint64_t controller, uint64_t index, HelHandle *handle
+	HelHandle accessHandle, uint32_t mode, uint64_t controller, uint64_t index,
+	const char *name, HelHandle *handle
 ) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
@@ -3564,6 +3565,21 @@ HelError helAccessIrq(
 		if(!irqController)
 			return kHelErrIllegalArgs;
 		pin = irqController->resolveIrqIndex(index);
+#else
+		return kHelErrUnsupportedOperation;
+#endif
+	}else if(mode == kHelAccessIrqAllocateMsi) {
+		// kHelAccessIrqAllocateMsi allocates from the system's default MSI controller.
+		if (controller || index)
+			return kHelErrIllegalArgs;
+		if (!name)
+			return kHelErrIllegalArgs;
+#ifdef __x86_64__
+		char nameBuffer[kHelIrqNameSize];
+		if(!readUserArray(name, nameBuffer, kHelIrqNameSize))
+			return kHelErrFault;
+		pin = allocateApicMsi(frg::string<KernelAlloc>{*kernelAlloc, nameBuffer,
+				strnlen(nameBuffer, kHelIrqNameSize)});
 #else
 		return kHelErrUnsupportedOperation;
 #endif
@@ -3627,6 +3643,30 @@ HelError helConfigureIrq(HelHandle pinHandle, uint32_t trigger, uint32_t polarit
 		return translateError(pinOutcome.error());
 
 	(*pinOutcome)->configure(IrqConfiguration{triggerMode, irqPolarity});
+
+	return kHelErrNone;
+}
+
+HelError helQueryMsiInfo(HelHandle pinHandle, HelMsiInfo *info) {
+	auto this_thread = getCurrentThread();
+	auto this_universe = this_thread->getUniverse();
+
+	auto pinOutcome = this_universe->resolveObject<DescriptorType::irqPin>(pinHandle,
+			kHelRightManage);
+	if(!pinOutcome)
+		return translateError(pinOutcome.error());
+
+	auto *msiPin = (*pinOutcome)->asMsiPin();
+	if(!msiPin)
+		return kHelErrUnsupportedOperation;
+
+	HelMsiInfo outInfo;
+	memset(&outInfo, 0, sizeof(HelMsiInfo));
+	outInfo.address = msiPin->getMessageAddress();
+	outInfo.data = msiPin->getMessageData();
+
+	if(!writeUserObject(info, outInfo))
+		return kHelErrFault;
 
 	return kHelErrNone;
 }

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -837,7 +837,8 @@ void handleSyscall(SyscallImageAccessor image) {
 	} break;
 	case kHelCallAccessIrq: {
 		HelHandle handle;
-		*image.error() = helAccessIrq((HelHandle)arg0, (uint32_t)arg1, (uint64_t)arg2, (uint64_t)arg3, &handle);
+		*image.error() = helAccessIrq((HelHandle)arg0, (uint32_t)arg1, (uint64_t)arg2, (uint64_t)arg3,
+				(const char *)arg4, &handle);
 		*image.out0() = handle;
 	} break;
 	case kHelCallHandleIrq: {
@@ -850,6 +851,9 @@ void handleSyscall(SyscallImageAccessor image) {
 	} break;
 	case kHelCallAutomateIrq: {
 		*image.error() = helAutomateIrq((HelHandle)arg0, (uint32_t)arg1, (HelHandle)arg2);
+	} break;
+	case kHelCallQueryMsiInfo: {
+		*image.error() = helQueryMsiInfo((HelHandle)arg0, (HelMsiInfo *)arg1);
 	} break;
 
 	case kHelCallAccessIo: {

--- a/kernel/thor/generic/thor-internal/irq.hpp
+++ b/kernel/thor/generic/thor-internal/irq.hpp
@@ -53,6 +53,7 @@ private:
 // ----------------------------------------------------------------------------
 
 struct IrqPin;
+struct MsiPin;
 
 // null is used for interrupt controllers that do not implement configurable trigger modes.
 enum class TriggerMode {
@@ -201,6 +202,9 @@ public:
 
 	virtual void dumpHardwareState();
 
+	// Non-null iff this pin is message-signaled.
+	virtual MsiPin *asMsiPin() { return nullptr; }
+
 protected:
 	virtual IrqStrategy program(TriggerMode mode, Polarity polarity) = 0;
 
@@ -267,6 +271,8 @@ private:
 struct MsiPin : IrqPin {
 	MsiPin(frg::string<KernelAlloc> name)
 	: IrqPin{std::move(name)} { }
+
+	MsiPin *asMsiPin() override { return this; }
 
 	virtual uint64_t getMessageAddress() = 0;
 	virtual uint32_t getMessageData() = 0;

--- a/rust/hel/src/lib.rs
+++ b/rust/hel/src/lib.rs
@@ -125,6 +125,7 @@ pub fn access_irq_by_gsi(access_handle: &Handle, gsi: u64) -> Result<Handle> {
             hel_sys::kHelAccessIrqByGsi as u32,
             0,
             gsi,
+            std::ptr::null(),
             &mut handle,
         )
     })?;
@@ -140,6 +141,7 @@ pub fn access_irq_by_phandle(access_handle: &Handle, phandle: u64, index: u64) -
             hel_sys::kHelAccessIrqByPhandle as u32,
             phandle,
             index,
+            std::ptr::null(),
             &mut handle,
         )
     })?;

--- a/rust/hel/src/lib.rs
+++ b/rust/hel/src/lib.rs
@@ -148,6 +148,50 @@ pub fn access_irq_by_phandle(access_handle: &Handle, phandle: u64, index: u64) -
     Ok(unsafe { Handle::from_raw(handle) })
 }
 
+/// Allocates a fresh MSI pin from the system's MSI controller.
+/// The name identifies the pin in kernel diagnostics.
+pub fn allocate_msi(access_handle: &Handle, name: &str) -> Result<Handle> {
+    // The kernel reads the whole buffer, hence pass one of exactly that size.
+    // Names that do not fit are truncated.
+    let mut buffer = [0 as std::ffi::c_char; hel_sys::kHelIrqNameSize as usize];
+    for (slot, &byte) in buffer.iter_mut().zip(name.as_bytes()) {
+        *slot = byte as std::ffi::c_char;
+    }
+
+    let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
+    result::hel_check(unsafe {
+        hel_sys::helAccessIrq(
+            access_handle.handle(),
+            hel_sys::kHelAccessIrqAllocateMsi as u32,
+            0,
+            0,
+            buffer.as_ptr(),
+            &mut handle,
+        )
+    })?;
+    Ok(unsafe { Handle::from_raw(handle) })
+}
+
+/// Message address / data pair that raises an MSI.
+#[derive(Debug, Clone, Copy)]
+pub struct MsiInfo {
+    pub address: u64,
+    pub data: u32,
+}
+
+/// Queries the message address and data of an MSI pin.
+pub fn query_msi_info(pin: &Handle) -> Result<MsiInfo> {
+    let mut info = hel_sys::HelMsiInfo {
+        address: 0,
+        data: 0,
+    };
+    result::hel_check(unsafe { hel_sys::helQueryMsiInfo(pin.handle(), &mut info) })?;
+    Ok(MsiInfo {
+        address: info.address,
+        data: info.data,
+    })
+}
+
 /// Returns an IRQ object that handles interrupts of the given IRQ pin.
 pub fn handle_irq(pin: &Handle) -> Result<Handle> {
     let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;

--- a/rust/managarm/src/hw/server.rs
+++ b/rust/managarm/src/hw/server.rs
@@ -49,9 +49,16 @@ pub trait PciDevice {
     fn access_vbt(&self) -> hel::Result<Option<(u32, Handle)>> {
         Ok(None)
     }
+    fn install_msi(&self, index: u32) -> hel::Result<Option<Handle>> {
+        let _ = index;
+        Ok(None)
+    }
 
     fn enable_busmaster(&self);
     fn enable_irq(&self);
+    fn enable_msi(&self) -> bool {
+        false
+    }
     fn get_dma_space(&self) -> hel::Result<(bool, Handle)> {
         Ok((false, hel::create_dma_space()?))
     }
@@ -274,6 +281,30 @@ async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> 
         bindings::EnableBusIrqRequest::MESSAGE_ID => {
             device.enable_irq();
             send_response(lane, &Errors::Success.into()).await?;
+        }
+        bindings::InstallMsiRequest::MESSAGE_ID => {
+            let req: bindings::InstallMsiRequest =
+                bragi::head_from_bytes(request).map_err(|_| hel::Error::IllegalArgs)?;
+            match device.install_msi(req.index()) {
+                Ok(Some(handle)) => {
+                    send_response_with_push(
+                        lane,
+                        &Errors::Success.into(),
+                        &handle,
+                        hel_sys::kHelRightWait | hel_sys::kHelRightSignal,
+                    )
+                    .await?
+                }
+                Ok(None) => send_response(lane, &Errors::IllegalArguments.into()).await?,
+                Err(_) => send_response(lane, &Errors::ResourceExhaustion.into()).await?,
+            }
+        }
+        bindings::EnableMsiRequest::MESSAGE_ID => {
+            if device.enable_msi() {
+                send_response(lane, &Errors::Success.into()).await?;
+            } else {
+                send_response(lane, &Errors::IllegalArguments.into()).await?;
+            }
         }
         bindings::GetDmaSpaceRequest::MESSAGE_ID => {
             let (iommu_active, space) = device.get_dma_space()?;

--- a/sif/src/pci/discover.rs
+++ b/sif/src/pci/discover.rs
@@ -1,8 +1,10 @@
 use std::sync::Mutex;
 use std::sync::atomic::Ordering;
 
+use managarm::svrctl::hardware_access_handle;
+
 use super::{
-    BarType, Capability, EXPECT_LOCK, ExtendedCapability, IrqIndex,
+    BarType, Capability, EXPECT_LOCK, ExtendedCapability, IrqIndex, MsixTable,
     PCI_BRIDGE_EXPANSION_ROM_BASE_ADDRESS, PCI_REGULAR_BAR0,
     PCI_REGULAR_EXPANSION_ROM_BASE_ADDRESS, PciBridge, PciBus, PciBusResource, PciDevice,
     PciEntity, PciExpansionRom, name_of_capability, name_of_extended_capability,
@@ -345,6 +347,95 @@ fn find_pci_caps(entity: &PciEntity) {
     }
 }
 
+// Setup MSI / MSI-X. This needs to happen after BARs are already allocated.
+fn setup_msis(device: &'static PciDevice) {
+    let entity = &device.entity;
+    let bus = entity.parent_bus;
+    let slot = entity.slot;
+    let function = entity.function;
+
+    let msix_index = device.msix_index.load(Ordering::Relaxed);
+    let msi_index = device.msi_index.load(Ordering::Relaxed);
+    if msix_index >= 0 {
+        let offset = entity.caps.lock().expect(EXPECT_LOCK)[msix_index as usize].offset;
+
+        let msg_control = unsafe { bus.read_config_half(slot, function, offset + 2) };
+        let num_msis = ((msg_control & 0x7FF) + 1) as u32;
+        println!(
+            "sif: {num_msis} MSI-X vectors available for PCI device {:04x}:{:02x}:{:02x}.{:x}",
+            entity.seg, entity.bus, slot, function
+        );
+
+        // Map the MSI-X BAR.
+        let table_info = unsafe { bus.read_config_word(slot, function, offset + 4) };
+        let table_bar = (table_info & 0x7) as usize;
+        let table_offset = table_info & 0xFFFF_FFF8;
+        assert!(table_bar < 6);
+
+        let bar = {
+            let bars = entity.bars.lock().expect(EXPECT_LOCK);
+            assert!(bars[table_bar].type_ == BarType::Memory);
+            bars[table_bar]
+        };
+        let table_address = (bar.host_address + table_offset as u64) as usize;
+        let mapping_disp = table_address & PAGE_MASK;
+        let mapping_size = (mapping_disp + num_msis as usize * 16 + PAGE_MASK) & !PAGE_MASK;
+
+        let handle = match hel::access_physical(
+            hardware_access_handle(),
+            table_address & !PAGE_MASK,
+            mapping_size,
+            hel::CachingMode::Mmio,
+        ) {
+            Ok(handle) => handle,
+            Err(err) => {
+                println!("sif: Failed to access the MSI-X table: {err}");
+                return;
+            }
+        };
+        let mapping = match unsafe {
+            hel::Mapping::<u8>::new(
+                &handle,
+                None,
+                0,
+                mapping_size,
+                hel::MappingFlags::READ | hel::MappingFlags::WRITE,
+            )
+        } {
+            Ok(mapping) => mapping,
+            Err(err) => {
+                println!("sif: Failed to map the MSI-X table: {err}");
+                return;
+            }
+        };
+        let table = MsixTable::new(mapping, mapping_disp);
+
+        // Mask all MSIs.
+        for i in 0..num_msis as usize {
+            table.set_masked(i, true);
+        }
+
+        *device.msix_mapping.lock().expect(EXPECT_LOCK) = Some(table);
+        device.num_msis.store(num_msis, Ordering::Relaxed);
+        device.msis_usable.store(true, Ordering::Relaxed);
+    } else if msi_index >= 0 {
+        let offset = entity.caps.lock().expect(EXPECT_LOCK)[msi_index as usize].offset;
+
+        let mut msg_control = unsafe { bus.read_config_half(slot, function, offset + 2) };
+        let num_msis = 1; // TODO(qookie): 1 << ((msg_control >> 1) & 0b111)
+        println!(
+            "sif: {num_msis} MSI vectors available for PCI device {:04x}:{:02x}:{:02x}.{:x}",
+            entity.seg, entity.bus, slot, function
+        );
+
+        msg_control &= !0x0001; // Disable MSI
+
+        unsafe { bus.write_config_half(slot, function, offset + 2, msg_control) };
+        device.num_msis.store(num_msis, Ordering::Relaxed);
+        device.msis_usable.store(true, Ordering::Relaxed);
+    }
+}
+
 fn check_pci_function(
     bus: &'static PciBus,
     slot: u8,
@@ -418,6 +509,22 @@ fn check_pci_function(
         );
 
         find_pci_caps(&device.entity);
+
+        for (i, cap) in device
+            .entity
+            .caps
+            .lock()
+            .expect(EXPECT_LOCK)
+            .iter()
+            .enumerate()
+        {
+            if cap.type_ == 0x5 {
+                device.msi_index.store(i as i32, Ordering::Relaxed);
+            }
+            if cap.type_ == 0x11 {
+                device.msix_index.store(i as i32, Ordering::Relaxed);
+            }
+        }
 
         read_entity_bars(&device.entity, 6);
         parse_expansion_rom(&device.entity, PCI_REGULAR_EXPANSION_ROM_BASE_ADDRESS);
@@ -1180,6 +1287,8 @@ fn configure_device(device: &'static PciDevice) {
         decode_bits |= 0x02;
     }
     enable_decodes_in_chain(decode_bits, &device.entity);
+
+    setup_msis(device);
 
     println!(
         "sif: Applying quirks for PCI device {:04x}:{:02x}:{:02x}.{:x}",

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -7,10 +7,11 @@ pub mod serve;
 
 use managarm::svrctl::hardware_access_handle;
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU8};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU8, AtomicU32};
 use std::sync::{Mutex, OnceLock};
 
 use anyhow::Result;
+use arch::{IoMemSpace, bit_register, scalar_register};
 use hel::{IrqPolarity, IrqTrigger};
 
 use config::PciConfigIo;
@@ -710,6 +711,54 @@ pub struct Capability {
     pub length: Option<u64>,
 }
 
+// Entry of the MSI-X vector table, from the PCI specification.
+const MSIX_ENTRY_SIZE: usize = 16;
+scalar_register!(MsixMessageAddress @ 0: u64);
+scalar_register!(MsixMessageData @ 8: u32);
+bit_register! {
+    MsixVectorControl @ 12: u32 {
+        MASK @ 0, 1: bool;
+    }
+}
+
+// MSI-X vector table of a device, mapped from the BAR named by the MSI-X capability.
+pub struct MsixTable {
+    mapping: hel::Mapping<u8>,
+    disp: usize,
+}
+
+impl MsixTable {
+    pub fn new(mapping: hel::Mapping<u8>, disp: usize) -> MsixTable {
+        MsixTable { mapping, disp }
+    }
+
+    // Returns the window of the vector table entry at `index`.
+    fn entry(&self, index: usize) -> IoMemSpace {
+        let space =
+            unsafe { IoMemSpace::new(self.mapping.as_ptr().unwrap().as_ptr(), self.mapping.len()) };
+        space.subspace(self.disp + index * MSIX_ENTRY_SIZE)
+    }
+
+    pub fn store_message_address(&self, index: usize, value: u64) {
+        unsafe { self.entry(index).store(MsixMessageAddress, value) };
+    }
+
+    pub fn store_message_data(&self, index: usize, value: u32) {
+        unsafe { self.entry(index).store(MsixMessageData, value) };
+    }
+
+    pub fn set_masked(&self, index: usize, masked: bool) {
+        let entry = self.entry(index);
+        let control = unsafe { entry.load(MsixVectorControl) };
+        unsafe {
+            entry.store(
+                MsixVectorControl,
+                control.with(MsixVectorControl::MASK, masked),
+            )
+        };
+    }
+}
+
 // Not consumed yet; kept to match the information thor collects.
 #[allow(dead_code)]
 pub struct ExtendedCapability {
@@ -847,6 +896,14 @@ pub struct PciDevice {
 
     // Physical address and size of the Intel IGD VBT, if any.
     pub igd_vbt: OnceLock<(u64, u64)>,
+
+    // MSI / MSI-X support.
+    // Only set once the vectors were fully set up (e.g. the MSI-X table could be mapped).
+    pub msis_usable: AtomicBool,
+    pub num_msis: AtomicU32,
+    pub msix_index: AtomicI32,
+    pub msix_mapping: Mutex<Option<MsixTable>>,
+    pub msi_index: AtomicI32,
 }
 
 impl PciDevice {
@@ -873,6 +930,11 @@ impl PciDevice {
             subsystem_device,
             interrupt: OnceLock::new(),
             igd_vbt: OnceLock::new(),
+            msis_usable: AtomicBool::new(false),
+            num_msis: AtomicU32::new(0),
+            msix_index: AtomicI32::new(-1),
+            msix_mapping: Mutex::new(None),
+            msi_index: AtomicI32::new(-1),
         })
     }
 

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -7,7 +7,7 @@ pub mod serve;
 
 use managarm::svrctl::hardware_access_handle;
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU8, AtomicU32};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU8, AtomicU32, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 use anyhow::Result;
@@ -42,6 +42,12 @@ impl IrqPin {
 }
 
 static IRQ_PINS: Mutex<BTreeMap<u32, &'static IrqPin>> = Mutex::new(BTreeMap::new());
+
+// thor only implements MSI allocation on x86-64 (LAPIC MSIs); mirror that here
+// until the kernel can report MSI availability.
+pub fn msi_controller_available() -> bool {
+    cfg!(target_arch = "x86_64")
+}
 
 // Configures a GSI and returns its pin, sharing pins between users of the same GSI.
 pub fn system_irq(gsi: u32, trigger: IrqTrigger, polarity: IrqPolarity) -> Option<&'static IrqPin> {
@@ -904,6 +910,8 @@ pub struct PciDevice {
     pub msix_index: AtomicI32,
     pub msix_mapping: Mutex<Option<MsixTable>>,
     pub msi_index: AtomicI32,
+    pub msi_enabled: AtomicBool,
+    pub msi_installed: AtomicBool,
 }
 
 impl PciDevice {
@@ -935,6 +943,8 @@ impl PciDevice {
             msix_index: AtomicI32::new(-1),
             msix_mapping: Mutex::new(None),
             msi_index: AtomicI32::new(-1),
+            msi_enabled: AtomicBool::new(false),
+            msi_installed: AtomicBool::new(false),
         })
     }
 
@@ -943,6 +953,99 @@ impl PciDevice {
 
         let command = bus.command(self.entity.slot, self.entity.function);
         bus.set_command(self.entity.slot, self.entity.function, command & !0x400);
+    }
+
+    pub fn setup_msi(&self, msi: &hel::MsiInfo, index: usize) {
+        let bus = self.entity.parent_bus;
+        let slot = self.entity.slot;
+        let function = self.entity.function;
+
+        if self.msix_index.load(Ordering::Relaxed) >= 0 {
+            // Setup the MSI-X table.
+            let msix_mapping = self.msix_mapping.lock().expect(EXPECT_LOCK);
+            let table = msix_mapping
+                .as_ref()
+                .expect("sif: MSI-X table is not mapped");
+            table.store_message_address(index, msi.address);
+            table.store_message_data(index, msi.data);
+            table.set_masked(index, false);
+        } else {
+            let msi_index = self.msi_index.load(Ordering::Relaxed);
+            assert!(msi_index >= 0);
+
+            // TODO(qookie): support non-zero indices
+            assert!(index == 0);
+            let offset = self.entity.caps.lock().expect(EXPECT_LOCK)[msi_index as usize].offset;
+
+            let mut msg_control = unsafe { bus.read_config_half(slot, function, offset + 2) };
+
+            let is_64_capable = msg_control & (1 << 7) != 0;
+
+            unsafe { bus.write_config_word(slot, function, offset + 4, msi.address as u32) };
+
+            if is_64_capable {
+                unsafe {
+                    bus.write_config_word(slot, function, offset + 8, (msi.address >> 32) as u32)
+                };
+                unsafe { bus.write_config_half(slot, function, offset + 12, msi.data as u16) };
+            } else {
+                assert!(msi.address >> 32 == 0);
+                unsafe { bus.write_config_half(slot, function, offset + 8, msi.data as u16) };
+            }
+
+            if self.msi_enabled.load(Ordering::Relaxed) {
+                // Enable MSI
+                msg_control |= 0x0001;
+
+                unsafe { bus.write_config_half(slot, function, offset + 2, msg_control) };
+            }
+
+            self.msi_installed.store(true, Ordering::Relaxed);
+        }
+    }
+
+    // Unlike thor, this does not unmask INTx: clients that use INTx alongside MSIs
+    // (e.g. virtio for configuration changes) enable it explicitly via EnableBusIrq.
+    pub fn enable_msi(&self) {
+        let bus = self.entity.parent_bus;
+        let slot = self.entity.slot;
+        let function = self.entity.function;
+
+        let msix_index = self.msix_index.load(Ordering::Relaxed);
+        if msix_index >= 0 {
+            let offset = self.entity.caps.lock().expect(EXPECT_LOCK)[msix_index as usize].offset;
+
+            let mut msg_control = unsafe { bus.read_config_half(slot, function, offset + 2) };
+
+            msg_control |= 0x8000; // Enable MSI-X.
+
+            msg_control &= !0x4000; // Disable the overall mask.
+            unsafe { bus.write_config_half(slot, function, offset + 2, msg_control) };
+        } else {
+            let msi_index = self.msi_index.load(Ordering::Relaxed);
+            assert!(msi_index >= 0);
+
+            let offset = self.entity.caps.lock().expect(EXPECT_LOCK)[msi_index as usize].offset;
+
+            let mut msg_control = unsafe { bus.read_config_half(slot, function, offset + 2) };
+
+            if !self.msi_installed.load(Ordering::Relaxed) {
+                // Disable MSI by default, configure to only 1 message
+                // MSIs will be reenabled once one is installed in setup_msi, since
+                // we may not have a way to mask it otherwise (mask register only
+                // exists if MSIs are 64-bit).
+                msg_control &= !0x0071;
+            } else {
+                // setup_msi was called before enable_msi, so we can enable them
+                // without worrying about needing the MSI to be masked.
+                msg_control &= !0x0070; // Only one message
+                msg_control |= 0x0001; // Enable MSI
+            }
+
+            unsafe { bus.write_config_half(slot, function, offset + 2, msg_control) };
+
+            self.msi_enabled.store(true, Ordering::Relaxed);
+        }
     }
 }
 

--- a/sif/src/pci/serve.rs
+++ b/sif/src/pci/serve.rs
@@ -9,7 +9,9 @@ use managarm::hw::server::{BarDescriptor, CapDescriptor, serve_pci_device};
 use managarm::mbus::{EntityManager, Item, Properties, create_entity};
 
 use super::discover::{all_devices, all_root_buses};
-use super::{BarType, EXPECT_LOCK, PciBridge, PciBus, PciDevice, PciEntity, leak};
+use super::{
+    BarType, EXPECT_LOCK, PciBridge, PciBus, PciDevice, PciEntity, leak, msi_controller_available,
+};
 
 use crate::acpi::{PAGE_MASK, PAGE_SIZE};
 
@@ -49,6 +51,23 @@ fn io_type_of(type_: BarType) -> IoType {
 }
 
 impl managarm::hw::server::PciDevice for ServedEntity {
+    fn num_msis(&self) -> u32 {
+        let ServedEntity::Device(device) = self else {
+            return 0;
+        };
+        if !msi_controller_available() || !device.msis_usable.load(Ordering::Relaxed) {
+            return 0;
+        }
+        device.num_msis.load(Ordering::Relaxed)
+    }
+
+    fn msi_x(&self) -> bool {
+        let ServedEntity::Device(device) = self else {
+            return false;
+        };
+        device.msix_index.load(Ordering::Relaxed) >= 0
+    }
+
     fn bars(&self) -> [BarDescriptor; 6] {
         let mut out = [BarDescriptor::default(); 6];
         for (i, bar) in self
@@ -233,6 +252,34 @@ impl managarm::hw::server::PciDevice for ServedEntity {
         }
     }
 
+    fn install_msi(&self, index: u32) -> hel::Result<Option<hel::Handle>> {
+        let ServedEntity::Device(device) = self else {
+            return Ok(None);
+        };
+        if !msi_controller_available()
+            || !device.msis_usable.load(Ordering::Relaxed)
+            || index >= device.num_msis.load(Ordering::Relaxed)
+        {
+            return Ok(None);
+        }
+
+        // Allocate the MSI.
+        let entity = &device.entity;
+        let name = format!(
+            "pci-msi.{:04x}:{:02x}:{:02x}.{:x}.{index}",
+            entity.seg, entity.bus, entity.slot, entity.function
+        );
+        let pin = hel::allocate_msi(hardware_access_handle(), &name)?;
+        let msi = hel::query_msi_info(&pin)?;
+
+        // Obtain an IRQ object for the interrupt.
+        let irq = hel::handle_irq(&pin)?;
+
+        device.setup_msi(&msi, index as usize);
+
+        Ok(Some(irq))
+    }
+
     fn enable_busmaster(&self) {
         self.entity().enable_busmaster();
     }
@@ -241,6 +288,17 @@ impl managarm::hw::server::PciDevice for ServedEntity {
         if let ServedEntity::Device(device) = self {
             device.enable_irq();
         }
+    }
+
+    fn enable_msi(&self) -> bool {
+        let ServedEntity::Device(device) = self else {
+            return false;
+        };
+        if !msi_controller_available() || !device.msis_usable.load(Ordering::Relaxed) {
+            return false;
+        }
+        device.enable_msi();
+        true
     }
 }
 


### PR DESCRIPTION
Add a mode to `helAccessIrq()` that allocates a new MSI. Add a new `helQueryMsiInfo()` syscall to obtain the MSI's address and data words.

Port thor's MSI enablement code over by using these new syscalls.