### PR TITLE
thor: Fix various page table concurrency issues

### DIFF
--- a/kernel/thor/arch/arm/thor-internal/arch/paging.hpp
+++ b/kernel/thor/arch/arm/thor-internal/arch/paging.hpp
@@ -31,6 +31,7 @@ inline constexpr uint64_t kPageWb = (0 << 2);
 inline constexpr uint64_t kPagenGnRnE = (2 << 2);
 inline constexpr uint64_t kPagenGnRE = (3 << 2);
 inline constexpr uint64_t kPageUc = (4 << 2);
+inline constexpr uint64_t kPageAttrIndx = (7 << 2);
 inline constexpr uint64_t kPageAddress = 0xFFFFFFFFF000;
 
 inline int getLowerHalfBits() {
@@ -107,6 +108,8 @@ struct ARMCursorPolicy {
 
 		return ps;
 	}
+
+	static inline constexpr uint64_t ptePageCachingMask = kPageAttrIndx;
 
 	static uint64_t pteClean(uint64_t *ptePtr) {
 		uint64_t pte = __atomic_fetch_or(ptePtr, kPageRO, __ATOMIC_RELAXED);

--- a/kernel/thor/arch/riscv/hypervisor-space.cpp
+++ b/kernel/thor/arch/riscv/hypervisor-space.cpp
@@ -51,8 +51,8 @@ frg::expected<Error, PagesAffected> Operations::mapPresentPages(
 }
 
 frg::expected<Error, PagesAffected>
-Operations::restrictPages(VirtualAddr va, size_t size, PageFlags flags, CachingMode mode) {
-	return restrictPagesByCursor<HypervisorCursor>(pageSpace_, va, size, flags, mode);
+Operations::restrictPages(VirtualAddr va, size_t size, PageFlags flags) {
+	return restrictPagesByCursor<HypervisorCursor>(pageSpace_, va, size, flags);
 }
 
 frg::expected<Error, PagesAffected> Operations::faultPage(

--- a/kernel/thor/arch/riscv/thor-internal/arch/hypervisor-space.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/hypervisor-space.hpp
@@ -40,7 +40,7 @@ public:
 		) override;
 
 		frg::expected<Error, PagesAffected>
-		restrictPages(VirtualAddr va, size_t size, PageFlags flags, CachingMode mode) override;
+		restrictPages(VirtualAddr va, size_t size, PageFlags flags) override;
 
 		frg::expected<Error, PagesAffected> faultPage(
 		    VirtualAddr va,

--- a/kernel/thor/arch/riscv/thor-internal/arch/paging.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/paging.hpp
@@ -67,6 +67,9 @@ struct RiscvCursorPolicy {
 		return status;
 	}
 
+	// Caching modes are not supported yet; see pteBuild().
+	static inline constexpr uint64_t ptePageCachingMask = 0;
+
 	static uint64_t pteClean(uint64_t *ptePtr) {
 		return __atomic_fetch_and(ptePtr, ~pteDirty, __ATOMIC_RELAXED);
 	}

--- a/kernel/thor/arch/x86/ept.cpp
+++ b/kernel/thor/arch/x86/ept.cpp
@@ -7,6 +7,7 @@ namespace thor::vmx {
 constexpr uint64_t eptRead = UINT64_C(1) << 0;
 constexpr uint64_t eptWrite = UINT64_C(1) << 1;
 constexpr uint64_t eptExecute = UINT64_C(1) << 2;
+constexpr uint64_t eptCacheType = UINT64_C(7) << 3;
 constexpr uint64_t eptCacheWb = UINT64_C(6) << 3;
 constexpr uint64_t eptIgnorePat = UINT64_C(1) << 6;
 constexpr uint64_t eptDirty = UINT64_C(1) << 9;
@@ -49,6 +50,8 @@ struct EptCursorPolicy {
 			status |= page_status::dirty;
 		return status;
 	}
+
+	static inline constexpr uint64_t ptePageCachingMask = eptCacheType;
 
 	static uint64_t pteClean(uint64_t *ptePtr) {
 		return __atomic_fetch_and(ptePtr, ~eptDirty, __ATOMIC_RELAXED);
@@ -134,8 +137,8 @@ frg::expected<Error, PagesAffected> EptOperations::mapPresentPages(VirtualAddr v
 }
 
 frg::expected<Error, PagesAffected> EptOperations::restrictPages(VirtualAddr va,
-		size_t size, PageFlags flags, CachingMode mode) {
-	return restrictPagesByCursor<EptCursor>(pageSpace_, va, size, flags, mode);
+		size_t size, PageFlags flags) {
+	return restrictPagesByCursor<EptCursor>(pageSpace_, va, size, flags);
 }
 
 frg::expected<Error, PagesAffected> EptOperations::faultPage(VirtualAddr va, MemoryView *view,

--- a/kernel/thor/arch/x86/npt.cpp
+++ b/kernel/thor/arch/x86/npt.cpp
@@ -109,13 +109,13 @@ NptOperations::NptOperations(NptPageSpace *pageSpace)
 
 void NptOperations::retire(RetireNode *node) {
 	// TODO: Shootdown needs to be implemented for NPT.
-	(void)node;
+	node->complete();
 }
 
 bool NptOperations::submitShootdown(ShootNode *node) {
 	// TODO: Shootdown needs to be implemented for NPT.
 	(void)node;
-	return false;
+	return true;
 }
 
 frg::expected<Error, PagesAffected> NptOperations::mapPresentPages(VirtualAddr va, MemoryView *view,

--- a/kernel/thor/arch/x86/npt.cpp
+++ b/kernel/thor/arch/x86/npt.cpp
@@ -47,6 +47,9 @@ struct NptCursorPolicy {
 		return status;
 	}
 
+	// Guest memory is always mapped write-back; see pteBuild().
+	static inline constexpr uint64_t ptePageCachingMask = 0;
+
 	static uint64_t pteClean(uint64_t *ptePtr) {
 		return __atomic_fetch_and(ptePtr, ~nptDirty, __ATOMIC_RELAXED);
 	}
@@ -122,8 +125,8 @@ frg::expected<Error, PagesAffected> NptOperations::mapPresentPages(VirtualAddr v
 }
 
 frg::expected<Error, PagesAffected> NptOperations::restrictPages(VirtualAddr va,
-		size_t size, PageFlags flags, CachingMode mode) {
-	return restrictPagesByCursor<NptCursor>(pageSpace_, va, size, flags, mode);
+		size_t size, PageFlags flags) {
+	return restrictPagesByCursor<NptCursor>(pageSpace_, va, size, flags);
 }
 
 frg::expected<Error, PagesAffected> NptOperations::faultPage(VirtualAddr va, MemoryView *view,

--- a/kernel/thor/arch/x86/npt.cpp
+++ b/kernel/thor/arch/x86/npt.cpp
@@ -8,7 +8,7 @@ constexpr uint64_t nptPresent = UINT64_C(1) << 0;
 constexpr uint64_t nptWrite = UINT64_C(1) << 1;
 constexpr uint64_t nptUser = UINT64_C(1) << 2;
 constexpr uint64_t nptDirty = UINT64_C(1) << 6;
-constexpr uint64_t nptXd = UINT64_C(1) << 6;
+constexpr uint64_t nptXd = UINT64_C(1) << 63;
 constexpr uint64_t nptAddress = 0x000F'FFFF'FFFF'F000;
 
 struct NptCursorPolicy {

--- a/kernel/thor/arch/x86/thor-internal/arch/ept.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/ept.hpp
@@ -41,7 +41,7 @@ struct EptOperations final : VirtualOperations {
 			uintptr_t offset, size_t size, PageFlags flags, CachingMode mode) override;
 
 	frg::expected<Error, PagesAffected> restrictPages(VirtualAddr va,
-			size_t size, PageFlags flags, CachingMode mode) override;
+			size_t size, PageFlags flags) override;
 
 	frg::expected<Error, PagesAffected> faultPage(VirtualAddr va, MemoryView *view,
 			uintptr_t offset, FetchFlags fetchFlags, PageFlags flags, CachingMode mode) override;

--- a/kernel/thor/arch/x86/thor-internal/arch/npt.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/npt.hpp
@@ -28,7 +28,7 @@ struct NptOperations final : VirtualOperations {
 			uintptr_t offset, size_t size, PageFlags flags, CachingMode mode) override;
 
 	frg::expected<Error, PagesAffected> restrictPages(VirtualAddr va,
-			size_t size, PageFlags flags, CachingMode mode) override;
+			size_t size, PageFlags flags) override;
 
 	frg::expected<Error, PagesAffected> faultPage(VirtualAddr va, MemoryView *view,
 			uintptr_t offset, FetchFlags fetchFlags, PageFlags flags, CachingMode mode) override;

--- a/kernel/thor/arch/x86/thor-internal/arch/paging.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/paging.hpp
@@ -74,6 +74,8 @@ struct X86CursorPolicy {
 		return status;
 	}
 
+	static inline constexpr uint64_t ptePageCachingMask = ptePwt | ptePcd | ptePat;
+
 	static uint64_t pteClean(uint64_t *ptePtr) {
 		return __atomic_fetch_and(ptePtr, ~pteDirty, __ATOMIC_RELAXED);
 	}

--- a/kernel/thor/arch/x86/vt_d.cpp
+++ b/kernel/thor/arch/x86/vt_d.cpp
@@ -415,6 +415,9 @@ public:
 		return status;
 	}
 
+	// The IOMMU does not use caching modes; see pteBuild().
+	static inline constexpr uint64_t ptePageCachingMask = 0;
+
 	static uint64_t pteClean(uint64_t *ptePtr) {
 		return __atomic_fetch_and(ptePtr, ~iommuDirty, __ATOMIC_RELAXED);
 	}
@@ -481,7 +484,7 @@ struct IntelIommuOperations final : PageSpace, VirtualOperations {
 			uintptr_t offset, size_t size, PageFlags flags, CachingMode mode) override;
 
 	frg::expected<Error, PagesAffected> restrictPages(VirtualAddr va,
-			size_t size, PageFlags flags, CachingMode mode) override;
+			size_t size, PageFlags flags) override;
 
 	frg::expected<Error, PagesAffected> faultPage(VirtualAddr va, MemoryView *view,
 			uintptr_t offset, FetchFlags fetchFlags, PageFlags flags, CachingMode mode) override;
@@ -1732,9 +1735,9 @@ frg::expected<Error, PagesAffected> IntelIommuOperations::mapPresentPages(Virtua
 }
 
 frg::expected<Error, PagesAffected> IntelIommuOperations::restrictPages(VirtualAddr va,
-		size_t size, PageFlags flags, CachingMode mode) {
+		size_t size, PageFlags flags) {
 	IntelIommuCursorPolicy policy{iommu_->sagaw(), iommu_->pageWalkingCoherent()};
-	return restrictPagesByCursor<IntelIommuCursor>(this, va, size, flags, mode, policy);
+	return restrictPagesByCursor<IntelIommuCursor>(this, va, size, flags, policy);
 }
 
 frg::expected<Error, PagesAffected> IntelIommuOperations::faultPage(VirtualAddr va, MemoryView *view,

--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -668,6 +668,8 @@ VirtualSpace::synchronize(VirtualAddr address, size_t size) {
 			if(anyRevoked)
 				co_await _ops->shootdown(mapping->address + mappingOffset, mappingChunk);
 		}
+		if(!anyRevoked)
+			co_await mapping->revokeRcu.barrier();
 
 		overallProgress += mappingChunk;
 	}

--- a/kernel/thor/generic/address-space.cpp
+++ b/kernel/thor/generic/address-space.cpp
@@ -586,10 +586,6 @@ VirtualSpace::protect(VirtualAddr address, size_t length, uint32_t flags) {
 		if((actualMappingFlags & MappingFlags::permissionMask) & MappingFlags::protRead)
 			pageFlags |= page_access::read;
 
-		auto caching = CachingMode::null;
-		if(mapping->slice->getCachingFlags() == cacheWriteCombine)
-			caching = CachingMode::writeCombine;
-
 		co_await mapping->exposeRcu.barrier();
 
 		bool anyRevoked;
@@ -599,7 +595,7 @@ VirtualSpace::protect(VirtualAddr address, size_t length, uint32_t flags) {
 			// A present page is always readable, so dropping all access requires unmapping.
 			if(pageFlags) {
 				auto restrictOutcome = _ops->restrictPages(mapping->address,
-						mapping->length, pageFlags, caching);
+						mapping->length, pageFlags);
 				assert(restrictOutcome);
 				anyRevoked = restrictOutcome.value().anyRevoked;
 			}else{

--- a/kernel/thor/generic/iommu.cpp
+++ b/kernel/thor/generic/iommu.cpp
@@ -27,7 +27,7 @@ frg::expected<Error, PagesAffected> NoopDmaSpace::NoopVirtualOperations::mapPres
 }
 
 frg::expected<Error, PagesAffected>
-NoopDmaSpace::NoopVirtualOperations::restrictPages(VirtualAddr, size_t, PageFlags, CachingMode) {
+NoopDmaSpace::NoopVirtualOperations::restrictPages(VirtualAddr, size_t, PageFlags) {
 	return PagesAffected{};
 }
 

--- a/kernel/thor/generic/thor-internal/address-space.hpp
+++ b/kernel/thor/generic/thor-internal/address-space.hpp
@@ -200,11 +200,11 @@ frg::expected<Error, PagesAffected> cleanPagesByCursor(PageSpace *ps, VirtualAdd
 	Cursor c{ps, va, policy};
 	while(c.findDirty(va + size)) {
 		auto [status, physical] = c.clean4k();
-		assert(status & page_status::present);
-		assert(status & page_status::dirty);
-		if(auto descriptor = globalPfnDb().find(physical))
-			markDirty(*descriptor);
-		affected.anyRevoked = true;
+		if((status & page_status::present) && (status & page_status::dirty)) {
+			if(auto descriptor = globalPfnDb().find(physical))
+				markDirty(*descriptor);
+			affected.anyRevoked = true;
+		}
 		c.advance4k();
 	}
 	return affected;
@@ -225,15 +225,16 @@ frg::expected<Error, PagesAffected> unmapPagesByCursor(PageSpace *ps, VirtualAdd
 	Cursor c{ps, va, policy};
 	while(c.findPresent(va + size)) {
 		auto [status, physical] = c.unmap4k();
-		assert(status & page_status::present);
-		if(status & page_status::dirty) {
+		if(status & page_status::present) {
+			if(status & page_status::dirty) {
+				if(auto descriptor = globalPfnDb().find(physical))
+					markDirty(*descriptor);
+			}
 			if(auto descriptor = globalPfnDb().find(physical))
-				markDirty(*descriptor);
+				decrementUses(*descriptor);
+			affected.rssDecrease += kPageSize;
+			affected.anyRevoked = true;
 		}
-		if(auto descriptor = globalPfnDb().find(physical))
-			decrementUses(*descriptor);
-		affected.rssDecrease += kPageSize;
-		affected.anyRevoked = true;
 
 		c.advance4k();
 	}

--- a/kernel/thor/generic/thor-internal/address-space.hpp
+++ b/kernel/thor/generic/thor-internal/address-space.hpp
@@ -133,6 +133,7 @@ frg::expected<Error, PagesAffected> restrictPagesByCursor(PageSpace *ps, Virtual
 		if((status & page_status::present) && (status & page_status::dirty)) {
 			if(auto descriptor = globalPfnDb().find(physical))
 				markDirty(*descriptor);
+			affected.anyRevoked = true;
 		}
 		if(restricted)
 			affected.anyRevoked = true;

--- a/kernel/thor/generic/thor-internal/address-space.hpp
+++ b/kernel/thor/generic/thor-internal/address-space.hpp
@@ -128,7 +128,7 @@ frg::expected<Error, PagesAffected> restrictPagesByCursor(PageSpace *ps, Virtual
 
 	PagesAffected affected{};
 	Cursor c{ps, va, policy};
-	while(c.virtualAddress() < va + size) {
+	while(c.findPresent(va + size)) {
 		auto [status, physical, restricted] = c.restrict4k(flags);
 		if((status & page_status::present) && (status & page_status::dirty)) {
 			if(auto descriptor = globalPfnDb().find(physical))

--- a/kernel/thor/generic/thor-internal/address-space.hpp
+++ b/kernel/thor/generic/thor-internal/address-space.hpp
@@ -47,7 +47,10 @@ struct PagesAffected {
 	// Number of bytes that were scanned by agePages().
 	ptrdiff_t scanned{0};
 	// Whether any page had its access rights revoked.
-	// This covers both pages that have their permission restricted and pages that are unmapped.
+	// This covers all of:
+	// - pages that are unmapped (and thus also pages that are remapped)
+	// - pages that have their permission restricted
+	// - pages that have their dirty bits cleared
 	bool anyRevoked{false};
 };
 
@@ -102,6 +105,7 @@ frg::expected<Error, PagesAffected> mapPresentPagesByCursor(PageSpace *ps, Virtu
 			affected.rssDecrease += kPageSize;
 			if(auto descriptor = globalPfnDb().find(oldPhysical))
 				decrementUses(*descriptor);
+			affected.anyRevoked = true;
 		}
 		c.advance4k();
 	}
@@ -177,6 +181,7 @@ frg::expected<Error, PagesAffected> faultPageByCursor(PageSpace *ps, VirtualAddr
 		if(auto descriptor = globalPfnDb().find(oldPhysical))
 			decrementUses(*descriptor);
 		affected.rssDecrease += kPageSize;
+		affected.anyRevoked = true;
 	}
 	affected.rssIncrease += kPageSize;
 

--- a/kernel/thor/generic/thor-internal/address-space.hpp
+++ b/kernel/thor/generic/thor-internal/address-space.hpp
@@ -121,8 +121,7 @@ frg::expected<Error, PagesAffected> mapPresentPagesByCursor(PageSpace *ps, Virtu
 
 template<typename Cursor, typename PageSpace>
 frg::expected<Error, PagesAffected> restrictPagesByCursor(PageSpace *ps, VirtualAddr va,
-		size_t size, PageFlags flags, CachingMode mode,
-		typename Cursor::PolicyType policy) {
+		size_t size, PageFlags flags, typename Cursor::PolicyType policy) {
 	assert(!(va & (kPageSize - 1)));
 	assert(!(size & (kPageSize - 1)));
 	// At least one access bit is always set; see VirtualOperations.
@@ -131,7 +130,7 @@ frg::expected<Error, PagesAffected> restrictPagesByCursor(PageSpace *ps, Virtual
 	PagesAffected affected{};
 	Cursor c{ps, va, policy};
 	while(c.virtualAddress() < va + size) {
-		auto [status, physical, restricted] = c.restrict4k(flags, mode);
+		auto [status, physical, restricted] = c.restrict4k(flags);
 		if((status & page_status::present) && (status & page_status::dirty)) {
 			if(auto descriptor = globalPfnDb().find(physical))
 				markDirty(*descriptor);
@@ -145,8 +144,8 @@ frg::expected<Error, PagesAffected> restrictPagesByCursor(PageSpace *ps, Virtual
 
 template<typename Cursor, typename PageSpace>
 frg::expected<Error, PagesAffected> restrictPagesByCursor(PageSpace *ps, VirtualAddr va,
-		size_t size, PageFlags flags, CachingMode mode) {
-	return restrictPagesByCursor<Cursor>(ps, va, size, flags, mode,
+		size_t size, PageFlags flags) {
+	return restrictPagesByCursor<Cursor>(ps, va, size, flags,
 			typename Cursor::PolicyType{});
 }
 
@@ -292,9 +291,10 @@ struct VirtualOperations {
 	virtual frg::expected<Error, PagesAffected> mapPresentPages(VirtualAddr va, MemoryView *view,
 			uintptr_t offset, size_t size, PageFlags flags, CachingMode mode) = 0;
 
+	// Restricts the permissions of present pages; the caching mode of a page is preserved.
 	// Precondition: flags has at least one access bit (read/write/execute) set.
 	virtual frg::expected<Error, PagesAffected> restrictPages(VirtualAddr va,
-			size_t size, PageFlags flags, CachingMode mode) = 0;
+			size_t size, PageFlags flags) = 0;
 
 	// Precondition: flags has at least one access bit (read/write/execute) set.
 	virtual frg::expected<Error, PagesAffected> faultPage(VirtualAddr va, MemoryView *view,
@@ -832,9 +832,9 @@ public:
 		}
 
 		frg::expected<Error, PagesAffected> restrictPages(VirtualAddr va,
-				size_t size, PageFlags flags, CachingMode mode) override {
+				size_t size, PageFlags flags) override {
 			return restrictPagesByCursor<ClientPageSpace::Cursor>(&space_->pageSpace_,
-					va, size, flags, mode);
+					va, size, flags);
 		}
 
 		frg::expected<Error, PagesAffected> faultPage(VirtualAddr va, MemoryView *view,

--- a/kernel/thor/generic/thor-internal/address-space.hpp
+++ b/kernel/thor/generic/thor-internal/address-space.hpp
@@ -96,15 +96,14 @@ frg::expected<Error, PagesAffected> mapPresentPagesByCursor(PageSpace *ps, Virtu
 			incrementUses(*descriptor);
 		auto [status, oldPhysical] = c.map4k(physicalRange.physical, effectiveFlags,
 			determineCachingMode(physicalRange.cachingMode, mode));
-		if((status & page_status::present) && (status & page_status::dirty)) {
-			if(auto descriptor = globalPfnDb().find(oldPhysical))
-				markDirty(*descriptor);
-		}
 		affected.rssIncrease += kPageSize;
 		if(status & page_status::present) {
-			affected.rssDecrease += kPageSize;
-			if(auto descriptor = globalPfnDb().find(oldPhysical))
+			if(auto descriptor = globalPfnDb().find(oldPhysical)) {
+				if(status & page_status::dirty)
+					markDirty(*descriptor);
 				decrementUses(*descriptor);
+			}
+			affected.rssDecrease += kPageSize;
 			affected.anyRevoked = true;
 		}
 		c.advance4k();
@@ -173,12 +172,11 @@ frg::expected<Error, PagesAffected> faultPageByCursor(PageSpace *ps, VirtualAddr
 	auto [status, oldPhysical] = c.remap4k(physicalRange.physical, effectiveFlags,
 		determineCachingMode(physicalRange.cachingMode, mode));
 	if(status & page_status::present) {
-		if(status & page_status::dirty) {
-			if(auto descriptor = globalPfnDb().find(oldPhysical))
+		if(auto descriptor = globalPfnDb().find(oldPhysical)) {
+			if(status & page_status::dirty)
 				markDirty(*descriptor);
-		}
-		if(auto descriptor = globalPfnDb().find(oldPhysical))
 			decrementUses(*descriptor);
+		}
 		affected.rssDecrease += kPageSize;
 		affected.anyRevoked = true;
 	}
@@ -230,12 +228,11 @@ frg::expected<Error, PagesAffected> unmapPagesByCursor(PageSpace *ps, VirtualAdd
 	while(c.findPresent(va + size)) {
 		auto [status, physical] = c.unmap4k();
 		if(status & page_status::present) {
-			if(status & page_status::dirty) {
-				if(auto descriptor = globalPfnDb().find(physical))
+			if(auto descriptor = globalPfnDb().find(physical)) {
+				if(status & page_status::dirty)
 					markDirty(*descriptor);
-			}
-			if(auto descriptor = globalPfnDb().find(physical))
 				decrementUses(*descriptor);
+			}
 			affected.rssDecrease += kPageSize;
 			affected.anyRevoked = true;
 		}
@@ -262,12 +259,11 @@ frg::expected<Error, PagesAffected> agePagesByCursor(PageSpace *ps, VirtualAddr 
 		affected.scanned += kPageSize;
 		auto [status, physical, unmapped] = c.age4k(vacate);
 		if(unmapped) {
-			if(status & page_status::dirty) {
-				if(auto descriptor = globalPfnDb().find(physical))
+			if(auto descriptor = globalPfnDb().find(physical)) {
+				if(status & page_status::dirty)
 					markDirty(*descriptor);
-			}
-			if(auto descriptor = globalPfnDb().find(physical))
 				decrementUses(*descriptor);
+			}
 			affected.rssDecrease += kPageSize;
 			affected.anyRevoked = true;
 		}

--- a/kernel/thor/generic/thor-internal/arch-generic/cursor.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/cursor.hpp
@@ -101,8 +101,9 @@ public:
 	}
 
 	void moveTo(uintptr_t va) {
+		// The table at level i is selected by the index that level i - 1 resolves.
 		for(size_t i = initialLevel_ + 1; i < Policy::maxLevels; i++) {
-			if((va_ ^ va) & (levelMask << levelShift(i))) {
+			if((va_ ^ va) & (levelMask << levelShift(i - 1))) {
 				for(size_t j = i; j < Policy::maxLevels; j++) {
 					accessors_[j] = {};
 				}

--- a/kernel/thor/generic/thor-internal/arch-generic/cursor.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/cursor.hpp
@@ -215,7 +215,7 @@ public:
 
 	std::tuple<PageStatus, PhysicalAddr> unmap4k() {
 		if(!accessors_[lastLevel])
-			return {0, 0};
+			return {0, PhysicalAddr(-1)};
 
 		auto ptEnt = exchangeCurrentPte_(0);
 		policy_.pteWriteBarrier(currentPtePtr_());

--- a/kernel/thor/generic/thor-internal/arch-generic/cursor.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/cursor.hpp
@@ -83,6 +83,18 @@ private:
 		return __atomic_exchange_n(currentPtePtr_(), value, __ATOMIC_RELAXED);
 	}
 
+	// Advances by the size of an entry in the deepest page table that is present.
+	// Precondition: the last level is not present.
+	void advancePastAbsentTable_(uintptr_t limit) {
+		assert(!accessors_[lastLevel]);
+		size_t level = initialLevel_;
+		while(level + 1 < Policy::maxLevels && accessors_[level + 1])
+			++level;
+
+		auto next = (va_ | ((uintptr_t{1} << levelShift(level)) - 1)) + 1;
+		moveTo(!next || next > limit ? limit : next);
+	}
+
 public:
 	uintptr_t virtualAddress() {
 		return va_;
@@ -109,7 +121,7 @@ public:
 	bool findPresent(uintptr_t limit) {
 		while(va_ < limit) {
 			if(!accessors_[lastLevel]) {
-				advance4k();
+				advancePastAbsentTable_(limit);
 				continue;
 			}
 
@@ -126,7 +138,7 @@ public:
 	bool findDirty(uintptr_t limit) {
 		while(va_ < limit) {
 			if(!accessors_[lastLevel]) {
-				advance4k();
+				advancePastAbsentTable_(limit);
 				continue;
 			}
 

--- a/kernel/thor/generic/thor-internal/arch-generic/cursor.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/cursor.hpp
@@ -30,6 +30,8 @@ concept CursorPolicy = requires (T policy, uint64_t pte, uint64_t *ptePtr,
 	{ T::ptePageAddress(pte) } -> std::same_as<PhysicalAddr>;
 	// Get the status (present, dirty) from the given PTE.
 	{ T::ptePageStatus(pte) } -> std::same_as<PageStatus>;
+	// Mask of the PTE bits that encode the caching mode.
+	{ T::ptePageCachingMask } -> std::convertible_to<uint64_t>;
 	// Clean the given PTE (remove the dirty status). Returns the previous PTE value.
 	{ T::pteClean(ptePtr) } -> std::same_as<uint64_t>;
 	// Age the given PTE. Returns the previous PTE value and whether the page was unmapped.
@@ -167,7 +169,7 @@ public:
 		return {Policy::ptePageStatus(ptEnt), Policy::ptePageAddress(ptEnt)};
 	}
 
-	std::tuple<PageStatus, PhysicalAddr, bool> restrict4k(PageFlags flags, CachingMode cachingMode) {
+	std::tuple<PageStatus, PhysicalAddr, bool> restrict4k(PageFlags flags) {
 		if(!accessors_[lastLevel])
 			return {0, PhysicalAddr(-1), false};
 
@@ -182,7 +184,10 @@ public:
 			if(!Policy::ptePageCanAccess(oldPte, page_access::execute))
 				effectiveFlags &= ~page_access::execute;
 
-			auto newPte = Policy::pteBuild(Policy::ptePageAddress(oldPte), effectiveFlags, cachingMode);
+			auto newPte = Policy::pteBuild(Policy::ptePageAddress(oldPte), effectiveFlags, CachingMode::null);
+			// Keep the caching mode of the page.
+			newPte &= ~Policy::ptePageCachingMask;
+			newPte |= (oldPte & Policy::ptePageCachingMask);
 			auto success = __atomic_compare_exchange_n(
 				currentPtePtr_(), &oldPte, newPte, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED
 			);

--- a/kernel/thor/generic/thor-internal/iommu.hpp
+++ b/kernel/thor/generic/thor-internal/iommu.hpp
@@ -65,7 +65,7 @@ public:
 		) override;
 
 		frg::expected<Error, PagesAffected>
-		restrictPages(VirtualAddr va, size_t size, PageFlags flags, CachingMode mode) override;
+		restrictPages(VirtualAddr va, size_t size, PageFlags flags) override;
 
 		frg::expected<Error, PagesAffected> faultPage(
 		    VirtualAddr va,


### PR DESCRIPTION
The most significant fix here is that two concurrent `cleanPagesByCursor()` calls could previously trigger an assertion failure.

Fix #1569