### PR TITLE
thor: Require hardware access token to be declared in server description

### DIFF
--- a/drivers/gfx/bochs/gfx-bochs.yml
+++ b/drivers/gfx/bochs/gfx-bochs.yml
@@ -3,3 +3,6 @@ exec: /usr/bin/gfx_bochs
 files:
   - /usr/bin/gfx_bochs
   - /usr/lib/libdrm_core.so
+owned_tokens:
+  # The Bochs graphics adapter uses a PIO region that is not exposed as a PCI BAR.
+  - 'access:thor.hardware'

--- a/drivers/uart/uart.yml
+++ b/drivers/uart/uart.yml
@@ -2,3 +2,6 @@ name: uart
 exec: /usr/bin/uart
 files:
   - /usr/bin/uart
+owned_tokens:
+  # UART access does not go through ACPI yet.
+  - 'access:thor.hardware'

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -350,11 +350,11 @@ extern "C" void thorMain() {
 		infoLogger() << "thor: Launching user space." << frg::endlog;
 		KernelFiber::asyncBlockCurrent(runMbus());
 		initializeKernletCtl();
-		KernelFiber::asyncBlockCurrent(runServer("usr/bin/sif"));
-		KernelFiber::asyncBlockCurrent(runServer("usr/bin/kernletcc"));
-		KernelFiber::asyncBlockCurrent(runServer("usr/bin/clocktracker"));
-		KernelFiber::asyncBlockCurrent(runServer("usr/bin/posix-subsystem"));
-		KernelFiber::asyncBlockCurrent(runServer("usr/bin/virtio-console"));
+		KernelFiber::asyncBlockCurrent(runServerFromInitrd("usr/lib/managarm/server/sif.bin"));
+		KernelFiber::asyncBlockCurrent(runServerFromInitrd("usr/lib/managarm/server/kernletcc.bin"));
+		KernelFiber::asyncBlockCurrent(runServerFromInitrd("usr/lib/managarm/server/clocktracker.bin"));
+		KernelFiber::asyncBlockCurrent(runServerFromInitrd("usr/lib/managarm/server/posix-subsystem.bin"));
+		KernelFiber::asyncBlockCurrent(runServerFromInitrd("usr/lib/managarm/server/tty-virtio-console.bin"));
 	});
 
 	Scheduler::resume(getCpuData()->wqFiber);

--- a/kernel/thor/generic/servers.cpp
+++ b/kernel/thor/generic/servers.cpp
@@ -11,9 +11,9 @@
 #include <thor-internal/fiber.hpp>
 #include <thor-internal/module.hpp>
 #include <thor-internal/stream.hpp>
+#include <thor-internal/servers.hpp>
 #include <thor-internal/thread.hpp>
 #include <thor-internal/mbus.hpp>
-#include "svrctl.frigg_bragi.hpp"
 
 namespace thor {
 
@@ -408,40 +408,42 @@ coroutine<void> runMbus() {
 	if(debugLaunch)
 		infoLogger() << "thor: Launching mbus" << frg::endlog;
 
+	auto desc = co_await parseServerFromInitrd("usr/lib/managarm/server/mbus.bin");
+
 	frg::tuple<smarter::shared_ptr<Stream, LanePolicy>, smarter::shared_ptr<Stream, LanePolicy>> controlStream;
 	{
 		auto lock = frg::guard(&allServersMutex);
 
-		frg::string<KernelAlloc> nameStr{*kernelAlloc, "/usr/bin/mbus"};
-		assert(!allServers->get(nameStr));
+		assert(!allServers->get(desc.name()));
 
 		auto controlStreamOutcome = createStream();
 		if(!controlStreamOutcome)
 			panicLogger() << "thor: Failed to create stream" << frg::endlog;
 		controlStream = std::move(*controlStreamOutcome);
-		allServers->insert(nameStr, controlStream.get<1>());
+		allServers->insert(desc.name(), controlStream.get<1>());
 	}
 
-	auto module = resolveModule("/usr/bin/mbus");
+	auto module = resolveModule(desc.exec());
 	assert(module && module->type == MfsType::regular);
-	co_await executeModule("/usr/bin/mbus", static_cast<MfsRegular *>(module),
+	co_await executeModule(desc.exec(), static_cast<MfsRegular *>(module),
 			controlStream.get<0>(),
 			std::move(*futureMbusServer), &localScheduler.get());
 }
 
-coroutine<smarter::shared_ptr<Stream, LanePolicy>> runServer(frg::string_view name) {
+coroutine<smarter::shared_ptr<Stream, LanePolicy>> runServer(
+	managarm::svrctl::Description<KernelAlloc> &desc
+) {
 	if(debugLaunch)
-		infoLogger() << "thor: Launching server " << name << frg::endlog;
+		infoLogger() << "thor: Launching server " << desc.name() << frg::endlog;
 
 	frg::tuple<smarter::shared_ptr<Stream, LanePolicy>, smarter::shared_ptr<Stream, LanePolicy>> controlStream;
 	{
 		auto lock = frg::guard(&allServersMutex);
 
-		frg::string<KernelAlloc> nameStr{*kernelAlloc, name.data(), name.size()};
-		if(auto server = allServers->get(nameStr); server) {
+		if(auto server = allServers->get(desc.name()); server) {
 			if(debugLaunch)
 				infoLogger() << "thor: Server "
-						<< name << " is already running" << frg::endlog;
+						<< desc.name() << " is already running" << frg::endlog;
 			co_return *server;
 		}
 
@@ -449,19 +451,44 @@ coroutine<smarter::shared_ptr<Stream, LanePolicy>> runServer(frg::string_view na
 		if(!controlStreamOutcome)
 			panicLogger() << "thor: Failed to create stream" << frg::endlog;
 		controlStream = std::move(*controlStreamOutcome);
-		allServers->insert(nameStr, controlStream.get<1>());
+		allServers->insert(desc.name(), controlStream.get<1>());
 	}
 
-	auto module = resolveModule(name);
+	auto module = resolveModule(desc.exec());
 	if(!module)
-		panicLogger() << "thor: Could not find module " << name << frg::endlog;
+		panicLogger() << "thor: Could not find module " << desc.exec() << frg::endlog;
 	assert(module->type == MfsType::regular);
 
-	co_await executeModule(name, static_cast<MfsRegular *>(module),
+	co_await executeModule(desc.exec(), static_cast<MfsRegular *>(module),
 			controlStream.get<0>(),
 			smarter::shared_ptr<Stream, LanePolicy>{}, &localScheduler.get());
 
 	co_return controlStream.get<1>();
+}
+
+coroutine<managarm::svrctl::Description<KernelAlloc>> parseServerFromInitrd(frg::string_view path) {
+	auto module = resolveModule(path);
+	if(!module)
+		panicLogger() << "thor: Could not find server description " << path << frg::endlog;
+	assert(module->type == MfsType::regular);
+	auto file = static_cast<MfsRegular *>(module);
+
+	frg::unique_memory<KernelAlloc> buffer{*kernelAlloc, file->size()};
+	auto copyOutcome = co_await file->getMemory()->copyFrom(0, buffer.data(), file->size());
+	assert(copyOutcome);
+
+	managarm::svrctl::Description<KernelAlloc> desc(*kernelAlloc);
+	bragi::limited_reader rd{buffer.data(), buffer.size()};
+	bragi::deserializer de;
+	if(!desc.decode_body(rd, de))
+		panicLogger() << "thor: Failed to parse server description " << path << frg::endlog;
+
+	co_return desc;
+}
+
+coroutine<smarter::shared_ptr<Stream, LanePolicy>> runServerFromInitrd(frg::string_view path) {
+	auto desc = co_await parseServerFromInitrd(path);
+	co_return co_await runServer(desc);
 }
 
 // ------------------------------------------------------------------------
@@ -528,7 +555,7 @@ private:
 			if(!req)
 				co_return Error::protocolViolation;
 
-			auto controlLane = co_await runServer(req->name());
+			auto controlLane = co_await runServer(req->description());
 
 			managarm::svrctl::RunServerResponse<KernelAlloc> resp(*kernelAlloc);
 			resp.set_error(managarm::svrctl::Errors::SUCCESS);

--- a/kernel/thor/generic/servers.cpp
+++ b/kernel/thor/generic/servers.cpp
@@ -39,8 +39,11 @@ static frg::manual_box<
 > allServers;
 
 // TODO: move this declaration to a header file
-void runService(frg::string<KernelAlloc> desc, smarter::shared_ptr<Stream, LanePolicy> control_lane,
-		smarter::shared_ptr<Thread, ActiveHandle> thread);
+void runService(
+	managarm::svrctl::Description<KernelAlloc> desc,
+	smarter::shared_ptr<Stream, LanePolicy> control_lane,
+	smarter::shared_ptr<Thread, ActiveHandle> thread
+);
 
 // ------------------------------------------------------------------------
 // File management.
@@ -269,7 +272,7 @@ uintptr_t copyToStack(frg::string<KernelAlloc> &stack_image, const T &data) {
 	return offset;
 }
 
-coroutine<void> executeModule(frg::string_view name, MfsRegular *module,
+coroutine<void> executeModule(managarm::svrctl::Description<KernelAlloc> &desc, MfsRegular *module,
 		smarter::shared_ptr<Stream, LanePolicy> control_lane,
 		smarter::shared_ptr<Stream, LanePolicy> xpipe_lane,
 		Scheduler *scheduler) {
@@ -391,9 +394,7 @@ coroutine<void> executeModule(frg::string_view name, MfsRegular *module,
 
 	// Listen to POSIX calls from the thread.
 	// Call this after resumeOther() to ensure that we do not see the initial interrupt.
-	runService(frg::string<KernelAlloc>{*kernelAlloc, name.data(), name.size()},
-			control_lane,
-			thread);
+	runService(desc, control_lane, thread);
 }
 
 void initializeMbusStream() {
@@ -425,7 +426,7 @@ coroutine<void> runMbus() {
 
 	auto module = resolveModule(desc.exec());
 	assert(module && module->type == MfsType::regular);
-	co_await executeModule(desc.exec(), static_cast<MfsRegular *>(module),
+	co_await executeModule(desc, static_cast<MfsRegular *>(module),
 			controlStream.get<0>(),
 			std::move(*futureMbusServer), &localScheduler.get());
 }
@@ -459,7 +460,7 @@ coroutine<smarter::shared_ptr<Stream, LanePolicy>> runServer(
 		panicLogger() << "thor: Could not find module " << desc.exec() << frg::endlog;
 	assert(module->type == MfsType::regular);
 
-	co_await executeModule(desc.exec(), static_cast<MfsRegular *>(module),
+	co_await executeModule(desc, static_cast<MfsRegular *>(module),
 			controlStream.get<0>(),
 			smarter::shared_ptr<Stream, LanePolicy>{}, &localScheduler.get());
 

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -30,7 +30,11 @@ coroutine<bool> createMfsFile(frg::string_view path, const void *buffer, size_t 
 
 static MfsRegular *urandomNode = nullptr;
 
-void runService(frg::string<KernelAlloc> name, smarter::shared_ptr<Stream, LanePolicy> controlLane, smarter::shared_ptr<Thread, ActiveHandle> thread);
+void runService(
+	managarm::svrctl::Description<KernelAlloc> desc,
+	smarter::shared_ptr<Stream, LanePolicy> controlLane,
+	smarter::shared_ptr<Thread, ActiveHandle> thread
+);
 
 struct OpenFile {
 	OpenFile()
@@ -530,7 +534,7 @@ namespace posix {
 
 		uint64_t nextTid_ = 1;
 
-		Handle hardwareAccessHandle;
+		Handle hardwareAccessHandle{kHelNullHandle};
 		Handle mbusHandle;
 		Handle controlHandle;
 		frg::vector<OpenFile *, KernelAlloc> openFiles;
@@ -1223,9 +1227,10 @@ coroutine<void> initPosixEmulation() {
 	co_await createMfsFile("/dev/urandom", nullptr, 0, &urandomNode);
 }
 
-void runService(frg::string<KernelAlloc> name, smarter::shared_ptr<Stream, LanePolicy> controlLane,
+void runService(managarm::svrctl::Description<KernelAlloc> desc,
+		smarter::shared_ptr<Stream, LanePolicy> controlLane,
 		smarter::shared_ptr<Thread, ActiveHandle> thread) {
-	KernelFiber::run([name, thread, controlLane = std::move(controlLane)] () mutable {
+	KernelFiber::run([desc, thread, controlLane = std::move(controlLane)] () mutable {
 		auto stdioStreamOutcome = createStream();
 		if(!stdioStreamOutcome)
 			panicLogger() << "thor: Failed to create stream" << frg::endlog;
@@ -1236,11 +1241,21 @@ void runService(frg::string<KernelAlloc> name, smarter::shared_ptr<Stream, LaneP
 		spawnOnWorkQueue(*kernelAlloc, WorkQueue::generalQueue().lock(),
 				stdio::runStdioRequests(stdioStream.get<0>()));
 
-		auto process = frg::construct<posix::Process>(*kernelAlloc, std::move(name));
-		KernelFiber::asyncBlockCurrent(process->setupAddressSpace(thread));
-		process->hardwareAccessHandle = thread->getUniverse()->attachDescriptor(
-			AnyDescriptor::make<DescriptorType::token>(hardwareAccessToken(), kHelRightInvoke)
+		bool hasHardwareAccess = std::any_of(
+			desc.owned_tokens().begin(),
+			desc.owned_tokens().end(),
+			[] (auto &token) {
+				return token.identifier() == "access:thor.hardware";
+			}
 		);
+
+		auto process = frg::construct<posix::Process>(*kernelAlloc, desc.exec());
+		KernelFiber::asyncBlockCurrent(process->setupAddressSpace(thread));
+		if (hasHardwareAccess) {
+			process->hardwareAccessHandle = thread->getUniverse()->attachDescriptor(
+				AnyDescriptor::make<DescriptorType::token>(hardwareAccessToken(), kHelRightInvoke)
+			);
+		}
 		process->attachControl(thread, std::move(controlLane));
 		process->attachMbus(thread);
 		KernelFiber::asyncBlockCurrent(process->attachFile(thread, stdioFile));

--- a/kernel/thor/generic/thor-internal/servers.hpp
+++ b/kernel/thor/generic/thor-internal/servers.hpp
@@ -2,6 +2,7 @@
 
 #include <thor-internal/coroutine.hpp>
 #include <thor-internal/universe.hpp>
+#include "svrctl.frigg_bragi.hpp"
 
 namespace thor {
 
@@ -9,6 +10,15 @@ void initializeSvrctl();
 void initializeMbusStream();
 coroutine<void> initPosixEmulation();
 coroutine<void> runMbus();
-coroutine<smarter::shared_ptr<Stream, LanePolicy>> runServer(frg::string_view name);
+
+coroutine<smarter::shared_ptr<Stream, LanePolicy>> runServer(
+	managarm::svrctl::Description<KernelAlloc> &desc
+);
+
+// Parse a server description that is stored on the initrd.
+coroutine<managarm::svrctl::Description<KernelAlloc>> parseServerFromInitrd(frg::string_view path);
+
+// Launch from a server description stored on the initrd.
+coroutine<smarter::shared_ptr<Stream, LanePolicy>> runServerFromInitrd(frg::string_view path);
 
 } // namespace thor

--- a/mbus/mbus.yml
+++ b/mbus/mbus.yml
@@ -1,0 +1,4 @@
+name: mbus
+exec: /usr/bin/mbus
+files:
+  - /usr/bin/mbus

--- a/mbus/meson.build
+++ b/mbus/meson.build
@@ -2,3 +2,11 @@ executable('mbus', 'src/main.cpp',
 	dependencies : [core_dep, mbus_proto_dep, frigg, libasync_dep],
 	install : true
 )
+
+custom_target('mbus-server',
+	command : [bakesvr, '-o', '@OUTPUT@', '@INPUT@'],
+	output : 'mbus.bin',
+	input : 'mbus.yml',
+	install : true,
+	install_dir : server
+)

--- a/protocols/svrctl/svrctl.bragi
+++ b/protocols/svrctl/svrctl.bragi
@@ -37,7 +37,7 @@ head(128):
 
 message RunServerRequest 3 {
 head(128):
-	string name;
+	Description description;
 }
 
 message RunServerResponse 4 {

--- a/protocols/svrctl/svrctl.bragi
+++ b/protocols/svrctl/svrctl.bragi
@@ -18,10 +18,15 @@ struct File {
 	string path;
 }
 
+struct Token {
+	string identifier;
+}
+
 struct Description {
 	string name;
 	string exec;
 	File[] files;
+	Token[] owned_tokens;
 }
 
 message FileUploadRequest 1 {

--- a/sif/sif.yml
+++ b/sif/sif.yml
@@ -2,3 +2,6 @@ name: sif
 exec: /usr/bin/sif
 files:
   - /usr/bin/sif
+owned_tokens:
+  # sif owns the platform devices.
+  - 'access:thor.hardware'

--- a/tools/bakesvr/src/main.cpp
+++ b/tools/bakesvr/src/main.cpp
@@ -25,6 +25,11 @@ int main(int argc, char **argv) {
 		f.set_path(config["files"][i].as<std::string>());
 		data.add_files(f);
 	}
+	for(size_t i = 0; i < config["owned_tokens"].size(); i++) {
+		managarm::svrctl::Token token{};
+		token.set_identifier(config["owned_tokens"][i].as<std::string>());
+		data.add_owned_tokens(token);
+	}
 
 	std::vector<char> buf(data.size_of_body());
 	bragi::limited_writer wr{buf.data(), data.size_of_body()};

--- a/utils/runsvr/src/main.cpp
+++ b/utils/runsvr/src/main.cpp
@@ -94,9 +94,9 @@ async::result<void> enumerateSvrctl() {
 	svrctlLane = (co_await entity.getRemoteLane()).unwrap();
 }
 
-async::result<helix::UniqueLane> runServer(const char *name) {
+async::result<helix::UniqueLane> runServer(const managarm::svrctl::Description &desc) {
 	managarm::svrctl::RunServerRequest req;
-	req.set_name(name);
+	req.set_description(desc);
 
 	auto [offer, send_req, recv_resp, pull_server] = co_await helix_ng::exchangeMsgs(
 		svrctlLane,
@@ -211,7 +211,7 @@ async::result<int> asyncMain(action act, std::string path) {
 			for(auto &file : desc.files())
 				co_await uploadFile(file.path().c_str());
 
-			co_await runServer(desc.exec().c_str());
+			co_await runServer(desc);
 
 			break;
 		}
@@ -230,7 +230,7 @@ async::result<int> asyncMain(action act, std::string path) {
 			for(auto &file : desc.files())
 				co_await uploadFile(file.path().c_str());
 
-			auto lane = co_await runServer(desc.exec().c_str());
+			auto lane = co_await runServer(desc);
 			co_await bindServer(lane, std::stoi(id_str));
 
 			break;


### PR DESCRIPTION
Let runsvr pass the server description to Thor. Add an `owned_tokens` list to the server description. Thor will only grant the hardware access token if this list contains the `access:thor.hardware` identifier.