### PR TITLE
runsvr: Add description for all servers and remove legacy `runsvr` subcommand

### DIFF
--- a/drivers/block/ata/block-ata.yml
+++ b/drivers/block/ata/block-ata.yml
@@ -1,0 +1,4 @@
+name: block-ata
+exec: /usr/bin/block-ata
+files:
+  - /usr/bin/block-ata

--- a/drivers/block/ata/meson.build
+++ b/drivers/block/ata/meson.build
@@ -6,3 +6,11 @@ executable('block-ata', 'src/main.cpp',
 	dependencies : [ libarch, hw_proto_dep, mbus_proto_dep, libblockfs_dep ],
 	install : true
 )
+
+custom_target('block-ata-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'block-ata.bin',
+	input : 'block-ata.yml',
+	install : true,
+	install_dir : server
+)

--- a/drivers/block/virtio-blk/meson.build
+++ b/drivers/block/virtio-blk/meson.build
@@ -2,3 +2,11 @@ executable('virtio-block', [ 'src/main.cpp', 'src/block.cpp' ],
 	dependencies : [ libblockfs_dep, virtio_core_dep ],
 	install : true
 )
+
+custom_target('virtio-block-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'virtio-block.bin',
+	input : 'virtio-block.yml',
+	install : true,
+	install_dir : server
+)

--- a/drivers/block/virtio-blk/virtio-block.yml
+++ b/drivers/block/virtio-blk/virtio-block.yml
@@ -1,0 +1,4 @@
+name: virtio-block
+exec: /usr/bin/virtio-block
+files:
+  - /usr/bin/virtio-block

--- a/drivers/clocktracker/clocktracker.yml
+++ b/drivers/clocktracker/clocktracker.yml
@@ -1,0 +1,4 @@
+name: clocktracker
+exec: /usr/bin/clocktracker
+files:
+  - /usr/bin/clocktracker

--- a/drivers/clocktracker/meson.build
+++ b/drivers/clocktracker/meson.build
@@ -2,3 +2,11 @@ executable('clocktracker', 'src/main.cpp',
 	dependencies : [ core_dep, mbus_proto_dep, clock_proto_dep ],
 	install : true
 )
+
+custom_target('clocktracker-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'clocktracker.bin',
+	input : 'clocktracker.yml',
+	install : true,
+	install_dir : server
+)

--- a/drivers/uart/meson.build
+++ b/drivers/uart/meson.build
@@ -6,3 +6,11 @@ executable('uart', 'src/main.cpp',
 	dependencies : [ libarch, fs_proto_dep, hw_proto_dep, mbus_proto_dep, svrctl_proto_dep ],
 	install : true
 )
+
+custom_target('uart-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'uart.bin',
+	input : 'uart.yml',
+	install : true,
+	install_dir : server
+)

--- a/drivers/uart/uart.yml
+++ b/drivers/uart/uart.yml
@@ -1,0 +1,4 @@
+name: uart
+exec: /usr/bin/uart
+files:
+  - /usr/bin/uart

--- a/drivers/usb/devices/storage/meson.build
+++ b/drivers/usb/devices/storage/meson.build
@@ -2,3 +2,11 @@ executable('storage', 'src/main.cpp',
 	dependencies : [ mbus_proto_dep, usb_proto_dep, libblockfs_dep ],
 	install : true
 )
+
+custom_target('usb-storage-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'usb-storage.bin',
+	input : 'usb-storage.yml',
+	install : true,
+	install_dir : server
+)

--- a/drivers/usb/devices/storage/usb-storage.yml
+++ b/drivers/usb/devices/storage/usb-storage.yml
@@ -1,0 +1,4 @@
+name: usb-storage
+exec: /usr/bin/storage
+files:
+  - /usr/bin/storage

--- a/drivers/usb/hcds/ehci/ehci.yml
+++ b/drivers/usb/hcds/ehci/ehci.yml
@@ -1,0 +1,4 @@
+name: ehci
+exec: /usr/bin/ehci
+files:
+  - /usr/bin/ehci

--- a/drivers/usb/hcds/ehci/meson.build
+++ b/drivers/usb/hcds/ehci/meson.build
@@ -2,3 +2,11 @@ executable('ehci', 'src/main.cpp',
 	dependencies : [ libarch, hw_proto_dep, mbus_proto_dep, usb_proto_dep, kernlet_proto_dep ],
 	install : true
 )
+
+custom_target('ehci-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'ehci.bin',
+	input : 'ehci.yml',
+	install : true,
+	install_dir : server
+)

--- a/drivers/usb/hcds/uhci/meson.build
+++ b/drivers/usb/hcds/uhci/meson.build
@@ -6,3 +6,11 @@ executable('uhci', 'src/main.cpp',
 	dependencies : [ libarch, hw_proto_dep, kernlet_proto_dep, mbus_proto_dep, usb_proto_dep ],
 	install : true
 )
+
+custom_target('uhci-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'uhci.bin',
+	input : 'uhci.yml',
+	install : true,
+	install_dir : server
+)

--- a/drivers/usb/hcds/uhci/uhci.yml
+++ b/drivers/usb/hcds/uhci/uhci.yml
@@ -1,0 +1,4 @@
+name: uhci
+exec: /usr/bin/uhci
+files:
+  - /usr/bin/uhci

--- a/drivers/usb/hcds/xhci/meson.build
+++ b/drivers/usb/hcds/xhci/meson.build
@@ -2,3 +2,11 @@ executable('xhci', 'src/main.cpp', 'src/ring.cpp',
 	dependencies : [ libarch, hw_proto_dep, mbus_proto_dep, usb_proto_dep, kernlet_proto_dep ],
 	install : true
 )
+
+custom_target('xhci-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'xhci.bin',
+	input : 'xhci.yml',
+	install : true,
+	install_dir : server
+)

--- a/drivers/usb/hcds/xhci/xhci.yml
+++ b/drivers/usb/hcds/xhci/xhci.yml
@@ -1,0 +1,4 @@
+name: xhci
+exec: /usr/bin/xhci
+files:
+  - /usr/bin/xhci

--- a/meson.build
+++ b/meson.build
@@ -253,6 +253,10 @@ if build_drivers
 		subdir('utils'/dir)
 	endforeach
 
+	# Descriptions for servers whose binaries are built outside of meson.
+	subdir('sif')
+	subdir('servers/kernletcc')
+
 	foreach dir : delay
 		subdir(dir)
 	endforeach

--- a/posix/init/src/stage1.cpp
+++ b/posix/init/src/stage1.cpp
@@ -182,7 +182,7 @@ int main() {
 #if defined (__x86_64__)
 	auto uart = fork();
 	if(!uart) {
-		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "runsvr", "/usr/bin/uart", nullptr);
+		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "run", "/usr/lib/managarm/server/uart.bin", nullptr);
 	}else assert(uart != -1);
 #endif
 
@@ -190,24 +190,24 @@ int main() {
 #if defined (__x86_64__)
 	auto ehci = fork();
 	if(!ehci) {
-		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "runsvr", "/usr/bin/ehci", nullptr);
+		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "run", "/usr/lib/managarm/server/ehci.bin", nullptr);
 	}else assert(ehci != -1);
 #endif
 
 	auto xhci = fork();
 	if(!xhci) {
-		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "runsvr", "/usr/bin/xhci", nullptr);
+		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "run", "/usr/lib/managarm/server/xhci.bin", nullptr);
 	}else assert(xhci != -1);
 
 	auto virtio = fork();
 	if(!virtio) {
-		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "runsvr", "/usr/bin/virtio-block", nullptr);
+		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "run", "/usr/lib/managarm/server/virtio-block.bin", nullptr);
 	}else assert(virtio != -1);
 
 #if defined (__x86_64__)
 	auto block_ata = fork();
 	if(!block_ata) {
-		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "runsvr", "/usr/bin/block-ata", nullptr);
+		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "run", "/usr/lib/managarm/server/block-ata.bin", nullptr);
 	}else assert(block_ata != -1);
 #endif
 
@@ -218,17 +218,17 @@ int main() {
 
 	auto block_nvme = fork();
 	if(!block_nvme) {
-		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "runsvr", "/usr/bin/block-nvme", nullptr);
+		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "run", "/usr/lib/managarm/server/block-nvme.bin", nullptr);
 	}else assert(block_nvme != -1);
 
 	auto block_usb = fork();
 	if(!block_usb) {
-		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "runsvr", "/usr/bin/storage", nullptr);
+		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "run", "/usr/lib/managarm/server/usb-storage.bin", nullptr);
 	}else assert(block_usb != -1);
 
 	auto snd_hda = fork();
 	if(!snd_hda) {
-		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "runsvr", "/usr/bin/snd-hda", nullptr);
+		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "run", "/usr/lib/managarm/server/snd-hda.bin", nullptr);
 	}else assert(snd_hda != -1);
 
 	Cmdline cmdlineHelper{};
@@ -333,7 +333,7 @@ int main() {
 	// Hack: Start UHCI only after EHCI devices are ready.
 	auto uhci = fork();
 	if(!uhci) {
-		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "runsvr", "/usr/bin/uhci", nullptr);
+		execl("/usr/bin/runsvr", "/usr/bin/runsvr", "run", "/usr/lib/managarm/server/uhci.bin", nullptr);
 	}else assert(uhci != -1);
 #endif
 

--- a/posix/subsystem/meson.build
+++ b/posix/subsystem/meson.build
@@ -81,3 +81,11 @@ executable('posix-subsystem', src,
 	dependencies : [ mbus_proto_dep, fs_proto_dep, posix_extra_dep, clock_proto_dep, kerncfg_proto_dep, hw_proto_dep, ostrace_proto_dep, usb_proto_dep, frigg, core_dep ],
 	install : true
 )
+
+custom_target('posix-subsystem-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'posix-subsystem.bin',
+	input : 'posix-subsystem.yml',
+	install : true,
+	install_dir : server
+)

--- a/posix/subsystem/posix-subsystem.yml
+++ b/posix/subsystem/posix-subsystem.yml
@@ -1,0 +1,4 @@
+name: posix-subsystem
+exec: /usr/bin/posix-subsystem
+files:
+  - /usr/bin/posix-subsystem

--- a/servers/kernletcc/kernletcc.yml
+++ b/servers/kernletcc/kernletcc.yml
@@ -1,0 +1,4 @@
+name: kernletcc
+exec: /usr/bin/kernletcc
+files:
+  - /usr/bin/kernletcc

--- a/servers/kernletcc/meson.build
+++ b/servers/kernletcc/meson.build
@@ -1,0 +1,7 @@
+custom_target('kernletcc-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'kernletcc.bin',
+	input : 'kernletcc.yml',
+	install : true,
+	install_dir : server
+)

--- a/sif/meson.build
+++ b/sif/meson.build
@@ -1,0 +1,7 @@
+custom_target('sif-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'sif.bin',
+	input : 'sif.yml',
+	install : true,
+	install_dir : server
+)

--- a/sif/sif.yml
+++ b/sif/sif.yml
@@ -1,0 +1,4 @@
+name: sif
+exec: /usr/bin/sif
+files:
+  - /usr/bin/sif

--- a/utils/runsvr/src/main.cpp
+++ b/utils/runsvr/src/main.cpp
@@ -191,20 +191,13 @@ async::result<int> bindServer(helix::UniqueLane &lane, int mbusId) {
 // ----------------------------------------------------------------
 
 enum class action {
-	runsvr, run, bind, upload
+	run, bind, upload
 };
 
 async::result<int> asyncMain(action act, std::string path) {
 	co_await enumerateSvrctl();
 
 	switch (act) {
-		case action::runsvr: {
-			log("runsvr: Running %s\n", path.c_str());
-			co_await runServer(path.c_str());
-
-			break;
-		}
-
 		case action::run: {
 			auto buffer = readEntireFile(path.c_str());
 
@@ -269,9 +262,6 @@ int main(int argc, const char **argv) {
 	CLI::App app{"runsvr"};
 	app.add_flag("-f,--fork", do_fork, "Fork off before continuing");
 
-	CLI::App *sub_runsvr = app.add_subcommand("runsvr", "Run a server (deprecated)");
-	sub_runsvr->add_option("path", path, "Path to executable")->required();
-
 	CLI::App *sub_run = app.add_subcommand("run", "Run a server (used in conjunction with bind)");
 	sub_run->add_option("path", path, "Path to description")->required();
 
@@ -285,9 +275,7 @@ int main(int argc, const char **argv) {
 
 	CLI11_PARSE(app, argc, argv);
 
-	if (*sub_runsvr)
-		act = action::runsvr;
-	else if (*sub_run)
+	if (*sub_run)
 		act = action::run;
 	else if (*sub_bind)
 		act = action::bind;


### PR DESCRIPTION
The `runsvr` subcommand of `runsvr` (that is, `runsvr runsvr`) allowed users to launch a server without pass a server description. Remove it and add a server description to all servers.