### PR TITLE
thor, libblockfs: Discard pages beyond end of file after truncation

### DIFF
--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -789,25 +789,45 @@ Inode::ensureBackingBlocks(size_t offset, size_t length) {
 async::result<frg::expected<protocols::fs::Error>>
 Inode::resizeFile(size_t newSize) {
 	auto oldSize = fileSize();
+	auto newMappingSize = (newSize + 0xFFF) & ~size_t(0xFFF);
 
 	if (newSize > oldSize) {
 		// TODO(qookie): Technically we only need to assign 0
 		// blocks here, not allocate new ones. We also should
 		// zero out the new blocks.
 		FRG_CO_TRY(co_await ensureBackingBlocks(oldSize, newSize - oldSize));
+
+		// Grow fileSize() first so the backing memory never covers a page beyond EOF.
+		setFileSize(newSize);
+
+		// Resize the memory object last (afterwards, initialization requests can appear for pages in the new range).
+		auto resizeResult = co_await helix_ng::resizeMemory(
+				helix::BorrowedDescriptor{backingMemory}, newMappingSize);
+		HEL_CHECK(resizeResult.error());
 	} else if (newSize < oldSize) {
 		// TODO(qookie): Deallocate blocks if they're no longer within the file.
 		std::println("libblockfs: Shrinking an Ext2 file does not free data blocks!");
-	} else if (newSize == oldSize) {
+
+		// Shrink the memory object first so that no new pages appear beyond the new size.
+		auto resizeResult = co_await helix_ng::resizeMemory(
+				helix::BorrowedDescriptor{backingMemory}, newMappingSize);
+		HEL_CHECK(resizeResult.error());
+
+		// Discard the truncated pages without writeback.
+		auto oldMappingSize = (oldSize + 0xFFF) & ~size_t(0xFFF);
+		if (oldMappingSize > newMappingSize) {
+			auto invalidateResult = co_await helix_ng::invalidateMemory(
+					helix::BorrowedDescriptor{backingMemory}, newMappingSize,
+					oldMappingSize - newMappingSize, kHelInvalidateNoWriteback);
+			HEL_CHECK(invalidateResult.error());
+		}
+
+		// Shrink fileSize() last (after no initialization/writeback is in flight anymore).
+		setFileSize(newSize);
+	} else {
 		// Nothing to do.
 		co_return frg::success;
 	}
-
-	auto resizeResult = co_await helix_ng::resizeMemory(
-			helix::BorrowedDescriptor{backingMemory},
-			(newSize + 0xFFF) & ~size_t(0xFFF));
-	HEL_CHECK(resizeResult.error());
-	setFileSize(newSize);
 
 	updateInodeChecksum(fs, diskInode(), number);
 
@@ -1152,13 +1172,9 @@ async::result<void> FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 				&manage, helix::Dispatcher::global());
 		co_await submit.async_wait();
 		HEL_CHECK(manage.error());
-		if(manage.type() == kHelManageInitialize) {
-			assert(manage.offset() + manage.length() <= ((inode->fileSize() + 0xFFF) & ~size_t(0xFFF)));
-		}else{
-			if(!(manage.offset() + manage.length() <= ((inode->fileSize() + 0xFFF) & ~size_t(0xFFF)))) {
-				continue;
-			}
-		}
+
+		// This is guaranteed by our resizing logic (since shrinking of fileSize() happens after backing memory resize).
+		assert(manage.offset() + manage.length() <= ((inode->fileSize() + 0xFFF) & ~size_t(0xFFF)));
 
 		protocols::ostrace::Timer timer;
 		auto fileView = pool->importMemory(

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -927,6 +927,9 @@ struct HelSqWritebackFence {
 	size_t size;
 };
 
+//! Flag for kHelSubmitInvalidateMemory: discard dirty pages instead of writing them back.
+static const uint32_t kHelInvalidateNoWriteback = 1;
+
 //! SQ data for kHelSubmitInvalidateMemory.
 struct HelSqInvalidateMemory {
 	//! Handle to the memory object.
@@ -935,6 +938,8 @@ struct HelSqInvalidateMemory {
 	uintptr_t offset;
 	//! Size of the range.
 	size_t size;
+	//! Flags (kHelInvalidate*).
+	uint32_t flags;
 };
 
 //! SQ data for kHelSubmitPopulateSpace.

--- a/hel/include/helix/ipc.hpp
+++ b/hel/include/helix/ipc.hpp
@@ -1460,14 +1460,17 @@ private:
 
 template <typename Receiver>
 struct InvalidateMemoryOperation : private Context {
-	InvalidateMemoryOperation(BorrowedDescriptor memory, uintptr_t offset, size_t size, Receiver r)
-	: memory_{std::move(memory)}, offset_{offset}, size_{size}, r_{std::move(r)} {}
+	InvalidateMemoryOperation(BorrowedDescriptor memory, uintptr_t offset, size_t size,
+			uint32_t flags, Receiver r)
+	: memory_{std::move(memory)}, offset_{offset}, size_{size}, flags_{flags},
+			r_{std::move(r)} {}
 
 	void start() {
 		HelSqInvalidateMemory header;
 		header.handle = memory_.getHandle();
 		header.offset = offset_;
 		header.size = size_;
+		header.flags = flags_;
 
 		std::array segments{
 			std::as_bytes(std::span{&header, 1})
@@ -1492,24 +1495,27 @@ private:
 	BorrowedDescriptor memory_;
 	uintptr_t offset_;
 	size_t size_;
+	uint32_t flags_;
 	Receiver r_;
 };
 
 struct [[nodiscard]] InvalidateMemorySender {
 	using value_type = InvalidateMemoryResult;
 
-	InvalidateMemorySender(BorrowedDescriptor memory, uintptr_t offset, size_t size)
-	: memory_{std::move(memory)}, offset_{offset}, size_{size} { }
+	InvalidateMemorySender(BorrowedDescriptor memory, uintptr_t offset, size_t size,
+			uint32_t flags)
+	: memory_{std::move(memory)}, offset_{offset}, size_{size}, flags_{flags} { }
 
 	template<typename Receiver>
 	InvalidateMemoryOperation<Receiver> connect(Receiver receiver) {
-		return {std::move(memory_), offset_, size_, std::move(receiver)};
+		return {std::move(memory_), offset_, size_, flags_, std::move(receiver)};
 	}
 
 private:
 	BorrowedDescriptor memory_;
 	uintptr_t offset_;
 	size_t size_;
+	uint32_t flags_;
 };
 
 inline async::sender_awaiter<InvalidateMemorySender, InvalidateMemoryResult>
@@ -1517,8 +1523,9 @@ operator co_await (InvalidateMemorySender sender) {
 	return {std::move(sender)};
 }
 
-inline auto invalidateMemory(BorrowedDescriptor memory, uintptr_t offset, size_t size) {
-	return InvalidateMemorySender{std::move(memory), offset, size};
+inline auto invalidateMemory(BorrowedDescriptor memory, uintptr_t offset, size_t size,
+		uint32_t flags = 0) {
+	return InvalidateMemorySender{std::move(memory), offset, size, flags};
 }
 
 // --------------------------------------------------------------------

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -937,9 +937,15 @@ HelError doSubmitWritebackFence(HelHandle handle, smarter::shared_ptr<IpcQueue> 
 }
 
 HelError doSubmitInvalidateMemory(HelHandle handle, smarter::shared_ptr<IpcQueue> queue,
-		uintptr_t offset, size_t size, uintptr_t context) {
+		uintptr_t offset, size_t size, uint32_t flags, uintptr_t context) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
+
+	if(flags & ~kHelInvalidateNoWriteback)
+		return kHelErrIllegalArgs;
+	auto mode = (flags & kHelInvalidateNoWriteback)
+			? DiscardMode::dropDirty
+			: DiscardMode::keepDirty;
 
 	auto memoryOutcome = this_universe->resolveObject<DescriptorType::memoryView>(handle, kHelRightManage);
 	if(!memoryOutcome)
@@ -949,17 +955,17 @@ HelError doSubmitInvalidateMemory(HelHandle handle, smarter::shared_ptr<IpcQueue
 	if(!queue->validSize(ipcSourceSize(sizeof(HelSimpleResult))))
 		return kHelErrQueueTooSmall;
 
-	[](smarter::shared_ptr<MemoryView> memory, uintptr_t offset, size_t size,
+	[](smarter::shared_ptr<MemoryView> memory, uintptr_t offset, size_t size, DiscardMode mode,
 			smarter::shared_ptr<IpcQueue> queue, uintptr_t context,
 			enable_detached_coroutine) -> void {
-		auto outcome = co_await onExceptionalWq(memory->invalidateRange(offset, size));
+		auto outcome = co_await onExceptionalWq(memory->invalidateRange(offset, size, mode));
 
 		HelSimpleResult helResult{.error = kHelErrNone, .reserved = {}};
 		if (!outcome)
 			helResult.error = translateError(outcome.error());
 		QueueSource ipcSource{&helResult, sizeof(HelSimpleResult), nullptr};
 		co_await queue->submit(&ipcSource, context);
-	}(std::move(memory), offset, size, std::move(queue), context,
+	}(std::move(memory), offset, size, mode, std::move(queue), context,
 		enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 
 	return kHelErrNone;
@@ -4303,7 +4309,8 @@ void thor::submitFromSq(smarter::shared_ptr<IpcQueue> queue, uint32_t opcode,
 		}
 		HelSqInvalidateMemory sqData;
 		memcpy(&sqData, sqSpan.data(), sizeof(sqData));
-		error = doSubmitInvalidateMemory(sqData.handle, queue, sqData.offset, sqData.size, context);
+		error = doSubmitInvalidateMemory(sqData.handle, queue, sqData.offset, sqData.size,
+				sqData.flags, context);
 		break;
 	}
 	case kHelSubmitPopulateSpace: {

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -970,6 +970,7 @@ std::expected<smarter::shared_ptr<ManagedSpace>, Error> ManagedSpace::create(
 	self->selfPtr = self;
 	spawnOnWorkQueue(*kernelAlloc, WorkQueue::generalQueue().lock(), self->_runReclaimLoop());
 	spawnOnWorkQueue(*kernelAlloc, WorkQueue::generalQueue().lock(), self->_runDrainLoop());
+	spawnOnWorkQueue(*kernelAlloc, WorkQueue::generalQueue().lock(), self->_runInvalidationLoop());
 	return self;
 }
 
@@ -1219,6 +1220,54 @@ coroutine<void> ManagedSpace::_runDrainLoop() {
 	}
 }
 
+coroutine<void> ManagedSpace::_runInvalidationLoop() {
+	assert(!isSwapSpace);
+	while(true) {
+		co_await _discardEvent.async_wait_if([this] () -> bool {
+			auto irqLock = frg::guard(&irqMutex());
+			auto lock = frg::guard(&mutex);
+			return _invalidationList.empty();
+		});
+
+		CachePagesList batch;
+		{
+			auto irqLock = frg::guard(&irqMutex());
+			auto lock = frg::guard(&mutex);
+
+			batch.splice(batch.end(), _invalidationList);
+		}
+
+		CachePagesList processed;
+		while(!batch.empty()) {
+			// Coalesce runs of consecutive identities into a single eviction each.
+			auto index = batch.front()->identity;
+			size_t count = 0;
+			while(!batch.empty() && batch.front()->identity == index + count) {
+				processed.push_back(batch.pop_front());
+				count++;
+			}
+			co_await _evictQueue.breakRange(index << kPageShift, count << kPageShift);
+		}
+
+		bool raiseDiscard = false;
+		{
+			auto irqLock = frg::guard(&irqMutex());
+			auto lock = frg::guard(&mutex);
+
+			while(!processed.empty()) {
+				auto cachePage = processed.pop_front();
+				auto *page = frg::container_of(cachePage, &ManagedPage::cachePage);
+				assert(page->discarded);
+				assert(page->transactionState == TxState::invalidation);
+				page->transactionState = TxState::none;
+				raiseDiscard |= _disposeDiscarded(page);
+			}
+		}
+		if(raiseDiscard)
+			_discardEvent.raise();
+	}
+}
+
 bool ManagedSpace::claimSwapBudget(ManagedPage *) {
 	// File caches write back to their backing store, so no budget applies.
 	return true;
@@ -1276,7 +1325,7 @@ void ManagedSpace::discardPage(uint64_t index) {
 			// is on its local batch list.
 			break;
 		default:
-			// TxState::discardQueued/performDiscard/avertDiscard are unreachable:
+			// TxState::discardQueued/performDiscard/avertDiscard/invalidation are unreachable:
 			// they imply discarded, which the idempotence guard above returns on.
 			assert(!"discardPage() on page in unexpected transaction state");
 		}
@@ -1305,8 +1354,18 @@ bool ManagedSpace::_disposeDiscarded(ManagedPage *page) {
 	assert(page->discarded);
 	assert(page->transactionState == TxState::none);
 	assert(!page->monitors);
-	if(page->lockCount || page->cachePage.useCount.load(std::memory_order_relaxed))
+	if(page->lockCount)
 		return false;
+	if(page->cachePage.useCount.load(std::memory_order_relaxed)) {
+		// Swap slot identities cannot be translated back to view offsets;
+		// hence, swap spaces cannot use TxState::invalidation.
+		// Instead, discarded pages will be re-routed to _disposeDiscarded() when their useCount drops to zero.
+		if(isSwapSpace)
+			return false;
+		page->transactionState = TxState::invalidation;
+		_invalidationList.push_back(&page->cachePage);
+		return true;
+	}
 	page->transactionState = TxState::discardQueued;
 	_discardList.push_back(&page->cachePage);
 	return true;

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -20,6 +20,9 @@ namespace {
 	// The following flags are debugging options to debug the correctness of various components.
 	bool tortureUncaching = false;
 	constexpr bool disableUncaching = false;
+
+	// Number of pages that BackingMemory::invalidateRange() discards per critical section.
+	constexpr size_t discardChunkSize = 512;
 }
 
 // --------------------------------------------------------
@@ -1042,7 +1045,6 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 		MonitorPendingList pendingMonitors;
 		while(!batch.empty()) {
 			PhysicalAddr physical;
-			frg::intrusive_shared_ptr<TransactionMonitor, Allocator> invalidateMonitor;
 			{
 				auto irqLock = frg::guard(&irqMutex());
 				auto lock = frg::guard(&mutex);
@@ -1051,13 +1053,19 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 				auto *page = frg::container_of(cachePage, &ManagedPage::cachePage);
 
 				if(page->discarded) {
-					// Discards only happen at view teardown, when no invalidateRange()
-					// on the page can be in flight anymore.
-					assert(!page->forceInvalidation);
-					// The frame is being discarded so it doesn't need to be written back.
-					page->stillDirty = false;
-					page->transactionState = TxState::none;
-					anyDiscardQueued |= _disposeDiscarded(page);
+					if(page->discardMode == DiscardMode::keepDirty && page->stillDirty) {
+						// Dirty contents must still be written back before the entry is erased.
+						page->stillDirty = false;
+						page->transactionState = TxState::dirty;
+						_dirtyList.push_back(&page->cachePage);
+						anyDirty = true;
+					} else {
+						assert(!page->stillDirty || page->discardMode == DiscardMode::dropDirty);
+						// The frame is being discarded so it doesn't need to be written back.
+						page->stillDirty = false;
+						page->transactionState = TxState::none;
+						anyDiscardQueued |= _disposeDiscarded(page);
+					}
 					continue;
 				}
 
@@ -1087,17 +1095,10 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 				page->loadState = LoadState::missing;
 				page->transactionState = TxState::none;
 				page->physical = PhysicalAddr(-1);
-
-				if(page->forceInvalidation) {
-					invalidateMonitor = page->detachMonitor(MonitorType::forcedInvalidation);
-					page->forceInvalidation = false;
-				}
 			}
 
 			globalPfnDb().erase(physical);
 			physicalAllocator->free(physical, kPageSize);
-			if(invalidateMonitor)
-				invalidateMonitor->event.raise();
 			sizeFreed += kPageSize;
 		}
 
@@ -1114,8 +1115,17 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 						|| page->transactionState == TxState::avertDiscard);
 
 				if(page->transactionState == TxState::avertDiscard) {
-					page->transactionState = TxState::none;
-					anyDiscardQueued |= _disposeDiscarded(page);
+					if(page->discardMode == DiscardMode::keepDirty && page->stillDirty) {
+						// Dirty contents must still be written back before the entry is erased.
+						page->stillDirty = false;
+						page->transactionState = TxState::dirty;
+						_dirtyList.push_back(&page->cachePage);
+						anyDirty = true;
+					} else {
+						assert(!page->stillDirty || page->discardMode == DiscardMode::dropDirty);
+						page->transactionState = TxState::none;
+						anyDiscardQueued |= _disposeDiscarded(page);
+					}
 					continue;
 				}
 
@@ -1172,7 +1182,7 @@ coroutine<void> ManagedSpace::_runDrainLoop() {
 				auto *cp = *it++;
 				auto *page = frg::container_of(cp, &ManagedPage::cachePage);
 				assert(page->transactionState == TxState::dirty);
-				assert(!page->discarded);
+				assert(!page->discarded || page->discardMode == DiscardMode::keepDirty);
 				if(!claimSwapBudget(page))
 					continue;
 				_dirtyList.erase(_dirtyList.iterator_to(cp));
@@ -1199,12 +1209,15 @@ coroutine<void> ManagedSpace::_runDrainLoop() {
 				auto *page = frg::container_of(cp, &ManagedPage::cachePage);
 				assert(page->transactionState == TxState::pendingWriteback);
 				if(page->discarded) {
-					// The page was discarded while we were waiting for the fence.
-					// Note that claimSwapBudget() already ran for this page - _pageDiscarded() undoes the claim.
-					page->transactionState = TxState::none;
-					if(_disposeDiscarded(page))
-						anyDiscardQueued = true;
-					continue;
+					if(page->discardMode == DiscardMode::dropDirty) {
+						// The page was discarded while we were waiting for the fence.
+						// Note that claimSwapBudget() already ran for this page - _pageDiscarded() undoes the claim.
+						page->transactionState = TxState::none;
+						if(_disposeDiscarded(page))
+							anyDiscardQueued = true;
+						continue;
+					}
+					assert(page->discardMode == DiscardMode::keepDirty);
 				}
 				page->transactionState = TxState::wantWriteback;
 				page->attachMonitor(MonitorType::writeback);
@@ -1253,6 +1266,7 @@ coroutine<void> ManagedSpace::_runInvalidationLoop() {
 		}
 
 		bool raiseDiscard = false;
+		bool anyDirty = false;
 		{
 			auto irqLock = frg::guard(&irqMutex());
 			auto lock = frg::guard(&mutex);
@@ -1262,12 +1276,23 @@ coroutine<void> ManagedSpace::_runInvalidationLoop() {
 				auto *page = frg::container_of(cachePage, &ManagedPage::cachePage);
 				assert(page->discarded);
 				assert(page->transactionState == TxState::invalidation);
-				page->transactionState = TxState::none;
-				raiseDiscard |= _disposeDiscarded(page);
+				if(page->discardMode == DiscardMode::keepDirty && page->stillDirty) {
+					// Breaking the mappings revealed dirty contents. Write them back.
+					page->stillDirty = false;
+					page->transactionState = TxState::dirty;
+					_dirtyList.push_back(&page->cachePage);
+					anyDirty = true;
+				} else {
+					assert(!page->stillDirty || page->discardMode == DiscardMode::dropDirty);
+					page->transactionState = TxState::none;
+					raiseDiscard |= _disposeDiscarded(page);
+				}
 			}
 		}
 		if(raiseDiscard)
 			_discardEvent.raise();
+		if(anyDirty)
+			_dirtyEvent.raise();
 	}
 }
 
@@ -1276,11 +1301,13 @@ bool ManagedSpace::claimSwapBudget(ManagedPage *) {
 	return true;
 }
 
-void ManagedSpace::discardPage(ManagedPage *pit, bool &raiseDiscard,
+void ManagedSpace::discardPage(ManagedPage *pit, DiscardMode mode, bool &raiseDiscard,
 		MonitorPendingList &pendingMonitors) {
+	assert(mode != DiscardMode::none);
 	if(pit->discarded)
 		return;
 	pit->discarded = true;
+	pit->discardMode = mode;
 
 	bool dispose = false;
 	switch(pit->transactionState) {
@@ -1293,11 +1320,19 @@ void ManagedSpace::discardPage(ManagedPage *pit, bool &raiseDiscard,
 		dispose = true;
 		break;
 	case TxState::dirty:
+		if(mode == DiscardMode::keepDirty) {
+			// The page stays in _dirtyList. The writeback pipeline completes the discard.
+			break;
+		}
 		_dirtyList.erase(_dirtyList.iterator_to(&pit->cachePage));
 		pit->transactionState = TxState::none;
 		dispose = true;
 		break;
 	case TxState::wantWriteback: {
+		if(mode == DiscardMode::keepDirty) {
+			// updateRange() completes the discard once the writeback finishes.
+			break;
+		}
 		_writebackList.erase(_writebackList.iterator_to(&pit->cachePage));
 		auto writebackMonitor = pit->detachMonitor(MonitorType::writeback);
 		pendingMonitors.push_back(writebackMonitor.release());
@@ -1654,9 +1689,12 @@ void ManagedSpace::markDirty(CachePage *cachePage) {
 		if(page->loadState == LoadState::missing)
 			return;
 
-		// Discarded data must not re-enter the writeback machinery.
-		if(page->discarded)
-			return;
+		// Data discarded without writeback must not re-enter the writeback machinery.
+		if(page->discarded) {
+			if(page->discardMode == DiscardMode::dropDirty)
+				return;
+			assert(page->discardMode == DiscardMode::keepDirty);
+		}
 
 		// The in-memory contents now diverge from the backing store's copy.
 		page->swapCopyValid = false;
@@ -1679,6 +1717,11 @@ void ManagedSpace::markDirty(CachePage *cachePage) {
 			page->transactionState = TxState::avertReclaim;
 			page->stillDirty = true;
 		} else if(page->transactionState == TxState::writeback) {
+			page->stillDirty = true;
+		} else if(page->transactionState == TxState::invalidation
+				|| page->transactionState == TxState::avertDiscard) {
+			// Only reachable on DiscardMode::keepDirty pages.
+			// The discard machinery re-routes them to the writeback pipeline.
 			page->stillDirty = true;
 		} else {
 			assert(page->transactionState == TxState::dirty
@@ -1864,28 +1907,34 @@ Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t lengt
 				auto pit = _managed->pages.find(index);
 
 				if(pit->discarded) {
-					// Raise the monitor as usual - writebackFence() waiters hold references to it.
-					auto monitor = pit->detachMonitor(ManagedSpace::MonitorType::writeback);
-					assert(monitor);
-					pendingMonitors.push_back(monitor.release());
-					// The frame is being discarded so it doesn't need to be written back.
-					pit->stillDirty = false;
-					pit->transactionState = ManagedSpace::TxState::none;
-					raiseDiscard |= _managed->_disposeDiscarded(pit);
-					continue;
+					if(pit->discardMode == DiscardMode::dropDirty) {
+						// Raise the monitor as usual - writebackFence() waiters hold references to it.
+						auto monitor = pit->detachMonitor(ManagedSpace::MonitorType::writeback);
+						assert(monitor);
+						pendingMonitors.push_back(monitor.release());
+						// The frame is being discarded so it doesn't need to be written back.
+						pit->stillDirty = false;
+						pit->transactionState = ManagedSpace::TxState::none;
+						raiseDiscard |= _managed->_disposeDiscarded(pit);
+						continue;
+					}
+					assert(pit->discardMode == DiscardMode::keepDirty);
 				}
 				if(!pit->stillDirty) {
 					// The backing store now holds the page's current contents.
 					pit->swapCopyValid = true;
-					if (pit->lockCount || pit->cachePage.useCount.load(std::memory_order_relaxed)) {
+					auto monitor = pit->detachMonitor(ManagedSpace::MonitorType::writeback);
+					assert(monitor);
+					pendingMonitors.push_back(monitor.release());
+					if(pit->discarded) {
+						pit->transactionState = ManagedSpace::TxState::none;
+						raiseDiscard |= _managed->_disposeDiscarded(pit);
+					} else if (pit->lockCount || pit->cachePage.useCount.load(std::memory_order_relaxed)) {
 						pit->transactionState = ManagedSpace::TxState::none;
 					} else {
 						globalReclaimer->addPage(&pit->cachePage);
 						pit->transactionState = ManagedSpace::TxState::inReclaimer;
 					}
-					auto monitor = pit->detachMonitor(ManagedSpace::MonitorType::writeback);
-					assert(monitor);
-					pendingMonitors.push_back(monitor.release());
 				}else{
 					pit->stillDirty = false;
 					pit->transactionState = ManagedSpace::TxState::wantWriteback;
@@ -1972,80 +2021,80 @@ coroutine<frg::expected<Error>> BackingMemory::writebackFence(uintptr_t offset, 
 }
 
 coroutine<frg::expected<Error>> BackingMemory::invalidateRange(uintptr_t offset, size_t size) {
+	assert(currentIpl() == ipl::exceptionalWork);
 	if(_managed->isSwapSpace)
 		co_return Error::illegalObject;
 	if (offset & (kPageSize - 1))
 		co_return Error::illegalArgs;
 	if (size & (kPageSize - 1))
 		co_return Error::illegalArgs;
+	if (offset > backingMemoryLength || size > backingMemoryLength - offset)
+		co_return Error::bufferTooSmall;
 
-	size_t pg = 0;
-	while(pg < size) {
-		size_t index = (offset + pg) >> kPageShift;
-		frg::intrusive_shared_ptr<ManagedSpace::TransactionMonitor, Allocator> monitor;
-		bool shouldEvict = false;
-		ManagedSpace::ManagedPage *pit = nullptr;
+	auto firstPage = offset >> kPageShift;
+	auto limitPage = (offset + size) >> kPageShift;
+
+	// Mark the pages as discarded; dirty contents are still written back.
+	// Do this in chunks so that the spinlock is not held for an unbounded time.
+	uint64_t markCursor = firstPage;
+	bool raiseDiscard = false;
+	while(true) {
+		bool exhausted = false;
+		ManagedSpace::MonitorPendingList pendingMonitors;
 		{
 			auto irqLock = frg::guard(&irqMutex());
 			auto lock = frg::guard(&_managed->mutex);
 
-			pit = _managed->pages.find(index);
-			if(!pit || pit->loadState == ManagedSpace::LoadState::missing) {
-				pg += kPageSize;
-				continue;
-			}
-
-			if(pit->loadState == ManagedSpace::LoadState::present) {
-				if(pit->transactionState == ManagedSpace::TxState::performReclaim
-						|| pit->transactionState == ManagedSpace::TxState::avertReclaim) {
-					pit->forceInvalidation = true;
-					monitor = pit->findMonitor(ManagedSpace::MonitorType::forcedInvalidation);
-					if(!monitor)
-						monitor = pit->attachMonitor(ManagedSpace::MonitorType::forcedInvalidation);
-				} else if(pit->transactionState == ManagedSpace::TxState::wantWriteback
-						|| pit->transactionState == ManagedSpace::TxState::writeback) {
-					// Wait for the writeback to complete, then re-examine the page.
-					monitor = pit->findMonitor(ManagedSpace::MonitorType::writeback);
-				} else if(!pit->lockCount) {
-					if(pit->transactionState == ManagedSpace::TxState::inReclaimer)
-						globalReclaimer->removePage(&pit->cachePage);
-					pit->transactionState = ManagedSpace::TxState::performReclaim;
-					shouldEvict = true;
-				} else {
-					co_return Error::illegalArgs;
+			auto it = _managed->pages.lower_bound(markCursor);
+			for(size_t i = 0; i < discardChunkSize; ++i) {
+				if(it == _managed->pages.end() || it->cachePage.identity >= limitPage) {
+					exhausted = true;
+					break;
 				}
+				// discardPage() can erase the entry, so advance first.
+				auto *page = &*it;
+				markCursor = page->cachePage.identity + 1;
+				++it;
+				_managed->discardPage(page, DiscardMode::keepDirty,
+						raiseDiscard, pendingMonitors);
 			}
 		}
+		ManagedSpace::_raiseMonitors(pendingMonitors);
+		if(exhausted)
+			break;
+	}
 
-		if(shouldEvict) {
-			co_await _managed->_evictQueue.breakRange(index << kPageShift, kPageSize);
-			PhysicalAddr physical;
-			{
-				auto irqLock = frg::guard(&irqMutex());
-				auto lock = frg::guard(&_managed->mutex);
+	// Wake the invalidation coroutine only after everything is marked as discarded.
+	// This helps the invalidation coroutine to coelesce ranges.
+	if(raiseDiscard)
+		_managed->_discardEvent.raise();
 
-				if(pit->transactionState == ManagedSpace::TxState::performReclaim) {
-					physical = pit->physical;
-					pit->loadState = ManagedSpace::LoadState::missing;
-					pit->transactionState = ManagedSpace::TxState::none;
-					pit->physical = PhysicalAddr(-1);
-				} else {
-					physical = PhysicalAddr(-1);
-				}
+	// Wait until every previously discarded page is erased.
+	uint64_t waitCursor = firstPage;
+	while(true) {
+		bool done = false;
+		frg::intrusive_shared_ptr<ManagedSpace::TransactionMonitor, Allocator> monitor;
+		{
+			auto irqLock = frg::guard(&irqMutex());
+			auto lock = frg::guard(&_managed->mutex);
+
+			auto it = _managed->pages.lower_bound(waitCursor);
+			while(it != _managed->pages.end() && it->cachePage.identity < limitPage
+					&& !it->discarded)
+				++it;
+
+			if(it == _managed->pages.end() || it->cachePage.identity >= limitPage) {
+				done = true;
+			} else {
+				waitCursor = it->cachePage.identity;
+				monitor = it->findMonitor(ManagedSpace::MonitorType::discard);
+				if(!monitor)
+					monitor = it->attachMonitor(ManagedSpace::MonitorType::discard);
 			}
-			if(physical != PhysicalAddr(-1)) {
-				globalPfnDb().erase(physical);
-				physicalAllocator->free(physical, kPageSize);
-			}
-			if(physical != PhysicalAddr(-1))
-				pg += kPageSize;
-			continue;
 		}
-
-		if(monitor)
-			co_await monitor->event.wait();
-		else
-			pg += kPageSize;
+		if(done)
+			break;
+		co_await monitor->event.wait();
 	}
 
 	co_return {};
@@ -2230,7 +2279,8 @@ SwappableMemory::~SwappableMemory() {
 
 			auto pit = _space->pages.find(*it);
 			assert(pit);
-			_space->discardPage(pit, raiseDiscard, pendingMonitors);
+			_space->discardPage(pit, DiscardMode::dropDirty,
+					raiseDiscard, pendingMonitors);
 		}
 		ManagedSpace::_raiseMonitors(pendingMonitors);
 		if(raiseDiscard)

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -1039,6 +1039,7 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 		bool anyDiscardQueued = false;
 		bool anyDiscardErased = false;
 		size_t sizeFreed = 0;
+		MonitorPendingList pendingMonitors;
 		while(!batch.empty()) {
 			PhysicalAddr physical;
 			frg::intrusive_shared_ptr<TransactionMonitor, Allocator> invalidateMonitor;
@@ -1122,6 +1123,10 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 				assert(!page->cachePage.useCount.load(std::memory_order_relaxed));
 				physical = page->physical;
 
+				auto monitor = page->detachMonitor(MonitorType::discard);
+				if(monitor)
+					pendingMonitors.push_back(monitor.release());
+
 				if(physical != PhysicalAddr(-1))
 					globalPfnDb().erase(physical);
 				_pageDiscarded(page);
@@ -1135,6 +1140,7 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 			anyDiscardErased = true;
 		}
 
+		_raiseMonitors(pendingMonitors);
 		if(anyDirty || anyDiscardErased)
 			_dirtyEvent.raise();
 		if(anyDiscardQueued)
@@ -1156,10 +1162,7 @@ coroutine<void> ManagedSpace::_runDrainLoop() {
 			return _dirtyList.empty() || _drainBlocked;
 		});
 
-		frg::intrusive_list<
-			CachePage,
-			frg::locate_member<CachePage, frg::default_list_hook<CachePage>, &CachePage::listHook>
-		> pending;
+		CachePagesList pending;
 		{
 			auto irqLock = frg::guard(&irqMutex());
 			auto lock = frg::guard(&mutex);
@@ -1275,7 +1278,7 @@ bool ManagedSpace::claimSwapBudget(ManagedPage *) {
 
 void ManagedSpace::discardPage(uint64_t index) {
 	bool raiseDiscard = false;
-	frg::intrusive_shared_ptr<TransactionMonitor, Allocator> writebackMonitor;
+	MonitorPendingList pendingMonitors;
 	{
 		auto irqLock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&mutex);
@@ -1301,12 +1304,14 @@ void ManagedSpace::discardPage(uint64_t index) {
 			pit->transactionState = TxState::none;
 			dispose = true;
 			break;
-		case TxState::wantWriteback:
+		case TxState::wantWriteback: {
 			_writebackList.erase(_writebackList.iterator_to(&pit->cachePage));
-			writebackMonitor = pit->detachMonitor(MonitorType::writeback);
+			auto writebackMonitor = pit->detachMonitor(MonitorType::writeback);
+			pendingMonitors.push_back(writebackMonitor.release());
 			pit->transactionState = TxState::none;
 			dispose = true;
 			break;
+		}
 		case TxState::pendingWriteback:
 			// The drain coroutine completes the discard, the page is on
 			// its local pending list.
@@ -1344,8 +1349,7 @@ void ManagedSpace::discardPage(uint64_t index) {
 			}
 		}
 	}
-	if(writebackMonitor)
-		writebackMonitor->event.raise();
+	_raiseMonitors(pendingMonitors);
 	if(raiseDiscard)
 		_discardEvent.raise();
 }
@@ -1353,7 +1357,9 @@ void ManagedSpace::discardPage(uint64_t index) {
 bool ManagedSpace::_disposeDiscarded(ManagedPage *page) {
 	assert(page->discarded);
 	assert(page->transactionState == TxState::none);
-	assert(!page->monitors);
+	// Only the discard monitor may outlive the page's last transaction.
+	assert(!(page->attachedMonitors
+			& ~(uint8_t{1} << static_cast<unsigned int>(MonitorType::discard))));
 	if(page->lockCount)
 		return false;
 	if(page->cachePage.useCount.load(std::memory_order_relaxed)) {
@@ -1369,6 +1375,15 @@ bool ManagedSpace::_disposeDiscarded(ManagedPage *page) {
 	page->transactionState = TxState::discardQueued;
 	_discardList.push_back(&page->cachePage);
 	return true;
+}
+
+void ManagedSpace::_raiseMonitors(MonitorPendingList &pendingMonitors) {
+	while(!pendingMonitors.empty()) {
+		frg::intrusive_shared_ptr<TransactionMonitor, Allocator> monitor{
+			frg::adopt_rc, pendingMonitors.pop_front()
+		};
+		monitor->event.raise();
+	}
 }
 
 void ManagedSpace::_pageDiscarded(ManagedPage *) {}
@@ -1820,14 +1835,7 @@ Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t lengt
 	if (length & (kPageSize - 1))
 		return Error::illegalArgs;
 
-	frg::intrusive_list<
-		ManagedSpace::TransactionMonitor,
-		frg::locate_member<
-			ManagedSpace::TransactionMonitor,
-			frg::default_list_hook<ManagedSpace::TransactionMonitor>,
-			&ManagedSpace::TransactionMonitor::pendingHook
-		>
-	> pendingMonitors;
+	ManagedSpace::MonitorPendingList pendingMonitors;
 	bool raiseDiscard = false;
 	{
 		auto irqLock = frg::guard(&irqMutex());
@@ -1913,12 +1921,7 @@ Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t lengt
 	if(raiseDiscard)
 		_managed->_discardEvent.raise();
 
-	while(!pendingMonitors.empty()) {
-		frg::intrusive_shared_ptr<ManagedSpace::TransactionMonitor, Allocator> monitor{
-			frg::adopt_rc, pendingMonitors.pop_front()
-		};
-		monitor->event.raise();
-	}
+	ManagedSpace::_raiseMonitors(pendingMonitors);
 
 	return Error::success;
 }

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -400,7 +400,7 @@ coroutine<frg::expected<Error>> MemoryView::writebackFence(uintptr_t, size_t) {
 	co_return {};
 }
 
-coroutine<frg::expected<Error>> MemoryView::invalidateRange(uintptr_t, size_t) {
+coroutine<frg::expected<Error>> MemoryView::invalidateRange(uintptr_t, size_t, DiscardMode) {
 	co_return {};
 }
 
@@ -2020,7 +2020,8 @@ coroutine<frg::expected<Error>> BackingMemory::writebackFence(uintptr_t offset, 
 	co_return {};
 }
 
-coroutine<frg::expected<Error>> BackingMemory::invalidateRange(uintptr_t offset, size_t size) {
+coroutine<frg::expected<Error>> BackingMemory::invalidateRange(uintptr_t offset, size_t size,
+		DiscardMode mode) {
 	assert(currentIpl() == ipl::exceptionalWork);
 	if(_managed->isSwapSpace)
 		co_return Error::illegalObject;
@@ -2034,7 +2035,7 @@ coroutine<frg::expected<Error>> BackingMemory::invalidateRange(uintptr_t offset,
 	auto firstPage = offset >> kPageShift;
 	auto limitPage = (offset + size) >> kPageShift;
 
-	// Mark the pages as discarded; dirty contents are still written back.
+	// Mark the pages as discarded.
 	// Do this in chunks so that the spinlock is not held for an unbounded time.
 	uint64_t markCursor = firstPage;
 	bool raiseDiscard = false;
@@ -2055,8 +2056,7 @@ coroutine<frg::expected<Error>> BackingMemory::invalidateRange(uintptr_t offset,
 				auto *page = &*it;
 				markCursor = page->cachePage.identity + 1;
 				++it;
-				_managed->discardPage(page, DiscardMode::keepDirty,
-						raiseDiscard, pendingMonitors);
+				_managed->discardPage(page, mode, raiseDiscard, pendingMonitors);
 			}
 		}
 		ManagedSpace::_raiseMonitors(pendingMonitors);

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -923,6 +923,45 @@ size_t AllocatedMemory::getLength() {
 // ManagedSpace
 // --------------------------------------------------------
 
+frg::intrusive_shared_ptr<ManagedSpace::TransactionMonitor, Allocator>
+ManagedSpace::ManagedPage::attachMonitor(MonitorType type) {
+	auto bit = uint8_t{1} << static_cast<unsigned int>(type);
+	assert(!(attachedMonitors & bit));
+	attachedMonitors |= bit;
+	auto monitor = frg::allocate_intrusive_shared<TransactionMonitor>(Allocator{}, type);
+	ref_rc(monitor.get());
+	monitor->chainNext = monitors;
+	monitors = monitor.get();
+	return monitor;
+}
+
+frg::intrusive_shared_ptr<ManagedSpace::TransactionMonitor, Allocator>
+ManagedSpace::ManagedPage::findMonitor(MonitorType type) {
+	auto bit = uint8_t{1} << static_cast<unsigned int>(type);
+	if(!(attachedMonitors & bit))
+		return {};
+	auto ptr = monitors;
+	while(ptr->type != type)
+		ptr = ptr->chainNext;
+	ref_rc(ptr);
+	return {frg::adopt_rc, ptr};
+}
+
+frg::intrusive_shared_ptr<ManagedSpace::TransactionMonitor, Allocator>
+ManagedSpace::ManagedPage::detachMonitor(MonitorType type) {
+	auto bit = uint8_t{1} << static_cast<unsigned int>(type);
+	if(!(attachedMonitors & bit))
+		return {};
+	attachedMonitors &= ~bit;
+	auto link = &monitors;
+	while((*link)->type != type)
+		link = &(*link)->chainNext;
+	auto ptr = *link;
+	*link = ptr->chainNext;
+	ptr->chainNext = nullptr;
+	return {frg::adopt_rc, ptr};
+}
+
 std::expected<smarter::shared_ptr<ManagedSpace>, Error> ManagedSpace::create(
 		size_t length, bool readahead) {
 	if(length > backingMemoryLength)
@@ -1048,7 +1087,7 @@ coroutine<void> ManagedSpace::_runReclaimLoop() {
 				page->physical = PhysicalAddr(-1);
 
 				if(page->forceInvalidation) {
-					invalidateMonitor = std::move(page->monitor);
+					invalidateMonitor = page->detachMonitor(MonitorType::forcedInvalidation);
 					page->forceInvalidation = false;
 				}
 			}
@@ -1164,7 +1203,7 @@ coroutine<void> ManagedSpace::_runDrainLoop() {
 					continue;
 				}
 				page->transactionState = TxState::wantWriteback;
-				page->monitor = frg::allocate_intrusive_shared<TransactionMonitor>(Allocator{});
+				page->attachMonitor(MonitorType::writeback);
 				_writebackList.push_back(cp);
 			}
 
@@ -1214,7 +1253,7 @@ void ManagedSpace::discardPage(uint64_t index) {
 			break;
 		case TxState::wantWriteback:
 			_writebackList.erase(_writebackList.iterator_to(&pit->cachePage));
-			writebackMonitor = std::move(pit->monitor);
+			writebackMonitor = pit->detachMonitor(MonitorType::writeback);
 			pit->transactionState = TxState::none;
 			dispose = true;
 			break;
@@ -1238,7 +1277,7 @@ void ManagedSpace::discardPage(uint64_t index) {
 		// Erases entries without a frame right away instead of paying for a fenceEphemeral().
 		if(dispose) {
 			assert(pit->transactionState == TxState::none);
-			assert(!pit->monitor);
+			assert(!pit->monitors);
 			if(pit->physical == PhysicalAddr(-1)
 					&& !pit->lockCount
 					&& !pit->cachePage.useCount.load(std::memory_order_relaxed)) {
@@ -1258,7 +1297,7 @@ void ManagedSpace::discardPage(uint64_t index) {
 bool ManagedSpace::_disposeDiscarded(ManagedPage *page) {
 	assert(page->discarded);
 	assert(page->transactionState == TxState::none);
-	assert(!page->monitor);
+	assert(!page->monitors);
 	if(page->lockCount || page->cachePage.useCount.load(std::memory_order_relaxed))
 		return false;
 	page->transactionState = TxState::discardQueued;
@@ -1758,9 +1797,9 @@ Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t lengt
 					globalReclaimer->addPage(&pit->cachePage);
 					pit->transactionState = ManagedSpace::TxState::inReclaimer;
 				}
-				ref_rc(pit->monitor.get());
-				pendingMonitors.push_back(pit->monitor.get());
-				pit->monitor = {};
+				auto monitor = pit->detachMonitor(ManagedSpace::MonitorType::initialization);
+				assert(monitor);
+				pendingMonitors.push_back(monitor.release());
 			}
 		}else{
 			for(size_t pg = 0; pg < length; pg += kPageSize) {
@@ -1769,9 +1808,9 @@ Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t lengt
 
 				if(pit->discarded) {
 					// Raise the monitor as usual - writebackFence() waiters hold references to it.
-					ref_rc(pit->monitor.get());
-					pendingMonitors.push_back(pit->monitor.get());
-					pit->monitor = {};
+					auto monitor = pit->detachMonitor(ManagedSpace::MonitorType::writeback);
+					assert(monitor);
+					pendingMonitors.push_back(monitor.release());
 					// The frame is being discarded so it doesn't need to be written back.
 					pit->stillDirty = false;
 					pit->transactionState = ManagedSpace::TxState::none;
@@ -1787,17 +1826,18 @@ Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t lengt
 						globalReclaimer->addPage(&pit->cachePage);
 						pit->transactionState = ManagedSpace::TxState::inReclaimer;
 					}
-					ref_rc(pit->monitor.get());
-					pendingMonitors.push_back(pit->monitor.get());
-					pit->monitor = {};
+					auto monitor = pit->detachMonitor(ManagedSpace::MonitorType::writeback);
+					assert(monitor);
+					pendingMonitors.push_back(monitor.release());
 				}else{
 					pit->stillDirty = false;
 					pit->transactionState = ManagedSpace::TxState::wantWriteback;
 					_managed->_writebackList.push_back(&pit->cachePage);
-					ref_rc(pit->monitor.get());
-					pendingMonitors.push_back(pit->monitor.get());
+					auto monitor = pit->detachMonitor(ManagedSpace::MonitorType::writeback);
+					assert(monitor);
+					pendingMonitors.push_back(monitor.release());
 					// Note that the monitor is destroyed and re-created here.
-					pit->monitor = frg::allocate_intrusive_shared<ManagedSpace::TransactionMonitor>(Allocator{});
+					pit->attachMonitor(ManagedSpace::MonitorType::writeback);
 				}
 			}
 		}
@@ -1835,10 +1875,12 @@ coroutine<frg::expected<Error>> BackingMemory::writebackFence(uintptr_t offset, 
 				auto pit = _managed->pages.find(index);
 				if(pit) {
 					if(pit->transactionState == ManagedSpace::TxState::wantWriteback) {
-						monitor = pit->monitor;
+						monitor = pit->findMonitor(ManagedSpace::MonitorType::writeback);
+						assert(monitor);
 						break;
 					} else if(pit->transactionState == ManagedSpace::TxState::writeback) {
-						monitor = pit->monitor;
+						monitor = pit->findMonitor(ManagedSpace::MonitorType::writeback);
+						assert(monitor);
 						needSecond = true;
 						break;
 					}
@@ -1863,8 +1905,8 @@ coroutine<frg::expected<Error>> BackingMemory::writebackFence(uintptr_t offset, 
 
 				size_t index = (offset + pg) >> kPageShift;
 				auto pit = _managed->pages.find(index);
-				if(pit && pit->monitor)
-					monitor = pit->monitor;
+				if(pit)
+					monitor = pit->findMonitor(ManagedSpace::MonitorType::writeback);
 			}
 
 			if(monitor)
@@ -1905,11 +1947,13 @@ coroutine<frg::expected<Error>> BackingMemory::invalidateRange(uintptr_t offset,
 				if(pit->transactionState == ManagedSpace::TxState::performReclaim
 						|| pit->transactionState == ManagedSpace::TxState::avertReclaim) {
 					pit->forceInvalidation = true;
-					if(!pit->monitor)
-						pit->monitor = frg::allocate_intrusive_shared<ManagedSpace::TransactionMonitor>(Allocator{});
-					monitor = pit->monitor;
-				} else if(pit->monitor) {
-					monitor = pit->monitor;
+					monitor = pit->findMonitor(ManagedSpace::MonitorType::forcedInvalidation);
+					if(!monitor)
+						monitor = pit->attachMonitor(ManagedSpace::MonitorType::forcedInvalidation);
+				} else if(pit->transactionState == ManagedSpace::TxState::wantWriteback
+						|| pit->transactionState == ManagedSpace::TxState::writeback) {
+					// Wait for the writeback to complete, then re-examine the page.
+					monitor = pit->findMonitor(ManagedSpace::MonitorType::writeback);
 				} else if(!pit->lockCount) {
 					if(pit->transactionState == ManagedSpace::TxState::inReclaimer)
 						globalReclaimer->removePage(&pit->cachePage);
@@ -2067,7 +2111,7 @@ FrontalMemory::touchRange(uintptr_t offset, size_t, FetchFlags flags) {
 				&& pit->transactionState == ManagedSpace::TxState::none) {
 			pit->transactionState = ManagedSpace::TxState::wantInitialization;
 			_managed->_initializationList.push_back(&pit->cachePage);
-			pit->monitor = frg::allocate_intrusive_shared<ManagedSpace::TransactionMonitor>(Allocator{});
+			pit->attachMonitor(ManagedSpace::MonitorType::initialization);
 		}
 
 		// Perform readahead.
@@ -2082,13 +2126,14 @@ FrontalMemory::touchRange(uintptr_t offset, size_t, FetchFlags flags) {
 						&& pit->transactionState == ManagedSpace::TxState::none) {
 					pit->transactionState = ManagedSpace::TxState::wantInitialization;
 					_managed->_initializationList.push_back(&pit->cachePage);
-					pit->monitor = frg::allocate_intrusive_shared<ManagedSpace::TransactionMonitor>(Allocator{});
+					pit->attachMonitor(ManagedSpace::MonitorType::initialization);
 				}
 			}
 
 		_managed->_progressManagement(pendingManagement);
 
-		fetchMonitor = pit->monitor;
+		fetchMonitor = pit->findMonitor(ManagedSpace::MonitorType::initialization);
+		assert(fetchMonitor);
 	}
 
 	while(!pendingManagement.empty()) {
@@ -2360,11 +2405,12 @@ SwappableMemory::touchRange(uintptr_t offset, size_t, FetchFlags flags) {
 				if(pit->transactionState == ManagedSpace::TxState::none) {
 					pit->transactionState = ManagedSpace::TxState::wantInitialization;
 					_space->_initializationList.push_back(&pit->cachePage);
-					pit->monitor = frg::allocate_intrusive_shared<ManagedSpace::TransactionMonitor>(Allocator{});
+					pit->attachMonitor(ManagedSpace::MonitorType::initialization);
 				}
 
 				_space->_progressManagement(pendingManagement);
-				fetchMonitor = pit->monitor;
+				fetchMonitor = pit->findMonitor(ManagedSpace::MonitorType::initialization);
+				assert(fetchMonitor);
 			}
 		}
 

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -1276,82 +1276,72 @@ bool ManagedSpace::claimSwapBudget(ManagedPage *) {
 	return true;
 }
 
-void ManagedSpace::discardPage(uint64_t index) {
-	bool raiseDiscard = false;
-	MonitorPendingList pendingMonitors;
-	{
-		auto irqLock = frg::guard(&irqMutex());
-		auto lock = frg::guard(&mutex);
+void ManagedSpace::discardPage(ManagedPage *pit, bool &raiseDiscard,
+		MonitorPendingList &pendingMonitors) {
+	if(pit->discarded)
+		return;
+	pit->discarded = true;
 
-		auto pit = pages.find(index);
-		assert(pit);
-		if(pit->discarded)
-			return;
-		pit->discarded = true;
+	bool dispose = false;
+	switch(pit->transactionState) {
+	case TxState::none:
+		dispose = true;
+		break;
+	case TxState::inReclaimer:
+		globalReclaimer->removePage(&pit->cachePage);
+		pit->transactionState = TxState::none;
+		dispose = true;
+		break;
+	case TxState::dirty:
+		_dirtyList.erase(_dirtyList.iterator_to(&pit->cachePage));
+		pit->transactionState = TxState::none;
+		dispose = true;
+		break;
+	case TxState::wantWriteback: {
+		_writebackList.erase(_writebackList.iterator_to(&pit->cachePage));
+		auto writebackMonitor = pit->detachMonitor(MonitorType::writeback);
+		pendingMonitors.push_back(writebackMonitor.release());
+		pit->transactionState = TxState::none;
+		dispose = true;
+		break;
+	}
+	case TxState::pendingWriteback:
+		// The drain coroutine completes the discard, the page is on
+		// its local pending list.
+		break;
+	case TxState::wantInitialization:
+	case TxState::initialization:
+		// Initialization completes normally (e.g., to allow reading from already locked pages).
+		// updateRange() completes the discard.
+		break;
+	case TxState::writeback:
+		// updateRange() completes the discard.
+		break;
+	case TxState::performReclaim:
+	case TxState::avertReclaim:
+		// The reclamation coroutine completes the discard, the page
+		// is on its local batch list.
+		break;
+	default:
+		// TxState::discardQueued/performDiscard/avertDiscard/invalidation are unreachable:
+		// they imply discarded, which the idempotence guard above returns on.
+		assert(!"discardPage() on page in unexpected transaction state");
+	}
 
-		bool dispose = false;
-		switch(pit->transactionState) {
-		case TxState::none:
-			dispose = true;
-			break;
-		case TxState::inReclaimer:
-			globalReclaimer->removePage(&pit->cachePage);
-			pit->transactionState = TxState::none;
-			dispose = true;
-			break;
-		case TxState::dirty:
-			_dirtyList.erase(_dirtyList.iterator_to(&pit->cachePage));
-			pit->transactionState = TxState::none;
-			dispose = true;
-			break;
-		case TxState::wantWriteback: {
-			_writebackList.erase(_writebackList.iterator_to(&pit->cachePage));
-			auto writebackMonitor = pit->detachMonitor(MonitorType::writeback);
-			pendingMonitors.push_back(writebackMonitor.release());
-			pit->transactionState = TxState::none;
-			dispose = true;
-			break;
-		}
-		case TxState::pendingWriteback:
-			// The drain coroutine completes the discard, the page is on
-			// its local pending list.
-			break;
-		case TxState::wantInitialization:
-		case TxState::initialization:
-			// Initialization completes normally (e.g., to allow reading from already locked pages).
-			// updateRange() completes the discard.
-			break;
-		case TxState::writeback:
-			// updateRange() completes the discard.
-			break;
-		case TxState::performReclaim:
-		case TxState::avertReclaim:
-			// The reclamation coroutine completes the discard, the page
-			// is on its local batch list.
-			break;
-		default:
-			// TxState::discardQueued/performDiscard/avertDiscard/invalidation are unreachable:
-			// they imply discarded, which the idempotence guard above returns on.
-			assert(!"discardPage() on page in unexpected transaction state");
-		}
-
-		// Erases entries without a frame right away instead of paying for a fenceEphemeral().
-		if(dispose) {
-			assert(pit->transactionState == TxState::none);
-			assert(!pit->monitors);
-			if(pit->physical == PhysicalAddr(-1)
-					&& !pit->lockCount
-					&& !pit->cachePage.useCount.load(std::memory_order_relaxed)) {
-				_pageDiscarded(pit);
-				pages.erase(index);
-			} else {
-				raiseDiscard = _disposeDiscarded(pit);
-			}
+	// Erases entries without a frame right away instead of paying for a fenceEphemeral().
+	if(dispose) {
+		assert(pit->transactionState == TxState::none);
+		assert(!pit->monitors);
+		if(pit->physical == PhysicalAddr(-1)
+				&& !pit->lockCount
+				&& !pit->cachePage.useCount.load(std::memory_order_relaxed)) {
+			auto index = pit->cachePage.identity;
+			_pageDiscarded(pit);
+			pages.erase(index);
+		} else {
+			raiseDiscard |= _disposeDiscarded(pit);
 		}
 	}
-	_raiseMonitors(pendingMonitors);
-	if(raiseDiscard)
-		_discardEvent.raise();
 }
 
 bool ManagedSpace::_disposeDiscarded(ManagedPage *page) {
@@ -2239,8 +2229,21 @@ SwappableMemory::SwappableMemory(CtorToken, smarter::shared_ptr<SwapSpace> space
 }
 
 SwappableMemory::~SwappableMemory() {
-	for(auto it = _table.begin(); it != _table.end(); ++it)
-		_space->discardPage(*it);
+	for(auto it = _table.begin(); it != _table.end(); ++it) {
+		bool raiseDiscard = false;
+		ManagedSpace::MonitorPendingList pendingMonitors;
+		{
+			auto irqLock = frg::guard(&irqMutex());
+			auto lock = frg::guard(&_space->mutex);
+
+			auto pit = _space->pages.find(*it);
+			assert(pit);
+			_space->discardPage(pit, raiseDiscard, pendingMonitors);
+		}
+		ManagedSpace::_raiseMonitors(pendingMonitors);
+		if(raiseDiscard)
+			_space->_discardEvent.raise();
+	}
 	// Discarding may have released swap budget.
 	_space->_wakeDrain();
 }

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -1702,6 +1702,8 @@ std::expected<smarter::shared_ptr<BackingMemory>, Error> BackingMemory::create(
 }
 
 // Note: This resizes the ManagedSpace but it does not affect BackingMemory::getLength().
+// On shrink, the caller is responsible for discarding the truncated pages
+// (e.g., via invalidateRange()) before it reuses their backing store.
 coroutine<frg::expected<Error>> BackingMemory::resize(size_t newSize) {
 	assert(currentIpl() == ipl::exceptionalWork);
 	if(_managed->isSwapSpace)
@@ -1712,21 +1714,11 @@ coroutine<frg::expected<Error>> BackingMemory::resize(size_t newSize) {
 		co_return Error::illegalArgs;
 	auto newPages = newSize >> kPageShift;
 
-	size_t oldPages;
 	{
 		auto irqLock = frg::guard(&irqMutex());
 		auto lock = frg::guard(&_managed->mutex);
 
-		oldPages = _managed->numPages;
 		_managed->numPages = newPages;
-	}
-
-	if(newPages > oldPages) {
-		// Do nothing for now.
-	}else if(newPages < oldPages) {
-		// TODO: also free the affected pages!
-		co_await _managed->_evictQueue.breakRange(newPages << kPageShift,
-				(oldPages - newPages) << kPageShift);
 	}
 
 	co_return {};

--- a/kernel/thor/generic/memory-view.cpp
+++ b/kernel/thor/generic/memory-view.cpp
@@ -1233,7 +1233,8 @@ void ManagedSpace::discardPage(uint64_t index) {
 
 		auto pit = pages.find(index);
 		assert(pit);
-		assert(!pit->discarded);
+		if(pit->discarded)
+			return;
 		pit->discarded = true;
 
 		bool dispose = false;
@@ -1261,6 +1262,11 @@ void ManagedSpace::discardPage(uint64_t index) {
 			// The drain coroutine completes the discard, the page is on
 			// its local pending list.
 			break;
+		case TxState::wantInitialization:
+		case TxState::initialization:
+			// Initialization completes normally (e.g., to allow reading from already locked pages).
+			// updateRange() completes the discard.
+			break;
 		case TxState::writeback:
 			// updateRange() completes the discard.
 			break;
@@ -1270,8 +1276,9 @@ void ManagedSpace::discardPage(uint64_t index) {
 			// is on its local batch list.
 			break;
 		default:
-			// Initialization is only entered by fetches, which hold view references.
-			assert(!"discardPage() on page under initialization");
+			// TxState::discardQueued/performDiscard/avertDiscard are unreachable:
+			// they imply discarded, which the idempotence guard above returns on.
+			assert(!"discardPage() on page in unexpected transaction state");
 		}
 
 		// Erases entries without a frame right away instead of paying for a fenceEphemeral().
@@ -1787,19 +1794,20 @@ Error BackingMemory::updateRange(ManageRequest type, size_t offset, size_t lengt
 			for(size_t pg = 0; pg < length; pg += kPageSize) {
 				size_t index = (offset + pg) / kPageSize;
 				auto pit = _managed->pages.find(index);
-				// Initialization implies an in-flight fetch, which holds a view
-				// reference; discardPage() thus never sees this state.
-				assert(!pit->discarded);
 				pit->loadState = ManagedSpace::LoadState::present;
-				if (pit->lockCount || pit->cachePage.useCount.load(std::memory_order_relaxed)) {
+				auto monitor = pit->detachMonitor(ManagedSpace::MonitorType::initialization);
+				assert(monitor);
+				pendingMonitors.push_back(monitor.release());
+				if(pit->discarded) {
+					// The page completed initialization normally but will now be discarded.
+					pit->transactionState = ManagedSpace::TxState::none;
+					raiseDiscard |= _managed->_disposeDiscarded(pit);
+				} else if (pit->lockCount || pit->cachePage.useCount.load(std::memory_order_relaxed)) {
 					pit->transactionState = ManagedSpace::TxState::none;
 				} else {
 					globalReclaimer->addPage(&pit->cachePage);
 					pit->transactionState = ManagedSpace::TxState::inReclaimer;
 				}
-				auto monitor = pit->detachMonitor(ManagedSpace::MonitorType::initialization);
-				assert(monitor);
-				pendingMonitors.push_back(monitor.release());
 			}
 		}else{
 			for(size_t pg = 0; pg < length; pg += kPageSize) {

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -692,19 +692,34 @@ struct ManagedSpace : CacheBundle {
 		avertDiscard,
 	};
 
+	// Type of transaction that a TransactionMonitor is attached to.
+	enum class MonitorType : uint8_t {
+		initialization,
+		writeback,
+		forcedInvalidation,
+	};
+
 	// Struct that is attached to ManagedPage for the duration of
-	// a single transaction (i.e., initialization, writeback, or forced eviction).
-	// For initialization:
+	// a single transaction (i.e., initialization, writeback, or forced invalidation).
+	// At most one monitor per type can be attached at a time; the attached monitors
+	// form a chain headed by ManagedPage::monitors.
+	// For MonitorType::initialization:
 	// * Attached when entering TxState::wantInitialization.
 	// * Completed when leaving TxState::initialization.
-	// For writeback:
+	// For MonitorType::writeback:
 	// * Attached when entering TxState::wantWriteback.
 	// * Completed when leaving TxState::writeback.
-	// For forced eviction (invalidateRange() on a page already in TxState::performReclaim):
+	// For MonitorType::forcedInvalidation (invalidateRange() on a page under reclamation):
 	// * Attached by invalidateRange() while the page is in TxState::performReclaim.
 	// * Completed by the eviction coroutine after transitioning to LoadState::missing.
 	struct TransactionMonitor final : frg::intrusive_rc {
+		explicit TransactionMonitor(MonitorType type)
+		: type{type} { }
+
+		MonitorType type;
 		async::oneshot_primitive event;
+		// Next monitor attached to the same ManagedPage.
+		TransactionMonitor *chainNext{nullptr};
 		frg::default_list_hook<TransactionMonitor> pendingHook;
 	};
 
@@ -717,6 +732,13 @@ struct ManagedSpace : CacheBundle {
 		ManagedPage(const ManagedPage &) = delete;
 
 		ManagedPage &operator= (const ManagedPage &) = delete;
+
+		// Allocates and attaches a monitor of the given type; the type must not be attached yet.
+		frg::intrusive_shared_ptr<TransactionMonitor, Allocator> attachMonitor(MonitorType type);
+		// Returns the attached monitor of the given type, or null.
+		frg::intrusive_shared_ptr<TransactionMonitor, Allocator> findMonitor(MonitorType type);
+		// Detaches and returns the monitor of the given type, or null.
+		frg::intrusive_shared_ptr<TransactionMonitor, Allocator> detachMonitor(MonitorType type);
 
 		PhysicalAddr physical = PhysicalAddr(-1);
 		LoadState loadState{LoadState::missing};
@@ -739,7 +761,11 @@ struct ManagedSpace : CacheBundle {
 		bool swapBudgetClaimed{false};
 		unsigned int lockCount = 0;
 		CachePage cachePage;
-		frg::intrusive_shared_ptr<TransactionMonitor, Allocator> monitor;
+		// Head of the chain of monitors attached to this page's in-flight transactions.
+		// The page owns one reference (= refcount) of each of these monitors.
+		TransactionMonitor *monitors{nullptr};
+		// Bitmask (indexed by MonitorType) of the attached monitor types.
+		uint8_t attachedMonitors{0};
 	};
 
 	static std::expected<smarter::shared_ptr<ManagedSpace>, Error> create(

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -312,6 +312,17 @@ private:
 	async::post_ack_mechanism<RangeToEvict> mechanism_;
 };
 
+// Selects how the discard path treats dirty page contents.
+enum class DiscardMode : uint8_t {
+	// The page is not being discarded.
+	none,
+	// Dirty contents are dropped without writeback (truncation semantics).
+	dropDirty,
+	// Dirty contents are still written back before the entry is erased
+	// (invalidation semantics).
+	keepDirty,
+};
+
 // View on some pages of memory. This is the "frontend" part of a memory object.
 struct MemoryView {
 protected:
@@ -701,12 +712,11 @@ struct ManagedSpace : CacheBundle {
 	enum class MonitorType : uint8_t {
 		initialization,
 		writeback,
-		forcedInvalidation,
 		discard,
 	};
 
 	// Struct that is attached to ManagedPage for the duration of
-	// a single transaction (i.e., initialization, writeback, or forced invalidation).
+	// a single transaction (i.e., initialization or writeback) or of a discard.
 	// At most one monitor per type can be attached at a time; the attached monitors
 	// form a chain headed by ManagedPage::monitors.
 	// For MonitorType::initialization:
@@ -715,9 +725,6 @@ struct ManagedSpace : CacheBundle {
 	// For MonitorType::writeback:
 	// * Attached when entering TxState::wantWriteback.
 	// * Completed when leaving TxState::writeback.
-	// For MonitorType::forcedInvalidation (invalidateRange() on a page under reclamation):
-	// * Attached by invalidateRange() while the page is in TxState::performReclaim.
-	// * Completed by the eviction coroutine after transitioning to LoadState::missing.
 	// For MonitorType::discard (waiting for a discarded page's entry to be erased):
 	// * Attached by a waiter to any page that has `discarded` set, in any TxState;
 	//   it stays attached across intermediate transactions.
@@ -764,17 +771,16 @@ struct ManagedSpace : CacheBundle {
 		TxState transactionState{TxState::none};
 		// Whether the page is dirty even after a pending writeback completes.
 		// Can only be true in LoadState::present and TxState::writeback.
-		// If set in TxState::performReclaim or TxState::avertReclaim, causes transition to dirty.
+		// Eventually causes a transition to TxState::dirty (unless the page is discarded without writeback).
 		bool stillDirty{false};
-		// Set by invalidateRange() when the page is already in TxState::performReclaim,
-		// to request that the eviction coroutine raise monitor after completing
-		// the transition to LoadState::missing.
-		bool forceInvalidation{false};
 		// Whether the backing store's copy of the page matches its last in-memory contents.
 		// Maintained by markDirty()/updateRange().
 		bool swapCopyValid{false};
 		// The page is being torn down - see discardPage(). Set once, never cleared.
 		bool discarded{false};
+		// How dirty contents are treated during the discard.
+		// DiscardMode::none until discarded is set. Fixed by the first discardPage() call.
+		DiscardMode discardMode{DiscardMode::none};
 		// Whether swap budget was claimed for this page.
 		// Owned by SwapSpace, not used by ManagedSpace.
 		bool swapBudgetClaimed{false};
@@ -804,11 +810,11 @@ struct ManagedSpace : CacheBundle {
 	// Discards the given page. The entry is either immediately erased
 	// or once the in-flight transaction is completed. The frames are freed by
 	// the reclamation behind a fenceEphemeral().
-	// Idempotent: discarding an already discarded page is a no-op.
+	// Idempotent: discarding an already discarded page is a no-op (i.e., the first call fixes the mode).
 	// Must be called under mutex; the caller must raise the appended monitors
 	// (and _discardEvent, if requested) after dropping it.
 	// After a batch of discards the caller must call _wakeDrain() as discards may release swap budget.
-	void discardPage(ManagedPage *pit, bool &raiseDiscard,
+	void discardPage(ManagedPage *pit, DiscardMode mode, bool &raiseDiscard,
 			MonitorPendingList &pendingMonitors);
 
 	// Queues a discarded page for the reclamation coroutine, which erases its entry.

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -785,7 +785,7 @@ struct ManagedSpace : CacheBundle {
 	// Discards the page at the given index. The entry is either immediately erased
 	// or once the in-flight transaction is completed. The frames are freed by
 	// the reclamation behind a fenceEphemeral().
-	// Should only be called when the owning view is being destructed.
+	// Idempotent: discarding an already discarded page is a no-op.
 	// After a batch of discards the caller must call _wakeDrain() as discards may release swap budget.
 	void discardPage(uint64_t index);
 

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -702,6 +702,7 @@ struct ManagedSpace : CacheBundle {
 		initialization,
 		writeback,
 		forcedInvalidation,
+		discard,
 	};
 
 	// Struct that is attached to ManagedPage for the duration of
@@ -717,6 +718,10 @@ struct ManagedSpace : CacheBundle {
 	// For MonitorType::forcedInvalidation (invalidateRange() on a page under reclamation):
 	// * Attached by invalidateRange() while the page is in TxState::performReclaim.
 	// * Completed by the eviction coroutine after transitioning to LoadState::missing.
+	// For MonitorType::discard (waiting for a discarded page's entry to be erased):
+	// * Attached by a waiter to any page that has `discarded` set, in any TxState;
+	//   it stays attached across intermediate transactions.
+	// * Completed by the reclamation coroutine when the entry is erased.
 	struct TransactionMonitor final : frg::intrusive_rc {
 		explicit TransactionMonitor(MonitorType type)
 		: type{type} { }
@@ -727,6 +732,15 @@ struct ManagedSpace : CacheBundle {
 		TransactionMonitor *chainNext{nullptr};
 		frg::default_list_hook<TransactionMonitor> pendingHook;
 	};
+
+	using MonitorPendingList = frg::intrusive_list<
+		TransactionMonitor,
+		frg::locate_member<
+			TransactionMonitor,
+			frg::default_list_hook<TransactionMonitor>,
+			&TransactionMonitor::pendingHook
+		>
+	>;
 
 	struct ManagedPage {
 		ManagedPage(ManagedSpace *bundle, uint64_t identity) {
@@ -799,6 +813,10 @@ struct ManagedSpace : CacheBundle {
 	// Returns whether the caller must raise _discardEvent after dropping the mutex.
 	[[nodiscard]] bool _disposeDiscarded(ManagedPage *page);
 
+	// Raises (and releases the references of) the given detached monitors.
+	// Must be called without holding mutex.
+	static void _raiseMonitors(MonitorPendingList &pendingMonitors);
+
 	// Notifies the subclass that a discarded page's entry is about to be erased.
 	// Called under mutex.
 	virtual void _pageDiscarded(ManagedPage *page);
@@ -830,32 +848,11 @@ struct ManagedSpace : CacheBundle {
 
 	EvictionQueue _evictQueue;
 
-	frg::intrusive_list<
-		CachePage,
-		frg::locate_member<
-			CachePage,
-			frg::default_list_hook<CachePage>,
-			&CachePage::listHook
-		>
-	> _dirtyList;
+	CachePagesList _dirtyList;
 
-	frg::intrusive_list<
-		CachePage,
-		frg::locate_member<
-			CachePage,
-			frg::default_list_hook<CachePage>,
-			&CachePage::listHook
-		>
-	> _initializationList;
+	CachePagesList _initializationList;
 
-	frg::intrusive_list<
-		CachePage,
-		frg::locate_member<
-			CachePage,
-			frg::default_list_hook<CachePage>,
-			&CachePage::listHook
-		>
-	> _writebackList;
+	CachePagesList _writebackList;
 
 	// Discarded pages waiting to be picked up by the reclamation coroutine.
 	// These pages are either in TxState::discardQueued or TxState::avertDiscard.

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -801,12 +801,15 @@ struct ManagedSpace : CacheBundle {
 	// Returning false leaves the page on _dirtyList until swap budget becomes available.
 	virtual bool claimSwapBudget(ManagedPage *page);
 
-	// Discards the page at the given index. The entry is either immediately erased
+	// Discards the given page. The entry is either immediately erased
 	// or once the in-flight transaction is completed. The frames are freed by
 	// the reclamation behind a fenceEphemeral().
 	// Idempotent: discarding an already discarded page is a no-op.
+	// Must be called under mutex; the caller must raise the appended monitors
+	// (and _discardEvent, if requested) after dropping it.
 	// After a batch of discards the caller must call _wakeDrain() as discards may release swap budget.
-	void discardPage(uint64_t index);
+	void discardPage(ManagedPage *pit, bool &raiseDiscard,
+			MonitorPendingList &pendingMonitors);
 
 	// Queues a discarded page for the reclamation coroutine, which erases its entry.
 	// Must be called under mutex with transactionState == TxState::none.

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -690,6 +690,11 @@ struct ManagedSpace : CacheBundle {
 		// Page is owned by the ManagedSpace reclamation logic.
 		// Valid in any LoadState, with or without a frame.
 		avertDiscard,
+		// Page is in _invalidationList and waiting for existing mappings to be invalidated.
+		// Page is owned by the invalidation coroutine.
+		// Valid in any LoadState, with or without a frame.
+		// Never entered on SwapSpaces (slot identities cannot be translated back to view offsets).
+		invalidation,
 	};
 
 	// Type of transaction that a TransactionMonitor is attached to.
@@ -803,6 +808,7 @@ struct ManagedSpace : CacheBundle {
 
 	coroutine<void> _runReclaimLoop();
 	coroutine<void> _runDrainLoop();
+	coroutine<void> _runInvalidationLoop();
 
 	Error lockPages(uintptr_t offset, size_t size);
 	void unlockPages(uintptr_t offset, size_t size);
@@ -855,6 +861,12 @@ struct ManagedSpace : CacheBundle {
 	// These pages are either in TxState::discardQueued or TxState::avertDiscard.
 	// Protected by mutex.
 	CachePagesList _discardList;
+
+	// Discarded pages whose remaining mappings the invalidation coroutine breaks.
+	// These pages are in TxState::invalidation.
+	// Like _discardList, the owning coroutine is woken by _discardEvent.
+	// Protected by mutex.
+	CachePagesList _invalidationList;
 
 	ManageList _managementQueue;
 

--- a/kernel/thor/generic/thor-internal/memory-view.hpp
+++ b/kernel/thor/generic/thor-internal/memory-view.hpp
@@ -390,7 +390,8 @@ public:
 
 	virtual coroutine<frg::expected<Error>> writebackFence(uintptr_t offset, size_t size);
 
-	virtual coroutine<frg::expected<Error>> invalidateRange(uintptr_t offset, size_t size);
+	virtual coroutine<frg::expected<Error>> invalidateRange(uintptr_t offset, size_t size,
+			DiscardMode mode);
 
 	virtual Error setIndirection(size_t slot, smarter::shared_ptr<MemoryView> view,
 			uintptr_t offset, size_t size, CachingFlags flags);
@@ -949,7 +950,8 @@ public:
 	coroutine<frg::expected<Error, MemoryNotification>> pollNotification() override;
 	Error updateRange(ManageRequest type, size_t offset, size_t length) override;
 	coroutine<frg::expected<Error>> writebackFence(uintptr_t offset, size_t size) override;
-	coroutine<frg::expected<Error>> invalidateRange(uintptr_t offset, size_t size) override;
+	coroutine<frg::expected<Error>> invalidateRange(uintptr_t offset, size_t size,
+			DiscardMode mode) override;
 
 private:
 	smarter::shared_ptr<ManagedSpace> _managed;


### PR DESCRIPTION
This PR writes the `BackingMemory::invalidateRange()` function to re-use the discard code path that we introduced for anonymous swap. libblockfs uses this to discard the pages beyond the end of a file when the file is truncated.

Fix https://github.com/managarm/managarm/issues/1122