### PR TITLE
drivers/libblockfs: Add ext2 block map cache

### DIFF
--- a/drivers/libblockfs/meson.build
+++ b/drivers/libblockfs/meson.build
@@ -4,6 +4,7 @@ src = [
 	'src/gpt.cpp',
 	'src/raw.cpp',
 	'src/scsi.cpp',
+	'src/ext2/block-map-cache.cpp',
 	'src/ext2/ext2fs.cpp',
 	'src/ext2/ops.cpp',
 	'src/btrfs/btrfs.cpp',

--- a/drivers/libblockfs/src/ext2/block-map-cache.cpp
+++ b/drivers/libblockfs/src/ext2/block-map-cache.cpp
@@ -1,0 +1,113 @@
+#include "block-map-cache.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+
+namespace blockfs {
+namespace ext2fs {
+
+namespace {
+
+// Whether the run at bBlock directly continues the run at aBlock,
+// i.e. whether the two can be merged into one.
+bool continues(uint64_t aBlock, const BlockMapCache::Run &a,
+		uint64_t bBlock, const BlockMapCache::Run &b) {
+	if(aBlock + a.size != bBlock)
+		return false;
+	// Holes merge with adjacent holes.
+	if(a.hole || b.hole)
+		return a.hole && b.hole;
+	// Non-holes merge only if they are contiguous on disk.
+	return a.diskBlock + a.size == b.diskBlock;
+}
+
+// Drops the first skip blocks of a run.
+BlockMapCache::Run advance(BlockMapCache::Run run, uint64_t skip) {
+	assert(skip < run.size);
+	if(!run.hole)
+		run.diskBlock += skip;
+	run.size -= skip;
+	return run;
+}
+
+} // anonymous namespace
+
+std::pair<std::optional<BlockMapCache::Run>, uint64_t>
+BlockMapCache::probe(uint64_t fileBlock, uint64_t limit) {
+	std::lock_guard cacheGuard{mutex_};
+
+	auto it = runs_.upper_bound(fileBlock);
+	if(it != runs_.begin()) {
+		auto pred = std::prev(it);
+		if(pred->first + pred->second.size > fileBlock) {
+			auto run = advance(pred->second, fileBlock - pred->first);
+			run.size = std::min(run.size, limit);
+			return {run, run.size};
+		}
+	}
+
+	// Cache miss; the gap extends up to the next cached run.
+	if(it != runs_.end())
+		limit = std::min(limit, it->first - fileBlock);
+	return {std::nullopt, limit};
+}
+
+void BlockMapCache::insertLocked_(uint64_t fileBlock, Run run) {
+	assert(run.size);
+	auto end = fileBlock + run.size;
+
+	// Trim (and possibly split) a preceding run that overlaps the start of the new run.
+	auto it = runs_.lower_bound(fileBlock);
+	if(it != runs_.begin()) {
+		auto pred = std::prev(it);
+		auto predEnd = pred->first + pred->second.size;
+		if(predEnd > fileBlock) {
+			if(predEnd > end)
+				runs_.emplace(end, advance(pred->second, end - pred->first));
+			pred->second.size = fileBlock - pred->first;
+		}
+	}
+
+	// Remove (and possibly trim) runs that start inside the new run.
+	while(it != runs_.end() && it->first < end) {
+		if(it->first + it->second.size > end) {
+			auto tail = advance(it->second, end - it->first);
+			runs_.erase(it);
+			runs_.emplace(end, tail);
+			break;
+		}
+		it = runs_.erase(it);
+	}
+
+	// Insert the new run, merging with contiguous neighbors.
+	auto succ = runs_.lower_bound(fileBlock);
+	if(succ != runs_.end() && continues(fileBlock, run, succ->first, succ->second)) {
+		run.size += succ->second.size;
+		runs_.erase(succ);
+	}
+
+	auto next = runs_.lower_bound(fileBlock);
+	if(next != runs_.begin()) {
+		auto pred = std::prev(next);
+		if(continues(pred->first, pred->second, fileBlock, run)) {
+			pred->second.size += run.size;
+			return;
+		}
+	}
+	runs_.emplace(fileBlock, run);
+}
+
+void BlockMapCache::insert(uint64_t fileBlock, Run run) {
+	std::lock_guard cacheGuard{mutex_};
+	insertLocked_(fileBlock, run);
+}
+
+void BlockMapCache::insertList(uint64_t fileBlock, const std::vector<uint32_t> &blocks) {
+	std::lock_guard cacheGuard{mutex_};
+	for(size_t i = 0; i < blocks.size(); i++)
+		insertLocked_(fileBlock + i, Run{.diskBlock = blocks[i], .size = 1, .hole = false});
+}
+
+} // namespace ext2fs
+} // namespace blockfs

--- a/drivers/libblockfs/src/ext2/block-map-cache.hpp
+++ b/drivers/libblockfs/src/ext2/block-map-cache.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace blockfs {
+namespace ext2fs {
+
+// In-memory cache of already-resolved runs of one inode's block map, keyed by file block.
+// Caches both actual mappings and holes.
+struct BlockMapCache {
+	struct Run {
+		// Only meaningful if the run is not a hole.
+		uint64_t diskBlock;
+		// Number of blocks this run represents.
+		uint64_t size;
+		// Whether the run is a hole or not.
+		bool hole;
+	};
+
+	// Resolves fileBlock against the cache, considering at most limit blocks.
+	// Returns the cached run starting at fileBlock, or nullopt if it is not cached,
+	// together with the number of blocks that the answer covers.
+	// The latter matches the run's size on a hit.
+	// On a miss, it equals the number of uncached blocks before the next cached run.
+	std::pair<std::optional<Run>, uint64_t> probe(uint64_t fileBlock, uint64_t limit);
+
+	// Inserts a run at fileBlock, replacing the cached runs that it overlaps.
+	void insert(uint64_t fileBlock, Run run);
+
+	// Inserts the disk blocks backing consecutive file blocks starting at fileBlock.
+	void insertList(uint64_t fileBlock, const std::vector<uint32_t> &blocks);
+
+private:
+	// Callers must hold mutex_.
+	void insertLocked_(uint64_t fileBlock, Run run);
+
+	std::mutex mutex_;
+	std::map<uint64_t, Run> runs_;
+};
+
+} // namespace ext2fs
+} // namespace blockfs

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1589,9 +1589,9 @@ async::result<uint32_t> FileSystem::allocateInode(uint32_t parentIno, bool direc
 	co_return 0;
 }
 
-async::result<std::vector<ExtentBlockRange>> FileSystem::lookupBlocksUsingExtent(Inode *inode,
+async::result<std::vector<BlockRange>> FileSystem::lookupBlocksUsingExtent(Inode *inode,
 		uint64_t block_offset, size_t num_blocks, bool errorIfNotFound) {
-	std::vector<ExtentBlockRange> ranges;
+	std::vector<BlockRange> ranges;
 
 	ExtentWalker walker{this, inode, true};
 
@@ -1617,11 +1617,11 @@ async::result<std::vector<ExtentBlockRange>> FileSystem::lookupBlocksUsingExtent
 			uint64_t absoluteStartBlock = static_cast<uint64_t>(extent.startLow)
 					| (static_cast<uint64_t>(extent.startHigh) << 32);
 
-			ExtentBlockRange range{
+			BlockRange range{
 				.relativeStartBlock = index,
 				.absoluteStartBlock = absoluteStartBlock + startOffset,
 				.size = toAdd,
-				.found = true
+				.hole = false
 			};
 			ranges.push_back(range);
 
@@ -1634,14 +1634,14 @@ async::result<std::vector<ExtentBlockRange>> FileSystem::lookupBlocksUsingExtent
 				assert(!"Block was not found in extent tree");
 
 			if(!ranges.empty() && ranges.back().relativeStartBlock + ranges.back().size == index
-					&& !ranges.back().found) {
+					&& ranges.back().hole) {
 				ranges.back().size++;
 			} else {
-				ExtentBlockRange range{
+				BlockRange range{
 					.relativeStartBlock = index,
 					.absoluteStartBlock = 0,
 					.size = 1,
-					.found = false
+					.hole = true
 				};
 				ranges.push_back(range);
 			}
@@ -1661,7 +1661,7 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 	auto blockRanges = co_await lookupBlocksUsingExtent(inode, block_offset, num_blocks, false);
 
 	for(auto &range : blockRanges) {
-		if(range.found)
+		if(!range.hole)
 			continue;
 
 		auto allocated = co_await allocateBlocks(range.size, inode->number);
@@ -1923,7 +1923,7 @@ async::result<void> FileSystem::readDataBlocksUsingExtents(std::shared_ptr<Inode
 	for(auto &range : blockRanges) {
 		assert(range.relativeStartBlock == block_offset + progress);
 
-		if(!range.found) {
+		if(range.hole) {
 			memset(buf.byte_data() + progress * blockSize, 0, range.size * blockSize);
 		}else {
 			assert(range.absoluteStartBlock);

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1316,7 +1316,12 @@ async::result<void> FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 				co_await inode->blockMapMutex.async_lock();
 				frg::unique_lock blockMapLock{frg::adopt_lock, inode->blockMapMutex};
 				lockDone = timer.elapsed();
-				co_await inode->fs.readDataBlocks(inode, manage.offset() / inode->fs.blockSize, fileView);
+				auto blockRanges = co_await inode->fs.lookupBlocks(inode.get(),
+						manage.offset() / inode->fs.blockSize, num_blocks);
+				// For blockSize < pageSize, the manage request (= fileView) may extend beyond the last block of the file.
+				// Clamp fileView to the number of blocks that we actually want to read.
+				co_await inode->fs.readDataBlocks(blockRanges,
+						fileView.view().subview(0, num_blocks * inode->fs.blockSize));
 				readDone = timer.elapsed();
 			}
 
@@ -1350,7 +1355,12 @@ async::result<void> FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 				lockDone = timer.elapsed();
 				co_await inode->fs.assignDataBlocks(inode.get(), blockOffset, numBlocks);
 				assignDone = timer.elapsed();
-				co_await inode->fs.writeDataBlocks(inode, blockOffset, fileView);
+				auto blockRanges = co_await inode->fs.lookupBlocks(inode.get(),
+						blockOffset, numBlocks);
+				// For blockSize < pageSize, the manage request (= fileView) may extend beyond the last block of the file.
+				// Clamp fileView to the number of blocks that we actually want to write.
+				co_await inode->fs.writeDataBlocks(blockRanges,
+						fileView.view().subview(0, numBlocks * inode->fs.blockSize));
 				writeDone = timer.elapsed();
 			}
 
@@ -1590,7 +1600,7 @@ async::result<uint32_t> FileSystem::allocateInode(uint32_t parentIno, bool direc
 }
 
 async::result<std::vector<BlockRange>> FileSystem::lookupBlocksUsingExtent(Inode *inode,
-		uint64_t block_offset, size_t num_blocks, bool errorIfNotFound) {
+		uint64_t block_offset, size_t num_blocks) {
 	std::vector<BlockRange> ranges;
 
 	ExtentWalker walker{this, inode, true};
@@ -1630,9 +1640,6 @@ async::result<std::vector<BlockRange>> FileSystem::lookupBlocksUsingExtent(Inode
 		}));
 
 		if(!res) {
-			if(errorIfNotFound)
-				assert(!"Block was not found in extent tree");
-
 			if(!ranges.empty() && ranges.back().relativeStartBlock + ranges.back().size == index
 					&& ranges.back().hole) {
 				ranges.back().size++;
@@ -1658,7 +1665,7 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 	protocols::ostrace::Timer timer;
 
 	auto diskInode = inode->diskInode();
-	auto blockRanges = co_await lookupBlocksUsingExtent(inode, block_offset, num_blocks, false);
+	auto blockRanges = co_await lookupBlocksUsingExtent(inode, block_offset, num_blocks);
 
 	for(auto &range : blockRanges) {
 		if(!range.hole)
@@ -1908,76 +1915,134 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 	);
 }
 
-async::result<void> FileSystem::readDataBlocksUsingExtents(std::shared_ptr<Inode> inode, uint64_t block_offset,
-		arch::dma_buffer_view buf) {
-	co_await inode->readyEvent.wait();
-	// TODO: Assert that we do not read past the EOF.
+namespace {
 
-	protocols::ostrace::Timer timer;
-	uint64_t deviceTime = 0;
+// Appends a run to a range list, merging it with the last range if contiguous.
+void mergeBlockRange(std::vector<BlockRange> &ranges,
+		uint64_t rel, uint64_t abs, uint64_t size) {
+	bool hole = !abs;
 
-	size_t num_blocks = buf.size() >> blockShift;
-	auto blockRanges = co_await lookupBlocksUsingExtent(inode.get(), block_offset, num_blocks, false);
+	auto continues = [&] (const BlockRange &back) {
+		if(back.relativeStartBlock + back.size != rel)
+			return false;
+		// Holes merge with adjacent holes.
+		if(back.hole || hole)
+			return back.hole && hole;
+		// Non-holes merge only if they are contiguous on disk.
+		return back.absoluteStartBlock + back.size == abs;
+	};
 
-	size_t progress = 0;
-	for(auto &range : blockRanges) {
-		assert(range.relativeStartBlock == block_offset + progress);
-
-		if(range.hole) {
-			memset(buf.byte_data() + progress * blockSize, 0, range.size * blockSize);
-		}else {
-			assert(range.absoluteStartBlock);
-			protocols::ostrace::Timer deviceTimer;
-			co_await device->readSectors(
-			    range.absoluteStartBlock * sectorsPerBlock,
-			    buf.subview(progress * blockSize, range.size * blockSize)
-			);
-			deviceTime += deviceTimer.elapsed();
-		}
-
-		progress += range.size;
+	if(!ranges.empty() && continues(ranges.back())) {
+		ranges.back().size += size;
+		return;
 	}
-
-	assert(progress == num_blocks);
-
-	ostContext.emit(
-		ostEvtExt2ReadDataBlocks,
-		ostAttrTime(timer.elapsed()),
-		ostAttrNumBytes(buf.size()),
-		ostAttrTimeDevice(deviceTime)
-	);
+	ranges.push_back({rel, abs, size, hole});
 }
 
-async::result<void> FileSystem::writeDataBlocksUsingExtents(std::shared_ptr<Inode> inode, uint64_t block_offset,
-		arch::dma_buffer_view buf) {
+} // anonymous namespace
+
+async::result<std::vector<BlockRange>> FileSystem::lookupBlocks(Inode *inode,
+		uint64_t block_offset, size_t num_blocks) {
 	co_await inode->readyEvent.wait();
-	// TODO: Assert that we do not read past the EOF.
 
-	protocols::ostrace::Timer timer;
-	uint64_t deviceTime = 0;
-
-	size_t num_blocks = buf.size() >> blockShift;
-	auto blockRanges = co_await lookupBlocksUsingExtent(inode.get(), block_offset, num_blocks, true);
-
-	size_t progress = 0;
-	for(auto &range : blockRanges) {
-		protocols::ostrace::Timer deviceTimer;
-		co_await device->writeSectors(
-		    range.absoluteStartBlock * sectorsPerBlock,
-		    buf.subview(progress * blockSize, range.size * blockSize)
-		);
-		deviceTime += deviceTimer.elapsed();
-		progress += range.size;
+	if(inode->usesExtents) {
+		auto blockRanges = co_await lookupBlocksUsingExtent(inode, block_offset, num_blocks);
+		co_await helix_ng::asyncNop();
+		co_return blockRanges;
 	}
 
-	assert(progress == num_blocks);
+	size_t per_indirect = blockSize / 4;
+	size_t per_single = per_indirect;
+	size_t per_double = per_indirect * per_indirect;
 
-	ostContext.emit(
-		ostEvtExt2WriteDataBlocks,
-		ostAttrTime(timer.elapsed()),
-		ostAttrNumBytes(buf.size()),
-		ostAttrTimeDevice(deviceTime)
-	);
+	// Number of blocks that can be accessed by:
+	size_t i_range = 12; // Direct blocks only.
+	size_t s_range = i_range + per_single; // Plus the first single indirect block.
+	size_t d_range = s_range + per_double; // Plus the first double indirect block.
+
+	std::vector<BlockRange> ranges;
+
+	// Buffer to store small fragments of indirect blocks.
+	// Short lookups read the block pointers through readMemory() instead of pinning the
+	// indirect block into the metadata cache (pinning is more expensive than readMemory()).
+	constexpr size_t indirectBufferSize = 8;
+	std::array<uint32_t, indirectBufferSize> indirectBuffer;
+
+	size_t progress = 0;
+	while(progress < num_blocks) {
+		auto index = block_offset + progress;
+		auto remaining = num_blocks - progress;
+
+		// Block pointers backing [index, index + count), or null if the range is a hole
+		// because no indirect block is allocated. The window keeps list alive.
+		MetadataCache::BlockWindow indirectWindow;
+		const uint32_t *list = nullptr;
+		size_t count;
+
+		assert(index < d_range);
+		if(index >= d_range) {
+			assert(!"Fix triple indirect blocks");
+		}else if(index >= s_range) { // Use the double indirect block.
+			int64_t indirect_frame = (index - s_range) >> (blockShift - 2);
+			int64_t indirect_index = (index - s_range) & ((1 << (blockShift - 2)) - 1);
+			count = std::min<size_t>(remaining, per_indirect - indirect_index);
+
+			auto disk_inode = inode->diskInode();
+			uint32_t indirect_block = 0;
+			if(disk_inode->data.blocks.doubleIndirect)
+				co_await metadataCache->read(disk_inode->data.blocks.doubleIndirect,
+						indirect_frame * 4, 4, &indirect_block);
+
+			if(!indirect_block) {
+				// Nothing to do: the whole range is a hole.
+			} else if (remaining > indirectBufferSize) {
+				indirectWindow = co_await metadataCache->access(indirect_block, false);
+
+				list = reinterpret_cast<const uint32_t *>(indirectWindow.get())
+						+ indirect_index;
+			} else {
+				co_await metadataCache->read(indirect_block,
+						indirect_index * 4, count * 4, indirectBuffer.data());
+
+				list = indirectBuffer.data();
+			}
+		}else if(index >= i_range) { // Use the single indirect block.
+			auto indirect_index = index - i_range;
+			count = std::min<size_t>(remaining, per_single - indirect_index);
+
+			auto disk_inode = inode->diskInode();
+			auto indirect_block = disk_inode->data.blocks.singleIndirect;
+
+			if(!indirect_block) {
+				// Nothing to do: the whole range is a hole.
+			} else if (remaining > indirectBufferSize) {
+				indirectWindow = co_await metadataCache->access(indirect_block, false);
+
+				list = reinterpret_cast<const uint32_t *>(indirectWindow.get())
+						+ indirect_index;
+			} else {
+				co_await metadataCache->read(indirect_block,
+						indirect_index * 4, count * 4, indirectBuffer.data());
+
+				list = indirectBuffer.data();
+			}
+		}else{
+			auto disk_inode = inode->diskInode();
+
+			count = std::min<size_t>(remaining, 12 - index);
+			list = disk_inode->data.blocks.direct + index;
+		}
+
+		if(list) {
+			for(size_t i = 0; i < count; i++)
+				mergeBlockRange(ranges, index + i, list[i], 1);
+		}else{
+			mergeBlockRange(ranges, index, 0, count);
+		}
+		progress += count;
+	}
+
+	co_return ranges;
 }
 
 async::result<void> FileSystem::assignDataBlocks(Inode *inode,
@@ -2156,126 +2221,34 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 	);
 }
 
-async::result<void> FileSystem::readDataBlocks(std::shared_ptr<Inode> inode,
-		uint64_t offset, arch::dma_buffer_view buf) {
-	size_t num_blocks = buf.size() >> blockShift;
-
-	if(inode->usesExtents) {
-		co_await readDataBlocksUsingExtents(std::move(inode), offset, buf);
-		co_await helix_ng::asyncNop();
-		co_return;
-	}
-
-	// We perform "block-fusion" here i.e. we try to read/write multiple
-	// consecutive blocks in a single read/writeSectors() operation.
-	auto fuse = [] (size_t remaining, uint32_t *list, size_t limit) {
-		size_t n = 1;
-		while(n < remaining && n < limit) {
-			if ((list[0] && (list[n] != list[0] + n)) || (!list[0] && list[n]))
-				break;
-			n++;
-		}
-		return std::pair<size_t, size_t>{list[0], n};
-	};
-
-	size_t per_indirect = blockSize / 4;
-	size_t per_single = per_indirect;
-	size_t per_double = per_indirect * per_indirect;
-
-	// Number of blocks that can be accessed by:
-	size_t i_range = 12; // Direct blocks only.
-	size_t s_range = i_range + per_single; // Plus the first single indirect block.
-	size_t d_range = s_range + per_double; // Plus the first double indirect block.
-
-	co_await inode->readyEvent.wait();
+async::result<void> FileSystem::readDataBlocks(const std::vector<BlockRange> &ranges,
+		arch::dma_buffer_view buf) {
+	assert(!(buf.size() & (blockSize - 1)));
 	// TODO: Assert that we do not read past the EOF.
 
 	protocols::ostrace::Timer timer;
 	uint64_t deviceTime = 0;
 
-	constexpr size_t indirectBufferSize = 8;
-
-	std::array<uint32_t, indirectBufferSize> indirectBuffer;
-
 	size_t progress = 0;
-	while(progress < num_blocks) {
-		// Block number and block count of the readSectors() command that we will issue here.
-		std::pair<size_t, size_t> issue;
+	for(auto &range : ranges) {
+		assert(range.relativeStartBlock == ranges.front().relativeStartBlock + progress);
 
-		auto index = offset + progress;
-//		std::cout << "Reading " << index << "-th block from inode " << inode->number
-//				<< " (" << progress << "/" << num_blocks << " in request)" << std::endl;
-
-		assert(index < d_range);
-		if(index >= d_range) {
-			assert(!"Fix triple indirect blocks");
-		}else if(index >= s_range) { // Use the double indirect block.
-			auto remaining = num_blocks - progress;
-			int64_t indirect_frame = (index - s_range) >> (blockShift - 2);
-			int64_t indirect_index = (index - s_range) & ((1 << (blockShift - 2)) - 1);
-
-			auto disk_inode = inode->diskInode();
-			uint32_t indirect_block = 0;
-			if(disk_inode->data.blocks.doubleIndirect)
-				co_await metadataCache->read(disk_inode->data.blocks.doubleIndirect,
-						indirect_frame * 4, 4, &indirect_block);
-
-			if(!indirect_block) {
-				issue = {0, std::min<size_t>(remaining, per_indirect - indirect_index)};
-			} else if (remaining > indirectBufferSize) {
-				auto indirectWindow = co_await metadataCache->access(indirect_block, false);
-
-				issue = fuse(remaining,
-						reinterpret_cast<uint32_t *>(indirectWindow.get()) + indirect_index,
-						per_indirect - indirect_index);
-			} else {
-				auto chunk = std::min<size_t>(remaining, per_indirect - indirect_index);
-				co_await metadataCache->read(indirect_block,
-						indirect_index * 4, chunk * 4, indirectBuffer.data());
-
-				issue = fuse(chunk, indirectBuffer.data(), chunk);
-			}
-		}else if(index >= i_range) { // Use the single indirect block.
-			auto remaining = num_blocks - progress;
-			auto indirect_index = index - i_range;
-
-			auto disk_inode = inode->diskInode();
-			auto indirect_block = disk_inode->data.blocks.singleIndirect;
-
-			if(!indirect_block) {
-				issue = {0, std::min<size_t>(remaining, per_single - indirect_index)};
-			} else if (remaining > indirectBufferSize) {
-				auto indirectWindow = co_await metadataCache->access(indirect_block, false);
-
-				issue = fuse(remaining,
-						reinterpret_cast<uint32_t *>(indirectWindow.get()) + indirect_index,
-						per_indirect - indirect_index);
-			} else {
-				auto chunk = std::min<size_t>(remaining, per_single - indirect_index);
-				co_await metadataCache->read(indirect_block,
-						indirect_index * 4, chunk * 4, indirectBuffer.data());
-
-				issue = fuse(chunk, indirectBuffer.data(), chunk);
-			}
-		}else{
-			auto disk_inode = inode->diskInode();
-
-			issue = fuse(num_blocks - progress,
-					disk_inode->data.blocks.direct + index, 12 - index);
-		}
-
-//		std::cout << "Issuing read of " << issue.second
-//				<< " blocks, starting at " << issue.first << std::endl;
-
-		if (issue.first) {
+		if(range.hole) {
+			memset(buf.byte_data() + progress * blockSize, 0, range.size * blockSize);
+		}else {
+			assert(range.absoluteStartBlock);
 			protocols::ostrace::Timer deviceTimer;
-			co_await device->readSectors(issue.first * sectorsPerBlock, buf.subview(progress * blockSize, issue.second * blockSize));
+			co_await device->readSectors(
+			    range.absoluteStartBlock * sectorsPerBlock,
+			    buf.subview(progress * blockSize, range.size * blockSize)
+			);
 			deviceTime += deviceTimer.elapsed();
-		} else {
-			memset(buf.byte_data() + progress * blockSize, 0, issue.second * blockSize);
 		}
-		progress += issue.second;
+
+		progress += range.size;
 	}
+
+	assert(progress == (buf.size() >> blockShift));
 
 	ostContext.emit(
 		ostEvtExt2ReadDataBlocks,
@@ -2285,101 +2258,29 @@ async::result<void> FileSystem::readDataBlocks(std::shared_ptr<Inode> inode,
 	);
 }
 
-// TODO: There is a lot of overlap between this method and readDataBlocks.
-//       Refactor common code into a another method.
-async::result<void> FileSystem::writeDataBlocks(std::shared_ptr<Inode> inode,
-		uint64_t offset, arch::dma_buffer_view buf) {
-	size_t num_blocks = buf.size() >> blockShift;
-
-	if(inode->usesExtents) {
-		co_await writeDataBlocksUsingExtents(std::move(inode), offset, buf);
-		co_await helix_ng::asyncNop();
-		co_return;
-	}
-
-	// We perform "block-fusion" here i.e. we try to read/write multiple
-	// consecutive blocks in a single read/writeSectors() operation.
-	auto fuse = [] (size_t index, size_t remaining, uint32_t *list, size_t limit) {
-		size_t n = 1;
-		while(n < remaining && index + n < limit) {
-			if(list[index + n] != list[index] + n)
-				break;
-			n++;
-		}
-		return std::pair<size_t, size_t>{list[index], n};
-	};
-
-	size_t per_indirect = blockSize / 4;
-	size_t per_single = per_indirect;
-	size_t per_double = per_indirect * per_indirect;
-
-	// Number of blocks that can be accessed by:
-	size_t i_range = 12; // Direct blocks only.
-	size_t s_range = i_range + per_single; // Plus the first single indirect block.
-	size_t d_range = s_range + per_double; // Plus the first double indirect block.
-
-	co_await inode->readyEvent.wait();
+async::result<void> FileSystem::writeDataBlocks(const std::vector<BlockRange> &ranges,
+		arch::dma_buffer_view buf) {
+	assert(!(buf.size() & (blockSize - 1)));
 	// TODO: Assert that we do not write past the EOF.
 
 	protocols::ostrace::Timer timer;
 	uint64_t deviceTime = 0;
 
 	size_t progress = 0;
-	while(progress < num_blocks) {
-		// Block number and block count of the writeSectors() command that we will issue here.
-		std::pair<size_t, size_t> issue;
+	for(auto &range : ranges) {
+		assert(range.relativeStartBlock == ranges.front().relativeStartBlock + progress);
+		assert(!range.hole && range.absoluteStartBlock);
 
-		auto index = offset + progress;
-//		std::cout << "Write " << index << "-th block to inode " << inode->number
-//				<< " (" << progress << "/" << num_blocks << " in request)" << std::endl;
-
-		assert(index < d_range);
-		if(index >= d_range) {
-			assert(!"Fix triple indirect blocks");
-		}else if(index >= s_range) { // Use the double indirect block.
-			// TODO: Use shift/and instead of div/mod.
-			int64_t indirect_frame = (index - s_range) >> (blockShift - 2);
-			int64_t indirect_index = (index - s_range) & ((1 << (blockShift - 2)) - 1);
-
-			auto disk_inode = inode->diskInode();
-			assert(disk_inode->data.blocks.doubleIndirect);
-			uint32_t indirect_block;
-			co_await metadataCache->read(disk_inode->data.blocks.doubleIndirect,
-					indirect_frame * 4, 4, &indirect_block);
-			assert(indirect_block);
-
-			auto indirectWindow = co_await metadataCache->access(indirect_block, false);
-
-			issue = fuse(indirect_index, num_blocks - progress,
-					reinterpret_cast<uint32_t *>(indirectWindow.get()), per_indirect);
-		}else if(index >= i_range) { // Use the single indirect block.
-			auto disk_inode = inode->diskInode();
-			assert(disk_inode->data.blocks.singleIndirect);
-
-			auto indirectWindow = co_await metadataCache->access(
-					disk_inode->data.blocks.singleIndirect, false);
-
-			issue = fuse(index - i_range, num_blocks - progress,
-					reinterpret_cast<uint32_t *>(indirectWindow.get()), per_indirect);
-		}else{
-			auto disk_inode = inode->diskInode();
-
-			issue = fuse(index, num_blocks - progress,
-					disk_inode->data.blocks.direct, 12);
-		}
-
-//		std::cout << "Issuing write of " << issue.second
-//				<< " blocks, starting at " << issue.first << std::endl;
-
-		assert(issue.first);
 		protocols::ostrace::Timer deviceTimer;
 		co_await device->writeSectors(
-		    issue.first * sectorsPerBlock,
-		    buf.subview(progress * blockSize, issue.second * blockSize)
+		    range.absoluteStartBlock * sectorsPerBlock,
+		    buf.subview(progress * blockSize, range.size * blockSize)
 		);
 		deviceTime += deviceTimer.elapsed();
-		progress += issue.second;
+		progress += range.size;
 	}
+
+	assert(progress == (buf.size() >> blockShift));
 
 	ostContext.emit(
 		ostEvtExt2WriteDataBlocks,

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1711,6 +1711,15 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 				.startLow = static_cast<uint32_t>(allocatedRange.first & 0xffffffff)
 			};
 
+			inode->blockMapCache.insert(
+				index,
+				{
+					.diskBlock = allocatedRange.first,
+					.size = allocatedRangeSize,
+					.hole = false
+				}
+			);
+
 			ExtentWalker walker{this, inode, false};
 			co_await walker.walk(index,
 				[](const ExtentWalkInfo &) -> async::result<void> { co_return; },
@@ -1945,6 +1954,41 @@ async::result<std::vector<BlockRange>> FileSystem::lookupBlocks(Inode *inode,
 		uint64_t block_offset, size_t num_blocks) {
 	co_await inode->readyEvent.wait();
 
+	std::vector<BlockRange> ranges;
+
+	size_t progress = 0;
+	while(progress < num_blocks) {
+		auto index = block_offset + progress;
+		auto [run, length] = inode->blockMapCache.probe(index, num_blocks - progress);
+		assert(length);
+
+		// Serve as much as possible from the per-inode cache.
+		if(run) {
+			mergeBlockRange(ranges, index, run->hole ? 0 : run->diskBlock, run->size);
+		}else{
+			// Resolve the gap from the on-disk block map and cache the result.
+			auto walked = co_await lookupBlocksOnDisk(inode, index, length);
+			for(auto &range : walked) {
+				inode->blockMapCache.insert(
+					range.relativeStartBlock,
+					{
+						.diskBlock = range.absoluteStartBlock,
+						.size = range.size,
+						.hole = range.hole
+					}
+				);
+				mergeBlockRange(ranges, range.relativeStartBlock,
+						range.hole ? 0 : range.absoluteStartBlock, range.size);
+			}
+		}
+		progress += length;
+	}
+
+	co_return ranges;
+}
+
+async::result<std::vector<BlockRange>> FileSystem::lookupBlocksOnDisk(Inode *inode,
+		uint64_t block_offset, size_t num_blocks) {
 	if(inode->usesExtents) {
 		auto blockRanges = co_await lookupBlocksUsingExtent(inode, block_offset, num_blocks);
 		co_await helix_ng::asyncNop();
@@ -2092,6 +2136,7 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 				auto allocated = co_await allocateBlocks(range, inode->number);
 				for (auto const [blocknum, block] : std::views::enumerate(allocated))
 					disk_inode->data.blocks.direct[idx + blocknum] = block;
+				inode->blockMapCache.insertList(idx, allocated);
 
 				disk_inode->blocks += allocated.size() * (blockSize / 512);
 				prg += allocated.size();
@@ -2138,6 +2183,7 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 				auto allocated = co_await allocateBlocks(range, inode->number);
 				for (auto const [blocknum, block] : std::views::enumerate(allocated))
 					window[idx + blocknum] = block;
+				inode->blockMapCache.insertList(block_offset + prg, allocated);
 
 				disk_inode->blocks += allocated.size() * (blockSize / 512);
 				prg += allocated.size();
@@ -2200,6 +2246,7 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 				auto allocated = co_await allocateBlocks(range, inode->number);
 				for (auto const [blocknum, block] : std::views::enumerate(allocated))
 					window[indirect_index + blocknum] = block;
+				inode->blockMapCache.insertList(block_offset + prg, allocated);
 
 				disk_inode->blocks += allocated.size() * (blockSize / 512);
 				prg += allocated.size();

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -328,14 +328,20 @@ struct DirEntry {
 };
 
 // --------------------------------------------------------
-// ExtentBlockRange
+// BlockRange
 // --------------------------------------------------------
 
-struct ExtentBlockRange {
+// Describes a mapping from per-file blocks to on-disk blocks.
+struct BlockRange {
+	// Offset of the range within the file.
 	uint64_t relativeStartBlock;
+	// Block number on the file system.
+	// Only meaningful if !hole.
 	uint64_t absoluteStartBlock;
+	// Number of blocks.
 	uint64_t size;
-	bool found;
+	// Whether the range represents a hole or not.
+	bool hole;
 };
 
 // --------------------------------------------------------
@@ -517,7 +523,7 @@ struct FileSystem final : BaseFileSystem {
 
 
 	// Callers must hold inode->blockMapMutex.
-	async::result<std::vector<ExtentBlockRange>> lookupBlocksUsingExtent(Inode *inode,
+	async::result<std::vector<BlockRange>> lookupBlocksUsingExtent(Inode *inode,
 			uint64_t block_offset, size_t num_blocks, bool errorIfNotFound);
 
 	// Callers must hold inode->blockMapMutex.

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -512,30 +512,27 @@ struct FileSystem final : BaseFileSystem {
 	async::result<void> assignDataBlocks(Inode *inode,
 			uint64_t block_offset, size_t num_blocks);
 
+	// Resolves a range of file blocks to runs of disk blocks and holes.
 	// Callers must hold inode->blockMapMutex.
-	async::result<void>
-	readDataBlocks(std::shared_ptr<Inode> inode, uint64_t block_offset, arch::dma_buffer_view buf);
+	async::result<std::vector<BlockRange>> lookupBlocks(Inode *inode,
+			uint64_t block_offset, size_t num_blocks);
 
 	// Callers must hold inode->blockMapMutex.
-	async::result<void> writeDataBlocks(
-	    std::shared_ptr<Inode> inode, uint64_t block_offset, arch::dma_buffer_view view
-	);
+	async::result<void> readDataBlocks(const std::vector<BlockRange> &ranges,
+			arch::dma_buffer_view buf);
+
+	// Callers must hold inode->blockMapMutex.
+	async::result<void> writeDataBlocks(const std::vector<BlockRange> &ranges,
+			arch::dma_buffer_view buf);
 
 
 	// Callers must hold inode->blockMapMutex.
 	async::result<std::vector<BlockRange>> lookupBlocksUsingExtent(Inode *inode,
-			uint64_t block_offset, size_t num_blocks, bool errorIfNotFound);
+			uint64_t block_offset, size_t num_blocks);
 
 	// Callers must hold inode->blockMapMutex.
 	async::result<void> assignDataBlocksUsingExtents(Inode *inode,
 			uint64_t block_offset, size_t num_blocks);
-
-	// Callers must hold inode->blockMapMutex.
-	async::result<void> readDataBlocksUsingExtents(std::shared_ptr<Inode> inode, uint64_t block_offset,
-			arch::dma_buffer_view buf);
-	// Callers must hold inode->blockMapMutex.
-	async::result<void> writeDataBlocksUsingExtents(std::shared_ptr<Inode> inode, uint64_t block_offset,
-			arch::dma_buffer_view buf);
 
 	BlockDevice *device;
 	uint16_t inodeSize;

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -23,6 +23,7 @@
 #include "fs.bragi.hpp"
 #include "../fs.hpp"
 #include "../metadata-cache.hpp"
+#include "block-map-cache.hpp"
 
 namespace blockfs {
 namespace ext2fs {
@@ -426,6 +427,9 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 	// Ordered after inodeMutex.
 	async::mutex blockMapMutex;
 
+	// Caches the runs of this inode's block map that were already resolved.
+	BlockMapCache blockMapCache;
+
 	// page cache that stores the contents of this file
 	HelHandle backingMemory;
 	HelHandle frontalMemory;
@@ -515,6 +519,11 @@ struct FileSystem final : BaseFileSystem {
 	// Resolves a range of file blocks to runs of disk blocks and holes.
 	// Callers must hold inode->blockMapMutex.
 	async::result<std::vector<BlockRange>> lookupBlocks(Inode *inode,
+			uint64_t block_offset, size_t num_blocks);
+
+	// Resolves a range of file blocks by walking the on-disk block map.
+	// Callers must hold inode->blockMapMutex.
+	async::result<std::vector<BlockRange>> lookupBlocksOnDisk(Inode *inode,
 			uint64_t block_offset, size_t num_blocks);
 
 	// Callers must hold inode->blockMapMutex.


### PR DESCRIPTION
This caches the mapping between per-file blocks and disk blocks. We cache both holes and actual blocks. This is faster than going through the indirect blocks as we do not need to perform any syscalls (pinning memory pages or reading them into userspace etc.) to do the lookup.

This also unifies the extent and non-extent code paths as both of these code paths now fill the cache and `readDataBlocks()` / `writeDataBlocks()` are always served from the cache.