### PR TITLE
thor, posix: Copy gp register in superClone on RISC-V

### DIFF
--- a/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
+++ b/kernel/thor/arch/riscv/thor-internal/arch/cpu.hpp
@@ -41,6 +41,7 @@ struct Frame {
 	}
 	constexpr uint64_t &ra() { return x(1); }
 	constexpr uint64_t &sp() { return x(2); }
+	constexpr uint64_t &gp() { return x(3); }
 	constexpr uint64_t &tp() { return x(4); }
 
 	bool umode() { return !(sstatus & riscv::sstatus::sppBit); }

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -1183,6 +1183,22 @@ namespace posix {
 				auto new_thread = std::move(*threadOutcome);
 				new_thread->flags |= Thread::kFlagServer;
 
+#if defined(__riscv) && __riscv_xlen == 64
+				// gp points to the executable's small data area and is only ever computed by
+				// crt0, hence the new thread has to inherit it from the calling thread.
+				uintptr_t argGp;
+				auto readGpOutcome = info.thread->accessRegisters([&](Executor *executor) {
+					argGp = executor->general()->gp();
+				});
+				if(!readGpOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
+				auto writeGpOutcome = new_thread->accessRegisters([&](Executor *executor) {
+					executor->general()->gp() = argGp;
+				});
+				if(!writeGpOutcome)
+					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
+#endif
+
 				// see helCreateThread for the reasoning here
 				new_thread.policy().increment();
 				new_thread.policy().increment();

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -1579,6 +1579,18 @@ Process::clone(std::shared_ptr<Process> original, void *ip, void *sp, posix::sup
 			process->vmContext()->getSpace().getHandle(), kHelAbiSystemV,
 			ip, sp, kHelThreadStopped, &new_thread));
 	process->_threadDescriptor = helix::UniqueDescriptor{new_thread};
+
+#if defined(__riscv) && __riscv_xlen == 64
+	// gp points to the executable's small data area and is only ever computed by crt0.
+	// New threads start out with all registers but ip and sp cleared, hence it is inherited here.
+	uintptr_t originalGprs[kHelNumGprs];
+	HEL_CHECK(helLoadRegisters(original->threadDescriptor().getHandle(),
+			kHelRegsGeneral, &originalGprs));
+	uintptr_t gprs[kHelNumGprs] = {};
+	gprs[kHelRegGp] = originalGprs[kHelRegGp];
+	HEL_CHECK(helStoreRegisters(new_thread, kHelRegsGeneral, &gprs));
+#endif
+
 	process->_posixLane = std::move(server_lane);
 	HEL_CHECK(helGetCredentials(process->_threadDescriptor.getHandle(), 0, process->credentials_.data()));
 


### PR DESCRIPTION
This prevents a crash when non-main threads try to access data through `gp`.