### PR TITLE
hel, thor: Turn zero memory object into a real handle

### DIFF
--- a/hel/include/hel-syscalls.h
+++ b/hel/include/hel-syscalls.h
@@ -60,6 +60,14 @@ extern inline __attribute__ (( always_inline )) HelError helCloseDescriptor(
 	return helSyscall2(kHelCallCloseDescriptor, (HelWord)universeHandle, (HelWord)handle);
 };
 
+extern inline __attribute__ (( always_inline )) HelError helObtainHandle(
+		int kind, HelHandle *handle) {
+	HelWord helHandle;
+	HelError error = helSyscall1_1(kHelCallObtainHandle, (HelWord)kind, &helHandle);
+	*handle = (HelHandle)helHandle;
+	return error;
+};
+
 extern inline __attribute__ (( always_inline )) HelError helCreateQueue(
 		const struct HelQueueParameters *params, HelHandle *handle) {
 	HelWord hel_handle;

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -383,8 +383,7 @@ typedef struct HelX86VirtualizationRegs HelVirtualizationRegs;
 enum {
 	kHelNullHandle = 0,
 	kHelThisUniverse = -1,
-	kHelThisThread = -2,
-	kHelZeroMemory = -3
+	kHelThisThread = -2
 };
 
 enum {

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -31,6 +31,7 @@ enum {
 	kHelCallDescriptorInfo = 32,
 	kHelCallGetCredentials = 84,
 	kHelCallCloseDescriptor = 21,
+	kHelCallObtainHandle = 4,
 
 	kHelCallCreateQueue = 89,
 	kHelCallDriveQueue = 105,
@@ -417,6 +418,10 @@ enum {
 
 static const uint32_t kHelTransferDescriptorOut = UINT32_C(1) << 0;
 static const uint32_t kHelTransferDescriptorIn = UINT32_C(1) << 1;
+
+enum {
+	kHelObtainZeroMemory = 1
+};
 
 struct HelSgItem {
 	void *buffer;
@@ -1167,6 +1172,13 @@ HEL_C_LINKAGE HelError helGetCredentials(HelHandle handle, uint32_t flags,
 //! @param[in] handle
 //!    	Handle to be closed.
 HEL_C_LINKAGE HelError helCloseDescriptor(HelHandle universeHandle, HelHandle handle);
+
+//! Obtains a descriptor to one of the kernel's global objects.
+//! @param[in] kind
+//!    	Kind of the object, e.g., ::kHelObtainZeroMemory.
+//! @param[out] handle
+//!    	Handle to the object.
+HEL_C_LINKAGE HelError helObtainHandle(int kind, HelHandle *handle);
 
 //! @}
 //! @name Management of IPC Queues

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -44,18 +44,6 @@
 using namespace thor;
 
 
-namespace {
-	// TODO: Replace this by a function that returns the type of special descriptor.
-	bool isSpecialMemoryView(HelHandle handle) {
-		return handle == kHelZeroMemory;
-	}
-
-	smarter::shared_ptr<MemoryView> getSpecialMemoryView(HelHandle handle) {
-		assert(handle == kHelZeroMemory);
-		return getZeroMemory();
-	}
-}
-
 extern "C" int doCopyFromUser(void *dest, const void *src, size_t size);
 extern "C" int doCopyToUser(void *dest, const void *src, size_t size);
 extern "C" int doAtomicUserLoad(unsigned int *out, const unsigned int *p);
@@ -703,20 +691,11 @@ HelError helCopyOnWrite(HelHandle memoryHandle,
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
-	smarter::shared_ptr<MemoryView> view;
+	auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(memoryHandle, kHelRightRead | kHelRightAssign);
+	if(!viewOutcome)
+		return translateError(viewOutcome.error());
 
-	if(memoryHandle < 0) {
-		if(!isSpecialMemoryView(memoryHandle))
-			return kHelErrBadDescriptor;
-		view = getSpecialMemoryView(memoryHandle);
-	} else {
-		auto viewOutcome = this_universe->resolveObject<DescriptorType::memoryView>(memoryHandle, kHelRightRead | kHelRightAssign);
-		if(!viewOutcome)
-			return translateError(viewOutcome.error());
-		view = std::move(*viewOutcome);
-	}
-
-	auto sliceOutcome = CopyOnWriteMemory::create(std::move(view), offset, size);
+	auto sliceOutcome = CopyOnWriteMemory::create(std::move(*viewOutcome), offset, size);
 	if(!sliceOutcome)
 		return translateError(sliceOutcome.error());
 	*outHandle = this_universe->attachDescriptor(

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -418,6 +418,26 @@ HelError helCloseDescriptor(HelHandle universeHandle, HelHandle handle) {
 	return kHelErrNone;
 }
 
+HelError helObtainHandle(int kind, HelHandle *handle) {
+	auto thisThread = getCurrentThread();
+	auto thisUniverse = thisThread->getUniverse();
+
+	switch(kind) {
+	case kHelObtainZeroMemory:
+		*handle = thisUniverse->attachDescriptor(
+			AnyDescriptor::make<DescriptorType::memoryView>(
+				getZeroMemory(),
+				kHelRightRead | kHelRightAssign
+			)
+		);
+		break;
+	default:
+		return kHelErrIllegalArgs;
+	}
+
+	return kHelErrNone;
+}
+
 HelError helCreateQueue(const HelQueueParameters *paramsPtr, HelHandle *handle) {
 	auto thisThread = getCurrentThread();
 	auto thisUniverse = thisThread->getUniverse();

--- a/kernel/thor/generic/main.cpp
+++ b/kernel/thor/generic/main.cpp
@@ -623,6 +623,11 @@ void handleSyscall(SyscallImageAccessor image) {
 	case kHelCallCloseDescriptor: {
 		*image.error() = helCloseDescriptor((HelHandle)arg0, (HelHandle)arg1);
 	} break;
+	case kHelCallObtainHandle: {
+		HelHandle handle;
+		*image.error() = helObtainHandle((int)arg0, &handle);
+		*image.out0() = handle;
+	} break;
 
 	case kHelCallCreateQueue: {
 		HelHandle handle;

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -44,6 +44,16 @@ Error resolveSetIdRequest(uint64_t requested, Id current, Id &result) {
 
 } // namespace
 
+helix::BorrowedDescriptor getZeroMemory() {
+	static helix::UniqueDescriptor memory = [] {
+		HelHandle handle;
+		HEL_CHECK(helObtainHandle(kHelObtainZeroMemory, &handle));
+		return helix::UniqueDescriptor{handle};
+	}();
+
+	return memory;
+}
+
 // ----------------------------------------------------------------------------
 // VmContext.
 // ----------------------------------------------------------------------------
@@ -165,7 +175,7 @@ VmContext::mapFile(uintptr_t hint, helix::UniqueDescriptor memory,
 		if(memory) {
 			HEL_CHECK(helCopyOnWrite(memory.getHandle(), offset, alignedSize, &handle));
 		}else{
-			HEL_CHECK(helCopyOnWrite(kHelZeroMemory, offset, alignedSize, &handle));
+			HEL_CHECK(helCopyOnWrite(getZeroMemory().getHandle(), offset, alignedSize, &handle));
 		}
 		copyView = helix::UniqueDescriptor{handle};
 

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -30,6 +30,9 @@ struct ControllingTerminalState;
 
 typedef int ProcessId;
 
+// Returns the global memory object that reads as zeros.
+helix::BorrowedDescriptor getZeroMemory();
+
 // TODO: This struct should store the process' VMAs once we implement them.
 // TODO: We need a clarification here: Does mmap() keep file descriptions open (e.g. for flock())?
 struct VmContext {

--- a/rust/hel/src/handle.rs
+++ b/rust/hel/src/handle.rs
@@ -34,14 +34,6 @@ static THIS_THREAD: ManuallyDrop<Handle> = unsafe {
     ))
 };
 
-/// A static handle that refers to a zeroed memory view.
-static ZERO_MEMORY: ManuallyDrop<Handle> = unsafe {
-    ManuallyDrop::new(Handle::from_raw_in_universe(
-        hel_sys::kHelZeroMemory as hel_sys::HelHandle as i64,
-        hel_sys::kHelNullHandle as hel_sys::HelHandle as i64,
-    ))
-};
-
 impl Handle {
     /// Returns a reference to the null handle.
     pub fn null() -> &'static Self {
@@ -56,11 +48,6 @@ impl Handle {
     /// Returns a reference to the current thread handle.
     pub fn this_thread() -> &'static Self {
         &THIS_THREAD
-    }
-
-    /// Returns a reference to the zero memory handle.
-    pub fn zero_memory() -> &'static Self {
-        &ZERO_MEMORY
     }
 
     pub const unsafe fn from_raw(handle: hel_sys::HelHandle) -> Self {

--- a/testsuites/kernel-torture/src/cow.cpp
+++ b/testsuites/kernel-torture/src/cow.cpp
@@ -6,8 +6,11 @@
 #include "testsuite.hpp"
 
 DEFINE_TEST(cows, ([] {
+	HelHandle zeroHandle;
+	HEL_CHECK(helObtainHandle(kHelObtainZeroMemory, &zeroHandle));
+
 	HelHandle handle;
-	HEL_CHECK(helCopyOnWrite(kHelZeroMemory, 0, 0x1000, &handle));
+	HEL_CHECK(helCopyOnWrite(zeroHandle, 0, 0x1000, &handle));
 
 	void *window;
 	HEL_CHECK(helMapMemory(handle, kHelNullHandle, nullptr, 0, 0x1000, kHelMapProtRead | kHelMapProtWrite, &window));
@@ -22,6 +25,7 @@ DEFINE_TEST(cows, ([] {
 	*reinterpret_cast<volatile uintptr_t *>(window) = 0xC0FFEE;
 	HEL_CHECK(helUnmapMemory(kHelNullHandle, window, 0x1000));
 
+	HEL_CHECK(helCloseDescriptor(kHelThisUniverse, zeroHandle));
 	HEL_CHECK(helCloseDescriptor(kHelThisUniverse, handle));
 	HEL_CHECK(helCloseDescriptor(kHelThisUniverse, forkHandle));
 }))


### PR DESCRIPTION
Turn the zero memory object into a real handle that can be obtained from a new `helObtainHandle()` syscall (without any privileges).

This was initially written to support mmap()ing of `/dev/zero`. However, it turned out to not be useful for that purpose.