### PR TITLE
hel, thor: Add userspace-readable clock page that enables the equivalent of helGetClock() without syscall

### DIFF
--- a/core/drm/src/core.cpp
+++ b/core/drm/src/core.cpp
@@ -10,6 +10,7 @@
 
 #include <async/result.hpp>
 #include <core/dispatch.hpp>
+#include <helix/clock.hpp>
 #include <helix/ipc.hpp>
 #include <protocols/fs/defs.hpp>
 #include <protocols/fs/server.hpp>
@@ -123,7 +124,7 @@ drm_core::File::importBufferObject(helix_ng::Credentials creds) {
 }
 
 void drm_core::File::postEvent(drm_core::Event event) {
-	HEL_CHECK(helGetClock(&event.timestamp));
+	event.timestamp = helix::getClock();
 
 	if(_pendingEvents.empty()) {
 		++_eventSequence;

--- a/core/lib/clock.cpp
+++ b/core/lib/clock.cpp
@@ -1,5 +1,6 @@
 
 #include <async/oneshot-event.hpp>
+#include <helix/clock.hpp>
 #include <helix/memory.hpp>
 #include <protocols/clock/defs.hpp>
 #include <protocols/mbus/client.hpp>
@@ -78,8 +79,7 @@ int64_t getRealtimeNanos() {
 	assert(__atomic_load_n(&page->seqlock, __ATOMIC_RELAXED) == seqlock);
 
 	// Calculate the current time.
-	uint64_t now;
-	HEL_CHECK(helGetClock(&now));
+	auto now = helix::getClock();
 
 	return base + (now - ref);
 }
@@ -93,8 +93,7 @@ struct timespec getRealtime() {
 }
 
 struct timespec getTimeSinceBoot() {
-	uint64_t now;
-	HEL_CHECK(helGetClock(&now));
+	auto now = helix::getClock();
 
 	struct timespec result;
 	result.tv_sec = now / 1'000'000'000;

--- a/drivers/block/virtio-blk/src/block.cpp
+++ b/drivers/block/virtio-blk/src/block.cpp
@@ -1,6 +1,7 @@
 
 #include <async/basic.hpp>
 #include <frg/scope_exit.hpp>
+#include <helix/clock.hpp>
 #include <stdlib.h>
 #include <iostream>
 #include <list>
@@ -15,9 +16,7 @@ static bool logInitiateRetire = false;
 namespace {
 
 uint64_t currentNs() {
-	uint64_t ns;
-	HEL_CHECK(helGetClock(&ns));
-	return ns;
+	return helix::getClock();
 }
 
 void emitRequestTrace(UserRequest *request) {

--- a/drivers/gfx/intel/src/main.cpp
+++ b/drivers/gfx/intel/src/main.cpp
@@ -6,6 +6,7 @@
 
 #include <arch/mem_space.hpp>
 #include <async/result.hpp>
+#include <helix/clock.hpp>
 #include <protocols/hw/client.hpp>
 #include <protocols/mbus/client.hpp>
 
@@ -371,10 +372,10 @@ void Controller::programDpll(PllParams params, int multiplier) {
 			| pll_control::enablePll(true));
 	_ctrl.load(regs::pllControl);
 
-	uint64_t ticks, now;
-	HEL_CHECK(helGetClock(&ticks));
+	auto ticks = helix::getClock();
+	uint64_t now;
 	do {
-		HEL_CHECK(helGetClock(&now));
+		now = helix::getClock();
 	} while(now - ticks <= 150000);
 	
 	std::cout << "State: " << (_ctrl.load(regs::pllControl) & pll_control::enablePll)
@@ -390,10 +391,10 @@ void Controller::programDpll(PllParams params, int multiplier) {
 				| pll_control::enablePll(true));
 		_ctrl.load(regs::pllControl);
 
-		uint64_t ticks, now;
-		HEL_CHECK(helGetClock(&ticks));
+		auto ticks = helix::getClock();
+		uint64_t now;
 		do {
-			HEL_CHECK(helGetClock(&now));
+			now = helix::getClock();
 		} while(now - ticks <= 150000);
 	
 		std::cout << "State: " << (_ctrl.load(regs::pllControl) & pll_control::enablePll)

--- a/drivers/gfx/nvidia-open/src/sysdeps/nvkms.cpp
+++ b/drivers/gfx/nvidia-open/src/sysdeps/nvkms.cpp
@@ -201,8 +201,7 @@ void workqueueTimerHandler(void *arg) {
 
 nvkms_timer_handle_t *
 nvkms_alloc_timer(nvkms_timer_proc_t *proc, void *dataPtr, NvU32 dataU32, NvU64 usec) {
-	uint64_t now;
-	HEL_CHECK(helGetClock(&now));
+	auto now = helix::getClock();
 
 	auto timer = new nvkmsTimer{proc, dataPtr, dataU32, now + (usec * 1'000)};
 
@@ -219,8 +218,7 @@ nvkms_alloc_timer(nvkms_timer_proc_t *proc, void *dataPtr, NvU32 dataU32, NvU64 
 NvBool nvkms_alloc_timer_with_ref_ptr(
     nvkms_timer_proc_t *proc, struct nvkms_ref_ptr *ref_ptr, NvU32 dataU32, NvU64 usec
 ) {
-	uint64_t now;
-	HEL_CHECK(helGetClock(&now));
+	auto now = helix::getClock();
 
 	nvkms_inc_ref(ref_ptr);
 	auto timer = new nvkmsTimer{proc, ref_ptr, dataU32, now + (usec * 1'000), true};

--- a/drivers/kbd/src/main.cpp
+++ b/drivers/kbd/src/main.cpp
@@ -239,19 +239,11 @@ std::optional<uint8_t> Controller::recvResponseByte(uint64_t timeout) {
 	assert(!_portsOwnData);
 
 	if (timeout) {
-		uint64_t start, end, current;
+		bool ready = helix::busyWaitUntil(timeout, [&] {
+			return _commandSpace.load(kbd_register::status) & status_bits::outBufferStatus;
+		});
 
-		HEL_CHECK(helGetClock(&start));
-		end = start + timeout;
-		current = start;
-
-		while (!(_commandSpace.load(kbd_register::status)
-				& status_bits::outBufferStatus) && current < end)
-			HEL_CHECK(helGetClock(&current));
-
-		bool cancelled = current >= end;
-
-		if (cancelled)
+		if (!ready)
 			return std::nullopt;
 
 		return _dataSpace.load(kbd_register::data);

--- a/drivers/libblockfs/src/raw.cpp
+++ b/drivers/libblockfs/src/raw.cpp
@@ -4,6 +4,7 @@
 
 #include <bragi/helpers-std.hpp>
 #include <core/dispatch.hpp>
+#include <helix/clock.hpp>
 #include <helix/dispatcher-pool.hpp>
 #include "fs.bragi.hpp"
 
@@ -93,8 +94,7 @@ namespace {
 
 async::result<protocols::fs::ReadResult> rawRead(void *object, helix_ng::CredentialsView,
 		void *buffer, size_t length, async::cancellation_token) {
-	uint64_t start;
-	HEL_CHECK(helGetClock(&start));
+	auto start = helix::getClock();
 
 	auto self = static_cast<raw::OpenFile *>(object);
 
@@ -125,8 +125,7 @@ async::result<protocols::fs::ReadResult> rawRead(void *object, helix_ng::Credent
 			chunk_offset, chunkSize, buffer);
 	HEL_CHECK(readMemory.error());
 
-	uint64_t end;
-	HEL_CHECK(helGetClock(&end));
+	auto end = helix::getClock();
 
 	ostContext.emit(
 		ostEvtRawRead,
@@ -141,8 +140,7 @@ async::result<protocols::fs::ReadResult>
 rawPread(void *object, int64_t offset, helix_ng::CredentialsView, void *buffer, size_t length) {
 	size_t unsignedOffset = offset;
 
-	uint64_t start;
-	HEL_CHECK(helGetClock(&start));
+	auto start = helix::getClock();
 
 	auto self = static_cast<raw::OpenFile *>(object);
 	// TODO(geert): pass cancellation token through here
@@ -162,8 +160,7 @@ rawPread(void *object, int64_t offset, helix_ng::CredentialsView, void *buffer, 
 			unsignedOffset, chunkSize, buffer);
 	HEL_CHECK(readMemory.error());
 
-	uint64_t end;
-	HEL_CHECK(helGetClock(&end));
+	auto end = helix::getClock();
 
 	ostContext.emit(
 		ostEvtRawRead,

--- a/drivers/usb/hcds/ehci/src/main.cpp
+++ b/drivers/usb/hcds/ehci/src/main.cpp
@@ -10,6 +10,7 @@
 #include <arch/dma_pool.hpp>
 #include <async/result.hpp>
 #include <fafnir/dsl.hpp>
+#include <helix/clock.hpp>
 #include <helix/ipc.hpp>
 #include <protocols/hw/client.hpp>
 #include <protocols/kernlet/compiler.hpp>
@@ -1076,8 +1077,7 @@ Controller::resetPort(int number) {
 //	std::cout << "ehci: Port reset." << std::endl;
 	port_space.store(port_regs::sc, portsc::portReset(true));
 
-	uint64_t tick;
-	HEL_CHECK(helGetClock(&tick));
+	auto tick = helix::getClock();
 
 	helix::AwaitClock await_clock;
 	auto &&submit = helix::submitAwaitClock(&await_clock, tick + 50'000'000,

--- a/drivers/usb/hcds/uhci/src/main.cpp
+++ b/drivers/usb/hcds/uhci/src/main.cpp
@@ -14,6 +14,7 @@
 #include <async/result.hpp>
 #include <fafnir/dsl.hpp>
 #include <frg/list.hpp>
+#include <helix/clock.hpp>
 #include <helix/ipc.hpp>
 #include <protocols/hw/client.hpp>
 #include <protocols/kernlet/compiler.hpp>
@@ -265,8 +266,7 @@ async::detached Controller::_refreshFrame() {
 //		std::cout << "uhci: Frame update" << std::endl;
 		_updateFrame();
 
-		uint64_t tick;
-		HEL_CHECK(helGetClock(&tick));
+		auto tick = helix::getClock();
 
 		helix::AwaitClock await_clock;
 		auto &&submit = helix::submitAwaitClock(&await_clock, tick + 500'000'000,
@@ -353,8 +353,7 @@ Controller::RootHub::issueReset(int port) {
 	// Reset the port for 50 ms.
 	port_space.store(port_regs::statusCtrl, port_status_ctrl::portReset(true));
 
-	uint64_t tick;
-	HEL_CHECK(helGetClock(&tick));
+	auto tick = helix::getClock();
 
 	helix::AwaitClock await_clock;
 	auto &&submit = helix::submitAwaitClock(&await_clock, tick + 50'000'000,
@@ -371,15 +370,13 @@ Controller::RootHub::issueReset(int port) {
 	// Enable the port and wait until it is available.
 	port_space.store(port_regs::statusCtrl, port_status_ctrl::enableStatus(true));
 
-	uint64_t start;
-	HEL_CHECK(helGetClock(&start));
+	auto start = helix::getClock();
 	while(true) {
 		auto sc = port_space.load(port_regs::statusCtrl);
 		if((sc & port_status_ctrl::enableStatus))
 			break;
 
-		uint64_t now;
-		HEL_CHECK(helGetClock(&now));
+		auto now = helix::getClock();
 		if(now - start > 1000'000'000) {
 			std::cout << "\e[31muhci: Could not enable device after reset\e[39m" << std::endl;
 			co_return UsbError::timeout;

--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -419,7 +419,41 @@ static const uint32_t kHelTransferDescriptorOut = UINT32_C(1) << 0;
 static const uint32_t kHelTransferDescriptorIn = UINT32_C(1) << 1;
 
 enum {
-	kHelObtainZeroMemory = 1
+	kHelObtainZeroMemory = 1,
+	kHelObtainClockPage = 2
+};
+
+//! Clocks that userspace can read without a syscall (see HelClockPage).
+enum {
+	//! No clock that is accessible to userspace (= helGetClock() has to be used).
+	kHelClockNone = 0,
+	//! x86: TSC.
+	kHelClockTsc = 1,
+	//! ARM: physical counter (CNTPCT_EL0).
+	kHelClockCntpct = 2,
+	//! ARM: virtual counter (CNTVCT_EL0).
+	kHelClockCntvct = 3,
+	//! RISC-V: time CSR.
+	kHelClockTime = 4
+};
+
+//! Parameters that allow userspace to compute the current time on the monotone clock
+//! (i.e., the clock read by helGetClock()) without performing syscalls.
+//!
+//! Obtained as a read-only memory object via helObtainHandle() with kHelObtainClockPage.
+//! All fields are protected by a seqlock:
+//! readers repeat the read while seqlock is odd or while it changes during the read.
+//!
+//! The conversion from clock ticks to nanoseconds is (tickFactor * ticks) >> tickShift.
+//! The multiplication is performed in 128-bit arithmetic.
+struct HelClockPage {
+	uint64_t seqlock;
+	//! One of the kHelClock* constants.
+	uint32_t clockType;
+	//! Scaling exponent of the tick -> nanosecond conversion.
+	int32_t tickShift;
+	//! Factor of the tick -> nanosecond conversion.
+	uint64_t tickFactor;
 };
 
 struct HelSgItem {

--- a/hel/include/helix/clock.hpp
+++ b/hel/include/helix/clock.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace helix {
+
+// Reads the system-wide monotone clock, i.e., the number of nanoseconds since boot.
+// Equivalent to helGetClock() but avoids the syscall if the kernel exports a clock that userspace can read on its own.
+uint64_t getClock();
+
+// Whether getClock() reads the clock in userspace instead of falling back to helGetClock().
+bool hasUserspaceClock();
+
+} // namespace helix

--- a/hel/include/helix/timer.hpp
+++ b/hel/include/helix/timer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <helix/clock.hpp>
 #include <helix/ipc.hpp>
 #include <async/cancellation.hpp>
 #include <async/result.hpp>
@@ -27,8 +28,7 @@ struct TimeoutCallback {
 
 private:
 	async::detached _runTimer(uint64_t duration) {
-		uint64_t tick;
-		HEL_CHECK(helGetClock(&tick));
+		auto tick = getClock();
 
 		helix::AwaitClock await;
 		auto &&submit = helix::submitAwaitClock(&await, tick + duration,
@@ -77,8 +77,7 @@ private:
 };
 
 inline async::result<bool> sleepFor(uint64_t duration, async::cancellation_token cancel = {}) {
-	uint64_t tick;
-	HEL_CHECK(helGetClock(&tick));
+	auto tick = getClock();
 
 	helix::AwaitClock await;
 	auto &&submit = helix::submitAwaitClock(&await, tick + duration,
@@ -119,9 +118,9 @@ inline async::result<bool> sleepUntil(uint64_t tick, async::cancellation_token c
 // Returns true if the operation succeeded, or false if it timed out
 template<typename F> requires (std::is_invocable_r_v<bool, F>)
 async::result<bool> kindaBusyWait(uint64_t timeoutNs, F cond) {
-	uint64_t startNs, currNs;
-	HEL_CHECK(helGetClock(&startNs));
+	auto startNs = getClock();
 
+	uint64_t currNs;
 	do {
 		if (std::invoke(cond))
 			co_return true;
@@ -129,7 +128,7 @@ async::result<bool> kindaBusyWait(uint64_t timeoutNs, F cond) {
 		// Sleep for 5ms (TODO: make adaptive?)
 		co_await sleepFor(5'000'000);
 
-		HEL_CHECK(helGetClock(&currNs));
+		currNs = getClock();
 	} while (currNs < startNs + timeoutNs);
 
 	co_return std::invoke(cond);
@@ -138,14 +137,14 @@ async::result<bool> kindaBusyWait(uint64_t timeoutNs, F cond) {
 // Returns true if the operation succeeded, or false if it timed out
 template<typename F> requires (std::is_invocable_r_v<bool, F>)
 bool busyWaitUntil(uint64_t timeoutNs, F cond) {
-	uint64_t startNs, currNs;
-	HEL_CHECK(helGetClock(&startNs));
+	auto startNs = getClock();
 
+	uint64_t currNs;
 	do {
 		if (std::invoke(cond))
 			return true;
 
-		HEL_CHECK(helGetClock(&currNs));
+		currNs = getClock();
 	} while (currNs < startNs + timeoutNs);
 
 	return std::invoke(cond);

--- a/hel/meson.build
+++ b/hel/meson.build
@@ -6,6 +6,7 @@ headers = [
 ]
 
 helix_headers = [
+	'include/helix/clock.hpp',
 	'include/helix/dispatcher-pool.hpp',
 	'include/helix/ipc-structs.hpp',
 	'include/helix/ipc.hpp',
@@ -15,6 +16,7 @@ helix_headers = [
 ]
 
 src = files(
+	'src/clock.cpp',
 	'src/dispatcher-pool.cpp',
 	'src/globals.cpp',
 	'src/passthrough-fd.cpp',

--- a/hel/src/clock.cpp
+++ b/hel/src/clock.cpp
@@ -1,0 +1,118 @@
+#include <stdint.h>
+
+#include <hel.h>
+#include <hel-syscalls.h>
+#include <helix/clock.hpp>
+#include <helix/memory.hpp>
+
+namespace helix {
+
+namespace {
+
+// Read-only mapping of the kernel's clock page.
+struct ClockPage {
+	ClockPage() {
+		HelHandle handle;
+		if(helObtainHandle(kHelObtainClockPage, &handle) != kHelErrNone)
+			return;
+		UniqueDescriptor descriptor{handle};
+
+		_mapping = Mapping{descriptor, 0, Mapping::pageSize, kHelMapProtRead};
+		page = static_cast<const HelClockPage *>(_mapping.get());
+	}
+
+	const HelClockPage *page{nullptr};
+
+private:
+	Mapping _mapping;
+};
+
+// Cache and access the clock page.
+const HelClockPage *clockPage() {
+	static ClockPage singleton;
+	return singleton.page;
+}
+
+// Reads the raw tick counter of the given clock. Returns false if this build cannot read it.
+// The memory clobbers keep the compiler from moving the read out of the seqlock window.
+bool readRawTicks(uint32_t clockType, uint64_t &ticks) {
+#if defined(__x86_64__)
+	if(clockType == kHelClockTsc) [[likely]] {
+		uint32_t lsw, msw;
+		asm volatile ("lfence; rdtsc" : "=a"(lsw), "=d"(msw) : : "memory");
+		ticks = (static_cast<uint64_t>(msw) << 32) | static_cast<uint64_t>(lsw);
+		return true;
+	}
+#elif defined(__aarch64__)
+	if(clockType == kHelClockCntpct) {
+		asm volatile ("mrs %0, cntpct_el0" : "=r"(ticks) : : "memory");
+		return true;
+	}
+	if(clockType == kHelClockCntvct) {
+		asm volatile ("mrs %0, cntvct_el0" : "=r"(ticks) : : "memory");
+		return true;
+	}
+#elif defined(__riscv) && __riscv_xlen == 64
+	if(clockType == kHelClockTime) [[likely]] {
+		asm volatile ("rdtime %0" : "=r"(ticks) : : "memory");
+		return true;
+	}
+#endif
+	return false;
+}
+
+uint64_t ticksToNanos(uint64_t tickFactor, int32_t tickShift, uint64_t ticks) {
+	auto product = static_cast<unsigned __int128>(tickFactor) * ticks;
+	auto quotient = product >> tickShift;
+	if(quotient >> 64)
+		return UINT64_MAX;
+	return static_cast<uint64_t>(quotient);
+}
+
+// Reads the clock without a syscall. Returns false if the kernel exports no clock that this
+// build can read, or if the read raced with a kernel update of the clock page.
+bool readUserspaceClock(uint64_t &nanos) {
+	auto page = clockPage();
+	if(!page)
+		return false;
+
+	// Start the seqlock read.
+	// We do not loop around here. Instead, we fall through into helGetClock().
+	auto seqlock = __atomic_load_n(&page->seqlock, __ATOMIC_ACQUIRE);
+	if(seqlock & 1)
+		return false;
+
+	// Perform the actual loads.
+	auto clockType = __atomic_load_n(&page->clockType, __ATOMIC_RELAXED);
+	auto tickShift = __atomic_load_n(&page->tickShift, __ATOMIC_RELAXED);
+	auto tickFactor = __atomic_load_n(&page->tickFactor, __ATOMIC_RELAXED);
+
+	uint64_t ticks;
+	auto readable = readRawTicks(clockType, ticks);
+
+	// Finish the seqlock read.
+	__atomic_thread_fence(__ATOMIC_ACQUIRE);
+	if(!readable || __atomic_load_n(&page->seqlock, __ATOMIC_RELAXED) != seqlock)
+		return false;
+
+	nanos = ticksToNanos(tickFactor, tickShift, ticks);
+	return true;
+}
+
+} // anonymous namespace
+
+uint64_t getClock() {
+	uint64_t nanos;
+	if(readUserspaceClock(nanos)) [[likely]]
+		return nanos;
+
+	HEL_CHECK(helGetClock(&nanos));
+	return nanos;
+}
+
+bool hasUserspaceClock() {
+	uint64_t nanos;
+	return readUserspaceClock(nanos);
+}
+
+} // namespace helix

--- a/kernel/common/riscv/csr.hpp
+++ b/kernel/common/riscv/csr.hpp
@@ -8,10 +8,11 @@ enum class Csr : uint16_t {
 	// Floating point control and status.
 	fcsr = 0x3,
 	// Supervisor trap setup.
-	sstatus = 0x100, // Status register.
-	sie = 0x104,     // Interrupt enable.
-	stvec = 0x105,   // Trap vector address.
-	senvcfg = 0x10A, // Environment configuration.
+	sstatus = 0x100,    // Status register.
+	sie = 0x104,        // Interrupt enable.
+	stvec = 0x105,      // Trap vector address.
+	scounteren = 0x106, // Counter enable.
+	senvcfg = 0x10A,    // Environment configuration.
 	// Supervisor trap handling.
 	sscratch = 0x140,
 	sepc = 0x141,     // Exception program counter.
@@ -133,6 +134,14 @@ constexpr uint64_t hupmmShift = 48;
 constexpr uint64_t hupmmMask = 0b11;
 
 } // namespace hstatus
+
+namespace scounteren {
+
+constexpr uint64_t cy = UINT64_C(1) << 0; // cycle register enable
+constexpr uint64_t tm = UINT64_C(1) << 1; // time register enable
+constexpr uint64_t ir = UINT64_C(1) << 2; // instret register enable
+
+} // namespace scounteren
 
 namespace hcounteren {
 

--- a/kernel/thor/arch/arm/cpu.cpp
+++ b/kernel/thor/arch/arm/cpu.cpp
@@ -253,6 +253,14 @@ void initializeThisProcessor() {
 
 	asm volatile ("msr sctlr_el1, %0" :: "r"(sctlr));
 
+	// Allow EL0 to read the counter that backs the monotonic clock.
+	// In EL2, the register is redirected to CNTHCTL_EL2, which eir and the SMP trampoline
+	// already program. Never preserve the other bits: the reset value is UNKNOWN.
+	if (!isKernelInEl2()) {
+		uint64_t cntkctl = uint64_t(1) << 1; // EL0VCTEN
+		asm volatile ("msr cntkctl_el1, %0" :: "r"(cntkctl));
+	}
+
 	uint64_t mpidr;
 	asm volatile("mrs %0, mpidr_el1" : "=r"(mpidr));
 	cpu_data->affinity = affinityFromMpidr(mpidr);

--- a/kernel/thor/arch/arm/timer.cpp
+++ b/kernel/thor/arch/arm/timer.cpp
@@ -80,6 +80,14 @@ uint64_t getClockNanos() {
 	return timerTickDuration * getRawTimestampCounter();
 }
 
+UserspaceClock getUserspaceClock() {
+	assert(timerTickDuration);
+	return {
+		.type = isKernelInEl2() ? UserspaceClockType::armCntpct : UserspaceClockType::armCntvct,
+		.tickDuration = timerTickDuration
+	};
+}
+
 void setTimerDeadline(frg::optional<uint64_t> deadline) {
 	if (deadline) {
 		uint64_t rawDeadline = timerTickFreq * *deadline;

--- a/kernel/thor/arch/riscv/cpu.cpp
+++ b/kernel/thor/arch/riscv/cpu.cpp
@@ -178,6 +178,9 @@ void initializeThisProcessor() {
 	senvcfg |= riscv::senvcfg::cbie | riscv::senvcfg::cbcfe;
 	riscv::writeCsr<riscv::Csr::senvcfg>(senvcfg);
 
+	// Allow U-mode to read the time CSR that backs the monotonic clock.
+	riscv::setCsrBits<riscv::Csr::scounteren>(riscv::scounteren::tm);
+
 	// Read back sstatus.
 	sstatus = riscv::readCsr<riscv::Csr::sstatus>();
 	if (sstatus & riscv::sstatus::ubeBit)

--- a/kernel/thor/arch/riscv/timer.cpp
+++ b/kernel/thor/arch/riscv/timer.cpp
@@ -104,6 +104,11 @@ uint64_t getRawTimestampCounter() {
 
 uint64_t getClockNanos() { return tickDuration * getRawTimestampCounter(); }
 
+UserspaceClock getUserspaceClock() {
+	assert(tickDuration);
+	return {.type = UserspaceClockType::riscvTime, .tickDuration = tickDuration};
+}
+
 void setTimerDeadline(frg::optional<uint64_t> deadline) {
 	assert(!intsAreEnabled());
 

--- a/kernel/thor/arch/x86/pic.cpp
+++ b/kernel/thor/arch/x86/pic.cpp
@@ -343,6 +343,17 @@ uint64_t getClockNanos() {
 	}
 }
 
+UserspaceClock getUserspaceClock() {
+	assert(localApicContext()->timersAreCalibrated);
+	// Without an invariant TSC, the clock is driven by the HPET, which userspace cannot read.
+	if(!getGlobalCpuFeatures()->haveInvariantTsc)
+		return {};
+	return {
+		.type = UserspaceClockType::x86Tsc,
+		.tickDuration = localApicContext()->tscTickDuration
+	};
+}
+
 void acknowledgeIpi() {
 	picBase.store(lApicEoi, 0);
 }

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -24,6 +24,7 @@
 #include <thor-internal/stream.hpp>
 #include <thor-internal/thread.hpp>
 #include <thor-internal/timer.hpp>
+#include <thor-internal/user-clock.hpp>
 #include <thor-internal/acpi/acpi.hpp>
 #ifdef THOR_HAS_DTB_SUPPORT
 #include <thor-internal/dtb/dtb.hpp>
@@ -415,6 +416,14 @@ HelError helObtainHandle(int kind, HelHandle *handle) {
 		*handle = thisUniverse->attachDescriptor(
 			AnyDescriptor::make<DescriptorType::memoryView>(
 				getZeroMemory(),
+				kHelRightRead | kHelRightAssign
+			)
+		);
+		break;
+	case kHelObtainClockPage:
+		*handle = thisUniverse->attachDescriptor(
+			AnyDescriptor::make<DescriptorType::memoryView>(
+				getUserClockMemory(),
 				kHelRightRead | kHelRightAssign
 			)
 		);

--- a/kernel/thor/generic/thor-internal/arch-generic/timer.hpp
+++ b/kernel/thor/generic/thor-internal/arch-generic/timer.hpp
@@ -2,8 +2,24 @@
 
 #include <frg/optional.hpp>
 #include <stdint.h>
+#include <thor-internal/util.hpp>
 
 namespace thor {
+
+enum class UserspaceClockType {
+	none,
+	x86Tsc,
+	armCntpct,
+	armCntvct,
+	riscvTime
+};
+
+struct UserspaceClock {
+	UserspaceClockType type{UserspaceClockType::none};
+	// Clock ticks to nanoseconds conversion factor.
+	// Only meaningful if type is not UserspaceClockType::none.
+	Pow2Fraction<Rounding::down> tickDuration{};
+};
 
 // Returns the number of nanoseconds elapsed on the monotonic clock.
 uint64_t getClockNanos();
@@ -19,6 +35,10 @@ bool timerDisarmsItself();
 bool haveTimer();
 // Get the raw timestamp in preemption timer ticks.
 uint64_t getRawTimestampCounter();
+
+// Returns the clock parameters for userspace or UserspaceClockType::none
+// if getClockNanos() cannot be reproduced in userspace.
+UserspaceClock getUserspaceClock();
 
 // Called by the architecture-specific code. Handles timer deadline
 // expiry.

--- a/kernel/thor/generic/thor-internal/user-clock.hpp
+++ b/kernel/thor/generic/thor-internal/user-clock.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <smarter.hpp>
+
+namespace thor {
+
+struct MemoryView;
+
+// Memory object that exports the parameters of the monotonic clock to userspace, such that
+// userspace can compute getClockNanos() without performing a syscall.
+smarter::shared_ptr<MemoryView> getUserClockMemory();
+
+} // namespace thor

--- a/kernel/thor/generic/user-clock.cpp
+++ b/kernel/thor/generic/user-clock.cpp
@@ -1,0 +1,69 @@
+#include <hel.h>
+#include <thor-internal/arch-generic/timer.hpp>
+#include <thor-internal/debug.hpp>
+#include <thor-internal/main.hpp>
+#include <thor-internal/memory-view.hpp>
+#include <thor-internal/user-clock.hpp>
+
+namespace thor {
+
+namespace {
+
+smarter::shared_ptr<ImmediateMemory> &userClockMemory() {
+	static frg::eternal<smarter::shared_ptr<ImmediateMemory>> singleton = [] {
+		auto memoryOutcome = ImmediateMemory::create(kPageSize);
+		if(!memoryOutcome)
+			panicLogger() << "thor: Failed to allocate the clock page" << frg::endlog;
+		return std::move(*memoryOutcome);
+	}();
+	return singleton.get();
+}
+
+uint32_t translateClockType(UserspaceClockType type) {
+	switch(type) {
+		case UserspaceClockType::x86Tsc: return kHelClockTsc;
+		case UserspaceClockType::armCntpct: return kHelClockCntpct;
+		case UserspaceClockType::armCntvct: return kHelClockCntvct;
+		case UserspaceClockType::riscvTime: return kHelClockTime;
+		default: return kHelClockNone;
+	}
+}
+
+initgraph::Task publishClockPageTask{&globalInitEngine, "generic.publish-clock-page",
+	initgraph::Requires{getTaskingAvailableStage()},
+	[] {
+		// Instantiate the memory object even if there is nothing to publish:
+		// helObtainHandle() hands it out unconditionally and cannot construct it concurrently.
+		auto page = userClockMemory()->accessImmediate<HelClockPage>(0);
+
+		auto clock = getUserspaceClock();
+		if(clock.type == UserspaceClockType::none) {
+			infoLogger() << "thor: Monotonic clock cannot be read from userspace"
+					<< frg::endlog;
+			return;
+		}
+
+		// Start the seqlock write.
+		// Only the kernel has write access, so we can trust the previous seqlock value.
+		auto seqlock = __atomic_load_n(&page->seqlock, __ATOMIC_RELAXED);
+		assert(!(seqlock & 1));
+		__atomic_store_n(&page->seqlock, seqlock + 1, __ATOMIC_RELAXED);
+		__atomic_thread_fence(__ATOMIC_RELEASE);
+
+		// Perform the actual update.
+		__atomic_store_n(&page->clockType, translateClockType(clock.type), __ATOMIC_RELAXED);
+		__atomic_store_n(&page->tickShift, clock.tickDuration.s, __ATOMIC_RELAXED);
+		__atomic_store_n(&page->tickFactor, clock.tickDuration.f, __ATOMIC_RELAXED);
+
+		// Complete the seqlock write.
+		__atomic_store_n(&page->seqlock, seqlock + 2, __ATOMIC_RELEASE);
+	}
+};
+
+} // anonymous namespace
+
+smarter::shared_ptr<MemoryView> getUserClockMemory() {
+	return userClockMemory();
+}
+
+} // namespace thor

--- a/kernel/thor/meson.build
+++ b/kernel/thor/meson.build
@@ -79,6 +79,7 @@ src = files(
 	'generic/servers.cpp',
 	'generic/ubsan.cpp',
 	'generic/universe.cpp',
+	'generic/user-clock.cpp',
 	'generic/work-queue.cpp',
 	'generic/asid.cpp',
 	'generic/cpu-data.cpp',

--- a/posix/subsystem/src/clocks.cpp
+++ b/posix/subsystem/src/clocks.cpp
@@ -2,6 +2,7 @@
 #include <core/clock.hpp>
 #include <frg/safe_int.hpp>
 #include <hel.h>
+#include <helix/clock.hpp>
 #include <print>
 
 #include "clocks.hpp"
@@ -16,15 +17,13 @@ uint64_t convertToNanos(const timespec &ts, clockid_t clock, bool relative) {
 		nanos = UINT64_MAX;
 
 	if(relative) {
-		uint64_t now;
-		HEL_CHECK(helGetClock(&now));
+		auto now = helix::getClock();
 		uint64_t r;
 		if(!(frg::safe_int{now} + frg::safe_int{nanos}).into(r))
 			return UINT64_MAX;
 		return r;
 	} else if(clock == CLOCK_REALTIME) {
-		uint64_t now;
-		HEL_CHECK(helGetClock(&now));
+		auto now = helix::getClock();
 
 		// Transform real time to time since boot.
 		int64_t bootTime = clk::getRealtimeNanos() - now;

--- a/posix/subsystem/src/interval-timer.cpp
+++ b/posix/subsystem/src/interval-timer.cpp
@@ -1,4 +1,5 @@
 #include <frg/safe_int.hpp>
+#include <helix/clock.hpp>
 
 #include "interval-timer.hpp"
 
@@ -45,8 +46,7 @@ async::detached IntervalTimer::arm(std::shared_ptr<IntervalTimer> timer) {
 }
 
 void IntervalTimer::getTime(uint64_t &initial, uint64_t &interval) {
-	uint64_t now;
-	HEL_CHECK(helGetClock(&now));
+	auto now = helix::getClock();
 
 	if(nextExpiration_ > now)
 		initial = nextExpiration_ - now;

--- a/protocols/ostrace/include/protocols/ostrace/ostrace.hpp
+++ b/protocols/ostrace/include/protocols/ostrace/ostrace.hpp
@@ -7,6 +7,7 @@
 #include <async/mutex.hpp>
 #include <async/queue.hpp>
 #include <async/result.hpp>
+#include <helix/clock.hpp>
 #include <helix/ipc.hpp>
 #include <ostrace.bragi.hpp>
 
@@ -174,8 +175,7 @@ struct Context {
 	void emit(const Event &event, Args... args) {
 		if (!isActive())
 			return;
-		uint64_t ts;
-		HEL_CHECK(helGetClock(&ts));
+		auto ts = helix::getClock();
 		emitWithTimestamp(event, ts, std::forward<Args>(args)...);
 	}
 
@@ -192,8 +192,8 @@ private:
 };
 
 struct Timer {
-	Timer() {
-		HEL_CHECK(helGetClock(&_start));
+	Timer()
+	: _start{helix::getClock()} {
 		_split = _start;
 	}
 
@@ -201,17 +201,14 @@ struct Timer {
 	Timer &operator= (const Timer &) = delete;
 
 	uint64_t elapsed() {
-		uint64_t now;
-		HEL_CHECK(helGetClock(&now));
-		return now - _start;
+		return helix::getClock() - _start;
 	}
 
 	// Ends the current phase of the timed operation and returns its duration.
 	// Storing the result in a zero-initialized variable keeps phases that an early return never
 	// reaches at zero, whereas subtracting stored timestamps would underflow.
 	uint64_t split() {
-		uint64_t now;
-		HEL_CHECK(helGetClock(&now));
+		auto now = helix::getClock();
 		auto duration = now - _split;
 		_split = now;
 		return duration;

--- a/servers/netserver/src/ip/arp.cpp
+++ b/servers/netserver/src/ip/arp.cpp
@@ -1,5 +1,6 @@
 #include "arp.hpp"
 
+#include <helix/clock.hpp>
 #include <helix/ipc.hpp>
 #include <helix/timer.hpp>
 #include <arch/bit.hpp>
@@ -139,8 +140,7 @@ void Neighbours::feedArp(nic::MacAddress, arch::dma_buffer_view view, std::weak_
 }
 
 Neighbours::Entry &Neighbours::getEntry(uint32_t ip) {
-	uint64_t time;
-	HEL_CHECK(helGetClock(&time));
+	auto time = helix::getClock();
 	if (auto f = table_.find(ip); f != table_.end()) {
 		if (time + staleTimeMs * 1'000'000 <= f->second.mtime_ns) {
 			f->second.state = State::stale;

--- a/servers/netserver/src/phy/generic.cpp
+++ b/servers/netserver/src/phy/generic.cpp
@@ -40,12 +40,10 @@ async::result<nic::PhyResult<void>> GenericEthernetPhy::configure() {
 	// Wait up to 500ms for reset to complete.
 	auto bmcr = FRG_CO_TRY(co_await mdio_->read(phyAddress_, miiBmcr));
 
-	uint64_t startNs;
-	HEL_CHECK(helGetClock(&startNs));
+	auto startNs = helix::getClock();
 
 	while (bmcr & bmcr::reset) {
-		uint64_t currNs;
-		HEL_CHECK(helGetClock(&currNs));
+		auto currNs = helix::getClock();
 
 		if (currNs - startNs > 500'000'000) { // 500ms
 			std::println("generic-phy: Waiting for PHY reset timed out after 500ms");
@@ -115,12 +113,10 @@ async::result<nic::PhyResult<void>> GenericEthernetPhy::updateLink() {
 		// Let's wait for auto-negotiation to complete.
 		std::println("generic-phy: Waiting for auto-negotiation to complete");
 
-		uint64_t startNs;
-		HEL_CHECK(helGetClock(&startNs));
+		auto startNs = helix::getClock();
 
 		while (!(bmsr & bmsr::anegComplete)) {
-			uint64_t currNs;
-			HEL_CHECK(helGetClock(&currNs));
+			auto currNs = helix::getClock();
 
 			if (currNs - startNs > 10'000'000'000) { // 10 seconds
 				std::println("generic-phy: Auto-negotiation timed out after 10 seconds");
@@ -137,8 +133,7 @@ async::result<nic::PhyResult<void>> GenericEthernetPhy::updateLink() {
 			co_await helix::sleepFor(500'000'000); // 500ms
 		}
 
-		uint64_t currNs;
-		HEL_CHECK(helGetClock(&currNs));
+		auto currNs = helix::getClock();
 
 		std::println(
 		    "generic-phy: Auto-negotiation complete in {}ms", (currNs - startNs) / 1'000'000

--- a/testsuites/kernel-tests/meson.build
+++ b/testsuites/kernel-tests/meson.build
@@ -1,6 +1,7 @@
 executable('kernel-tests',
 	[
 		'src/main.cpp',
+		'src/clock.cpp',
 		'src/faults.cpp',
 		'src/mapping.cpp',
 		'src/memory.cpp',

--- a/testsuites/kernel-tests/src/clock.cpp
+++ b/testsuites/kernel-tests/src/clock.cpp
@@ -1,0 +1,37 @@
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+
+#include <hel.h>
+#include <hel-syscalls.h>
+#include <helix/clock.hpp>
+
+#include "testsuite.hpp"
+
+DEFINE_TEST(clockMatchesSyscall, ([] {
+	if(!helix::hasUserspaceClock()) {
+		printf("kernel-tests: clockMatchesSyscall test was NOT exercised"
+				" (the kernel exports no clock that userspace can read)\n");
+	}
+
+	// The userspace-accessible clock must exactly reproduce the helGetClock()-provided time.
+	for(int i = 0; i < 1000; ++i) {
+		uint64_t before;
+		HEL_CHECK(helGetClock(&before));
+		auto nanos = helix::getClock();
+		uint64_t after;
+		HEL_CHECK(helGetClock(&after));
+
+		assert(nanos >= before);
+		assert(nanos <= after);
+	}
+}))
+
+DEFINE_TEST(clockIsMonotone, ([] {
+	auto previous = helix::getClock();
+	for(int i = 0; i < 1000; ++i) {
+		auto nanos = helix::getClock();
+		assert(nanos >= previous);
+		previous = nanos;
+	}
+}))


### PR DESCRIPTION
This extends the `helObtainHandle()` syscall that was introduced in #1583 to allow userspace to access a read-only page containing the parameters of the clock that backs `helGetClock()`.

In case the clock is backed by a userspace-readable clock (i.e., the TSC on x86_64 or any of the clocks we use on Aarch64 / RISC-V), this allows userspace to read the clock without a syscall. The data is protected by a seqlock in case the kernel ever needs to switch to a different clock at runtime (or adjust the clock parameters).