### PR TITLE
sif: Port mbus objects over from thor

### DIFF
--- a/drivers/kbd/src/main.cpp
+++ b/drivers/kbd/src/main.cpp
@@ -119,8 +119,8 @@ struct EventDevice final : libevbackend::EventDevice {
 
 Controller::Controller(mbus_ng::EntityId mbusParent, std::shared_ptr<protocols::hw::Device> device,
 	std::array<uintptr_t, 2> ports,
-	std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> primaryIrq,
-	std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> secondaryIrq)
+	std::optional<std::pair<uint32_t, std::shared_ptr<protocols::hw::Device>>> primaryIrq,
+	std::optional<std::pair<uint32_t, std::shared_ptr<protocols::hw::Device>>> secondaryIrq)
 	: _hwDevice{std::move(device)}, mbusParent_{mbusParent}, _ioPorts{ports}, _primaryIrq{primaryIrq},
 	_secondaryIrq{secondaryIrq} {
 
@@ -1306,8 +1306,8 @@ async::detached observeControllers() {
 	std::optional<std::shared_ptr<protocols::hw::Device>> hwDevice = std::nullopt;
 	std::optional<uintptr_t> primaryPort = std::nullopt;
 	std::optional<uintptr_t> secondaryPort = std::nullopt;
-	std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> primaryIrq = std::nullopt;
-	std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> secondaryIrq = std::nullopt;
+	std::optional<std::pair<uint32_t, std::shared_ptr<protocols::hw::Device>>> primaryIrq = std::nullopt;
+	std::optional<std::pair<uint32_t, std::shared_ptr<protocols::hw::Device>>> secondaryIrq = std::nullopt;
 	std::optional<mbus_ng::EntityId> entityId = std::nullopt;
 
 	auto enumerator = mbus_ng::Instance::global().enumerate(filter);

--- a/drivers/kbd/src/ps2.hpp
+++ b/drivers/kbd/src/ps2.hpp
@@ -77,8 +77,8 @@ struct DeviceType {
 struct Controller {
 	Controller(mbus_ng::EntityId mbusParent, std::shared_ptr<protocols::hw::Device> device,
 		std::array<uintptr_t, 2> ports,
-		std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> primaryIrq,
-		std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> secondaryIrq);
+		std::optional<std::pair<uint32_t, std::shared_ptr<protocols::hw::Device>>> primaryIrq,
+		std::optional<std::pair<uint32_t, std::shared_ptr<protocols::hw::Device>>> secondaryIrq);
 	async::detached init();
 
 	struct Device {
@@ -208,8 +208,8 @@ private:
 	arch::io_space _dataSpace;
 	arch::io_space _commandSpace;
 
-	std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> _primaryIrq;
-	std::optional<std::pair<int, std::shared_ptr<protocols::hw::Device>>> _secondaryIrq;
+	std::optional<std::pair<uint32_t, std::shared_ptr<protocols::hw::Device>>> _primaryIrq;
+	std::optional<std::pair<uint32_t, std::shared_ptr<protocols::hw::Device>>> _secondaryIrq;
 
 	helix::UniqueIrq _port1Irq;
 	std::optional<helix::UniqueIrq> _port2Irq;

--- a/kernel/thor/system/dtb/dtb_discover.cpp
+++ b/kernel/thor/system/dtb/dtb_discover.cpp
@@ -1,3 +1,4 @@
+#include <thor-internal/debug.hpp>
 #include <thor-internal/fiber.hpp>
 #include <thor-internal/main.hpp>
 #include <thor-internal/dtb/dtb.hpp>
@@ -363,6 +364,11 @@ static initgraph::Task discoverDtNodes{&globalInitEngine, "dt.discover-nodes",
 	initgraph::Requires{getDeviceTreeParsedStage()},
 	[] {
 		allNodes.initialize(*kernelAlloc);
+
+		if (debugOptionsNote->useSif) {
+			infoLogger() << "thor: Skipping DT mbus node discovery (sif)" << frg::endlog;
+			return;
+		}
 
 		auto root = getDeviceTreeRoot();
 		if (!root)

--- a/protocols/hw/hw.bragi
+++ b/protocols/hw/hw.bragi
@@ -183,7 +183,7 @@ head(16):
 tail:
 	uint16[] io_ports;
 	uint16[] fixed_io_ports;
-	uint8[] irqs;
+	uint32[] irqs;
 }
 
 message GetDtInfoRequest 21 {

--- a/protocols/hw/include/protocols/hw/client.hpp
+++ b/protocols/hw/include/protocols/hw/client.hpp
@@ -74,7 +74,7 @@ struct BatteryState {
 
 struct AcpiResources {
 	std::vector<uint16_t> io_ports;
-	std::vector<uint8_t> irqs;
+	std::vector<uint32_t> irqs;
 };
 
 struct DtRegister {

--- a/protocols/hw/src/client.cpp
+++ b/protocols/hw/src/client.cpp
@@ -127,13 +127,14 @@ async::result<helix::UniqueDescriptor> Device::accessBar(int index) {
 		);
 
 	HEL_CHECK(recv_tail.error());
-	HEL_CHECK(pull_bar.error());
 
 	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
 	auto ok = resp.decode_tail(reader);
 	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
+
+	HEL_CHECK(pull_bar.error());
 
 	auto bar = pull_bar.descriptor();
 	co_return std::move(bar);
@@ -169,13 +170,14 @@ async::result<helix::UniqueDescriptor> Device::accessExpansionRom() {
 		);
 
 	HEL_CHECK(recv_tail.error());
-	HEL_CHECK(pull_bar.error());
 
 	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
 	auto ok = resp.decode_tail(reader);
 	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
+
+	HEL_CHECK(pull_bar.error());
 
 	auto expansion_rom = pull_bar.descriptor();
 	co_return std::move(expansion_rom);
@@ -212,13 +214,14 @@ async::result<helix::UniqueDescriptor> Device::accessIrq(size_t index) {
 		);
 
 	HEL_CHECK(recv_tail.error());
-	HEL_CHECK(pull_irq.error());
 
 	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
 	auto ok = resp.decode_tail(reader);
 	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
+
+	HEL_CHECK(pull_irq.error());
 
 	co_return pull_irq.descriptor();
 }
@@ -254,13 +257,14 @@ async::result<helix::UniqueDescriptor> Device::installMsi(int index) {
 		);
 
 	HEL_CHECK(recv_tail.error());
-	HEL_CHECK(pull_msi.error());
 
 	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
 	auto ok = resp.decode_tail(reader);
 	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
+
+	HEL_CHECK(pull_msi.error());
 
 	co_return pull_msi.descriptor();
 }
@@ -613,13 +617,14 @@ async::result<helix::UniqueDescriptor> Device::accessFbMemory() {
 		);
 
 	HEL_CHECK(recv_tail.error());
-	HEL_CHECK(pull_bar.error());
 
 	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
 	auto ok = resp.decode_tail(reader);
 	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
+
+	HEL_CHECK(pull_bar.error());
 
 	auto bar = pull_bar.descriptor();
 	co_return std::move(bar);
@@ -933,13 +938,14 @@ async::result<helix::UniqueDescriptor> Device::accessDtRegister(uint32_t index) 
 		);
 
 	HEL_CHECK(recv_tail.error());
-	HEL_CHECK(pull_reg.error());
 
 	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
 	auto ok = resp.decode_tail(reader);
 	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
+
+	HEL_CHECK(pull_reg.error());
 
 	auto reg = pull_reg.descriptor();
 	co_return std::move(reg);
@@ -976,13 +982,14 @@ async::result<helix::UniqueDescriptor> Device::installDtIrq(uint32_t index) {
 		);
 
 	HEL_CHECK(recv_tail.error());
-	HEL_CHECK(pull_irq.error());
 
 	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
 	auto ok = resp.decode_tail(reader);
 	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
+
+	HEL_CHECK(pull_irq.error());
 
 	auto irq = pull_irq.descriptor();
 	co_return std::move(irq);
@@ -1112,13 +1119,14 @@ async::result<std::pair<helix::UniqueDescriptor, uint32_t>> Device::getVbt() {
 		);
 
 	HEL_CHECK(recv_tail.error());
-	HEL_CHECK(pull_desc.error());
 
 	bragi::limited_reader reader{tailBuffer.data(), tailBuffer.size()};
 	auto ok = resp.decode_tail(reader);
 	assert(ok);
 
 	assert(resp.error() == managarm::hw::Errors::SUCCESS);
+
+	HEL_CHECK(pull_desc.error());
 
 	auto desc = pull_desc.descriptor();
 	co_return { std::move(desc), resp.vbt_size() };

--- a/rust/managarm/src/hw/server.rs
+++ b/rust/managarm/src/hw/server.rs
@@ -377,7 +377,7 @@ pub async fn serve_pci_device<D: PciDevice + 'static>(lane: Handle, device: Arc<
 pub struct AcpiResources {
     pub io_ports: Vec<u16>,
     pub fixed_io_ports: Vec<u16>,
-    pub irqs: Vec<u8>,
+    pub irqs: Vec<u32>,
 }
 
 pub trait AcpiObject {

--- a/rust/managarm/src/hw/server.rs
+++ b/rust/managarm/src/hw/server.rs
@@ -463,3 +463,139 @@ pub async fn serve_acpi_object<D: AcpiObject + 'static>(lane: Handle, object: Ar
     })
     .await
 }
+
+/// A register range of a device tree node's reg property.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DtRegisterDescriptor {
+    pub address: u64,
+    pub length: u64,
+    pub offset: u32,
+}
+
+pub trait DtNode {
+    fn regs(&self) -> Vec<DtRegisterDescriptor>;
+    fn num_irqs(&self) -> u32;
+    fn path(&self) -> String;
+    fn property(&self, name: &str) -> Option<Vec<u8>>;
+    fn properties(&self) -> Vec<(String, Vec<u8>)>;
+
+    /// Returns a memory view of the index-th register range.
+    fn access_register(&self, index: usize) -> super::Result<Handle>;
+    /// Returns the IRQ object for the index-th interrupt of the node.
+    fn install_irq(&self, index: usize) -> super::Result<&Handle>;
+    /// Configures all interrupts of the node.
+    fn enable_irqs(&self);
+}
+
+async fn handle_one_dt<D: DtNode>(lane: &Handle, request: &[u8], node: &D) -> hel::Result<()> {
+    let preamble = match bragi::preamble_from_bytes(request) {
+        Ok(p) => p,
+        Err(_) => return Ok(()),
+    };
+
+    match preamble.id() {
+        bindings::GetDtInfoRequest::MESSAGE_ID => {
+            let mut resp = bindings::SvrResponse::default();
+            resp.set_error(Errors::Success);
+            resp.set_num_dt_irqs(node.num_irqs());
+            let regs = node
+                .regs()
+                .iter()
+                .map(|reg| {
+                    let mut msg = bindings::DtRegister::default();
+                    msg.set_address(reg.address);
+                    msg.set_length(reg.length);
+                    msg.set_offset(reg.offset);
+                    msg
+                })
+                .collect();
+            resp.set_dt_regs(regs);
+            send_response(lane, &resp).await?;
+        }
+        bindings::AccessDtRegisterRequest::MESSAGE_ID => {
+            let req: bindings::AccessDtRegisterRequest =
+                bragi::head_from_bytes(request).map_err(|_| hel::Error::IllegalArgs)?;
+            match node.access_register(req.index() as usize) {
+                Ok(handle) => {
+                    send_response_with_push(
+                        lane,
+                        &error_response(Errors::Success),
+                        &handle,
+                        hel_sys::kHelRightRead
+                            | hel_sys::kHelRightWrite
+                            | hel_sys::kHelRightAssign
+                            | hel_sys::kHelRightProvision
+                            | hel_sys::kHelRightPin,
+                    )
+                    .await?
+                }
+                Err(err) => send_response(lane, &error_response(encode_hw_error(&err))).await?,
+            }
+        }
+        bindings::InstallDtIrqRequest::MESSAGE_ID => {
+            let req: bindings::InstallDtIrqRequest =
+                bragi::head_from_bytes(request).map_err(|_| hel::Error::IllegalArgs)?;
+            match node.install_irq(req.index() as usize) {
+                Ok(handle) => {
+                    send_response_with_push(
+                        lane,
+                        &error_response(Errors::Success),
+                        handle,
+                        hel_sys::kHelRightWait | hel_sys::kHelRightSignal,
+                    )
+                    .await?
+                }
+                Err(err) => send_response(lane, &error_response(encode_hw_error(&err))).await?,
+            }
+        }
+        bindings::EnableBusIrqRequest::MESSAGE_ID => {
+            node.enable_irqs();
+            send_response(lane, &error_response(Errors::Success)).await?;
+        }
+        bindings::GetDtPropertyRequest::MESSAGE_ID => {
+            let req: bindings::GetDtPropertyRequest =
+                bragi::head_from_bytes(request).map_err(|_| hel::Error::IllegalArgs)?;
+            let mut resp = bindings::GetDtPropertyResponse::default();
+            match node.property(req.name()) {
+                Some(data) => {
+                    resp.set_error(Errors::Success);
+                    resp.set_data(data);
+                }
+                None => resp.set_error(Errors::PropertyNotFound),
+            }
+            send_response(lane, &resp).await?;
+        }
+        bindings::GetDtPropertiesRequest::MESSAGE_ID => {
+            let mut resp = bindings::GetDtPropertiesResponse::default();
+            resp.set_error(Errors::Success);
+            let properties = node
+                .properties()
+                .into_iter()
+                .map(|(name, data)| {
+                    let mut msg = bindings::DtProperty::default();
+                    msg.set_name(name);
+                    msg.set_data(data);
+                    msg
+                })
+                .collect();
+            resp.set_properties(properties);
+            send_response(lane, &resp).await?;
+        }
+        bindings::GetDtPathRequest::MESSAGE_ID => {
+            let mut resp = bindings::GetDtPathResponse::default();
+            resp.set_error(Errors::Success);
+            resp.set_path(node.path());
+            send_response(lane, &resp).await?;
+        }
+        _ => send_response(lane, &error_response(Errors::DeviceError)).await?,
+    }
+
+    Ok(())
+}
+
+pub async fn serve_dt_node<D: DtNode + 'static>(lane: Handle, node: Arc<D>) {
+    serve_requests(lane, async |conversation: &Handle, request: &[u8]| {
+        handle_one_dt(conversation, request, node.as_ref()).await
+    })
+    .await
+}

--- a/rust/managarm/src/hw/server.rs
+++ b/rust/managarm/src/hw/server.rs
@@ -121,7 +121,7 @@ fn build_pci_info<D: PciDevice>(device: &D) -> bindings::SvrResponse {
     resp
 }
 
-async fn send_response(lane: &Handle, resp: &bindings::SvrResponse) -> hel::Result<()> {
+async fn send_response<M: Message>(lane: &Handle, resp: &M) -> hel::Result<()> {
     let (head, tail) = bragi::head_tail_to_bytes(resp).expect("failed to encode hw response");
     let (head, tail) = submit_async(lane, (SendBuffer::new(&head), SendBuffer::new(&tail))).await?;
     head?;
@@ -129,9 +129,9 @@ async fn send_response(lane: &Handle, resp: &bindings::SvrResponse) -> hel::Resu
     Ok(())
 }
 
-async fn send_response_with_push(
+async fn send_response_with_push<M: Message>(
     lane: &Handle,
-    resp: &bindings::SvrResponse,
+    resp: &M,
     push: &Handle,
     rights: u32,
 ) -> hel::Result<()> {
@@ -149,12 +149,10 @@ async fn send_response_with_push(
     Ok(())
 }
 
-impl Into<bindings::SvrResponse> for Errors {
-    fn into(self) -> bindings::SvrResponse {
-        let mut resp = bindings::SvrResponse::default();
-        resp.set_error(self);
-        resp
-    }
+fn error_response(error: Errors) -> bindings::SvrResponse {
+    let mut resp = bindings::SvrResponse::default();
+    resp.set_error(error);
+    resp
 }
 
 async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> hel::Result<()> {
@@ -176,7 +174,7 @@ async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> 
                 Ok(handle) => {
                     send_response_with_push(
                         lane,
-                        &Errors::Success.into(),
+                        &error_response(Errors::Success),
                         &handle,
                         hel_sys::kHelRightRead
                             | hel_sys::kHelRightWrite
@@ -186,7 +184,7 @@ async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> 
                     )
                     .await?
                 }
-                Err(_) => send_response(lane, &Errors::OutOfBounds.into()).await?,
+                Err(_) => send_response(lane, &error_response(Errors::OutOfBounds)).await?,
             }
         }
         bindings::AccessIrqRequest::MESSAGE_ID => {
@@ -196,20 +194,20 @@ async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> 
                 Ok(Some(handle)) => {
                     send_response_with_push(
                         lane,
-                        &Errors::Success.into(),
+                        &error_response(Errors::Success),
                         &handle,
                         hel_sys::kHelRightWait | hel_sys::kHelRightSignal,
                     )
                     .await?
                 }
-                _ => send_response(lane, &Errors::IllegalArguments.into()).await?,
+                _ => send_response(lane, &error_response(Errors::IllegalArguments)).await?,
             }
         }
         bindings::AccessExpansionRomRequest::MESSAGE_ID => match device.access_expansion_rom() {
             Ok(Some(handle)) => {
                 send_response_with_push(
                     lane,
-                    &Errors::Success.into(),
+                    &error_response(Errors::Success),
                     &handle,
                     hel_sys::kHelRightRead
                         | hel_sys::kHelRightAssign
@@ -218,7 +216,7 @@ async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> 
                 )
                 .await?
             }
-            _ => send_response(lane, &Errors::DeviceError.into()).await?,
+            _ => send_response(lane, &error_response(Errors::DeviceError)).await?,
         },
         bindings::GetVbtRequest::MESSAGE_ID => match device.access_vbt() {
             Ok(Some((size, handle))) => {
@@ -236,7 +234,7 @@ async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> 
                 )
                 .await?
             }
-            _ => send_response(lane, &Errors::IllegalArguments.into()).await?,
+            _ => send_response(lane, &error_response(Errors::IllegalArguments)).await?,
         },
         bindings::LoadPciSpaceRequest::MESSAGE_ID => {
             let req: bindings::LoadPciSpaceRequest =
@@ -259,7 +257,7 @@ async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> 
             } else {
                 Errors::IllegalArguments
             };
-            send_response(lane, &error.into()).await?;
+            send_response(lane, &error_response(error)).await?;
         }
         bindings::LoadPciCapabilityRequest::MESSAGE_ID => {
             let req: bindings::LoadPciCapabilityRequest =
@@ -276,11 +274,11 @@ async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> 
         }
         bindings::EnableBusmasterRequest::MESSAGE_ID => {
             device.enable_busmaster();
-            send_response(lane, &Errors::Success.into()).await?;
+            send_response(lane, &error_response(Errors::Success)).await?;
         }
         bindings::EnableBusIrqRequest::MESSAGE_ID => {
             device.enable_irq();
-            send_response(lane, &Errors::Success.into()).await?;
+            send_response(lane, &error_response(Errors::Success)).await?;
         }
         bindings::InstallMsiRequest::MESSAGE_ID => {
             let req: bindings::InstallMsiRequest =
@@ -289,21 +287,21 @@ async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> 
                 Ok(Some(handle)) => {
                     send_response_with_push(
                         lane,
-                        &Errors::Success.into(),
+                        &error_response(Errors::Success),
                         &handle,
                         hel_sys::kHelRightWait | hel_sys::kHelRightSignal,
                     )
                     .await?
                 }
-                Ok(None) => send_response(lane, &Errors::IllegalArguments.into()).await?,
-                Err(_) => send_response(lane, &Errors::ResourceExhaustion.into()).await?,
+                Ok(None) => send_response(lane, &error_response(Errors::IllegalArguments)).await?,
+                Err(_) => send_response(lane, &error_response(Errors::ResourceExhaustion)).await?,
             }
         }
         bindings::EnableMsiRequest::MESSAGE_ID => {
             if device.enable_msi() {
-                send_response(lane, &Errors::Success.into()).await?;
+                send_response(lane, &error_response(Errors::Success)).await?;
             } else {
-                send_response(lane, &Errors::IllegalArguments.into()).await?;
+                send_response(lane, &error_response(Errors::IllegalArguments)).await?;
             }
         }
         bindings::GetDmaSpaceRequest::MESSAGE_ID => {
@@ -326,15 +324,15 @@ async fn handle_one<D: PciDevice>(lane: &Handle, request: &[u8], device: &D) -> 
         }
         bindings::ClaimDeviceRequest::MESSAGE_ID => {
             device.claim_device();
-            send_response(lane, &Errors::Success.into()).await?;
+            send_response(lane, &error_response(Errors::Success)).await?;
         }
-        _ => send_response(lane, &Errors::DeviceError.into()).await?,
+        _ => send_response(lane, &error_response(Errors::DeviceError)).await?,
     }
 
     Ok(())
 }
 
-pub async fn serve_pci_device<D: PciDevice + 'static>(lane: Handle, device: Arc<D>) {
+async fn serve_requests(lane: Handle, handler: impl AsyncFn(&Handle, &[u8]) -> hel::Result<()>) {
     loop {
         let (conversation, request) = match submit_async(&lane, Accept::new(ReceiveInline)).await {
             Ok((conversation, request)) => (conversation, request),
@@ -351,11 +349,15 @@ pub async fn serve_pci_device<D: PciDevice + 'static>(lane: Handle, device: Arc<
             Err(_) => continue,
         };
 
-        if handle_one(&conversation, &request, device.as_ref())
-            .await
-            .is_err()
-        {
+        if handler(&conversation, &request).await.is_err() {
             continue;
         }
     }
+}
+
+pub async fn serve_pci_device<D: PciDevice + 'static>(lane: Handle, device: Arc<D>) {
+    serve_requests(lane, async |conversation: &Handle, request: &[u8]| {
+        handle_one(conversation, request, device.as_ref()).await
+    })
+    .await
 }

--- a/rust/managarm/src/hw/server.rs
+++ b/rust/managarm/src/hw/server.rs
@@ -8,6 +8,16 @@ use crate::hw::bindings::Errors;
 use super::bindings;
 use super::pci::IoType;
 
+fn encode_hw_error(err: &super::Error) -> Errors {
+    match err {
+        super::Error::OutOfBounds => Errors::OutOfBounds,
+        super::Error::IllegalArguments => Errors::IllegalArguments,
+        super::Error::ResourceExhaustion => Errors::ResourceExhaustion,
+        super::Error::PropertyNotFound => Errors::PropertyNotFound,
+        _ => Errors::DeviceError,
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct BarDescriptor {
     pub io_type: IoType,
@@ -358,6 +368,98 @@ async fn serve_requests(lane: Handle, handler: impl AsyncFn(&Handle, &[u8]) -> h
 pub async fn serve_pci_device<D: PciDevice + 'static>(lane: Handle, device: Arc<D>) {
     serve_requests(lane, async |conversation: &Handle, request: &[u8]| {
         handle_one(conversation, request, device.as_ref()).await
+    })
+    .await
+}
+
+/// The IO ports and IRQs that an ACPI object's _CRS describes.
+#[derive(Debug, Default)]
+pub struct AcpiResources {
+    pub io_ports: Vec<u16>,
+    pub fixed_io_ports: Vec<u16>,
+    pub irqs: Vec<u8>,
+}
+
+pub trait AcpiObject {
+    /// Returns the resources of the object's _CRS, or None if evaluation fails.
+    fn resources(&self) -> Option<AcpiResources>;
+    /// Returns an IO-space handle covering the ports of the index-th port resource of _CRS.
+    fn access_ports(&self, index: usize) -> super::Result<Handle>;
+    /// Returns the IRQ object for the index-th interrupt of _CRS.
+    fn access_irq(&self, index: usize) -> super::Result<&Handle>;
+}
+
+async fn handle_one_acpi<D: AcpiObject>(
+    lane: &Handle,
+    request: &[u8],
+    object: &D,
+) -> hel::Result<()> {
+    let preamble = match bragi::preamble_from_bytes(request) {
+        Ok(p) => p,
+        Err(_) => return Ok(()),
+    };
+
+    match preamble.id() {
+        bindings::AcpiGetResourcesRequest::MESSAGE_ID => {
+            let mut resp = bindings::AcpiGetResourcesReply::default();
+            match object.resources() {
+                Some(resources) => {
+                    resp.set_error(Errors::Success);
+                    resp.set_io_ports(resources.io_ports);
+                    resp.set_fixed_io_ports(resources.fixed_io_ports);
+                    resp.set_irqs(resources.irqs);
+                }
+                None => resp.set_error(Errors::DeviceError),
+            }
+            send_response(lane, &resp).await?;
+        }
+        bindings::AccessBarRequest::MESSAGE_ID => {
+            let req: bindings::AccessBarRequest =
+                bragi::head_from_bytes(request).map_err(|_| hel::Error::IllegalArgs)?;
+            let index = usize::try_from(req.index()).map_err(|_| hel::Error::IllegalArgs)?;
+            match object.access_ports(index) {
+                Ok(handle) => {
+                    send_response_with_push(
+                        lane,
+                        &error_response(Errors::Success),
+                        &handle,
+                        hel_sys::kHelRightRead
+                            | hel_sys::kHelRightWrite
+                            | hel_sys::kHelRightAssign
+                            | hel_sys::kHelRightProvision
+                            | hel_sys::kHelRightPin,
+                    )
+                    .await?
+                }
+                Err(err) => send_response(lane, &error_response(encode_hw_error(&err))).await?,
+            }
+        }
+        bindings::AccessIrqRequest::MESSAGE_ID => {
+            let req: bindings::AccessIrqRequest =
+                bragi::head_from_bytes(request).map_err(|_| hel::Error::IllegalArgs)?;
+            let index = usize::try_from(req.index()).map_err(|_| hel::Error::IllegalArgs)?;
+            match object.access_irq(index) {
+                Ok(handle) => {
+                    send_response_with_push(
+                        lane,
+                        &error_response(Errors::Success),
+                        handle,
+                        hel_sys::kHelRightWait | hel_sys::kHelRightSignal,
+                    )
+                    .await?
+                }
+                Err(err) => send_response(lane, &error_response(encode_hw_error(&err))).await?,
+            }
+        }
+        _ => send_response(lane, &error_response(Errors::DeviceError)).await?,
+    }
+
+    Ok(())
+}
+
+pub async fn serve_acpi_object<D: AcpiObject + 'static>(lane: Handle, object: Arc<D>) {
+    serve_requests(lane, async |conversation: &Handle, request: &[u8]| {
+        handle_one_acpi(conversation, request, object.as_ref()).await
     })
     .await
 }

--- a/sif/src/acpi/mod.rs
+++ b/sif/src/acpi/mod.rs
@@ -1,4 +1,5 @@
 pub mod glue;
+pub mod ps2;
 
 use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/sif/src/acpi/ps2.rs
+++ b/sif/src/acpi/ps2.rs
@@ -10,7 +10,7 @@ use managarm::hw::server::{AcpiObject, AcpiResources, serve_acpi_object};
 use managarm::mbus::create_entity;
 use managarm::svrctl::hardware_access_handle;
 
-use crate::entity::{serve_entity_lanes, string};
+use crate::entity::{dismiss_requests, serve_entity_lanes, string};
 use crate::leak;
 use crate::uacpi::namespace::{self, IterationDecision, NamespaceNode};
 use crate::uacpi::resources::Resource;
@@ -189,10 +189,27 @@ async fn publish_devices(hids: &[&CStr]) -> Result<()> {
     Ok(())
 }
 
+// Notifies listeners that all PS/2 objects of the ACPI namespace have been published,
+// so that they can stop running mbus filters indefinitely.
+async fn publish_status() -> Result<()> {
+    let mut props = HashMap::new();
+    props.insert("unix.subsystem".into(), string("acpi"));
+    props.insert("acpi.status".into(), string("ps2.init_complete"));
+
+    let manager = leak(create_entity("acpi-status", &props).await?);
+    hel::spawn(serve_entity_lanes(manager, |lane| {
+        hel::spawn(dismiss_requests(lane));
+    }));
+
+    Ok(())
+}
+
 /// Publishes the acpi-object entities of all PS/2 keyboards and mice.
 pub async fn publish() -> Result<()> {
     publish_devices(ACPI_HID_PS2_KEYBOARDS).await?;
     publish_devices(ACPI_HID_PS2_MICE).await?;
+
+    publish_status().await?;
 
     Ok(())
 }

--- a/sif/src/acpi/ps2.rs
+++ b/sif/src/acpi/ps2.rs
@@ -53,23 +53,23 @@ fn port_list(resource: &Resource) -> Option<Vec<u16>> {
 }
 
 /// Returns the IRQs of an IRQ resource, or None for other resource types.
-fn irq_list(resource: &Resource) -> Option<Vec<u8>> {
+fn irq_list(resource: &Resource) -> Option<Vec<u32>> {
     match resource {
-        Resource::Irq(irq) => Some(irq.irqs().to_vec()),
-        Resource::ExtendedIrq(irq) => Some(irq.irqs().iter().map(|&i| i as u8).collect()),
+        Resource::Irq(irq) => Some(irq.irqs().iter().map(|&i| u32::from(i)).collect()),
+        Resource::ExtendedIrq(irq) => Some(irq.irqs().to_vec()),
         _ => None,
     }
 }
 
 /// Resolves an IRQ of _CRS to the GSI that raises it.
-fn resolve_irq_to_gsi(irq: u8) -> u32 {
+fn resolve_irq_to_gsi(irq: u32) -> u32 {
     #[cfg(target_arch = "x86_64")]
     {
         crate::isa::resolve_isa_irq(irq).gsi
     }
     #[cfg(not(target_arch = "x86_64"))]
     {
-        u32::from(irq)
+        irq
     }
 }
 

--- a/sif/src/acpi/ps2.rs
+++ b/sif/src/acpi/ps2.rs
@@ -1,0 +1,198 @@
+//! Publishes the PS/2 devices of the ACPI namespace; port of thor's system/acpi/ps2.cpp.
+
+use std::collections::{BTreeMap, HashMap};
+use std::ffi::CStr;
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use managarm::hw::Error as HwError;
+use managarm::hw::server::{AcpiObject, AcpiResources, serve_acpi_object};
+use managarm::mbus::create_entity;
+use managarm::svrctl::hardware_access_handle;
+
+use crate::entity::{serve_entity_lanes, string};
+use crate::leak;
+use crate::uacpi::namespace::{self, IterationDecision, NamespaceNode};
+use crate::uacpi::resources::Resource;
+
+const ACPI_HID_PS2_KEYBOARDS: &[&CStr] = &[
+    c"PNP0300", c"PNP0301", c"PNP0302", c"PNP0303", c"PNP0304", c"PNP0305", c"PNP0306", c"PNP0307",
+    c"PNP0308", c"PNP0309", c"PNP030A", c"PNP030B", c"PNP0320", c"PNP0321", c"PNP0322", c"PNP0323",
+    c"PNP0324", c"PNP0325", c"PNP0326", c"PNP0327", c"PNP0340", c"PNP0341", c"PNP0342", c"PNP0343",
+    c"PNP0344",
+];
+
+const ACPI_HID_PS2_MICE: &[&CStr] = &[
+    c"PNP0F00", c"PNP0F01", c"PNP0F02", c"PNP0F03", c"PNP0F04", c"PNP0F05", c"PNP0F06", c"PNP0F07",
+    c"PNP0F08", c"PNP0F09", c"PNP0F0A", c"PNP0F0B", c"PNP0F0C", c"PNP0F0D", c"PNP0F0E", c"PNP0F0F",
+    c"PNP0F10", c"PNP0F11", c"PNP0F12", c"PNP0F13", c"PNP0F14", c"PNP0F15", c"PNP0F16", c"PNP0F17",
+    c"PNP0F18", c"PNP0F19", c"PNP0F1A", c"PNP0F1B", c"PNP0F1C", c"PNP0F1D", c"PNP0F1E", c"PNP0F1F",
+    c"PNP0F20", c"PNP0F21", c"PNP0F22", c"PNP0F23", c"PNP0FFC", c"PNP0FFF",
+];
+
+// The IRQ object map is only locked for the duration of a single operation, none of which can panic.
+const EXPECT_LOCK: &str = "sif: ACPI IRQ object mutex was poisoned";
+
+struct Ps2Object {
+    node: NamespaceNode,
+    // Created on demand but shared between requests, as thor has one IRQ object per interrupt.
+    irq_objects: Mutex<BTreeMap<usize, &'static hel::Handle>>,
+}
+
+/// Returns the individual ports of a port resource, or None for other resource types.
+fn port_list(resource: &Resource) -> Option<Vec<u16>> {
+    match resource {
+        Resource::Io(io) => Some((io.minimum()..=io.maximum()).collect()),
+        Resource::FixedIo(io) => Some(
+            (0..u16::from(io.length()))
+                .map(|i| io.address() + i)
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
+/// Returns the IRQs of an IRQ resource, or None for other resource types.
+fn irq_list(resource: &Resource) -> Option<Vec<u8>> {
+    match resource {
+        Resource::Irq(irq) => Some(irq.irqs().to_vec()),
+        Resource::ExtendedIrq(irq) => Some(irq.irqs().iter().map(|&i| i as u8).collect()),
+        _ => None,
+    }
+}
+
+/// Resolves an IRQ of _CRS to the GSI that raises it.
+fn resolve_irq_to_gsi(irq: u8) -> u32 {
+    #[cfg(target_arch = "x86_64")]
+    {
+        crate::isa::resolve_isa_irq(irq).gsi
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        u32::from(irq)
+    }
+}
+
+impl AcpiObject for Ps2Object {
+    fn resources(&self) -> Option<AcpiResources> {
+        let resources = self.node.current_resources().ok()?;
+
+        let mut out = AcpiResources::default();
+        for resource in resources.iter() {
+            match &resource {
+                Resource::Io(io) => out.io_ports.extend(io.minimum()..=io.maximum()),
+                Resource::FixedIo(io) => out
+                    .fixed_io_ports
+                    .extend((0..u16::from(io.length())).map(|i| io.address() + i)),
+                Resource::Other(type_) => {
+                    println!("sif: acpi: Ignoring _CRS resource of type {type_}")
+                }
+                // IRQ resources are collected below.
+                Resource::Irq(_) | Resource::ExtendedIrq(_) => (),
+            }
+            if let Some(irqs) = irq_list(&resource) {
+                out.irqs.extend(irqs);
+            }
+        }
+        Some(out)
+    }
+
+    fn access_ports(&self, index: usize) -> managarm::hw::Result<hel::Handle> {
+        let resources = self
+            .node
+            .current_resources()
+            .map_err(|_| HwError::DeviceError)?;
+
+        let mut i = 0;
+        for resource in resources.iter() {
+            let Some(ports) = port_list(&resource) else {
+                continue;
+            };
+            if i == index {
+                let ports: Vec<usize> = ports.iter().map(|&port| usize::from(port)).collect();
+                return Ok(hel::access_io(hardware_access_handle(), &ports)?);
+            }
+            i += 1;
+        }
+        Err(HwError::OutOfBounds)
+    }
+
+    fn access_irq(&self, index: usize) -> managarm::hw::Result<&hel::Handle> {
+        let mut objects = self.irq_objects.lock().expect(EXPECT_LOCK);
+        if let Some(&object) = objects.get(&index) {
+            return Ok(object);
+        }
+
+        let resources = self
+            .node
+            .current_resources()
+            .map_err(|_| HwError::DeviceError)?;
+
+        let mut irqs = Vec::new();
+        for resource in resources.iter() {
+            if let Some(list) = irq_list(&resource) {
+                irqs.extend(list);
+            }
+        }
+
+        let &irq = irqs.get(index).ok_or(HwError::OutOfBounds)?;
+        let gsi = resolve_irq_to_gsi(irq);
+        let pin = hel::access_irq_by_gsi(hardware_access_handle(), u64::from(gsi))?;
+        let object = leak(hel::handle_irq(&pin)?);
+        objects.insert(index, object);
+        Ok(object)
+    }
+}
+
+async fn publish_object(node: NamespaceNode, instance: usize) -> Result<()> {
+    let path = node.absolute_path();
+
+    let mut props = HashMap::new();
+    props.insert("unix.subsystem".into(), string("acpi"));
+    props.insert("acpi.path".into(), string(&path));
+    if let Some(hid) = node.eval_hid().ok().flatten() {
+        props.insert("acpi.hid".into(), string(&hid));
+    }
+    if let Some(cid) = node
+        .eval_cid()
+        .ok()
+        .flatten()
+        .and_then(|ids| ids.into_iter().next())
+    {
+        props.insert("acpi.cid".into(), string(&cid));
+    }
+    props.insert("acpi.instance".into(), string(&instance.to_string()));
+
+    println!("sif: acpi: publishing object {path}");
+    let manager = leak(create_entity("acpi-object", &props).await?);
+    let object = Arc::new(Ps2Object {
+        node,
+        irq_objects: Mutex::new(BTreeMap::new()),
+    });
+    hel::spawn(serve_entity_lanes(manager, move |lane| {
+        hel::spawn(serve_acpi_object(lane, object.clone()));
+    }));
+
+    Ok(())
+}
+
+async fn publish_devices(hids: &[&CStr]) -> Result<()> {
+    let mut nodes = Vec::new();
+    namespace::find_devices_at(NamespaceNode::root(), hids, |node| {
+        nodes.push(node);
+        IterationDecision::Continue
+    })?;
+
+    for (instance, node) in nodes.into_iter().enumerate() {
+        publish_object(node, instance).await?;
+    }
+    Ok(())
+}
+
+/// Publishes the acpi-object entities of all PS/2 keyboards and mice.
+pub async fn publish() -> Result<()> {
+    publish_devices(ACPI_HID_PS2_KEYBOARDS).await?;
+    publish_devices(ACPI_HID_PS2_MICE).await?;
+
+    Ok(())
+}

--- a/sif/src/dt/mod.rs
+++ b/sif/src/dt/mod.rs
@@ -1,3 +1,4 @@
 pub mod fdt;
 pub mod irq;
 pub mod node;
+pub mod serve;

--- a/sif/src/dt/node.rs
+++ b/sif/src/dt/node.rs
@@ -340,6 +340,18 @@ impl DeviceTreeNode {
         self.name
     }
 
+    pub fn parent(&self) -> Option<&'static DeviceTreeNode> {
+        self.parent
+    }
+
+    pub fn compatible(&self) -> &[&'static str] {
+        &self.compatible
+    }
+
+    pub fn interrupt_parent(&self) -> Option<&'static DeviceTreeNode> {
+        self.interrupt_parent.get().copied()
+    }
+
     pub fn path(&self) -> &str {
         &self.path
     }
@@ -487,6 +499,48 @@ pub fn init(address: u64, size: u64) -> Result<()> {
     root.finalize_init();
 
     Ok(())
+}
+
+/// Walks the "interrupts" property of a node; port of thor's dt::walkInterrupts().
+/// Returns None if the node has no interrupts property.
+pub fn walk_interrupts(
+    f: &mut impl FnMut(&'static DeviceTreeNode, fdt::Cells<'static>),
+    node: &'static DeviceTreeNode,
+) -> Option<bool> {
+    let prop = node.dt_node.find_property("interrupts")?;
+
+    let Some(parent) = node.interrupt_parent() else {
+        println!(
+            "sif: {}: interrupts property without an interrupt parent",
+            node.path()
+        );
+        return Some(false);
+    };
+    let parent_interrupt_cells = parent.interrupt_cells;
+    if parent_interrupt_cells == 0 {
+        println!(
+            "sif: {}: interrupt parent {} has no #interrupt-cells",
+            node.path(),
+            parent.path()
+        );
+        return Some(false);
+    }
+
+    let mut it = prop.access();
+    while !it.at_end_of_property() {
+        let Some(parent_irq) = it.into_cells(parent_interrupt_cells) else {
+            println!(
+                "sif: {}: failed to read parent IRQ from interrupts",
+                node.path()
+            );
+            return Some(false);
+        };
+        it.advance(parent_interrupt_cells * size_of::<u32>());
+
+        f(parent, parent_irq);
+    }
+
+    Some(true)
 }
 
 pub fn walk_interrupt_map(

--- a/sif/src/dt/serve.rs
+++ b/sif/src/dt/serve.rs
@@ -1,0 +1,199 @@
+//! Publishes dt-node entities for the device tree; port of thor's system/dtb/dtb_discover.cpp.
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use anyhow::Result;
+use managarm::hw::Error as HwError;
+use managarm::hw::server::{DtNode, DtRegisterDescriptor, serve_dt_node};
+use managarm::mbus::create_entity;
+use managarm::svrctl::hardware_access_handle;
+
+use crate::acpi::{PAGE_MASK, PAGE_SIZE};
+use crate::entity::{decimal, serve_entity_lanes, string};
+use crate::irq::{IrqPin, dt_irq};
+use crate::leak;
+
+use super::fdt::Cells;
+use super::node::{DeviceTreeNode, get_device_tree_root, walk_interrupts};
+
+struct DtRegister {
+    address: u64,
+    length: u64,
+    offset: u32,
+}
+
+struct DtIrq {
+    parent: &'static DeviceTreeNode,
+    cells: Cells<'static>,
+    // Created on demand but shared between requests, as thor has one IRQ object per interrupt.
+    object: OnceLock<hel::Handle>,
+}
+
+impl DtIrq {
+    fn pin(&self) -> managarm::hw::Result<&'static IrqPin> {
+        let controller = self
+            .parent
+            .associated_irq_controller()
+            .ok_or(HwError::DeviceError)?;
+        let irq = controller
+            .resolve_dt_irq(self.cells)
+            .ok_or(HwError::DeviceError)?;
+        dt_irq(self.parent, irq.index, irq.trigger, irq.polarity).ok_or(HwError::DeviceError)
+    }
+
+    fn object(&self) -> managarm::hw::Result<&hel::Handle> {
+        if let Some(object) = self.object.get() {
+            return Ok(object);
+        }
+        let object = hel::handle_irq(self.pin()?.handle())?;
+        Ok(self.object.get_or_init(|| object))
+    }
+}
+
+struct ServedDtNode {
+    node: &'static DeviceTreeNode,
+    regs: Vec<DtRegister>,
+    irqs: Vec<DtIrq>,
+}
+
+impl ServedDtNode {
+    fn new(node: &'static DeviceTreeNode) -> ServedDtNode {
+        let regs = node
+            .reg()
+            .iter()
+            .map(|reg| DtRegister {
+                address: reg.addr,
+                length: reg.size,
+                offset: (reg.addr as usize & PAGE_MASK) as u32,
+            })
+            .collect();
+
+        let mut irqs = Vec::new();
+        let mut collect = |parent, cells| {
+            irqs.push(DtIrq {
+                parent,
+                cells,
+                object: OnceLock::new(),
+            });
+        };
+        if walk_interrupts(&mut collect, node) == Some(false) {
+            println!(
+                "sif: {}: failed to parse interrupts for mbus node",
+                node.path()
+            );
+        }
+        // TODO(qookie): Try interrupts-extended if interrupts failed.
+
+        ServedDtNode { node, regs, irqs }
+    }
+}
+
+impl DtNode for ServedDtNode {
+    fn regs(&self) -> Vec<DtRegisterDescriptor> {
+        self.regs
+            .iter()
+            .map(|reg| DtRegisterDescriptor {
+                address: reg.address,
+                length: reg.length,
+                offset: reg.offset,
+            })
+            .collect()
+    }
+
+    fn num_irqs(&self) -> u32 {
+        self.irqs.len() as u32
+    }
+
+    fn path(&self) -> String {
+        self.node.path().to_string()
+    }
+
+    fn property(&self, name: &str) -> Option<Vec<u8>> {
+        self.node
+            .dt_node()
+            .find_property(name)
+            .map(|prop| prop.data().to_vec())
+    }
+
+    fn properties(&self) -> Vec<(String, Vec<u8>)> {
+        self.node
+            .dt_node()
+            .properties()
+            .map(|prop| (prop.name().to_string(), prop.data().to_vec()))
+            .collect()
+    }
+
+    fn access_register(&self, index: usize) -> managarm::hw::Result<hel::Handle> {
+        let reg = self.regs.get(index).ok_or(HwError::OutOfBounds)?;
+        let aligned = (reg.address as usize) & !PAGE_MASK;
+        let page_off = (reg.address as usize) & PAGE_MASK;
+        let span = ((reg.length as usize) + page_off + PAGE_MASK) & !PAGE_MASK;
+        Ok(hel::access_physical(
+            hardware_access_handle(),
+            aligned,
+            span.max(PAGE_SIZE),
+            hel::CachingMode::MmioNonPosted,
+        )?)
+    }
+
+    fn install_irq(&self, index: usize) -> managarm::hw::Result<&hel::Handle> {
+        self.irqs.get(index).ok_or(HwError::OutOfBounds)?.object()
+    }
+
+    fn enable_irqs(&self) {
+        for (index, irq) in self.irqs.iter().enumerate() {
+            if irq.object().is_err() {
+                println!("sif: {}: failed to configure IRQ {index}", self.node.path());
+            }
+        }
+    }
+}
+
+async fn publish_node(node: &'static DeviceTreeNode, parent: Option<i64>) -> Result<i64> {
+    let mut props = HashMap::new();
+    props.insert("unix.subsystem".into(), string("dt"));
+    if let Some(parent) = parent {
+        props.insert("drvcore.mbus-parent".into(), decimal(parent));
+    }
+    // mbus filters can only match on keys, hence the value is part of the key.
+    for compatible in node.compatible() {
+        props.insert(format!("dt.compatible={compatible}"), string(""));
+    }
+
+    let manager = leak(create_entity("dt-node", &props).await?);
+    let served = Arc::new(ServedDtNode::new(node));
+    hel::spawn(serve_entity_lanes(manager, move |lane| {
+        hel::spawn(serve_dt_node(lane, served.clone()));
+    }));
+
+    Ok(manager.id())
+}
+
+/// Publishes a dt-node entity for every node of the device tree.
+pub async fn publish_all() -> Result<()> {
+    let Some(root) = get_device_tree_root() else {
+        return Ok(());
+    };
+
+    // Collect in pre-order so that parents are published before their children.
+    let mut nodes = Vec::new();
+    root.for_each(&mut |node| {
+        if !node.name().starts_with("memory@") {
+            nodes.push(node);
+        }
+        false
+    });
+    println!("sif: Found {} DT nodes in total.", nodes.len());
+
+    let mut mbus_ids: HashMap<*const DeviceTreeNode, i64> = HashMap::new();
+    for node in nodes {
+        let parent = node
+            .parent()
+            .and_then(|parent| mbus_ids.get(&std::ptr::from_ref(parent)).copied());
+        let id = publish_node(node, parent).await?;
+        mbus_ids.insert(std::ptr::from_ref(node), id);
+    }
+
+    Ok(())
+}

--- a/sif/src/entity.rs
+++ b/sif/src/entity.rs
@@ -14,6 +14,18 @@ pub fn decimal(value: i64) -> Item {
     Item::String(format!("{value}"))
 }
 
+/// Serves a lane of an entity that exists only for its properties by dismissing every request.
+pub async fn dismiss_requests(lane: hel::Handle) {
+    loop {
+        if hel::submit_async(&lane, hel::Accept::new(hel::Dismiss))
+            .await
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
 /// Keeps stream lanes queued on the entity so that each connecting client obtains one.
 pub async fn serve_entity_lanes(manager: &'static EntityManager, serve_lane: impl Fn(hel::Handle)) {
     let id = manager.id();

--- a/sif/src/entity.rs
+++ b/sif/src/entity.rs
@@ -1,0 +1,35 @@
+//! Helpers for publishing and serving mbus entities.
+
+use managarm::mbus::{EntityManager, Item};
+
+pub fn string(value: &str) -> Item {
+    Item::String(value.to_string())
+}
+
+pub fn hex(value: u32, width: usize) -> Item {
+    Item::String(format!("{value:0width$x}"))
+}
+
+pub fn decimal(value: i64) -> Item {
+    Item::String(format!("{value}"))
+}
+
+/// Keeps stream lanes queued on the entity so that each connecting client obtains one.
+pub async fn serve_entity_lanes(manager: &'static EntityManager, serve_lane: impl Fn(hel::Handle)) {
+    let id = manager.id();
+
+    loop {
+        let (local, remote) = match hel::create_stream() {
+            Ok(pair) => pair,
+            Err(err) => {
+                println!("sif: entity {id}: create_stream failed: {err}");
+                return;
+            }
+        };
+        if let Err(err) = manager.serve_remote_lane(remote).await {
+            println!("sif: entity {id}: serve_remote_lane failed: {err}");
+            return;
+        }
+        serve_lane(local);
+    }
+}

--- a/sif/src/irq.rs
+++ b/sif/src/irq.rs
@@ -1,0 +1,115 @@
+//! IRQ pins accessed from the kernel, shared between the PCI and DT subsystems.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use hel::{IrqPolarity, IrqTrigger};
+use managarm::svrctl::hardware_access_handle;
+
+use crate::dt::node::DeviceTreeNode;
+use crate::leak;
+
+// The pin maps are only locked for the duration of a single operation, none of which can panic.
+const EXPECT_LOCK: &str = "sif: IRQ pin map mutex was poisoned";
+
+pub struct IrqPin {
+    name: String,
+    handle: hel::Handle,
+    // None if the interrupt controller has no configurable trigger mode / polarity.
+    trigger: Option<IrqTrigger>,
+    polarity: Option<IrqPolarity>,
+}
+
+impl IrqPin {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn handle(&self) -> &hel::Handle {
+        &self.handle
+    }
+}
+
+static IRQ_PINS: Mutex<BTreeMap<u32, &'static IrqPin>> = Mutex::new(BTreeMap::new());
+
+// Configures a GSI and returns its pin, sharing pins between users of the same GSI.
+pub fn system_irq(gsi: u32, trigger: IrqTrigger, polarity: IrqPolarity) -> Option<&'static IrqPin> {
+    let mut pins = IRQ_PINS.lock().expect(EXPECT_LOCK);
+    if let Some(pin) = pins.get(&gsi) {
+        if pin.trigger != Some(trigger) || pin.polarity != Some(polarity) {
+            println!("sif: Conflicting configurations for GSI {gsi}");
+        }
+        return Some(*pin);
+    }
+
+    let handle = match hel::access_irq_by_gsi(hardware_access_handle(), gsi as u64) {
+        Ok(handle) => handle,
+        Err(err) => {
+            println!("sif: Failed to access GSI {gsi}: {err}");
+            return None;
+        }
+    };
+    if let Err(err) = hel::configure_irq(&handle, Some(trigger), Some(polarity)) {
+        println!("sif: Failed to configure GSI {gsi}: {err}");
+        return None;
+    }
+
+    let pin = leak(IrqPin {
+        name: format!("gsi-{gsi}"),
+        handle,
+        trigger: Some(trigger),
+        polarity: Some(polarity),
+    });
+    pins.insert(gsi, pin);
+    Some(pin)
+}
+
+static DT_IRQ_PINS: Mutex<BTreeMap<(u32, u64), &'static IrqPin>> = Mutex::new(BTreeMap::new());
+
+// Configures a DT interrupt and returns its pin, sharing pins between users of the same
+// (controller, index) pair.
+pub fn dt_irq(
+    controller: &'static DeviceTreeNode,
+    index: u64,
+    trigger: Option<IrqTrigger>,
+    polarity: Option<IrqPolarity>,
+) -> Option<&'static IrqPin> {
+    let phandle = controller.phandle();
+    let mut pins = DT_IRQ_PINS.lock().expect(EXPECT_LOCK);
+    if let Some(pin) = pins.get(&(phandle, index)) {
+        if pin.trigger != trigger || pin.polarity != polarity {
+            println!(
+                "sif: Conflicting configurations for IRQ {index} of {}",
+                controller.path()
+            );
+        }
+        return Some(*pin);
+    }
+
+    let handle = match hel::access_irq_by_phandle(hardware_access_handle(), phandle.into(), index) {
+        Ok(handle) => handle,
+        Err(err) => {
+            println!(
+                "sif: Failed to access IRQ {index} of {}: {err}",
+                controller.path()
+            );
+            return None;
+        }
+    };
+    if let Err(err) = hel::configure_irq(&handle, trigger, polarity) {
+        println!(
+            "sif: Failed to configure IRQ {index} of {}: {err}",
+            controller.path()
+        );
+        return None;
+    }
+
+    let pin = leak(IrqPin {
+        name: format!("{}:{index}", controller.name()),
+        handle,
+        trigger,
+        polarity,
+    });
+    pins.insert((phandle, index), pin);
+    Some(pin)
+}

--- a/sif/src/isa.rs
+++ b/sif/src/isa.rs
@@ -13,7 +13,7 @@ const NUM_ISA_IRQS: usize = 16;
 /// ISA IRQs that we configure upfront, i.e., before any driver claims them.
 ///
 /// TODO: This is a hack. We assume that HPET will use legacy replacement.
-const PRECONFIGURED_ISA_IRQS: [u8; 5] = [0, 1, 4, 12, 14];
+const PRECONFIGURED_ISA_IRQS: [u32; 5] = [0, 1, 4, 12, 14];
 
 /// The GSI that an ISA IRQ is wired to, and how the interrupt controller drives it.
 #[derive(Clone, Copy)]
@@ -25,9 +25,9 @@ pub struct IsaIrq {
 
 impl IsaIrq {
     /// Without an override, ISA IRQs are identity mapped to GSIs and use the ISA bus defaults.
-    fn identity(irq: u8) -> IsaIrq {
+    fn identity(irq: u32) -> IsaIrq {
         IsaIrq {
-            gsi: irq.into(),
+            gsi: irq,
             trigger: IrqTrigger::Edge,
             polarity: IrqPolarity::High,
         }
@@ -99,10 +99,10 @@ fn read_isa_overrides() -> IsaOverrides {
 static ISA_OVERRIDES: OnceLock<IsaOverrides> = OnceLock::new();
 
 /// Resolves an ISA IRQ to the GSI that it is wired to.
-pub fn resolve_isa_irq(irq: u8) -> IsaIrq {
+pub fn resolve_isa_irq(irq: u32) -> IsaIrq {
     let overrides = ISA_OVERRIDES.get_or_init(read_isa_overrides);
     overrides
-        .get(usize::from(irq))
+        .get(irq as usize)
         .copied()
         .flatten()
         .unwrap_or_else(|| IsaIrq::identity(irq))

--- a/sif/src/isa.rs
+++ b/sif/src/isa.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use hel::{IrqPolarity, IrqTrigger};
 use managarm::svrctl::hardware_access_handle;
 use uacpi_sys::acpi_madt_interrupt_source_override;
@@ -15,10 +17,10 @@ const PRECONFIGURED_ISA_IRQS: [u8; 5] = [0, 1, 4, 12, 14];
 
 /// The GSI that an ISA IRQ is wired to, and how the interrupt controller drives it.
 #[derive(Clone, Copy)]
-struct IsaIrq {
-    gsi: u32,
-    trigger: IrqTrigger,
-    polarity: IrqPolarity,
+pub struct IsaIrq {
+    pub gsi: u32,
+    pub trigger: IrqTrigger,
+    pub polarity: IrqPolarity,
 }
 
 impl IsaIrq {
@@ -94,13 +96,23 @@ fn read_isa_overrides() -> IsaOverrides {
     overrides
 }
 
+static ISA_OVERRIDES: OnceLock<IsaOverrides> = OnceLock::new();
+
+/// Resolves an ISA IRQ to the GSI that it is wired to.
+pub fn resolve_isa_irq(irq: u8) -> IsaIrq {
+    let overrides = ISA_OVERRIDES.get_or_init(read_isa_overrides);
+    overrides
+        .get(usize::from(irq))
+        .copied()
+        .flatten()
+        .unwrap_or_else(|| IsaIrq::identity(irq))
+}
+
 /// Configures the ISA IRQs of devices whose drivers cannot resolve them themselves.
 pub fn configure_isa_irqs() {
-    let overrides = read_isa_overrides();
-
     println!("sif: Configuring ISA IRQs");
     for irq in PRECONFIGURED_ISA_IRQS {
-        let line = overrides[usize::from(irq)].unwrap_or_else(|| IsaIrq::identity(irq));
+        let line = resolve_isa_irq(irq);
         let pin = match hel::access_irq_by_gsi(hardware_access_handle(), line.gsi as u64) {
             Ok(pin) => pin,
             Err(err) => {

--- a/sif/src/main.rs
+++ b/sif/src/main.rs
@@ -24,6 +24,17 @@ fn main() -> Result<()> {
         println!("sif: enabled");
 
         let rsdp = managarm::kerncfg::get_acpi_rsdp().await?;
+        let (dt_address, dt_size) = managarm::kerncfg::get_device_tree().await?;
+        if rsdp == 0 && dt_address == 0 {
+            bail!("sif: kernel reported neither an ACPI RSDP nor a device tree");
+        }
+
+        // thor publishes dt-node objects whenever a device tree exists, even on ACPI systems.
+        if dt_address != 0 {
+            dt::node::init(dt_address, dt_size)?;
+            dt::irq::init();
+        }
+
         if rsdp != 0 {
             acpi::set_rsdp(rsdp);
             acpi::configure_log_level(&cmdline);
@@ -34,13 +45,6 @@ fn main() -> Result<()> {
             // Configure the ISA IRQs before the PCI links to match thor's ordering.
             #[cfg(target_arch = "x86_64")]
             isa::configure_isa_irqs();
-        } else {
-            let (address, size) = managarm::kerncfg::get_device_tree().await?;
-            if address == 0 {
-                bail!("sif: kernel reported neither an ACPI RSDP nor a device tree");
-            }
-            dt::node::init(address, size)?;
-            dt::irq::init();
         }
 
         pci::publish_devices().await?;
@@ -50,6 +54,8 @@ fn main() -> Result<()> {
         if acpi::has_rsdp() {
             acpi::ps2::publish().await?;
         }
+
+        dt::serve::publish_all().await?;
 
         std::future::pending::<Result<()>>().await
     })?

--- a/sif/src/main.rs
+++ b/sif/src/main.rs
@@ -3,6 +3,7 @@ use anyhow::{Result, bail};
 mod acpi;
 mod dt;
 mod entity;
+mod irq;
 // Only x86 has an ISA bus (and hence ISA IRQs).
 #[cfg(target_arch = "x86_64")]
 mod isa;

--- a/sif/src/main.rs
+++ b/sif/src/main.rs
@@ -2,11 +2,16 @@ use anyhow::{Result, bail};
 
 mod acpi;
 mod dt;
+mod entity;
 // Only x86 has an ISA bus (and hence ISA IRQs).
 #[cfg(target_arch = "x86_64")]
 mod isa;
 mod pci;
 mod uacpi;
+
+pub(crate) fn leak<T>(value: T) -> &'static T {
+    Box::leak(Box::new(value))
+}
 
 fn main() -> Result<()> {
     hel::block_on(async {

--- a/sif/src/main.rs
+++ b/sif/src/main.rs
@@ -46,6 +46,10 @@ fn main() -> Result<()> {
 
         println!("sif: published PCI devices");
 
+        if acpi::has_rsdp() {
+            acpi::ps2::publish().await?;
+        }
+
         std::future::pending::<Result<()>>().await
     })?
 }

--- a/sif/src/pci/acpi.rs
+++ b/sif/src/pci/acpi.rs
@@ -85,7 +85,7 @@ fn resolve_link(source: NamespaceNode, index: u32) -> Option<(u32, IrqTrigger, I
             irq.triggering(),
             irq.polarity(),
         ),
-        Resource::Other => {
+        _ => {
             println!("sif: Resource {index} of an IRQ link does not describe an IRQ");
             return None;
         }

--- a/sif/src/pci/dtb.rs
+++ b/sif/src/pci/dtb.rs
@@ -1,16 +1,11 @@
-use std::collections::BTreeMap;
-use std::sync::Mutex;
-
-use hel::{IrqPolarity, IrqTrigger};
-use managarm::svrctl::hardware_access_handle;
-
 use crate::dt::node::{DeviceTreeNode, get_device_tree_root, walk_interrupt_map};
+use crate::irq::{IrqPin, dt_irq};
 
 use super::config::PciConfigIo;
 use super::config::ecam::EcamPcieConfigIo;
 use super::discover::add_root_bus;
 use super::{
-    EXPECT_LOCK, IrqIndex, IrqPin, PciBus, PciBusResource, PciIrqRouter, RouterState, RoutingEntry,
+    EXPECT_LOCK, IrqIndex, PciBus, PciBusResource, PciIrqRouter, RouterState, RoutingEntry,
     RoutingModel, leak,
 };
 
@@ -21,56 +16,6 @@ static DT_PCI_COMPATIBLE: [&str; 3] = [
     "pci-host-ecam-generic",
     "brcm,bcm2711-pcie",
 ];
-
-static DT_IRQ_PINS: Mutex<BTreeMap<(u32, u64), &'static IrqPin>> = Mutex::new(BTreeMap::new());
-
-// Configures a DT interrupt and returns its pin, sharing pins between users of the same
-// (controller, index) pair.
-fn dt_irq(
-    controller: &'static DeviceTreeNode,
-    index: u64,
-    trigger: Option<IrqTrigger>,
-    polarity: Option<IrqPolarity>,
-) -> Option<&'static IrqPin> {
-    let phandle = controller.phandle();
-    let mut pins = DT_IRQ_PINS.lock().expect(EXPECT_LOCK);
-    if let Some(pin) = pins.get(&(phandle, index)) {
-        if pin.trigger != trigger || pin.polarity != polarity {
-            println!(
-                "sif: Conflicting configurations for IRQ {index} of {}",
-                controller.path()
-            );
-        }
-        return Some(*pin);
-    }
-
-    let handle = match hel::access_irq_by_phandle(hardware_access_handle(), phandle.into(), index) {
-        Ok(handle) => handle,
-        Err(err) => {
-            println!(
-                "sif: Failed to access IRQ {index} of {}: {err}",
-                controller.path()
-            );
-            return None;
-        }
-    };
-    if let Err(err) = hel::configure_irq(&handle, trigger, polarity) {
-        println!(
-            "sif: Failed to configure IRQ {index} of {}: {err}",
-            controller.path()
-        );
-        return None;
-    }
-
-    let pin = leak(IrqPin {
-        name: format!("{}:{index}", controller.name()),
-        handle,
-        trigger,
-        polarity,
-    });
-    pins.insert((phandle, index), pin);
-    Some(pin)
-}
 
 pub struct DtbPciIrqRouter {
     state: RouterState,

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -16,9 +16,7 @@ use hel::{IrqPolarity, IrqTrigger};
 
 use config::PciConfigIo;
 
-pub(crate) fn leak<T>(value: T) -> &'static T {
-    Box::leak(Box::new(value))
-}
+pub(crate) use crate::leak;
 
 // The PCI tree is only locked for the duration of a single operation, none of which can panic.
 pub(crate) const EXPECT_LOCK: &str = "sif: PCI tree mutex was poisoned";

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -1026,9 +1026,12 @@ pub const PCI_BRIDGE_SECONDARY: u16 = 0x19;
 pub const PCI_BRIDGE_SUBORDINATE: u16 = 0x1A;
 
 pub async fn publish_devices() -> Result<()> {
-    // Each discovery source no-ops if its firmware interface is absent.
+    // Each discovery source no-ops if its firmware interface is absent. ACPI systems
+    // describe PCI via the MCFG even when a device tree is also present.
     acpi::discover_root_buses();
-    dtb::discover_root_buses();
+    if !crate::acpi::has_rsdp() {
+        dtb::discover_root_buses();
+    }
 
     discover::enumerate_all();
     serve::publish_all().await?;

--- a/sif/src/pci/mod.rs
+++ b/sif/src/pci/mod.rs
@@ -5,78 +5,24 @@ pub mod dtb;
 pub mod quirks;
 pub mod serve;
 
-use managarm::svrctl::hardware_access_handle;
-use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU8, AtomicU32, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 use anyhow::Result;
 use arch::{IoMemSpace, bit_register, scalar_register};
-use hel::{IrqPolarity, IrqTrigger};
 
 use config::PciConfigIo;
 
+pub(crate) use crate::irq::{IrqPin, system_irq};
 pub(crate) use crate::leak;
 
 // The PCI tree is only locked for the duration of a single operation, none of which can panic.
 pub(crate) const EXPECT_LOCK: &str = "sif: PCI tree mutex was poisoned";
 
-pub struct IrqPin {
-    name: String,
-    handle: hel::Handle,
-    // None if the interrupt controller has no configurable trigger mode / polarity.
-    trigger: Option<IrqTrigger>,
-    polarity: Option<IrqPolarity>,
-}
-
-impl IrqPin {
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn handle(&self) -> &hel::Handle {
-        &self.handle
-    }
-}
-
-static IRQ_PINS: Mutex<BTreeMap<u32, &'static IrqPin>> = Mutex::new(BTreeMap::new());
-
 // thor only implements MSI allocation on x86-64 (LAPIC MSIs); mirror that here
 // until the kernel can report MSI availability.
 pub fn msi_controller_available() -> bool {
     cfg!(target_arch = "x86_64")
-}
-
-// Configures a GSI and returns its pin, sharing pins between users of the same GSI.
-pub fn system_irq(gsi: u32, trigger: IrqTrigger, polarity: IrqPolarity) -> Option<&'static IrqPin> {
-    let mut pins = IRQ_PINS.lock().expect(EXPECT_LOCK);
-    if let Some(pin) = pins.get(&gsi) {
-        if pin.trigger != Some(trigger) || pin.polarity != Some(polarity) {
-            println!("sif: Conflicting configurations for GSI {gsi}");
-        }
-        return Some(*pin);
-    }
-
-    let handle = match hel::access_irq_by_gsi(hardware_access_handle(), gsi as u64) {
-        Ok(handle) => handle,
-        Err(err) => {
-            println!("sif: Failed to access GSI {gsi}: {err}");
-            return None;
-        }
-    };
-    if let Err(err) = hel::configure_irq(&handle, Some(trigger), Some(polarity)) {
-        println!("sif: Failed to configure GSI {gsi}: {err}");
-        return None;
-    }
-
-    let pin = leak(IrqPin {
-        name: format!("gsi-{gsi}"),
-        handle,
-        trigger: Some(trigger),
-        polarity: Some(polarity),
-    });
-    pins.insert(gsi, pin);
-    Some(pin)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/sif/src/pci/serve.rs
+++ b/sif/src/pci/serve.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::Ordering;
 use anyhow::Result;
 use managarm::hw::pci::IoType;
 use managarm::hw::server::{BarDescriptor, CapDescriptor, serve_pci_device};
-use managarm::mbus::{EntityManager, Item, Properties, create_entity};
+use managarm::mbus::{EntityManager, Properties, create_entity};
 
 use super::discover::{all_devices, all_root_buses};
 use super::{
@@ -14,18 +14,7 @@ use super::{
 };
 
 use crate::acpi::{PAGE_MASK, PAGE_SIZE};
-
-fn string(value: &str) -> Item {
-    Item::String(value.to_string())
-}
-
-fn hex(value: u32, width: usize) -> Item {
-    Item::String(format!("{value:0width$x}"))
-}
-
-fn decimal(value: i64) -> Item {
-    Item::String(format!("{value}"))
-}
+use crate::entity::{decimal, hex, serve_entity_lanes, string};
 
 #[derive(Clone, Copy)]
 enum ServedEntity {
@@ -303,23 +292,12 @@ impl managarm::hw::server::PciDevice for ServedEntity {
 }
 
 async fn serve_entity(manager: &'static EntityManager, served: ServedEntity) {
-    let id = manager.id();
     let device = Arc::new(served);
 
-    loop {
-        let (local, remote) = match hel::create_stream() {
-            Ok(pair) => pair,
-            Err(err) => {
-                println!("sif: entity {id}: create_stream failed: {err}");
-                return;
-            }
-        };
-        if let Err(err) = manager.serve_remote_lane(remote).await {
-            println!("sif: entity {id}: serve_remote_lane failed: {err}");
-            return;
-        }
-        hel::spawn(serve_pci_device(local, device.clone()));
-    }
+    serve_entity_lanes(manager, move |lane| {
+        hel::spawn(serve_pci_device(lane, device.clone()));
+    })
+    .await;
 }
 
 fn entity_properties(entity: &PciEntity, pci_type: &str) -> Properties {

--- a/sif/src/uacpi/namespace.rs
+++ b/sif/src/uacpi/namespace.rs
@@ -53,11 +53,69 @@ unsafe impl Send for NamespaceNode {}
 unsafe impl Sync for NamespaceNode {}
 
 impl NamespaceNode {
+    /// Wraps uacpi_namespace_root().
+    pub fn root() -> NamespaceNode {
+        // SAFETY: uACPI does not take any arguments that we could get wrong.
+        let node = unsafe { uacpi_sys::uacpi_namespace_root() };
+        NamespaceNode::from_raw(node).expect("uACPI lacks a root namespace node")
+    }
+
     /// Wraps uacpi_namespace_get_predefined().
     pub fn predefined(which: PredefinedNamespace) -> NamespaceNode {
         // SAFETY: uACPI does not take any arguments that we could get wrong.
         let node = unsafe { uacpi_sys::uacpi_namespace_get_predefined(which.to_raw()) };
         NamespaceNode::from_raw(node).expect("uACPI lacks a predefined namespace node")
+    }
+
+    /// Wraps uacpi_namespace_node_generate_absolute_path().
+    pub fn absolute_path(self) -> String {
+        // SAFETY: uACPI allocates the path string; we free it below.
+        let path = unsafe { uacpi_sys::uacpi_namespace_node_generate_absolute_path(self.node) };
+        assert!(!path.is_null(), "uACPI failed to generate an absolute path");
+        let string = unsafe { CStr::from_ptr(path) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { uacpi_sys::uacpi_free_absolute_path(path) };
+        string
+    }
+
+    /// Wraps uacpi_eval_hid(). Returns None if the device has no _HID.
+    pub fn eval_hid(self) -> Result<Option<String>> {
+        let mut id: *mut uacpi_sys::uacpi_id_string = std::ptr::null_mut();
+        // SAFETY: uACPI only writes the pointer to the id string that it allocates.
+        let status = unsafe { uacpi_sys::uacpi_eval_hid(self.node, &mut id) };
+        if !check_optional("uacpi_eval_hid", status)? {
+            return Ok(None);
+        }
+
+        // SAFETY: uACPI hands out a valid id string; we free it below.
+        let value = unsafe { CStr::from_ptr((*id).value) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { uacpi_sys::uacpi_free_id_string(id) };
+        Ok(Some(value))
+    }
+
+    /// Wraps uacpi_eval_cid(). Returns None if the device has no _CID.
+    pub fn eval_cid(self) -> Result<Option<Vec<String>>> {
+        let mut list: *mut uacpi_sys::uacpi_pnp_id_list = std::ptr::null_mut();
+        // SAFETY: uACPI only writes the pointer to the id list that it allocates.
+        let status = unsafe { uacpi_sys::uacpi_eval_cid(self.node, &mut list) };
+        if !check_optional("uacpi_eval_cid", status)? {
+            return Ok(None);
+        }
+
+        // SAFETY: uACPI hands out a list of num_ids valid id strings; we free it below.
+        let values = unsafe {
+            (*list)
+                .ids
+                .as_slice((*list).num_ids as usize)
+                .iter()
+                .map(|id| CStr::from_ptr(id.value).to_string_lossy().into_owned())
+                .collect()
+        };
+        unsafe { uacpi_sys::uacpi_free_pnp_id_list(list) };
+        Ok(Some(values))
     }
 
     pub(super) fn from_raw(node: *mut uacpi_namespace_node) -> Option<NamespaceNode> {

--- a/sif/src/uacpi/resources.rs
+++ b/sif/src/uacpi/resources.rs
@@ -1,7 +1,10 @@
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
-use uacpi_sys::{uacpi_resource, uacpi_resource_extended_irq, uacpi_resource_irq, uacpi_resources};
+use uacpi_sys::{
+    uacpi_resource, uacpi_resource_extended_irq, uacpi_resource_fixed_io, uacpi_resource_io,
+    uacpi_resource_irq, uacpi_resource_type, uacpi_resources,
+};
 
 use super::namespace::NamespaceNode;
 use super::{Result, check};
@@ -88,12 +91,46 @@ impl<'a> ExtendedIrq<'a> {
     }
 }
 
+/// An IO port range resource, i.e., a resource of type UACPI_RESOURCE_TYPE_IO.
+#[derive(Clone, Copy)]
+pub struct Io<'a> {
+    io: &'a uacpi_resource_io,
+}
+
+impl Io<'_> {
+    pub fn minimum(self) -> u16 {
+        self.io.minimum
+    }
+
+    pub fn maximum(self) -> u16 {
+        self.io.maximum
+    }
+}
+
+/// A fixed IO port range resource, i.e., a resource of type UACPI_RESOURCE_TYPE_FIXED_IO.
+#[derive(Clone, Copy)]
+pub struct FixedIo<'a> {
+    io: &'a uacpi_resource_fixed_io,
+}
+
+impl FixedIo<'_> {
+    pub fn address(self) -> u16 {
+        self.io.address
+    }
+
+    pub fn length(self) -> u8 {
+        self.io.length
+    }
+}
+
 /// A single resource of a [`Resources`] list.
 pub enum Resource<'a> {
     Irq(Irq<'a>),
     ExtendedIrq(ExtendedIrq<'a>),
-    /// A resource of a type that we do not wrap yet.
-    Other,
+    Io(Io<'a>),
+    FixedIo(FixedIo<'a>),
+    /// A resource of a type that we do not wrap yet, i.e., a UACPI_RESOURCE_TYPE_* value.
+    Other(uacpi_resource_type),
 }
 
 /// A list of resources that uACPI allocated for us.
@@ -180,7 +217,13 @@ impl<'a> Iterator for ResourceIter<'a> {
                 uacpi_sys::UACPI_RESOURCE_TYPE_EXTENDED_IRQ => Resource::ExtendedIrq(ExtendedIrq {
                     irq: &*payload.cast::<uacpi_resource_extended_irq>(),
                 }),
-                _ => Resource::Other,
+                uacpi_sys::UACPI_RESOURCE_TYPE_IO => Resource::Io(Io {
+                    io: &*payload.cast::<uacpi_resource_io>(),
+                }),
+                uacpi_sys::UACPI_RESOURCE_TYPE_FIXED_IO => Resource::FixedIo(FixedIo {
+                    io: &*payload.cast::<uacpi_resource_fixed_io>(),
+                }),
+                _ => Resource::Other(type_),
             }
         };
 


### PR DESCRIPTION
This ports DT and PS2 mbus objects over to sif. We do not port `pm-interface` yet as that is part of the ACPI-outside-the-kernel work and separate (and it requires SCI and EC support which sif does not have yet).