### PR TITLE
rust/hel: Make it possible to build as no_std

### DIFF
--- a/rust/hel-sys/build.rs
+++ b/rust/hel-sys/build.rs
@@ -15,6 +15,7 @@ fn main() {
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .prepend_enum_name(false)
         .generate_inline_functions(true)
+        .use_core()
         .generate()
         .expect("Unable to generate bindings");
 

--- a/rust/hel-sys/src/lib.rs
+++ b/rust/hel-sys/src/lib.rs
@@ -1,5 +1,5 @@
 //! Raw bindings for the Hel API.
-
+#![no_std]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/rust/hel/Cargo.toml
+++ b/rust/hel/Cargo.toml
@@ -3,6 +3,10 @@ name = "hel"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 bitflags = "2.9.0"
 hel-sys.workspace = true

--- a/rust/hel/src/executor.rs
+++ b/rust/hel/src/executor.rs
@@ -171,6 +171,7 @@ impl Executor {
 }
 
 /// Spawns a new task.
+#[cfg(feature = "std")]
 pub fn spawn<F>(future: F)
 where
     F: Future<Output = ()> + 'static,
@@ -179,6 +180,7 @@ where
 }
 
 /// Blocks the current thread until the given future is ready.
+#[cfg(feature = "std")]
 pub fn block_on<F, R: 'static>(future: F) -> Result<R>
 where
     F: Future<Output = R> + 'static,
@@ -189,6 +191,7 @@ where
 /// Temporarily replaces the default per-thread executor with the given one.
 /// The returned value ensures that the executor is restored to its previous state
 /// when dropped.
+#[cfg(feature = "std")]
 pub fn enter_executor(new_executor: Executor) -> ExecutorGuard {
     let previous_executor = EXECUTOR.with(|executor| executor.replace(new_executor));
 
@@ -196,20 +199,24 @@ pub fn enter_executor(new_executor: Executor) -> ExecutorGuard {
 }
 
 /// Returns a new reference to the current executor.
+#[cfg(feature = "std")]
 pub fn current_executor() -> Executor {
     EXECUTOR.with(|executor| executor.borrow().clone())
 }
 
+#[cfg(feature = "std")]
 thread_local! {
     /// The current executor for the thread.
     pub(crate) static EXECUTOR: RefCell<Executor>
         = RefCell::new(Executor::new().expect("Failed to create executor"));
 }
 
+#[cfg(feature = "std")]
 pub struct ExecutorGuard {
     previous_executor: Executor,
 }
 
+#[cfg(feature = "std")]
 impl Drop for ExecutorGuard {
     fn drop(&mut self) {
         EXECUTOR.with(|executor| executor.replace(self.previous_executor.clone()));

--- a/rust/hel/src/executor.rs
+++ b/rust/hel/src/executor.rs
@@ -1,10 +1,14 @@
-use std::{
-    cell::{Cell, RefCell},
+use alloc::{
+    boxed::Box,
     collections::VecDeque,
+    rc::{Rc, Weak},
+    task::LocalWake,
+};
+use core::{
+    cell::{Cell, RefCell},
     future::Future,
     pin::Pin,
-    rc::{Rc, Weak},
-    task::{ContextBuilder, LocalWake, LocalWaker, Waker},
+    task::{ContextBuilder, LocalWaker, Waker},
 };
 
 use crate::{handle::Handle, queue::Queue, result::Result, submission::OperationState};
@@ -205,7 +209,7 @@ pub fn current_executor() -> Executor {
 }
 
 #[cfg(feature = "std")]
-thread_local! {
+std::thread_local! {
     /// The current executor for the thread.
     pub(crate) static EXECUTOR: RefCell<Executor>
         = RefCell::new(Executor::new().expect("Failed to create executor"));

--- a/rust/hel/src/handle.rs
+++ b/rust/hel/src/handle.rs
@@ -1,4 +1,4 @@
-use std::mem::ManuallyDrop;
+use core::mem::ManuallyDrop;
 
 use crate::result::{Result, hel_check};
 

--- a/rust/hel/src/lib.rs
+++ b/rust/hel/src/lib.rs
@@ -12,18 +12,18 @@ pub mod submission;
 
 use std::time::Duration;
 
+#[cfg(feature = "std")]
 pub use executor::{block_on, spawn};
 pub use handle::Handle;
 pub use mapping::{Mapping, MappingFlags};
 pub use queue::Queue;
 pub use result::{Error, Result};
-pub use submission::{
-    action::{
-        Accept, Dismiss, ExtractCredentials, Offer, PullDescriptor, PushDescriptor, ReceiveBuffer,
-        ReceiveInline, SendBuffer,
-    },
-    sleep_for, sleep_until, submit_async,
+pub use submission::action::{
+    Accept, Dismiss, ExtractCredentials, Offer, PullDescriptor, PushDescriptor, ReceiveBuffer,
+    ReceiveInline, SendBuffer,
 };
+#[cfg(feature = "std")]
+pub use submission::{sleep_for, sleep_until, submit_async};
 
 /// Creates a pair of connected lanes that can be used to communicate.
 pub fn create_stream() -> Result<(Handle, Handle)> {

--- a/rust/hel/src/lib.rs
+++ b/rust/hel/src/lib.rs
@@ -1,7 +1,12 @@
 //! A Rust wrapper for Hel.
+#![no_std]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 #![feature(local_waker)]
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod executor;
 pub mod handle;
@@ -10,7 +15,7 @@ pub mod queue;
 pub mod result;
 pub mod submission;
 
-use std::time::Duration;
+use core::time::Duration;
 
 #[cfg(feature = "std")]
 pub use executor::{block_on, spawn};
@@ -125,7 +130,7 @@ pub fn access_irq_by_gsi(access_handle: &Handle, gsi: u64) -> Result<Handle> {
             hel_sys::kHelAccessIrqByGsi as u32,
             0,
             gsi,
-            std::ptr::null(),
+            core::ptr::null(),
             &mut handle,
         )
     })?;
@@ -141,7 +146,7 @@ pub fn access_irq_by_phandle(access_handle: &Handle, phandle: u64, index: u64) -
             hel_sys::kHelAccessIrqByPhandle as u32,
             phandle,
             index,
-            std::ptr::null(),
+            core::ptr::null(),
             &mut handle,
         )
     })?;
@@ -153,9 +158,9 @@ pub fn access_irq_by_phandle(access_handle: &Handle, phandle: u64, index: u64) -
 pub fn allocate_msi(access_handle: &Handle, name: &str) -> Result<Handle> {
     // The kernel reads the whole buffer, hence pass one of exactly that size.
     // Names that do not fit are truncated.
-    let mut buffer = [0 as std::ffi::c_char; hel_sys::kHelIrqNameSize as usize];
+    let mut buffer = [0 as core::ffi::c_char; hel_sys::kHelIrqNameSize as usize];
     for (slot, &byte) in buffer.iter_mut().zip(name.as_bytes()) {
-        *slot = byte as std::ffi::c_char;
+        *slot = byte as core::ffi::c_char;
     }
 
     let mut handle = hel_sys::kHelNullHandle as hel_sys::HelHandle;
@@ -262,7 +267,7 @@ impl Time {
     }
 }
 
-impl std::ops::Add<Duration> for Time {
+impl core::ops::Add<Duration> for Time {
     type Output = Self;
 
     fn add(self, rhs: Duration) -> Self::Output {
@@ -270,7 +275,7 @@ impl std::ops::Add<Duration> for Time {
     }
 }
 
-impl std::ops::Sub<Duration> for Time {
+impl core::ops::Sub<Duration> for Time {
     type Output = Self;
 
     fn sub(self, rhs: Duration) -> Self::Output {

--- a/rust/hel/src/mapping.rs
+++ b/rust/hel/src/mapping.rs
@@ -1,5 +1,5 @@
-use std::ptr::NonNull;
-use std::{ffi::c_void, num::NonZeroUsize};
+use core::ptr::NonNull;
+use core::{ffi::c_void, num::NonZeroUsize};
 
 use crate::{
     handle::Handle,
@@ -54,13 +54,13 @@ impl<T> Mapping<T> {
         length: usize,
         flags: MappingFlags,
     ) -> Result<Self> {
-        let mut mapping = std::ptr::null_mut();
+        let mut mapping = core::ptr::null_mut();
 
         hel_check(unsafe {
             hel_sys::helMapMemory(
                 handle.handle(),
                 space.handle(),
-                pointer.map_or(std::ptr::null_mut(), |p| p.get() as *mut c_void),
+                pointer.map_or(core::ptr::null_mut(), |p| p.get() as *mut c_void),
                 offset,
                 length,
                 flags.bits(),

--- a/rust/hel/src/queue.rs
+++ b/rust/hel/src/queue.rs
@@ -1,8 +1,9 @@
-use std::ffi::c_uint;
-use std::marker::PhantomData;
-use std::mem::{MaybeUninit, offset_of};
-use std::ptr::NonNull;
-use std::sync::atomic::{AtomicI32, Ordering};
+use alloc::{boxed::Box, vec};
+use core::ffi::c_uint;
+use core::marker::PhantomData;
+use core::mem::{MaybeUninit, offset_of};
+use core::ptr::NonNull;
+use core::sync::atomic::{AtomicI32, Ordering};
 
 use crate::{
     handle::Handle,
@@ -276,7 +277,7 @@ impl Queue {
             break Ok(QueueElement::new(
                 self,
                 unsafe {
-                    std::slice::from_raw_parts(
+                    core::slice::from_raw_parts(
                         pointer
                             .byte_add(size_of::<hel_sys::HelElement>())
                             .cast()
@@ -558,14 +559,14 @@ impl Queue {
         let element: &mut hel_sys::HelElement = unsafe { ptr.cast().as_mut() };
         element.length = data_length as u32;
         element.opcode = opcode;
-        element.context = context as *mut std::ffi::c_void;
+        element.context = context as *mut core::ffi::c_void;
 
         // Write each segment after the header.
         let mut offset = size_of::<hel_sys::HelElement>();
         for segment in segments {
             if !segment.is_empty() {
                 unsafe {
-                    std::ptr::copy_nonoverlapping(
+                    core::ptr::copy_nonoverlapping(
                         segment.as_ptr(),
                         ptr.byte_add(offset).cast().as_ptr(),
                         segment.len(),

--- a/rust/hel/src/result.rs
+++ b/rust/hel/src/result.rs
@@ -25,8 +25,8 @@ pub enum Error {
     AlreadyExists,
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::IllegalSyscall => write!(f, "Illegal syscall"),
             Error::IllegalArgs => write!(f, "Illegal arguments"),
@@ -52,7 +52,7 @@ impl std::fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl From<hel_sys::HelError> for Error {
     fn from(error: hel_sys::HelError) -> Self {
@@ -82,7 +82,7 @@ impl From<hel_sys::HelError> for Error {
     }
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 /// Utility function to check Hel errors and convert them to `Result`.
 pub(crate) fn hel_check(error: hel_sys::HelError) -> Result<()> {

--- a/rust/hel/src/submission.rs
+++ b/rust/hel/src/submission.rs
@@ -12,9 +12,11 @@ use std::{
 use action::Action;
 use result::{FromQueueElement, SimpleResult};
 
+#[cfg(feature = "std")]
+use crate::executor::current_executor;
 use crate::{
     Time,
-    executor::{Executor, ExecutorInner, current_executor},
+    executor::{Executor, ExecutorInner},
     handle::Handle,
     queue::QueueElement,
     result::Result,
@@ -139,6 +141,7 @@ pub fn sleep_until_with_executor(
 
 /// Returns a future that will be completed when the system clock
 /// reaches the given time value.
+#[cfg(feature = "std")]
 pub fn sleep_until(time: Time) -> impl Future<Output = Result<()>> {
     sleep_until_with_executor(current_executor(), time)
 }
@@ -179,6 +182,7 @@ pub fn sleep_for_with_executor(
 /// Returns a future that will be completed after the given duration
 /// has passed. This is equivalent to calling `sleep_until` with the
 /// current time plus the given duration.
+#[cfg(feature = "std")]
 pub fn sleep_for(duration: Duration) -> impl Future<Output = Result<()>> {
     sleep_for_with_executor(current_executor(), duration)
 }
@@ -229,6 +233,7 @@ where
     )
 }
 
+#[cfg(feature = "std")]
 pub fn submit_async<T: Action>(
     lane: &Handle,
     action: T,

--- a/rust/hel/src/submission.rs
+++ b/rust/hel/src/submission.rs
@@ -1,10 +1,10 @@
 pub mod action;
 pub mod result;
 
-use std::{
+use alloc::rc::Rc;
+use core::{
     cell::Cell,
     mem::{MaybeUninit, size_of},
-    rc::Rc,
     task::{LocalWaker, Poll},
     time::Duration,
 };
@@ -124,7 +124,7 @@ pub fn sleep_until_with_executor(
                 cancellationTag: 0, // No cancellation needed
             };
             let header_bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(
+                core::slice::from_raw_parts(
                     &header as *const _ as *const u8,
                     size_of::<hel_sys::HelSqAwaitClock>(),
                 )
@@ -164,7 +164,7 @@ pub fn sleep_for_with_executor(
                 cancellationTag: 0, // No cancellation needed
             };
             let header_bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(
+                core::slice::from_raw_parts(
                     &header as *const _ as *const u8,
                     size_of::<hel_sys::HelSqAwaitClock>(),
                 )
@@ -212,13 +212,13 @@ where
                 flags: 0,
             };
             let header_bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(
+                core::slice::from_raw_parts(
                     &header as *const _ as *const u8,
                     size_of::<hel_sys::HelSqExchangeMsgs>(),
                 )
             };
             let actions_bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(
+                core::slice::from_raw_parts(
                     actions.as_ptr() as *const u8,
                     actions.len() * size_of::<hel_sys::HelAction>(),
                 )

--- a/rust/hel/src/submission/action.rs
+++ b/rust/hel/src/submission/action.rs
@@ -1,4 +1,4 @@
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 use crate::handle::Handle;
 use crate::submission::result::{
@@ -7,7 +7,7 @@ use crate::submission::result::{
 
 const fn default_hel_action() -> hel_sys::HelAction {
     hel_sys::HelAction {
-        type_: hel_sys::kHelActionNone as std::ffi::c_int,
+        type_: hel_sys::kHelActionNone as core::ffi::c_int,
         flags: 0,
         __bindgen_anon_1: hel_sys::HelAction__bindgen_ty_1 { word0: 0 },
         __bindgen_anon_2: hel_sys::HelAction__bindgen_ty_2 { word1: 0 },

--- a/rust/hel/src/submission/result.rs
+++ b/rust/hel/src/submission/result.rs
@@ -1,3 +1,5 @@
+use alloc::{borrow::ToOwned, vec::Vec};
+
 use crate::{
     handle::Handle,
     queue::QueueElement,
@@ -153,7 +155,7 @@ impl FromQueueElement for InlineResult {
         // SAFETY: The data after the [`hel_sys::HelInlineResult`] is guaranteed
         // to be valid for up to `result.length` bytes.
         let inline_data = unsafe {
-            std::slice::from_raw_parts(inline_data.as_ptr() as *const u8, inline_data.len())
+            core::slice::from_raw_parts(inline_data.as_ptr() as *const u8, inline_data.len())
         };
 
         element.advance(size_of::<hel_sys::HelInlineResult>());


### PR DESCRIPTION
This is a prerequisite for servers that don't use a lightweight POSIX emulation.