### PR TITLE
thor: Add TxState::performDiscard and TxState::avertDiscard to mirror reclaim

### DIFF
--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -979,6 +979,13 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 			}
 
 			discardBatch.splice(discardBatch.end(), _discardList);
+
+			for(auto cachePage : discardBatch) {
+				auto *page = frg::container_of(cachePage, &ManagedPage::cachePage);
+				assert(page->discarded);
+				assert(page->transactionState == TxState::discardQueued);
+				page->transactionState = TxState::performDiscard;
+			}
 		}
 
 		if(batch.empty() && discardBatch.empty())
@@ -1060,7 +1067,7 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 				auto cachePage = discardBatch.pop_front();
 				auto *page = frg::container_of(cachePage, &ManagedPage::cachePage);
 				assert(page->discarded);
-				assert(page->transactionState == TxState::discardQueued);
+				assert(page->transactionState == TxState::performDiscard);
 
 				// Re-check the counts in case the page has been locked/re-used.
 				if(page->lockCount

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -983,8 +983,10 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 			for(auto cachePage : discardBatch) {
 				auto *page = frg::container_of(cachePage, &ManagedPage::cachePage);
 				assert(page->discarded);
-				assert(page->transactionState == TxState::discardQueued);
-				page->transactionState = TxState::performDiscard;
+				assert(page->transactionState == TxState::discardQueued
+						|| page->transactionState == TxState::avertDiscard);
+				if(page->transactionState == TxState::discardQueued)
+					page->transactionState = TxState::performDiscard;
 			}
 		}
 
@@ -1067,15 +1069,17 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 				auto cachePage = discardBatch.pop_front();
 				auto *page = frg::container_of(cachePage, &ManagedPage::cachePage);
 				assert(page->discarded);
-				assert(page->transactionState == TxState::performDiscard);
+				assert(page->transactionState == TxState::performDiscard
+						|| page->transactionState == TxState::avertDiscard);
 
-				// Re-check the counts in case the page has been locked/re-used.
-				if(page->lockCount
-						|| page->cachePage.useCount.load(std::memory_order_relaxed)) {
+				if(page->transactionState == TxState::avertDiscard) {
 					page->transactionState = TxState::none;
+					anyDiscardQueued |= _disposeDiscarded(page);
 					continue;
 				}
 
+				assert(!page->lockCount);
+				assert(!page->cachePage.useCount.load(std::memory_order_relaxed));
 				physical = page->physical;
 
 				if(physical != PhysicalAddr(-1))
@@ -1362,6 +1366,11 @@ Error ManagedSpace::lockPages(uintptr_t offset, size_t size) {
 				pit->transactionState = TxState::none;
 			}else if(pit->transactionState == TxState::performReclaim) {
 				pit->transactionState = TxState::avertReclaim;
+			}else if(pit->transactionState == TxState::discardQueued
+					|| pit->transactionState == TxState::performDiscard) {
+				// Handle discardQueued pages by moving them into avertDiscard.
+				// This avoids raising monitors on this code path.
+				pit->transactionState = TxState::avertDiscard;
 			}
 		}
 	}
@@ -1487,6 +1496,11 @@ void ManagedSpace::incrementUses(CachePage *cachePage) {
 			page->transactionState = TxState::none;
 		} else if(page->transactionState == TxState::performReclaim) {
 			page->transactionState = TxState::avertReclaim;
+		} else if(page->transactionState == TxState::discardQueued
+				|| page->transactionState == TxState::performDiscard) {
+			// Handle discardQueued pages by moving them into avertDiscard.
+			// This avoids raising monitors on this code path.
+			page->transactionState = TxState::avertDiscard;
 		}
 	}
 }
@@ -1632,6 +1646,12 @@ PhysicalRange BackingMemory::peekRange(uintptr_t offset, FetchFlags) {
 	if(!pit)
 		return PhysicalRange{};
 
+	if(pit->transactionState == ManagedSpace::TxState::performReclaim) {
+		pit->transactionState = ManagedSpace::TxState::avertReclaim;
+	} else if(pit->transactionState == ManagedSpace::TxState::performDiscard) {
+		pit->transactionState = ManagedSpace::TxState::avertDiscard;
+	}
+
 	return PhysicalRange{
 		.physical = pit->physical + misalign,
 		.size = kPageSize - misalign,
@@ -1655,6 +1675,12 @@ BackingMemory::touchRange(uintptr_t offset, size_t, FetchFlags) {
 
 	auto [pit, wasInserted] = _managed->pages.find_or_insert(index, _managed.get(), index);
 	assert(pit);
+
+	if(pit->transactionState == ManagedSpace::TxState::performReclaim) {
+		pit->transactionState = ManagedSpace::TxState::avertReclaim;
+	} else if(pit->transactionState == ManagedSpace::TxState::performDiscard) {
+		pit->transactionState = ManagedSpace::TxState::avertDiscard;
+	}
 
 	if(pit->physical == PhysicalAddr(-1)) {
 		PhysicalAddr physical = physicalAllocator->allocate(kPageSize);
@@ -1980,6 +2006,8 @@ PhysicalRange FrontalMemory::peekRange(uintptr_t offset, FetchFlags) {
 
 		if(pit->transactionState == ManagedSpace::TxState::performReclaim) {
 			pit->transactionState = ManagedSpace::TxState::avertReclaim;
+		} else if(pit->transactionState == ManagedSpace::TxState::performDiscard) {
+			pit->transactionState = ManagedSpace::TxState::avertDiscard;
 		}
 
 		return PhysicalRange{
@@ -2020,6 +2048,8 @@ FrontalMemory::touchRange(uintptr_t offset, size_t, FetchFlags flags) {
 				globalReclaimer->bumpPage(&pit->cachePage);
 			}else if(pit->transactionState == ManagedSpace::TxState::performReclaim) {
 				pit->transactionState = ManagedSpace::TxState::avertReclaim;
+			}else if(pit->transactionState == ManagedSpace::TxState::performDiscard) {
+				pit->transactionState = ManagedSpace::TxState::avertDiscard;
 			}
 
 			co_return kPageSize - misalign;
@@ -2167,6 +2197,11 @@ Error SwappableMemory::lockRange(uintptr_t offset, size_t size) {
 					pit->transactionState = ManagedSpace::TxState::none;
 				}else if(pit->transactionState == ManagedSpace::TxState::performReclaim) {
 					pit->transactionState = ManagedSpace::TxState::avertReclaim;
+				}else if(pit->transactionState == ManagedSpace::TxState::discardQueued
+						|| pit->transactionState == ManagedSpace::TxState::performDiscard) {
+					// Handle discardQueued pages by moving them into avertDiscard.
+					// This avoids raising monitors on this code path.
+					pit->transactionState = ManagedSpace::TxState::avertDiscard;
 				}
 			}
 		}
@@ -2234,6 +2269,8 @@ PhysicalRange SwappableMemory::peekRange(uintptr_t offset, FetchFlags) {
 
 		if(pit->transactionState == ManagedSpace::TxState::performReclaim) {
 			pit->transactionState = ManagedSpace::TxState::avertReclaim;
+		} else if(pit->transactionState == ManagedSpace::TxState::performDiscard) {
+			pit->transactionState = ManagedSpace::TxState::avertDiscard;
 		}
 
 		return PhysicalRange{
@@ -2287,6 +2324,8 @@ SwappableMemory::touchRange(uintptr_t offset, size_t, FetchFlags flags) {
 					globalReclaimer->bumpPage(&pit->cachePage);
 				}else if(pit->transactionState == ManagedSpace::TxState::performReclaim) {
 					pit->transactionState = ManagedSpace::TxState::avertReclaim;
+				}else if(pit->transactionState == ManagedSpace::TxState::performDiscard) {
+					pit->transactionState = ManagedSpace::TxState::avertDiscard;
 				}
 
 				co_return kPageSize - misalign;

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -675,11 +675,14 @@ struct ManagedSpace : CacheBundle {
 		// Page is owned by the ManagedSpace reclamation logic.
 		// Valid in LoadState::present.
 		avertReclaim,
-		// Page is in _discardList or the reclamation coroutine's local discard batch,
-		// awaiting fenceEphemeral() before its entry is erased.
+		// Page is in _discardList, waiting to be picked up by the reclamation coroutine.
 		// Page is owned by the ManagedSpace reclamation logic.
 		// Valid in any LoadState, with or without a frame.
 		discardQueued,
+		// Page has been picked up for discarding and is awaiting fenceEphemeral().
+		// Page is owned by the ManagedSpace reclamation logic.
+		// Valid in any LoadState, with or without a frame.
+		performDiscard,
 	};
 
 	// Struct that is attached to ManagedPage for the duration of
@@ -815,7 +818,7 @@ struct ManagedSpace : CacheBundle {
 		>
 	> _writebackList;
 
-	// Discarded pages awaiting a fenceEphemeral() before their entries are erased.
+	// Discarded pages waiting to be picked up by the reclamation coroutine.
 	// Protected by mutex.
 	CachePagesList _discardList;
 

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -677,12 +677,19 @@ struct ManagedSpace : CacheBundle {
 		avertReclaim,
 		// Page is in _discardList, waiting to be picked up by the reclamation coroutine.
 		// Page is owned by the ManagedSpace reclamation logic.
-		// Valid in any LoadState, with or without a frame.
+		// Valid in any LoadState, with or without a frame,
+		// with lockCount == 0 and useCount == 0.
 		discardQueued,
 		// Page has been picked up for discarding and is awaiting fenceEphemeral().
 		// Page is owned by the ManagedSpace reclamation logic.
-		// Valid in any LoadState, with or without a frame.
+		// Valid in any LoadState, with or without a frame,
+		// with lockCount == 0 and useCount == 0.
 		performDiscard,
+		// Page will not be discarded in this iteration but is still awaiting fenceEphemeral().
+		// The page may be in the _discardList (on discardQueued -> avertDiscard transitions).
+		// Page is owned by the ManagedSpace reclamation logic.
+		// Valid in any LoadState, with or without a frame.
+		avertDiscard,
 	};
 
 	// Struct that is attached to ManagedPage for the duration of
@@ -819,6 +826,7 @@ struct ManagedSpace : CacheBundle {
 	> _writebackList;
 
 	// Discarded pages waiting to be picked up by the reclamation coroutine.
+	// These pages are either in TxState::discardQueued or TxState::avertDiscard.
 	// Protected by mutex.
 	CachePagesList _discardList;
 


### PR DESCRIPTION
This closes an ABA: the previous code re-checked `useCount` and `lockCount` after `fenceEphemeral()` but these can go transition zero -> non-zero -> zero. Fix this by adding `performDiscard` and `avertDiscard` to the state machine.