### PR TITLE
drivers/libblockfs: Lazily track dirty blocks in MetadataCache

### DIFF
--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -235,10 +235,7 @@ Inode::insertEntry(std::string name, int64_t ino, blockfs::FileType type) {
 		updateInodeChecksum(fs, target->diskInode(), ino);
 
 		// Flush the target inode to disk.
-		auto syncInode = co_await helix_ng::synchronizeSpace(
-				helix::BorrowedDescriptor{kHelNullHandle},
-				target->diskInode(), fs.inodeSize);
-		HEL_CHECK(syncInode.error());
+		target->diskInodeWindow.markDirty();
 
 		DirEntry entry;
 		entry.inode = ino;
@@ -263,10 +260,7 @@ Inode::insertEntry(std::string name, int64_t ino, blockfs::FileType type) {
 
 	updateInodeChecksum(fs, diskInode(), number);
 
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			diskInode(), fs.inodeSize);
-	HEL_CHECK(syncInode.error());
+	diskInodeWindow.markDirty();
 
 	// Space required for the new directory entry.
 	// We use name.size() + 1 for the entry name length to account for the null terminator
@@ -387,10 +381,7 @@ async::result<frg::expected<protocols::fs::Error>> Inode::removeEntry(std::strin
 
 			updateInodeChecksum(fs, target->diskInode(), targetIno);
 
-			auto syncInode = co_await helix_ng::synchronizeSpace(
-					helix::BorrowedDescriptor{kHelNullHandle},
-					target->diskInode(), fs.inodeSize);
-			HEL_CHECK(syncInode.error());
+			target->diskInodeWindow.markDirty();
 
 			// A removed subdirectory drops its ".." backlink to this directory.
 			if(target->fileType == kTypeDirectory) {
@@ -398,10 +389,7 @@ async::result<frg::expected<protocols::fs::Error>> Inode::removeEntry(std::strin
 
 				updateInodeChecksum(fs, diskInode(), number);
 
-				auto syncParent = co_await helix_ng::synchronizeSpace(
-						helix::BorrowedDescriptor{kHelNullHandle},
-						diskInode(), fs.inodeSize);
-				HEL_CHECK(syncParent.error());
+				diskInodeWindow.markDirty();
 			}
 
 			co_return {};
@@ -615,10 +603,7 @@ async::result<std::expected<DirEntry, protocols::fs::Error>> Inode::mkdir(std::s
 	updateInodeChecksum(fs, dirNode->diskInode(), dirNode->number);
 
 	// Synchronize the new directory's inode to update its linksCount
-	auto syncNewInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			dirNode->diskInode(), fs.inodeSize);
-	HEL_CHECK(syncNewInode.error());
+	dirNode->diskInodeWindow.markDirty();
 
 	// Synchronize the data blocks
 	auto syncNewDir = co_await helix_ng::synchronizeSpace(
@@ -701,10 +686,7 @@ async::result<std::expected<DirEntry, protocols::fs::Error>> Inode::symlink(std:
 
 	updateInodeChecksum(fs, newNode->diskInode(), newNode->number);
 
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			newNode->diskInode(), fs.inodeSize);
-	HEL_CHECK(syncInode.error());
+	newNode->diskInodeWindow.markDirty();
 
 	auto result = co_await insertEntry(name, newNode->number, kTypeSymlink);
 	if(!result)
@@ -719,10 +701,7 @@ async::result<protocols::fs::Error> Inode::chmod(int mode) {
 
 	updateInodeChecksum(fs, diskInode(), number);
 
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			diskInode(), fs.inodeSize);
-	HEL_CHECK(syncInode.error());
+	diskInodeWindow.markDirty();
 
 	co_return protocols::fs::Error::none;
 }
@@ -737,10 +716,7 @@ async::result<protocols::fs::Error> Inode::chown(std::optional<uid_t> uid, std::
 
 	updateInodeChecksum(fs, diskInode(), number);
 
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			diskInode(), fs.inodeSize);
-	HEL_CHECK(syncInode.error());
+	diskInodeWindow.markDirty();
 
 	co_return protocols::fs::Error::none;
 }
@@ -760,10 +736,7 @@ async::result<protocols::fs::Error> Inode::updateTimes(
 
 	updateInodeChecksum(fs, diskInode(), number);
 
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			diskInode(), fs.inodeSize);
-	HEL_CHECK(syncInode.error());
+	diskInodeWindow.markDirty();
 
 	co_return protocols::fs::Error::none;
 }
@@ -809,10 +782,7 @@ Inode::resizeFile(size_t newSize) {
 
 	updateInodeChecksum(fs, diskInode(), number);
 
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-		helix::BorrowedDescriptor{kHelNullHandle},
-		diskInode(), fs.inodeSize);
-	HEL_CHECK(syncInode.error());
+	diskInodeWindow.markDirty();
 
 	co_return frg::success;
 }
@@ -1685,10 +1655,7 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 	updateInodeChecksum(*this, diskInode, inode->number);
 
 	bgdtWriteback.raise();
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			inode->diskInode(), inodeSize);
-	HEL_CHECK(syncInode.error());
+	inode->diskInodeWindow.markDirty();
 
 	ostContext.emit(
 		ostEvtExt2AssignDataBlocks,
@@ -1911,10 +1878,7 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 	updateInodeChecksum(*this, inode->diskInode(), inode->number);
 
 	bgdtWriteback.raise();
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			inode->diskInode(), inodeSize);
-	HEL_CHECK(syncInode.error());
+	inode->diskInodeWindow.markDirty();
 
 	ostContext.emit(
 		ostEvtExt2AssignDataBlocks,

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -30,8 +30,6 @@ namespace ext2fs {
 namespace {
 	constexpr bool logSuperblock = true;
 
-	constexpr int pageShift = 12;
-
 	void updateInodeChecksum(FileSystem &fs, DiskInode *inode, uint32_t number) {
 		if(fs.metadataChecksum) {
 			inode->osd2.checksumLow = 0;
@@ -860,7 +858,6 @@ async::result<void> FileSystem::init() {
 	inodeSize = sb.inodeSize;
 	blockShift = 10 + sb.logBlockSize;
 	blockSize = 1024 << sb.logBlockSize;
-	blockPagesShift = blockShift < pageShift ? pageShift : blockShift;
 	sectorsPerBlock = blockSize / device->sectorSize;
 	blocksPerGroup = sb.blocksPerGroup;
 	inodesPerGroup = sb.inodesPerGroup;
@@ -1024,11 +1021,6 @@ async::result<std::shared_ptr<BaseInode>> FileSystem::createRegular(int uid, int
 
 	updateInodeChecksum(*this, disk_inode, ino);
 
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			disk_inode, inodeSize);
-	HEL_CHECK(syncInode.error());
-
 	co_return accessInode(ino);
 }
 
@@ -1060,11 +1052,6 @@ async::result<std::shared_ptr<Inode>> FileSystem::createDirectory() {
 
 	updateInodeChecksum(*this, disk_inode, ino);
 
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			disk_inode, inodeSize);
-	HEL_CHECK(syncInode.error());
-
 	co_return std::static_pointer_cast<Inode>(accessInode(ino));
 }
 
@@ -1088,11 +1075,6 @@ async::result<std::shared_ptr<Inode>> FileSystem::createSymlink() {
 	disk_inode->mtime = time.tv_sec;
 
 	updateInodeChecksum(*this, disk_inode, ino);
-
-	auto syncInode = co_await helix_ng::synchronizeSpace(
-			helix::BorrowedDescriptor{kHelNullHandle},
-			disk_inode, inodeSize);
-	HEL_CHECK(syncInode.error());
 
 	co_return std::static_pointer_cast<Inode>(accessInode(ino));
 }
@@ -1245,11 +1227,6 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 						updateBlockBitmapChecksum(*this, &bgdt[preferred_bg], words, blockSize);
 						updateBlockGroupChecksum(*this, &bgdt[preferred_bg], preferred_bg);
 
-						auto syncBitmap = co_await helix_ng::synchronizeSpace(
-								helix::BorrowedDescriptor{kHelNullHandle},
-								words, 1 << blockPagesShift);
-						HEL_CHECK(syncBitmap.error());
-
 						ostContext.emit(
 							ostEvtExt2AllocateBlocks,
 							ostAttrTime(timer.elapsed())
@@ -1262,11 +1239,6 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 			if(!result.empty()) {
 				updateBlockBitmapChecksum(*this, &bgdt[preferred_bg], words, blockSize);
 				updateBlockGroupChecksum(*this, &bgdt[preferred_bg], preferred_bg);
-
-				auto syncBitmap = co_await helix_ng::synchronizeSpace(
-						helix::BorrowedDescriptor{kHelNullHandle},
-						words, 1 << blockPagesShift);
-				HEL_CHECK(syncBitmap.error());
 			}
 		}
 	}
@@ -1299,11 +1271,6 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 					updateBlockBitmapChecksum(*this, &bgdt[bg_idx], words, blockSize);
 					updateBlockGroupChecksum(*this, &bgdt[bg_idx], bg_idx);
 
-					auto syncBitmap = co_await helix_ng::synchronizeSpace(
-							helix::BorrowedDescriptor{kHelNullHandle},
-							words, 1 << blockPagesShift);
-					HEL_CHECK(syncBitmap.error());
-
 					ostContext.emit(
 						ostEvtExt2AllocateBlocks,
 						ostAttrTime(timer.elapsed())
@@ -1315,11 +1282,6 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 
 		updateBlockBitmapChecksum(*this, &bgdt[bg_idx], words, blockSize);
 		updateBlockGroupChecksum(*this, &bgdt[bg_idx], bg_idx);
-
-		auto syncBitmap = co_await helix_ng::synchronizeSpace(
-				helix::BorrowedDescriptor{kHelNullHandle},
-				words, 1 << blockPagesShift);
-		HEL_CHECK(syncBitmap.error());
 	}
 
 	assert(!"Failed to find zero-bit");
@@ -1359,11 +1321,6 @@ async::result<uint32_t> FileSystem::allocateInode(uint32_t parentIno, bool direc
 				updateBlockGroupChecksum(*this, &bgdt[bg], bg);
 
 				bgdtWriteback.raise();
-
-				auto syncBitmap = co_await helix_ng::synchronizeSpace(
-						helix::BorrowedDescriptor{kHelNullHandle},
-						words, 1 << blockPagesShift);
-				HEL_CHECK(syncBitmap.error());
 
 				ostContext.emit(
 					ostEvtExt2AllocateInode,

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -535,7 +535,6 @@ struct FileSystem final : BaseFileSystem {
 	uint16_t inodeSize;
 	uint32_t blockShift;
 	uint32_t blockSize;
-	uint32_t blockPagesShift;
 	uint32_t sectorsPerBlock;
 	uint32_t numBlockGroups;
 	uint32_t blocksPerGroup;

--- a/drivers/libblockfs/src/metadata-cache.cpp
+++ b/drivers/libblockfs/src/metadata-cache.cpp
@@ -1,6 +1,8 @@
 #include <bit>
 #include <string.h>
+#include <utility>
 
+#include <frg/mutex.hpp>
 #include <helix/dispatcher-pool.hpp>
 
 #include "metadata-cache.hpp"
@@ -9,6 +11,8 @@ namespace blockfs {
 
 namespace {
 	constexpr uint32_t pageShift = 12;
+	// Number of blocks that stay locked and mapped after their last BlockWindow is gone.
+	constexpr size_t lruCapacity = 128;
 }
 
 MetadataCache::MetadataCache(BlockDevice *device, uint64_t numBlocks, size_t blockSize)
@@ -25,10 +29,87 @@ MetadataCache::MetadataCache(BlockDevice *device, uint64_t numBlocks, size_t blo
 	frontal_ = helix::UniqueDescriptor{frontal};
 
 	manage_(helix::UniqueDescriptor{backing});
+	flushDirty_();
+}
+
+void MetadataCache::CacheBlockPolicy::increment() const {
+	cacheBlock_->refCount.increment();
+}
+
+void MetadataCache::CacheBlockPolicy::decrement() const {
+	if(cacheBlock_->refCount.decrement_and_check_if_zero())
+		cacheBlock_->cache->destroyCacheBlock_(cacheBlock_);
+}
+
+void MetadataCache::BlockWindow::markDirty() {
+	assert(cacheBlock_);
+	cacheBlock_->cache->markDirty_(cacheBlock_);
+}
+
+MetadataCache::CacheBlockPtr MetadataCache::findCacheBlock_(uint64_t block) {
+	CacheBlockPtr evicted; // Drop after the lock.
+	CacheBlockPtr cacheBlock;
+	{
+		std::lock_guard cacheBlockLock{cacheBlockMutex_};
+
+		auto it = cacheBlocks_.find(block);
+		if(it == cacheBlocks_.end())
+			return nullptr;
+		// The entry may refer to a cache block that already expired but did not erase it yet.
+		if(!it->second->refCount.increment_if_nonzero())
+			return nullptr;
+		cacheBlock = CacheBlockPtr{smarter::adopt_rc, it->second, CacheBlockPolicy{it->second}};
+		evicted = touchLru_(cacheBlock.get());
+	}
+	return cacheBlock;
+}
+
+// Moves the cache block to the front of the LRU.
+// Returns a cache block evicted to make room, if any.
+// The caller must drop that reference only after releasing cacheBlockMutex_.
+MetadataCache::CacheBlockPtr MetadataCache::touchLru_(CacheBlock *cacheBlock) {
+	if(cacheBlock->inLru) {
+		lru_.erase(lru_.iterator_to(cacheBlock));
+		lru_.push_front(cacheBlock);
+		return nullptr;
+	}
+	// LRU owns a reference to the cache block.
+	cacheBlock->refCount.increment();
+	lru_.push_front(cacheBlock);
+	cacheBlock->inLru = true;
+	if(++lruSize_ <= lruCapacity)
+		return nullptr;
+	auto *evicted = lru_.pop_back();
+	evicted->inLru = false;
+	--lruSize_;
+	return CacheBlockPtr{smarter::adopt_rc, evicted, CacheBlockPolicy{evicted}};
+}
+
+void MetadataCache::destroyCacheBlock_(CacheBlock *cacheBlock) {
+	{
+		std::lock_guard cacheBlockLock{cacheBlockMutex_};
+
+		assert(!cacheBlock->inLru);
+		// The entry may already refer to a replacement cache block that was created after this one expired.
+		auto it = cacheBlocks_.find(cacheBlock->block);
+		if(it != cacheBlocks_.end() && it->second == cacheBlock)
+			cacheBlocks_.erase(it);
+	}
+	delete cacheBlock;
 }
 
 async::result<MetadataCache::BlockWindow> MetadataCache::access(uint64_t block, bool writable) {
 	assert(block < numBlocks_);
+
+	if(auto cacheBlock = findCacheBlock_(block))
+		co_return BlockWindow{std::move(cacheBlock), writable};
+
+	co_await creationMutex_.async_lock();
+	frg::unique_lock creationLock{frg::adopt_lock, creationMutex_};
+
+	if(auto cacheBlock = findCacheBlock_(block))
+		co_return BlockWindow{std::move(cacheBlock), writable};
+
 	auto frameSize = size_t{1} << blockPagesShift_;
 
 	helix::LockMemoryView lockMemory;
@@ -37,13 +118,17 @@ async::result<MetadataCache::BlockWindow> MetadataCache::access(uint64_t block, 
 	co_await submit.async_wait();
 	HEL_CHECK(lockMemory.error());
 
-	uint32_t flags = kHelMapProtRead | kHelMapDontRequireBacking;
-	if(writable)
-		flags |= kHelMapProtWrite;
 	helix::Mapping mapping{frontal_, static_cast<ptrdiff_t>(block << blockPagesShift_),
-			frameSize, flags};
+			frameSize, kHelMapProtRead | kHelMapProtWrite | kHelMapDontRequireBacking};
 
-	co_return BlockWindow{lockMemory.descriptor(), std::move(mapping)};
+	auto cacheBlock = CacheBlock::create(this, block, lockMemory.descriptor(), std::move(mapping));
+	CacheBlockPtr evicted; // Drop after the lock.
+	{
+		std::lock_guard cacheBlockLock{cacheBlockMutex_};
+		cacheBlocks_[block] = cacheBlock.get();
+		evicted = touchLru_(cacheBlock.get());
+	}
+	co_return BlockWindow{std::move(cacheBlock), writable};
 }
 
 async::result<void> MetadataCache::read(uint64_t block, size_t offset, size_t length, void *buffer) {
@@ -95,6 +180,47 @@ async::result<void> MetadataCache::serviceRequest_(helix::BorrowedDescriptor bac
 	}
 
 	HEL_CHECK(helUpdateMemory(backing.getHandle(), type, offset, length));
+}
+
+void MetadataCache::markDirty_(CacheBlockPtr cacheBlock) {
+	{
+		std::lock_guard dirtyLock{dirtyMutex_};
+
+		// An entry that is already queued is covered by the raise that queued it.
+		if(!dirtyCacheBlocks_.insert(std::move(cacheBlock)).second)
+			return;
+	}
+
+	dirtyEvent_.raise();
+}
+
+async::detached MetadataCache::flushDirty_() {
+	// Cache blocks dirtied while a batch is being synchronized are picked up by the next iteration.
+	uint64_t seenSeq = 0;
+	std::vector<CacheBlockPtr> batch;
+	while(true) {
+		co_await dirtyEvent_.async_wait(seenSeq);
+
+		{
+			std::lock_guard dirtyLock{dirtyMutex_};
+
+			// Take the sequence together with the batch, so that no request is missed.
+			// TODO: Use async::sequenced_event::current_sequence() once it exists.
+			seenSeq = dirtyEvent_.next_sequence() - 1;
+			batch.assign(dirtyCacheBlocks_.begin(), dirtyCacheBlocks_.end());
+			dirtyCacheBlocks_.clear();
+		}
+
+		for(auto &cacheBlock : batch) {
+			auto synchronize = co_await helix_ng::synchronizeSpace(
+					helix::BorrowedDescriptor{kHelNullHandle},
+					cacheBlock->mapping.get(), cacheBlock->mapping.size());
+			HEL_CHECK(synchronize.error());
+		}
+
+		// Drop the references that kept the mappings alive across the writeback.
+		batch.clear();
+	}
 }
 
 } // namespace blockfs

--- a/drivers/libblockfs/src/metadata-cache.cpp
+++ b/drivers/libblockfs/src/metadata-cache.cpp
@@ -28,6 +28,11 @@ MetadataCache::MetadataCache(BlockDevice *device, uint64_t numBlocks, size_t blo
 			0, &backing, &frontal));
 	frontal_ = helix::UniqueDescriptor{frontal};
 
+	// The mapping is lazy, i.e., its cost does not scale with the cache size.
+	mapping_ = helix::Mapping{frontal_, 0,
+			static_cast<size_t>(numBlocks << blockPagesShift_),
+			kHelMapProtRead | kHelMapProtWrite | kHelMapDontRequireBacking};
+
 	manage_(helix::UniqueDescriptor{backing});
 	flushDirty_();
 }
@@ -43,7 +48,7 @@ void MetadataCache::CacheBlockPolicy::decrement() const {
 
 void MetadataCache::BlockWindow::markDirty() {
 	assert(cacheBlock_);
-	cacheBlock_->cache->markDirty_(cacheBlock_);
+	cacheBlock_->cache->markDirty_(cacheBlock_->block);
 }
 
 MetadataCache::CacheBlockPtr MetadataCache::findCacheBlock_(uint64_t block) {
@@ -118,10 +123,7 @@ async::result<MetadataCache::BlockWindow> MetadataCache::access(uint64_t block, 
 	co_await submit.async_wait();
 	HEL_CHECK(lockMemory.error());
 
-	helix::Mapping mapping{frontal_, static_cast<ptrdiff_t>(block << blockPagesShift_),
-			frameSize, kHelMapProtRead | kHelMapProtWrite | kHelMapDontRequireBacking};
-
-	auto cacheBlock = CacheBlock::create(this, block, lockMemory.descriptor(), std::move(mapping));
+	auto cacheBlock = CacheBlock::create(this, block, lockMemory.descriptor());
 	CacheBlockPtr evicted; // Drop after the lock.
 	{
 		std::lock_guard cacheBlockLock{cacheBlockMutex_};
@@ -182,12 +184,12 @@ async::result<void> MetadataCache::serviceRequest_(helix::BorrowedDescriptor bac
 	HEL_CHECK(helUpdateMemory(backing.getHandle(), type, offset, length));
 }
 
-void MetadataCache::markDirty_(CacheBlockPtr cacheBlock) {
+void MetadataCache::markDirty_(uint64_t block) {
 	{
 		std::lock_guard dirtyLock{dirtyMutex_};
 
 		// An entry that is already queued is covered by the raise that queued it.
-		if(!dirtyCacheBlocks_.insert(std::move(cacheBlock)).second)
+		if(!dirtyBlocks_.insert(block).second)
 			return;
 	}
 
@@ -195,9 +197,9 @@ void MetadataCache::markDirty_(CacheBlockPtr cacheBlock) {
 }
 
 async::detached MetadataCache::flushDirty_() {
-	// Cache blocks dirtied while a batch is being synchronized are picked up by the next iteration.
+	// Blocks dirtied while a batch is being synchronized are picked up by the next iteration.
 	uint64_t seenSeq = 0;
-	std::vector<CacheBlockPtr> batch;
+	std::vector<uint64_t> batch;
 	while(true) {
 		co_await dirtyEvent_.async_wait(seenSeq);
 
@@ -207,19 +209,17 @@ async::detached MetadataCache::flushDirty_() {
 			// Take the sequence together with the batch, so that no request is missed.
 			// TODO: Use async::sequenced_event::current_sequence() once it exists.
 			seenSeq = dirtyEvent_.next_sequence() - 1;
-			batch.assign(dirtyCacheBlocks_.begin(), dirtyCacheBlocks_.end());
-			dirtyCacheBlocks_.clear();
+			batch.assign(dirtyBlocks_.begin(), dirtyBlocks_.end());
+			dirtyBlocks_.clear();
 		}
 
-		for(auto &cacheBlock : batch) {
+		auto frameSize = size_t{1} << blockPagesShift_;
+		for(auto block : batch) {
 			auto synchronize = co_await helix_ng::synchronizeSpace(
 					helix::BorrowedDescriptor{kHelNullHandle},
-					cacheBlock->mapping.get(), cacheBlock->mapping.size());
+					blockAddress_(block), frameSize);
 			HEL_CHECK(synchronize.error());
 		}
-
-		// Drop the references that kept the mappings alive across the writeback.
-		batch.clear();
 	}
 }
 

--- a/drivers/libblockfs/src/metadata-cache.hpp
+++ b/drivers/libblockfs/src/metadata-cache.hpp
@@ -18,6 +18,9 @@ namespace blockfs {
 struct MetadataCache {
 	// A locked and mapped view of a single metadata block.
 	// The block stays present in the cache for the lifetime of this object.
+	//
+	// Destroying a writable window marks it as dirty in the kernel's writeback machinery.
+	// Callers that write through a short-lived window therefore need not request a writeback explicitly.
 	struct BlockWindow {
 		BlockWindow() = default;
 

--- a/drivers/libblockfs/src/metadata-cache.hpp
+++ b/drivers/libblockfs/src/metadata-cache.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <functional>
+#include <cstddef>
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
@@ -26,6 +26,10 @@ namespace blockfs {
 // Each block occupies its own page-aligned frame, i.e., blocks smaller than a page
 // are never packed into the same page (to keep writeback of a page confined to a
 // single block).
+//
+// The whole cache is mapped once at construction; windows only pin blocks into
+// the cache. Blocks must only be touched while a window pins them: a fault on a
+// non-resident block would have to be serviced by this very process.
 struct MetadataCache {
 private:
 	struct CacheBlock;
@@ -51,46 +55,30 @@ private:
 
 	using CacheBlockPtr = smarter::shared_ptr<CacheBlock, CacheBlockPolicy>;
 
-	// smarter::shared_ptr is neither hashable nor equality comparable on its own.
-	struct CacheBlockPtrHash {
-		size_t operator() (const CacheBlockPtr &cacheBlock) const {
-			return std::hash<CacheBlock *>{}(cacheBlock.get());
-		}
-	};
-
-	struct CacheBlockPtrEqual {
-		bool operator() (const CacheBlockPtr &x, const CacheBlockPtr &y) const {
-			return x.get() == y.get();
-		}
-	};
-
-	// All BlockWindows of a block share one CacheBlock (and hence one mapping).
+	// All BlockWindows of a block share one CacheBlock (and hence one lock that pins the block into the cache).
 	struct CacheBlock {
 		// The returned pointer adopts the reference that refCount starts out with.
 		static CacheBlockPtr create(MetadataCache *cache, uint64_t block,
-				helix::UniqueDescriptor lock, helix::Mapping mapping) {
-			auto cacheBlock = new CacheBlock{cache, block, std::move(lock), std::move(mapping)};
+				helix::UniqueDescriptor lock) {
+			auto cacheBlock = new CacheBlock{cache, block, std::move(lock)};
 			return CacheBlockPtr{smarter::adopt_rc, cacheBlock, CacheBlockPolicy{cacheBlock}};
 		}
 
 		MetadataCache *cache;
 		uint64_t block;
-		// The lock descriptor is declared before the mapping so that the mapping is destroyed first.
 		helix::UniqueDescriptor lock;
-		helix::Mapping mapping;
 		smarter::counter refCount{smarter::adopt_rc, 1};
 		// Protected by cacheBlockMutex_. The LRU holds a reference iff inLru.
 		frg::default_list_hook<CacheBlock> lruHook;
 		bool inLru = false;
 
 	private:
-		CacheBlock(MetadataCache *cache, uint64_t block,
-				helix::UniqueDescriptor lock, helix::Mapping mapping)
-		: cache{cache}, block{block}, lock{std::move(lock)}, mapping{std::move(mapping)} { }
+		CacheBlock(MetadataCache *cache, uint64_t block, helix::UniqueDescriptor lock)
+		: cache{cache}, block{block}, lock{std::move(lock)} { }
 	};
 
 public:
-	// A locked and mapped view of a single metadata block.
+	// A locked view of a single metadata block through the cache's persistent mapping.
 	// The block stays present in the cache for the lifetime of this object.
 	//
 	// Destroying a writable window marks it as dirty in the kernel's writeback machinery.
@@ -121,9 +109,7 @@ public:
 				markDirty();
 		}
 
-		void *get() {
-			return cacheBlock_->mapping.get();
-		}
+		void *get();
 
 		// Requests a writeback of the pages written through this window's block.
 		void markDirty();
@@ -144,7 +130,7 @@ public:
 	MetadataCache(const MetadataCache &) = delete;
 	MetadataCache &operator=(const MetadataCache &) = delete;
 
-	// Locks and maps the given block.
+	// Locks the given block and returns a window into the persistent mapping.
 	// Writes through a writable window are eventually written back to the block.
 	async::result<BlockWindow> access(uint64_t block, bool writable);
 
@@ -155,10 +141,13 @@ private:
 	async::detached manage_(helix::UniqueDescriptor backing);
 	async::result<void> serviceRequest_(helix::BorrowedDescriptor backing,
 			int type, uintptr_t offset, size_t length);
+	void *blockAddress_(uint64_t block) {
+		return static_cast<std::byte *>(mapping_.get()) + (block << blockPagesShift_);
+	}
 	CacheBlockPtr findCacheBlock_(uint64_t block);
 	CacheBlockPtr touchLru_(CacheBlock *cacheBlock);
 	void destroyCacheBlock_(CacheBlock *cacheBlock);
-	void markDirty_(CacheBlockPtr cacheBlock);
+	void markDirty_(uint64_t block);
 	async::detached flushDirty_();
 
 	BlockDevice *device_;
@@ -167,6 +156,8 @@ private:
 	uint32_t blockPagesShift_;
 	size_t sectorsPerBlock_;
 	helix::UniqueDescriptor frontal_;
+	// Persistent mapping of the whole cache.
+	helix::Mapping mapping_;
 
 	std::mutex cacheBlockMutex_;
 	// One entry per block that is currently cached.
@@ -174,7 +165,7 @@ private:
 	// Thus, lookup under cacheBlockMutex_ can always dereference the pointer and trying to acquire a shared_ptr may fail.
 	// Protected by cacheBlockMutex_.
 	std::unordered_map<uint64_t, CacheBlock *> cacheBlocks_;
-	// Keeps the most recently accessed blocks locked and mapped even while no BlockWindow refers to them.
+	// Keeps the most recently accessed blocks pinned even while no BlockWindow refers to them.
 	// Protected by cacheBlockMutex_.
 	frg::intrusive_list<
 		CacheBlock,
@@ -187,11 +178,15 @@ private:
 	async::mutex creationMutex_;
 
 	std::mutex dirtyMutex_;
-	// Cache blocks awaiting a deferred writeback.
+	// Blocks awaiting a deferred writeback.
 	// Protected by dirtyMutex_.
-	std::unordered_set<CacheBlockPtr, CacheBlockPtrHash, CacheBlockPtrEqual> dirtyCacheBlocks_;
-	// Raised to request a writeback of dirtyCacheBlocks_.
+	std::unordered_set<uint64_t> dirtyBlocks_;
+	// Raised to request a writeback of dirtyBlocks_.
 	async::sequenced_event dirtyEvent_;
 };
+
+inline void *MetadataCache::BlockWindow::get() {
+	return cacheBlock_->cache->blockAddress_(cacheBlock_->block);
+}
 
 } // namespace blockfs

--- a/drivers/libblockfs/src/metadata-cache.hpp
+++ b/drivers/libblockfs/src/metadata-cache.hpp
@@ -1,9 +1,20 @@
 #pragma once
 
+#include <functional>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <async/mutex.hpp>
 #include <async/result.hpp>
+#include <async/sequenced-event.hpp>
+#include <frg/list.hpp>
 #include <hel.h>
 #include <helix/ipc.hpp>
 #include <helix/memory.hpp>
+#include <smarter.hpp>
 
 #include <blockfs.hpp>
 
@@ -16,26 +27,115 @@ namespace blockfs {
 // are never packed into the same page (to keep writeback of a page confined to a
 // single block).
 struct MetadataCache {
+private:
+	struct CacheBlock;
+
+	// Cache blocks are reference counted in place.
+	struct CacheBlockPolicy {
+		CacheBlockPolicy() = default;
+
+		explicit CacheBlockPolicy(CacheBlock *cacheBlock)
+		: cacheBlock_{cacheBlock} { }
+
+		explicit operator bool () const {
+			return cacheBlock_;
+		}
+
+		void increment() const;
+		void decrement() const;
+
+	private:
+		CacheBlock *cacheBlock_ = nullptr;
+	};
+	static_assert(smarter::rc_policy<CacheBlockPolicy>);
+
+	using CacheBlockPtr = smarter::shared_ptr<CacheBlock, CacheBlockPolicy>;
+
+	// smarter::shared_ptr is neither hashable nor equality comparable on its own.
+	struct CacheBlockPtrHash {
+		size_t operator() (const CacheBlockPtr &cacheBlock) const {
+			return std::hash<CacheBlock *>{}(cacheBlock.get());
+		}
+	};
+
+	struct CacheBlockPtrEqual {
+		bool operator() (const CacheBlockPtr &x, const CacheBlockPtr &y) const {
+			return x.get() == y.get();
+		}
+	};
+
+	// All BlockWindows of a block share one CacheBlock (and hence one mapping).
+	struct CacheBlock {
+		// The returned pointer adopts the reference that refCount starts out with.
+		static CacheBlockPtr create(MetadataCache *cache, uint64_t block,
+				helix::UniqueDescriptor lock, helix::Mapping mapping) {
+			auto cacheBlock = new CacheBlock{cache, block, std::move(lock), std::move(mapping)};
+			return CacheBlockPtr{smarter::adopt_rc, cacheBlock, CacheBlockPolicy{cacheBlock}};
+		}
+
+		MetadataCache *cache;
+		uint64_t block;
+		// The lock descriptor is declared before the mapping so that the mapping is destroyed first.
+		helix::UniqueDescriptor lock;
+		helix::Mapping mapping;
+		smarter::counter refCount{smarter::adopt_rc, 1};
+		// Protected by cacheBlockMutex_. The LRU holds a reference iff inLru.
+		frg::default_list_hook<CacheBlock> lruHook;
+		bool inLru = false;
+
+	private:
+		CacheBlock(MetadataCache *cache, uint64_t block,
+				helix::UniqueDescriptor lock, helix::Mapping mapping)
+		: cache{cache}, block{block}, lock{std::move(lock)}, mapping{std::move(mapping)} { }
+	};
+
+public:
 	// A locked and mapped view of a single metadata block.
 	// The block stays present in the cache for the lifetime of this object.
 	//
 	// Destroying a writable window marks it as dirty in the kernel's writeback machinery.
 	// Callers that write through a short-lived window therefore need not request a writeback explicitly.
+	// Callers that use long-lived windows can use markDirty(). The writeback is asynchronous in both cases.
 	struct BlockWindow {
+		friend void swap(BlockWindow &lhs, BlockWindow &rhs) {
+			std::swap(lhs.cacheBlock_, rhs.cacheBlock_);
+			std::swap(lhs.writable_, rhs.writable_);
+		}
+
 		BlockWindow() = default;
 
-		void *get() {
-			return mapping_.get();
+		BlockWindow(BlockWindow &&other)
+		: BlockWindow{} {
+			swap(*this, other);
 		}
+
+		BlockWindow &operator=(BlockWindow other) {
+			swap(*this, other);
+			return *this;
+		}
+
+		~BlockWindow() {
+			if(!cacheBlock_)
+				return;
+			if(writable_)
+				markDirty();
+		}
+
+		void *get() {
+			return cacheBlock_->mapping.get();
+		}
+
+		// Requests a writeback of the pages written through this window's block.
+		void markDirty();
 
 	private:
 		friend struct MetadataCache;
 
-		BlockWindow(helix::UniqueDescriptor lock, helix::Mapping mapping)
-		: lock_{std::move(lock)}, mapping_{std::move(mapping)} { }
+		BlockWindow(CacheBlockPtr cacheBlock, bool writable)
+		: cacheBlock_{std::move(cacheBlock)}, writable_{writable} { }
 
-		helix::UniqueDescriptor lock_;
-		helix::Mapping mapping_;
+		CacheBlockPtr cacheBlock_;
+		bool writable_ = false;
 	};
 
 	MetadataCache(BlockDevice *device, uint64_t numBlocks, size_t blockSize);
@@ -55,6 +155,11 @@ private:
 	async::detached manage_(helix::UniqueDescriptor backing);
 	async::result<void> serviceRequest_(helix::BorrowedDescriptor backing,
 			int type, uintptr_t offset, size_t length);
+	CacheBlockPtr findCacheBlock_(uint64_t block);
+	CacheBlockPtr touchLru_(CacheBlock *cacheBlock);
+	void destroyCacheBlock_(CacheBlock *cacheBlock);
+	void markDirty_(CacheBlockPtr cacheBlock);
+	async::detached flushDirty_();
 
 	BlockDevice *device_;
 	uint64_t numBlocks_;
@@ -62,6 +167,31 @@ private:
 	uint32_t blockPagesShift_;
 	size_t sectorsPerBlock_;
 	helix::UniqueDescriptor frontal_;
+
+	std::mutex cacheBlockMutex_;
+	// One entry per block that is currently cached.
+	// Entries are erased before their cache block is deleted, but their refcounts may already be zero.
+	// Thus, lookup under cacheBlockMutex_ can always dereference the pointer and trying to acquire a shared_ptr may fail.
+	// Protected by cacheBlockMutex_.
+	std::unordered_map<uint64_t, CacheBlock *> cacheBlocks_;
+	// Keeps the most recently accessed blocks locked and mapped even while no BlockWindow refers to them.
+	// Protected by cacheBlockMutex_.
+	frg::intrusive_list<
+		CacheBlock,
+		frg::locate_member<CacheBlock, frg::default_list_hook<CacheBlock>, &CacheBlock::lruHook>
+	> lru_;
+	// Number of cache blocks on lru_, which does not track its own size.
+	// Protected by cacheBlockMutex_.
+	size_t lruSize_ = 0;
+	// Serializes cache block creation so that concurrent misses on the same block cannot create two of them.
+	async::mutex creationMutex_;
+
+	std::mutex dirtyMutex_;
+	// Cache blocks awaiting a deferred writeback.
+	// Protected by dirtyMutex_.
+	std::unordered_set<CacheBlockPtr, CacheBlockPtrHash, CacheBlockPtrEqual> dirtyCacheBlocks_;
+	// Raised to request a writeback of dirtyCacheBlocks_.
+	async::sequenced_event dirtyEvent_;
 };
 
 } // namespace blockfs


### PR DESCRIPTION
libblockfs uses `synchronizeSpace()` calls to report dirty bits to the kernel. This PR moves these `synchronizeSpace()` calls out of the critical path and into a separate coroutine that runs concurrently with the normal FS operations. Additionally, we also change the `MetadataCache` to use one persistent mapping instead of a per-block mapping.