### PR TITLE
thor: Fix missed timer IRQs on edge-triggered timers

### DIFF
--- a/kernel/thor/arch/arm/timer.cpp
+++ b/kernel/thor/arch/arm/timer.cpp
@@ -21,9 +21,11 @@
 
 namespace thor {
 
-// Timer frequency and it's inverse stored in nHz and ns respectively.
-constinit FreqFraction timerFreq;
-constinit FreqFraction timerInverseFreq;
+// Timer tick duration stored in ns, and its reciprocal (= its frequency).
+constinit Pow2Fraction<Rounding::down> timerTickDuration;
+// The frequency is used to program the timer based on a deadline in ns.
+// Round up such that the timer fires after the deadline, not before.
+constinit Pow2Fraction<Rounding::up> timerTickFreq;
 
 // In EL2 with VHE, CNTP_* and CNTV_* access the EL2 timers (CNTHP_* and CNTHV_*).
 // We use the physical one of the two since firmware always describes its interrupt,
@@ -75,12 +77,12 @@ struct GenericTimerSink : IrqSink {
 };
 
 uint64_t getClockNanos() {
-	return timerInverseFreq * getRawTimestampCounter();
+	return timerTickDuration * getRawTimestampCounter();
 }
 
 void setTimerDeadline(frg::optional<uint64_t> deadline) {
 	if (deadline) {
-		uint64_t rawDeadline = timerFreq * *deadline;
+		uint64_t rawDeadline = timerTickFreq * *deadline;
 
 		setRawTimerDeadline(rawDeadline);
 		// Unmask the timer interrupt.
@@ -97,8 +99,8 @@ void initializeTimers() {
 	asm volatile ("mrs %0, cntfrq_el0" : "=r"(freqHz));
 
 	// Divide by 10^9 to convert Hz to nHz.
-	timerFreq = computeFreqFraction(freqHz, divisor);
-	timerInverseFreq = computeFreqFraction(divisor, freqHz);
+	timerTickDuration = computePow2Fraction<Rounding::down>(divisor, freqHz);
+	timerTickFreq = computeReciprocal(timerTickDuration);
 
 	// Enable and mask the timer interrupt.
 	setTimerControl(0b11);

--- a/kernel/thor/arch/arm/timer.cpp
+++ b/kernel/thor/arch/arm/timer.cpp
@@ -93,6 +93,11 @@ void setTimerDeadline(frg::optional<uint64_t> deadline) {
 	}
 }
 
+bool timerDisarmsItself() {
+	// The generic timer keeps asserting its interrupt while cntvct is past cntv_cval.
+	return false;
+}
+
 void initializeTimers() {
 	constexpr uint64_t divisor = 1'000'000'000;
 	uint64_t freqHz;

--- a/kernel/thor/arch/riscv/timer.cpp
+++ b/kernel/thor/arch/riscv/timer.cpp
@@ -118,6 +118,11 @@ void setTimerDeadline(frg::optional<uint64_t> deadline) {
 	}
 }
 
+bool timerDisarmsItself() {
+	// STIP stays pending while time is past stimecmp.
+	return false;
+}
+
 bool haveTimer() { return static_cast<bool>(tickDuration); }
 
 } // namespace thor

--- a/kernel/thor/arch/riscv/timer.cpp
+++ b/kernel/thor/arch/riscv/timer.cpp
@@ -17,9 +17,11 @@ namespace thor {
 
 namespace {
 
-// Frequency and inverse frequency of the CPU timer in nHz and ns, respectively.
-constinit FreqFraction freq;
-constinit FreqFraction inverseFreq;
+// Timer tick duration stored in ns, and its reciprocal (= its frequency).
+constinit Pow2Fraction<Rounding::down> tickDuration;
+// The frequency is used to program the timer based on a deadline in ns.
+// Round up such that the timer fires after the deadline, not before.
+constinit Pow2Fraction<Rounding::up> tickFreq;
 
 initgraph::Task initTimerAcpi{
     &globalInitEngine,
@@ -50,8 +52,8 @@ initgraph::Task initTimerAcpi{
 
 	    // Frequency is given in Hz. Hence, we need to divide by 10^9 to convert to nHz.
 	    uint64_t divisor = 1'000'000'000;
-	    freq = computeFreqFraction(freqSeconds, divisor);
-	    inverseFreq = computeFreqFraction(divisor, freqSeconds);
+	    tickDuration = computePow2Fraction<Rounding::down>(divisor, freqSeconds);
+	    tickFreq = computeReciprocal(tickDuration);
     }
 };
 
@@ -87,8 +89,8 @@ initgraph::Task initTimer{
 
 	    // Frequency is given in Hz. Hence, we need to divide by 10^9 to convert to nHz.
 	    uint64_t divisor = 1'000'000'000;
-	    freq = computeFreqFraction(freqSeconds, divisor);
-	    inverseFreq = computeFreqFraction(divisor, freqSeconds);
+	    tickDuration = computePow2Fraction<Rounding::down>(divisor, freqSeconds);
+	    tickFreq = computeReciprocal(tickDuration);
     }
 };
 
@@ -100,14 +102,14 @@ uint64_t getRawTimestampCounter() {
 	return v;
 }
 
-uint64_t getClockNanos() { return inverseFreq * getRawTimestampCounter(); }
+uint64_t getClockNanos() { return tickDuration * getRawTimestampCounter(); }
 
 void setTimerDeadline(frg::optional<uint64_t> deadline) {
 	assert(!intsAreEnabled());
 
 	uint64_t rawDeadline = ~UINT64_C(0);
 	if (deadline)
-		rawDeadline = freq * (*deadline);
+		rawDeadline = tickFreq * *deadline;
 
 	if (riscvHartCapsNote->hasExtension(RiscvExtension::sstc)) {
 		riscv::writeCsr<riscv::Csr::stimecmp>(rawDeadline);
@@ -116,6 +118,6 @@ void setTimerDeadline(frg::optional<uint64_t> deadline) {
 	}
 }
 
-bool haveTimer() { return static_cast<bool>(freq); }
+bool haveTimer() { return static_cast<bool>(tickDuration); }
 
 } // namespace thor

--- a/kernel/thor/arch/x86/pic.cpp
+++ b/kernel/thor/arch/x86/pic.cpp
@@ -128,6 +128,10 @@ namespace {
 	LocalApicContext *localApicContext() {
 		return &apicContext.get();
 	}
+
+	uint64_t tscTicksForDeadline(uint64_t deadline) {
+		return localApicContext()->tscTickFreq * deadline;
+	}
 }
 
 void setTimerDeadline(frg::optional<uint64_t> deadline) {
@@ -139,7 +143,7 @@ void setTimerDeadline(frg::optional<uint64_t> deadline) {
 			return;
 		}
 
-		uint64_t ticks = localApicContext()->timerFreq * *deadline;
+		uint64_t ticks = tscTicksForDeadline(*deadline);
 		common::x86::wrmsr(common::x86::kMsrIa32TscDeadline, ticks);
 		if(debugTimer)
 			infoLogger() << "thor [CPU " << getLocalApicId() << "]: Setting TSC deadline to "
@@ -161,7 +165,7 @@ void setTimerDeadline(frg::optional<uint64_t> deadline) {
 			if(debugTimer)
 				infoLogger() << "thor [CPU " << getLocalApicId() << "]: Setting timer "
 						<< ((*deadline - now) / 1000) << " us in the future" << frg::endlog;
-			ticks = localApicContext()->timerFreq * (*deadline - now);
+			ticks = localApicContext()->lapicTickFreq * (*deadline - now);
 			if(!ticks)
 				ticks = 1;
 		}
@@ -279,8 +283,8 @@ void calibrateApicTimer() {
 				- picBase.load(lApicCurCount);
 		picBase.store(lApicInitCount, 0);
 
-		localApicContext()->timerFreq
-			= computeFreqFraction(elapsed, nanos);
+		localApicContext()->lapicTickFreq
+			= computePow2Fraction<Rounding::up>(elapsed, nanos);
 
 		infoLogger() << "thor: Local APIC ticks/ms: "
 				<< (elapsed / millis)
@@ -293,21 +297,17 @@ void calibrateApicTimer() {
 		pollSleepNano(nanos);
 		auto tscElapsed = getRawTimestampCounter() - tscStart;
 
-		localApicContext()->tscInverseFreq
-			= computeFreqFraction(nanos, tscElapsed);
-		if (localApicContext()->useTscMode) {
-			localApicContext()->timerFreq
-				= computeFreqFraction(tscElapsed, nanos);
-		}
+		localApicContext()->tscTickDuration
+			= computePow2Fraction<Rounding::down>(nanos, tscElapsed);
+		localApicContext()->tscTickFreq
+			= computeReciprocal(localApicContext()->tscTickDuration);
 
 		infoLogger() << "thor: TSC ticks/ms: " << (tscElapsed / millis)
 					<< " on CPU #" << getCpuData()->cpuIndex << frg::endlog;
 	} else {
 		// Linux assumes invariant TSC to be globally synchronized.
-		localApicContext()->tscInverseFreq = apicContext.getFor(0).tscInverseFreq;
-		if (localApicContext()->useTscMode) {
-			localApicContext()->timerFreq = apicContext.getFor(0).timerFreq;
-		}
+		localApicContext()->tscTickDuration = apicContext.getFor(0).tscTickDuration;
+		localApicContext()->tscTickFreq = apicContext.getFor(0).tscTickFreq;
 	}
 
 	localApicContext()->timersAreCalibrated = true;
@@ -328,7 +328,7 @@ static initgraph::Task assessTimersTask{&globalInitEngine, "x86.assess-timers",
 uint64_t getClockNanos() {
 	assert(localApicContext()->timersAreCalibrated);
 	if(getGlobalCpuFeatures()->haveInvariantTsc) [[likely]] {
-		return localApicContext()->tscInverseFreq * getRawTimestampCounter();
+		return localApicContext()->tscTickDuration * getRawTimestampCounter();
 	} else {
 		return hpetClockSource->currentNanos();
 	}

--- a/kernel/thor/arch/x86/pic.cpp
+++ b/kernel/thor/arch/x86/pic.cpp
@@ -168,6 +168,10 @@ void setTimerDeadline(frg::optional<uint64_t> deadline) {
 			ticks = localApicContext()->lapicTickFreq * (*deadline - now);
 			if(!ticks)
 				ticks = 1;
+			// lApicInitCount is only 32 bits wide. A clamped timer fires early but
+			// handleTimerInterrupt() reprograms it since its deadline is not reached yet.
+			if(ticks > UINT32_MAX)
+				ticks = UINT32_MAX;
 		}
 		picBase.store(lApicInitCount, ticks);
 	}

--- a/kernel/thor/arch/x86/pic.cpp
+++ b/kernel/thor/arch/x86/pic.cpp
@@ -177,6 +177,11 @@ void setTimerDeadline(frg::optional<uint64_t> deadline) {
 	}
 }
 
+bool timerDisarmsItself() {
+	// Both TSC deadline and local APIC one-shot timer are edge-triggered.
+	return true;
+}
+
 void LocalApicContext::clearPmi() {
 	picBase.store(lApicLvtPerfCount, apicLvtMode(4));
 }

--- a/kernel/thor/arch/x86/thor-internal/arch/pic.hpp
+++ b/kernel/thor/arch/x86/thor-internal/arch/pic.hpp
@@ -88,12 +88,16 @@ struct LocalApicContext {
 	bool useTscMode = false;
 	bool timersAreCalibrated = false;
 
-	// Inverse of the TSC frequency in ns.
+	// TSC tick duration stored in ns.
 	// Used for the timestamp -> monotonic clock time conversion.
-	FreqFraction tscInverseFreq;
-	// Frequency of the timer in nHz (1/tscInverseFreq if using
-	// TSC deadline mode, freq. of the APIC timer otherwise).
-	FreqFraction timerFreq;
+	Pow2Fraction<Rounding::down> tscTickDuration;
+	// The frequency is used to program the TSC timer based on a deadline in ns.
+	// Round up such that the TSC timer fires after the deadline, not before.
+	Pow2Fraction<Rounding::up> tscTickFreq;
+
+	// Frequency of the local APIC timer in nHz.
+	// Round up such that the APIC timer fires after the deadline, not before.
+	Pow2Fraction<Rounding::up> lapicTickFreq;
 };
 
 initgraph::Stage *getApicDiscoveryStage();

--- a/kernel/thor/generic/thor-internal/arch-generic/timer.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/timer.hpp
@@ -10,6 +10,11 @@ uint64_t getClockNanos();
 // Schedules an interrupt to fire once the monotonic clock reaches the
 // deadline, or disarms the interrupt if deadline is frg::null_opt.
 void setTimerDeadline(frg::optional<uint64_t> deadline);
+
+// Returns whether the timer disarms itself once it reaches the deadline.
+// This is true for edge-triggered timers. Level triggered timers keep asserting the interrupt until they are disarmed.
+bool timerDisarmsItself();
+
 // Returns whether timers are available and ready to use.
 bool haveTimer();
 // Get the raw timestamp in preemption timer ticks.

--- a/kernel/thor/generic/thor-internal/util.hpp
+++ b/kernel/thor/generic/thor-internal/util.hpp
@@ -11,11 +11,17 @@ namespace thor {
 
 inline int ceil_log2(unsigned long x) { return 8 * sizeof(unsigned long) - __builtin_clzl(x); }
 
-// Helper class to store the frequency or inverse frequency (= tick duration) of a timer.
-// Designed to support the conversion of ticks into durations and vice versa with high accuracy.
-// The fraction is represented as (f / 2^s) where f is a 64-bit factor and s is a scaling exponent.
+// Direction in which a Pow2Fraction rounds the value that it represents.
+enum class Rounding { down, up };
+
+// Helper class to store a fraction as (f / 2^s) where f is a 64-bit factor and s is a scaling
+// exponent. Used for the frequency and inverse frequency (= tick duration) of timers, i.e. to
+// convert ticks into durations and vice versa with high accuracy.
 // When doing conversions, the multiplication is done in 128-bit to avoid loss of precision.
-struct FreqFraction {
+// Both the representation and the multiplication round towards R,
+// i.e. conversions yield an lower/upper bound on the true value.
+template<Rounding R>
+struct Pow2Fraction {
 	explicit operator bool () {
 		return f;
 	}
@@ -27,24 +33,66 @@ struct FreqFraction {
 	// Clamping is usually not an issue when converting ticks (since boot) to nanoseconds
 	// as the system will not be up for 2^64 nanoseconds.
 	uint64_t operator*(uint64_t rhs) {
-		auto product = (static_cast<__uint128_t>(f) * static_cast<__uint128_t>(rhs)) >> s;
-		if (product >> 64)
+		auto product = static_cast<__uint128_t>(f) * static_cast<__uint128_t>(rhs);
+		auto quotient = product >> s;
+		if constexpr (R == Rounding::up) {
+			if (product & ((static_cast<__uint128_t>(1) << s) - 1))
+				++quotient;
+		}
+		if (quotient >> 64)
 			return UINT64_MAX;
-		return static_cast<uint64_t>(product);
+		return static_cast<uint64_t>(quotient);
 	}
 
 	uint64_t f{0};
 	int s{0};
 };
 
-// Converts the fraction (num / denom) to a FreqFraction.
-inline FreqFraction computeFreqFraction(uint64_t num, uint64_t denom) {
+// Converts the fraction (num / denom) to a Pow2Fraction, rounding the representation towards R.
+template<Rounding R>
+inline Pow2Fraction<R> computePow2Fraction(uint64_t num, uint64_t denom) {
 	// TODO: We could use a higher shift (i.e., subtract floor_log2(denom))
 	//       since the division by denom would bring the number back below 64-bit.
 	//       For now, we do not use this fact as it requires a 128-bit division.
 	auto s = 63 - ceil_log2(num);
-	auto f = (num << s) / denom;
-	return FreqFraction{f, s};
+	auto scaled = num << s;
+	auto f = scaled / denom;
+	if constexpr (R == Rounding::up) {
+		if (scaled % denom)
+			++f;
+	}
+	return Pow2Fraction<R>{f, s};
+}
+
+// Computes ceil(2^exp / divisor) using only 64-bit divisions, i.e. by long division.
+// The caller picks exp such that the quotient fits into 64 bits.
+inline uint64_t ceilPow2Divide(int exp, uint64_t divisor) {
+	assert(divisor > 1);
+
+	// Consume the leading one of the dividend, then shift in its zeros one at a time.
+	uint64_t quotient = 0;
+	uint64_t remainder = 1;
+	for (int i = 0; i < exp; ++i) {
+		// The doubled remainder does not fit into 64 bits iff it exceeds the divisor anyway.
+		bool overflow = remainder >> 63;
+		remainder <<= 1;
+		quotient <<= 1;
+		if (overflow || remainder >= divisor) {
+			remainder -= divisor;
+			quotient |= 1;
+		}
+	}
+	return remainder ? quotient + 1 : quotient;
+}
+
+// Computes the reciprocal of the given fraction such that
+// (fraction * (computeReciprocal(fraction) * value)) >= value for all values.
+// Timers need this direction: converting a deadline to ticks and back must not land before the
+// deadline, or the timer fires before the deadline is considered to be reached.
+inline Pow2Fraction<Rounding::up> computeReciprocal(Pow2Fraction<Rounding::down> fraction) {
+	// The reciprocal is 2^fraction.s / fraction.f. Scale it such that it keeps 63 bits.
+	auto exp = 62 + ceil_log2(fraction.f);
+	return Pow2Fraction<Rounding::up>{ceilPow2Divide(exp, fraction.f), exp - fraction.s};
 }
 
 template <size_t Mod = std::dynamic_extent>

--- a/kernel/thor/generic/timer.cpp
+++ b/kernel/thor/generic/timer.cpp
@@ -22,7 +22,7 @@ extern PerCpu<DeadlineState> deadlineState;
 THOR_DEFINE_PERCPU(deadlineState);
 
 
-void updateDeadline_() {
+void updateDeadline_(bool inTimerInterrupt = false) {
 	assert(!intsAreEnabled());
 	auto &state = deadlineState.get();
 
@@ -37,14 +37,21 @@ void updateDeadline_() {
 	consider(state.timerDeadline);
 	consider(state.preemptionDeadline);
 
-	// No need to do anything if the current deadline didn't change.
-
-	// FIXME(qookie): This is just deadline == state.currentDeadline,
-	// but frg::optional is missing the overload to do that.
+	// If there is no deadline, we do not need to reprogram the hardware.
 	if (!deadline && !state.currentDeadline)
 		return;
-	if (deadline && state.currentDeadline && deadline == *state.currentDeadline)
-		return;
+
+	// Skip reprogramming on unchanged deadlines.
+	// There are various situations in which a timer interrupt can fire even if the deadline
+	// has not passed from the callers point of view. For example:
+	// - The hardware register is too narrow to store the full deadline and we have to saturate.
+	// - The timer's clock does not match getClockNanos() and the calibration is inaccurate.
+	// - A timer interrupt fires too early because of hardware of VMM bugs.
+	// Thus, this check is only done outside of timer interrupts.
+	if (!inTimerInterrupt) {
+		if (deadline && state.currentDeadline && deadline == *state.currentDeadline)
+			return;
+	}
 
 	state.currentDeadline = deadline;
 	setTimerDeadline(state.currentDeadline);
@@ -87,7 +94,15 @@ void handleTimerInterrupt() {
 	auto preemptionExpired = checkAndClear(state.preemptionDeadline);
 
 	// Update the timer hardware.
-	updateDeadline_();
+	// Note that timer deadlines may be computed based on a different clock than getClockNanos(),
+	// hence the IRQ can arrive before we consider the programmed deadline to be expired.
+	// The consequences depend on the timer mechanism:
+	// - Edge triggered timers (e.g., TSC deadline on x86) are disarmed by now
+	//   and we may need to reprogram them.
+	// - Level triggered timers (e.g., sstc on RISC-V) never need to be reprogrammed here
+	//   (they need to be disarmed to prevent them from firing again;
+	//   however, this this disarming happens whether inTimerInterrupt is set or not).
+	updateDeadline_(true);
 
 	// Finally, take action for the deadlines that have expired.
 	if (timerExpired)

--- a/kernel/thor/generic/timer.cpp
+++ b/kernel/thor/generic/timer.cpp
@@ -54,6 +54,11 @@ void updateDeadline_(bool inTimerInterrupt = false) {
 	}
 
 	state.currentDeadline = deadline;
+
+	// Do not explicitly disarm edge-triggered timers that just fired.
+	if (!deadline && inTimerInterrupt && timerDisarmsItself())
+		return;
+
 	setTimerDeadline(state.currentDeadline);
 }
 


### PR DESCRIPTION
Fix the possibility of a missed timer update when the timer IRQ fires but the deadline has not passed yet according to `getClockNanos()`. Also fix the rounding direction of timer tick computations: round up such that the timer IRQ always happens after the deadline and never before.

Fix #1530