### PR TITLE
drivers/libblockfs: Use one MetadataCache per block group

### DIFF
--- a/drivers/libblockfs/meson.build
+++ b/drivers/libblockfs/meson.build
@@ -1,6 +1,7 @@
 src = [
 	'src/libblockfs.cpp',
 	'src/metadata-cache.cpp',
+	'src/service-budget.cpp',
 	'src/gpt.cpp',
 	'src/raw.cpp',
 	'src/scsi.cpp',

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1024,7 +1024,18 @@ async::result<void> FileSystem::init() {
 	assert(blockSize >= device->sectorSize);
 	assert(blockSize % device->sectorSize == 0);
 
-	metadataCache.emplace(device, blocksCount, blockSize);
+	metadataCaches.reserve(numBlockGroups);
+	for(uint32_t bg = 0; bg < numBlockGroups; bg++) {
+		auto baseBlock = uint64_t{bg} * blocksPerGroup;
+		metadataCaches.push_back(
+			std::make_unique<MetadataCache>(
+				device,
+				baseBlock,
+				std::min<uint64_t>(blocksPerGroup, blocksCount - baseBlock),
+				blockSize
+			)
+		);
+	}
 
 	blockGroupDescriptorBuffer = arch::dma_buffer{
 	    pool,

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -24,6 +24,7 @@
 #include "ext2fs.hpp"
 #include "extents.hpp"
 #include "../checksums.hpp"
+#include "../service-budget.hpp"
 #include "../trace.hpp"
 
 namespace blockfs {
@@ -1310,10 +1311,6 @@ async::result<void> FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 		assert(manage.offset() + manage.length() <= ((inode->fileSize() + 0xFFF) & ~size_t(0xFFF)));
 
 		protocols::ostrace::Timer timer;
-		auto fileView = pool->importMemory(
-		    helix::BorrowedDescriptor{inode->backingMemory}, manage.offset(), manage.length()
-		);
-		uint64_t importDone = timer.elapsed();
 
 		if(manage.type() == kHelManageInitialize) {
 			assert(!(manage.offset() % inode->fs.blockSize));
@@ -1321,19 +1318,38 @@ async::result<void> FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 			size_t num_blocks = (backed_size + (inode->fs.blockSize - 1)) / inode->fs.blockSize;
 			assert(num_blocks * inode->fs.blockSize <= manage.length());
 
-			uint64_t lockDone;
-			uint64_t readDone;
+			uint64_t lockTime = 0;
+			uint64_t lookupTime = 0;
+			uint64_t budgetTime = 0;
+			uint64_t importTime = 0;
+			uint64_t readTime = 0;
+			ServiceBudget::Token budgetToken;
+			arch::imported_dma_buffer fileView;
 			{
 				co_await inode->blockMapMutex.async_lock();
 				frg::unique_lock blockMapLock{frg::adopt_lock, inode->blockMapMutex};
-				lockDone = timer.elapsed();
+
+				// We must resolve any metadata before acquiring servicing budget below;
+				// otherwise, we could deadlock if metadata reads are stuck on budget acquisition.
+				lockTime = timer.split();
 				auto blockRanges = co_await inode->fs.lookupBlocks(inode.get(),
 						manage.offset() / inode->fs.blockSize, num_blocks);
+				lookupTime = timer.split();
+
+				// Acquire servicing budget before importMemory().
+				budgetToken = co_await servicingBudget().acquire(false, manage.length());
+				budgetTime = timer.split();
+
+				fileView = pool->importMemory(
+				    helix::BorrowedDescriptor{inode->backingMemory}, manage.offset(), manage.length()
+				);
+				importTime = timer.split();
+
 				// For blockSize < pageSize, the manage request (= fileView) may extend beyond the last block of the file.
 				// Clamp fileView to the number of blocks that we actually want to read.
 				co_await inode->fs.readDataBlocks(blockRanges,
 						fileView.view().subview(0, num_blocks * inode->fs.blockSize));
-				readDone = timer.elapsed();
+				readTime = timer.split();
 			}
 
 			HEL_CHECK(helUpdateMemory(inode->backingMemory, kHelManageInitialize,
@@ -1343,9 +1359,11 @@ async::result<void> FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 				ostEvtExt2InitializeFile,
 				ostAttrTime(timer.elapsed()),
 				ostAttrNumBytes(manage.length()),
-				ostAttrTimeImport(importDone),
-				ostAttrTimeLock(lockDone - importDone),
-				ostAttrTimeRead(readDone - lockDone)
+				ostAttrTimeLock(lockTime),
+				ostAttrTimeLookup(lookupTime),
+				ostAttrTimeBudget(budgetTime),
+				ostAttrTimeImport(importTime),
+				ostAttrTimeRead(readTime)
 			);
 		}else{
 			assert(manage.type() == kHelManageWriteback);
@@ -1357,22 +1375,41 @@ async::result<void> FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 
 			assert(numBlocks * inode->fs.blockSize <= manage.length());
 
-			uint64_t lockDone;
-			uint64_t assignDone;
-			uint64_t writeDone;
+			uint64_t lockTime = 0;
+			uint64_t assignTime = 0;
+			uint64_t lookupTime = 0;
+			uint64_t budgetTime = 0;
+			uint64_t importTime = 0;
+			uint64_t writeTime = 0;
+			ServiceBudget::Token budgetToken;
+			arch::imported_dma_buffer fileView;
 			{
 				co_await inode->blockMapMutex.async_lock();
 				frg::unique_lock blockMapLock{frg::adopt_lock, inode->blockMapMutex};
-				lockDone = timer.elapsed();
+
+				// We must resolve any metadata before acquiring servicing budget below;
+				// otherwise, we could deadlock if metadata reads are stuck on budget acquisition.
+				lockTime = timer.split();
 				co_await inode->fs.assignDataBlocks(inode.get(), blockOffset, numBlocks);
-				assignDone = timer.elapsed();
+				assignTime = timer.split();
 				auto blockRanges = co_await inode->fs.lookupBlocks(inode.get(),
 						blockOffset, numBlocks);
+				lookupTime = timer.split();
+
+				// Acquire servicing budget before importMemory().
+				budgetToken = co_await servicingBudget().acquire(true, manage.length());
+				budgetTime = timer.split();
+
+				fileView = pool->importMemory(
+				    helix::BorrowedDescriptor{inode->backingMemory}, manage.offset(), manage.length()
+				);
+				importTime = timer.split();
+
 				// For blockSize < pageSize, the manage request (= fileView) may extend beyond the last block of the file.
 				// Clamp fileView to the number of blocks that we actually want to write.
 				co_await inode->fs.writeDataBlocks(blockRanges,
 						fileView.view().subview(0, numBlocks * inode->fs.blockSize));
-				writeDone = timer.elapsed();
+				writeTime = timer.split();
 			}
 
 			HEL_CHECK(helUpdateMemory(inode->backingMemory, kHelManageWriteback,
@@ -1382,10 +1419,12 @@ async::result<void> FileSystem::manageFileData(std::shared_ptr<Inode> inode) {
 				ostEvtExt2WritebackFile,
 				ostAttrTime(timer.elapsed()),
 				ostAttrNumBytes(manage.length()),
-				ostAttrTimeImport(importDone),
-				ostAttrTimeLock(lockDone - importDone),
-				ostAttrTimeAssign(assignDone - lockDone),
-				ostAttrTimeWrite(writeDone - assignDone)
+				ostAttrTimeLock(lockTime),
+				ostAttrTimeAssign(assignTime),
+				ostAttrTimeLookup(lookupTime),
+				ostAttrTimeBudget(budgetTime),
+				ostAttrTimeImport(importTime),
+				ostAttrTimeWrite(writeTime)
 			);
 		}
 	}

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1146,7 +1146,7 @@ async::result<std::shared_ptr<BaseInode>> FileSystem::createRegular(int uid, int
 	assert(ino);
 
 	auto [inodeBlock, inodeOffset] = locateDiskInode(ino);
-	auto inodeWindow = co_await metadataCache->access(inodeBlock, true);
+	auto inodeWindow = co_await accessMetadata(inodeBlock, true);
 
 	// TODO: Set the UID, GID, timestamps.
 	auto disk_inode = reinterpret_cast<DiskInode *>(
@@ -1179,7 +1179,7 @@ async::result<std::shared_ptr<Inode>> FileSystem::createDirectory() {
 	assert(ino);
 
 	auto [inodeBlock, inodeOffset] = locateDiskInode(ino);
-	auto inodeWindow = co_await metadataCache->access(inodeBlock, true);
+	auto inodeWindow = co_await accessMetadata(inodeBlock, true);
 
 	// TODO: Set the UID, GID, timestamps.
 	auto disk_inode = reinterpret_cast<DiskInode *>(
@@ -1210,7 +1210,7 @@ async::result<std::shared_ptr<Inode>> FileSystem::createSymlink() {
 	assert(ino);
 
 	auto [inodeBlock, inodeOffset] = locateDiskInode(ino);
-	auto inodeWindow = co_await metadataCache->access(inodeBlock, true);
+	auto inodeWindow = co_await accessMetadata(inodeBlock, true);
 
 	// TODO: Set the UID, GID, timestamps.
 	auto disk_inode = reinterpret_cast<DiskInode *>(
@@ -1240,7 +1240,7 @@ async::result<void> FileSystem::initiateInode(std::shared_ptr<Inode> inode) {
 	protocols::ostrace::Timer timer;
 
 	auto [inodeBlock, inodeOffset] = locateDiskInode(inode->number);
-	inode->diskInodeWindow = co_await metadataCache->access(inodeBlock, true);
+	inode->diskInodeWindow = co_await accessMetadata(inodeBlock, true);
 	inode->diskInodeOffset = inodeOffset;
 	uint64_t accessDone = timer.elapsed();
 
@@ -1393,7 +1393,7 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 	// Accesses the bitmap of a block group, accounting the access to the emitted event.
 	auto accessBitmap = [&] (uint64_t block) -> async::result<MetadataCache::BlockWindow> {
 		protocols::ostrace::Timer accessTimer;
-		auto window = co_await metadataCache->access(block, true);
+		auto window = co_await accessMetadata(block, true);
 		accessTime += accessTimer.elapsed();
 		++numGroups;
 		co_return window;
@@ -1509,7 +1509,7 @@ async::result<uint32_t> FileSystem::allocateInode(uint32_t parentIno, bool direc
 	auto searchBlockGroup = [&](uint32_t bg) -> async::result<std::optional<uint32_t>> {
 		assert(bgdt[bg].inodeBitmap);
 		protocols::ostrace::Timer accessTimer;
-		auto bitmapWindow = co_await metadataCache->access(bgdt[bg].inodeBitmap, true);
+		auto bitmapWindow = co_await accessMetadata(bgdt[bg].inodeBitmap, true);
 		accessTime += accessTimer.elapsed();
 		++numGroups;
 		auto words = reinterpret_cast<uint32_t *>(bitmapWindow.get());
@@ -1755,7 +1755,7 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 
 						diskInode->blocks += blockSize / 512;
 
-						newBlockWindow = co_await metadataCache->access(newBlock[0], true);
+						newBlockWindow = co_await accessMetadata(newBlock[0], true);
 						auto newHdr = reinterpret_cast<ExtentHeader *>(newBlockWindow.get());
 
 						newHdr->magic = EXT4_EXTENT_MAGIC;
@@ -1809,7 +1809,7 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 
 							diskInode->blocks += blockSize / 512;
 
-							newRootWindow = co_await metadataCache->access(newRoot[0], true);
+							newRootWindow = co_await accessMetadata(newRoot[0], true);
 							auto newRootHdr = reinterpret_cast<ExtentHeader *>(newRootWindow.get());
 
 							memcpy(newRootHdr, info.hdr, sizeof(ExtentHeader) + info.hdr->entries * sizeof(Extent));
@@ -2034,18 +2034,18 @@ async::result<std::vector<BlockRange>> FileSystem::lookupBlocksOnDisk(Inode *ino
 			auto disk_inode = inode->diskInode();
 			uint32_t indirect_block = 0;
 			if(disk_inode->data.blocks.doubleIndirect)
-				co_await metadataCache->read(disk_inode->data.blocks.doubleIndirect,
+				co_await readMetadata(disk_inode->data.blocks.doubleIndirect,
 						indirect_frame * 4, 4, &indirect_block);
 
 			if(!indirect_block) {
 				// Nothing to do: the whole range is a hole.
 			} else if (remaining > indirectBufferSize) {
-				indirectWindow = co_await metadataCache->access(indirect_block, false);
+				indirectWindow = co_await accessMetadata(indirect_block, false);
 
 				list = reinterpret_cast<const uint32_t *>(indirectWindow.get())
 						+ indirect_index;
 			} else {
-				co_await metadataCache->read(indirect_block,
+				co_await readMetadata(indirect_block,
 						indirect_index * 4, count * 4, indirectBuffer.data());
 
 				list = indirectBuffer.data();
@@ -2060,12 +2060,12 @@ async::result<std::vector<BlockRange>> FileSystem::lookupBlocksOnDisk(Inode *ino
 			if(!indirect_block) {
 				// Nothing to do: the whole range is a hole.
 			} else if (remaining > indirectBufferSize) {
-				indirectWindow = co_await metadataCache->access(indirect_block, false);
+				indirectWindow = co_await accessMetadata(indirect_block, false);
 
 				list = reinterpret_cast<const uint32_t *>(indirectWindow.get())
 						+ indirect_index;
 			} else {
-				co_await metadataCache->read(indirect_block,
+				co_await readMetadata(indirect_block,
 						indirect_index * 4, count * 4, indirectBuffer.data());
 
 				list = indirectBuffer.data();
@@ -2153,7 +2153,7 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 				needsReset = true;
 			}
 
-			auto indirectWindow = co_await metadataCache->access(
+			auto indirectWindow = co_await accessMetadata(
 					disk_inode->data.blocks.singleIndirect, true);
 			auto window = reinterpret_cast<uint32_t *>(indirectWindow.get());
 
@@ -2198,7 +2198,7 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 				doubleNeedsReset = true;
 			}
 
-			auto doubleIndirectWindow = co_await metadataCache->access(
+			auto doubleIndirectWindow = co_await accessMetadata(
 					disk_inode->data.blocks.doubleIndirect, true);
 			auto double_window = reinterpret_cast<uint32_t *>(doubleIndirectWindow.get());
 
@@ -2220,7 +2220,7 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 					needsReset = true;
 				}
 
-				auto indirectWindow = co_await metadataCache->access(
+				auto indirectWindow = co_await accessMetadata(
 						double_window[indirect_frame], true);
 				auto window = reinterpret_cast<uint32_t *>(indirectWindow.get());
 

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <assert.h>
 #include <expected>
 #include <functional>
 #include <string.h>
@@ -545,12 +546,18 @@ struct FileSystem final : BaseFileSystem {
 
 	// Locks a metadata block and returns a window into it.
 	async::result<MetadataCache::BlockWindow> accessMetadata(uint64_t block, bool writable) {
-		return metadataCache->access(block, writable);
+		return metadataCacheFor(block).access(block, writable);
 	}
 
 	// Reads bytes from a metadata block without mapping it.
 	async::result<void> readMetadata(uint64_t block, size_t offset, size_t length, void *buffer) {
-		return metadataCache->read(block, offset, length, buffer);
+		return metadataCacheFor(block).read(block, offset, length, buffer);
+	}
+
+	MetadataCache &metadataCacheFor(uint64_t block) {
+		auto index = block / blocksPerGroup;
+		assert(index < metadataCaches.size());
+		return *metadataCaches[index];
 	}
 
 	BlockDevice *device;
@@ -585,8 +592,9 @@ struct FileSystem final : BaseFileSystem {
 	bool metadataChecksum;
 	bool bgdtChecksum;
 
-	// Mount-wide cache of metadata blocks, indexed by disk block number.
-	std::optional<MetadataCache> metadataCache;
+	// We use one cache of metadata blocks per block group.
+	// This allows multiple block groups to be served in parallel on helix::DispatcherPool.
+	std::vector<std::unique_ptr<MetadataCache>> metadataCaches;
 
 	std::mutex activeInodesMutex;
 

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -543,6 +543,16 @@ struct FileSystem final : BaseFileSystem {
 	async::result<void> assignDataBlocksUsingExtents(Inode *inode,
 			uint64_t block_offset, size_t num_blocks);
 
+	// Locks a metadata block and returns a window into it.
+	async::result<MetadataCache::BlockWindow> accessMetadata(uint64_t block, bool writable) {
+		return metadataCache->access(block, writable);
+	}
+
+	// Reads bytes from a metadata block without mapping it.
+	async::result<void> readMetadata(uint64_t block, size_t offset, size_t length, void *buffer) {
+		return metadataCache->read(block, offset, length, buffer);
+	}
+
 	BlockDevice *device;
 	uint16_t inodeSize;
 	uint32_t blockShift;

--- a/drivers/libblockfs/src/ext2/extents.hpp
+++ b/drivers/libblockfs/src/ext2/extents.hpp
@@ -85,7 +85,7 @@ struct ExtentWalker {
 			uint64_t nextBlock = static_cast<uint64_t>(idx.leafLow)
 					| (static_cast<uint64_t>(idx.leafHigh) << 32);
 
-			windows[pathCount] = co_await fs->metadataCache->access(nextBlock, !lookup);
+			windows[pathCount] = co_await fs->accessMetadata(nextBlock, !lookup);
 			currentBlock = nextBlock;
 			hdr = reinterpret_cast<ExtentHeader *>(windows[pathCount].get());
 		}

--- a/drivers/libblockfs/src/metadata-cache.cpp
+++ b/drivers/libblockfs/src/metadata-cache.cpp
@@ -36,8 +36,9 @@ MetadataCache::MetadataCache(BlockDevice *device, uint64_t baseBlock, uint64_t n
 			static_cast<size_t>(numBlocks << blockPagesShift_),
 			kHelMapProtRead | kHelMapProtWrite | kHelMapDontRequireBacking};
 
-	manage_(helix::UniqueDescriptor{backing});
-	flushDirty_();
+	// Distribute MetadataCache servicing coroutines over the helix::DispatcherPool,
+	// but keep manage_() and flushDirty_() on the same thread.
+	helix::DispatcherPool::global().detach(run_(helix::UniqueDescriptor{backing}));
 }
 
 void MetadataCache::CacheBlockPolicy::increment() const {
@@ -178,7 +179,14 @@ async::result<void> MetadataCache::read(uint64_t block, size_t offset, size_t le
 	);
 }
 
-async::detached MetadataCache::manage_(helix::UniqueDescriptor backing) {
+async::result<void> MetadataCache::run_(helix::UniqueDescriptor backing) {
+	co_await async::when_all(
+		flushDirty_(),
+		manage_(std::move(backing))
+	);
+}
+
+async::result<void> MetadataCache::manage_(helix::UniqueDescriptor backing) {
 	while(true) {
 		helix::ManageMemory manage;
 		auto &&submitManage = helix::submitManageMemory(backing,
@@ -186,8 +194,7 @@ async::detached MetadataCache::manage_(helix::UniqueDescriptor backing) {
 		co_await submitManage.async_wait();
 		HEL_CHECK(manage.error());
 
-		helix::DispatcherPool::global().detach(
-				serviceRequest_(backing, manage.type(), manage.offset(), manage.length()));
+		async::detach(serviceRequest_(backing, manage.type(), manage.offset(), manage.length()));
 	}
 }
 
@@ -250,7 +257,7 @@ void MetadataCache::markDirty_(uint64_t block) {
 	dirtyEvent_.raise();
 }
 
-async::detached MetadataCache::flushDirty_() {
+async::result<void> MetadataCache::flushDirty_() {
 	// Blocks dirtied while a batch is being synchronized are picked up by the next iteration.
 	uint64_t seenSeq = 0;
 	std::vector<uint64_t> batch;

--- a/drivers/libblockfs/src/metadata-cache.cpp
+++ b/drivers/libblockfs/src/metadata-cache.cpp
@@ -17,8 +17,9 @@ namespace {
 	constexpr size_t lruCapacity = 128;
 }
 
-MetadataCache::MetadataCache(BlockDevice *device, uint64_t numBlocks, size_t blockSize)
-: device_{device}, numBlocks_{numBlocks}, blockSize_{blockSize} {
+MetadataCache::MetadataCache(BlockDevice *device, uint64_t baseBlock, uint64_t numBlocks,
+		size_t blockSize)
+: device_{device}, baseBlock_{baseBlock}, numBlocks_{numBlocks}, blockSize_{blockSize} {
 	assert(std::has_single_bit(blockSize));
 	assert(blockSize >= device->sectorSize);
 	auto blockShift = static_cast<uint32_t>(std::countr_zero(blockSize));
@@ -115,7 +116,7 @@ void MetadataCache::destroyCacheBlock_(CacheBlock *cacheBlock) {
 }
 
 async::result<MetadataCache::BlockWindow> MetadataCache::access(uint64_t block, bool writable) {
-	assert(block < numBlocks_);
+	assert(block >= baseBlock_ && block - baseBlock_ < numBlocks_);
 
 	protocols::ostrace::Timer timer;
 	uint64_t timePin = 0;
@@ -144,7 +145,7 @@ async::result<MetadataCache::BlockWindow> MetadataCache::access(uint64_t block, 
 
 	helix::LockMemoryView lockMemory;
 	auto &&submit = helix::submitLockMemoryView(frontal_, &lockMemory,
-			block << blockPagesShift_, frameSize, helix::Dispatcher::global());
+			blockOffset_(block), frameSize, helix::Dispatcher::global());
 	co_await submit.async_wait();
 	HEL_CHECK(lockMemory.error());
 	timePin = timer.split();
@@ -160,13 +161,13 @@ async::result<MetadataCache::BlockWindow> MetadataCache::access(uint64_t block, 
 }
 
 async::result<void> MetadataCache::read(uint64_t block, size_t offset, size_t length, void *buffer) {
-	assert(block < numBlocks_);
+	assert(block >= baseBlock_ && block - baseBlock_ < numBlocks_);
 	assert(offset + length <= blockSize_);
 
 	protocols::ostrace::Timer timer;
 
 	auto readMemory = co_await helix_ng::readMemory(frontal_,
-			(block << blockPagesShift_) + offset, length, buffer);
+			blockOffset_(block) + offset, length, buffer);
 	HEL_CHECK(readMemory.error());
 
 	ostContext.emit(
@@ -203,8 +204,8 @@ async::result<void> MetadataCache::serviceRequest_(helix::BorrowedDescriptor bac
 	auto importTime = timer.split();
 
 	for(size_t progress = 0; progress < length; progress += frameSize) {
-		auto block = (offset + progress) >> blockPagesShift_;
-		assert(block < numBlocks_);
+		auto block = baseBlock_ + ((offset + progress) >> blockPagesShift_);
+		assert(block - baseBlock_ < numBlocks_);
 
 		auto subview = view.view().subview(progress, blockSize_);
 
@@ -229,7 +230,7 @@ async::result<void> MetadataCache::serviceRequest_(helix::BorrowedDescriptor bac
 		type == kHelManageInitialize ? ostEvtMetadataInitialize : ostEvtMetadataWriteback,
 		ostAttrTime(timer.elapsed()),
 		ostAttrNumBytes(length),
-		ostAttrBlock(offset >> blockPagesShift_),
+		ostAttrBlock(baseBlock_ + (offset >> blockPagesShift_)),
 		ostAttrTimeImport(importTime),
 		ostAttrTimeDevice(deviceTime)
 	);

--- a/drivers/libblockfs/src/metadata-cache.cpp
+++ b/drivers/libblockfs/src/metadata-cache.cpp
@@ -7,6 +7,7 @@
 #include <helix/dispatcher-pool.hpp>
 
 #include "metadata-cache.hpp"
+#include "service-budget.hpp"
 #include "trace.hpp"
 
 namespace blockfs {
@@ -194,7 +195,8 @@ async::result<void> MetadataCache::manage_(helix::UniqueDescriptor backing) {
 		co_await submitManage.async_wait();
 		HEL_CHECK(manage.error());
 
-		async::detach(serviceRequest_(backing, manage.type(), manage.offset(), manage.length()));
+		async::detach(serviceRequest_(backing, manage.type(), manage.offset(),
+				manage.length()));
 	}
 }
 
@@ -206,6 +208,10 @@ async::result<void> MetadataCache::serviceRequest_(helix::BorrowedDescriptor bac
 
 	protocols::ostrace::Timer timer;
 	uint64_t deviceTime = 0;
+
+	// Acquire servicing budget before importMemory().
+	auto budgetToken = co_await servicingBudget().acquire(type == kHelManageWriteback, length);
+	auto budgetTime = timer.split();
 
 	auto view = device_->pagePool->importMemory(backing, offset, length);
 	auto importTime = timer.split();
@@ -238,6 +244,7 @@ async::result<void> MetadataCache::serviceRequest_(helix::BorrowedDescriptor bac
 		ostAttrTime(timer.elapsed()),
 		ostAttrNumBytes(length),
 		ostAttrBlock(baseBlock_ + (offset >> blockPagesShift_)),
+		ostAttrTimeBudget(budgetTime),
 		ostAttrTimeImport(importTime),
 		ostAttrTimeDevice(deviceTime)
 	);

--- a/drivers/libblockfs/src/metadata-cache.hpp
+++ b/drivers/libblockfs/src/metadata-cache.hpp
@@ -20,7 +20,7 @@
 
 namespace blockfs {
 
-// Mount-wide page cache for filesystem metadata blocks, indexed by disk block number.
+// Page cache for a range of filesystem metadata blocks, indexed by disk block number.
 // The cache offset of a block is a fixed function of its block number alone;
 // hence, servicing a page reads no mutable filesystem state (such as block maps).
 // Each block occupies its own page-aligned frame, i.e., blocks smaller than a page
@@ -124,7 +124,8 @@ public:
 		bool writable_ = false;
 	};
 
-	MetadataCache(BlockDevice *device, uint64_t numBlocks, size_t blockSize);
+	// The cache covers the blocks [baseBlock, baseBlock + numBlocks).
+	MetadataCache(BlockDevice *device, uint64_t baseBlock, uint64_t numBlocks, size_t blockSize);
 
 	// The servicer coroutine started by the constructor refers back to this object.
 	MetadataCache(const MetadataCache &) = delete;
@@ -141,8 +142,12 @@ private:
 	async::detached manage_(helix::UniqueDescriptor backing);
 	async::result<void> serviceRequest_(helix::BorrowedDescriptor backing,
 			int type, uintptr_t offset, size_t length);
+	// Offset of the given block within this cache's mapping.
+	uintptr_t blockOffset_(uint64_t block) {
+		return (block - baseBlock_) << blockPagesShift_;
+	}
 	void *blockAddress_(uint64_t block) {
-		return static_cast<std::byte *>(mapping_.get()) + (block << blockPagesShift_);
+		return static_cast<std::byte *>(mapping_.get()) + blockOffset_(block);
 	}
 	CacheBlockPtr findCacheBlock_(uint64_t block);
 	CacheBlockPtr touchLru_(CacheBlock *cacheBlock);
@@ -151,6 +156,7 @@ private:
 	async::detached flushDirty_();
 
 	BlockDevice *device_;
+	uint64_t baseBlock_;
 	uint64_t numBlocks_;
 	size_t blockSize_;
 	uint32_t blockPagesShift_;

--- a/drivers/libblockfs/src/metadata-cache.hpp
+++ b/drivers/libblockfs/src/metadata-cache.hpp
@@ -127,7 +127,7 @@ public:
 	// The cache covers the blocks [baseBlock, baseBlock + numBlocks).
 	MetadataCache(BlockDevice *device, uint64_t baseBlock, uint64_t numBlocks, size_t blockSize);
 
-	// The servicer coroutine started by the constructor refers back to this object.
+	// The coroutines started by the constructor refer back to this object.
 	MetadataCache(const MetadataCache &) = delete;
 	MetadataCache &operator=(const MetadataCache &) = delete;
 
@@ -139,7 +139,8 @@ public:
 	async::result<void> read(uint64_t block, size_t offset, size_t length, void *buffer);
 
 private:
-	async::detached manage_(helix::UniqueDescriptor backing);
+	async::result<void> run_(helix::UniqueDescriptor backing);
+	async::result<void> manage_(helix::UniqueDescriptor backing);
 	async::result<void> serviceRequest_(helix::BorrowedDescriptor backing,
 			int type, uintptr_t offset, size_t length);
 	// Offset of the given block within this cache's mapping.
@@ -153,7 +154,7 @@ private:
 	CacheBlockPtr touchLru_(CacheBlock *cacheBlock);
 	void destroyCacheBlock_(CacheBlock *cacheBlock);
 	void markDirty_(uint64_t block);
-	async::detached flushDirty_();
+	async::result<void> flushDirty_();
 
 	BlockDevice *device_;
 	uint64_t baseBlock_;

--- a/drivers/libblockfs/src/service-budget.cpp
+++ b/drivers/libblockfs/src/service-budget.cpp
@@ -1,0 +1,45 @@
+#include <algorithm>
+#include <cstdint>
+
+#include "service-budget.hpp"
+
+namespace blockfs {
+
+namespace {
+	constexpr uint32_t pageShift = 12;
+	// Pages that one thread may have pinned, i.e. 4 MiB.
+	constexpr size_t budgetPages = 1024;
+	// Share of a budget that writeback may occupy.
+	constexpr size_t writebackNumerator = 3;
+	constexpr size_t writebackDenominator = 4;
+}
+
+ServiceBudget::ServiceBudget(size_t numPages)
+: capacity_{numPages},
+		writebackCapacity_{numPages * writebackNumerator / writebackDenominator},
+		semaphore_{capacity_}, writebackSemaphore_{writebackCapacity_} { }
+
+async::result<ServiceBudget::Token> ServiceBudget::acquire(bool writeback, size_t length) {
+	auto numPages = (length + (size_t{1} << pageShift) - 1) >> pageShift;
+	numPages = std::min(numPages, writeback ? writebackCapacity_ : capacity_);
+
+	// Writebacks take *both* the writeback budget and the overall budget.
+	// Initializations only take the overall budget.
+	if(writeback)
+		co_await writebackSemaphore_.async_acquire(numPages);
+	co_await semaphore_.async_acquire(numPages);
+	co_return Token{this, writeback, numPages};
+}
+
+void ServiceBudget::release_(bool writeback, size_t numPages) {
+	semaphore_.release(numPages);
+	if(writeback)
+		writebackSemaphore_.release(numPages);
+}
+
+ServiceBudget &servicingBudget() {
+	thread_local ServiceBudget budget{budgetPages};
+	return budget;
+}
+
+} // namespace blockfs

--- a/drivers/libblockfs/src/service-budget.hpp
+++ b/drivers/libblockfs/src/service-budget.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include <async/counting-semaphore.hpp>
+#include <async/result.hpp>
+
+namespace blockfs {
+
+// Bounds the memory that in-flight manage requests pin.
+// This is a backstop. More accurate backpressure handling should happen at the BlockDevice level.
+//
+// A budget belongs to one thread, so requests must be released on the thread that reserved them.
+struct ServiceBudget {
+	// Move-only handle to budget reserved by acquire(); releases automatically on destruction.
+	struct Token {
+		Token() = default;
+
+		Token(const Token &) = delete;
+
+		Token(Token &&other) : Token{} {
+			swap(*this, other);
+		}
+
+		Token &operator=(Token other) {
+			swap(*this, other);
+			return *this;
+		}
+
+		~Token() {
+			if(budget_)
+				budget_->release_(writeback_, numPages_);
+		}
+
+		friend void swap(Token &a, Token &b) {
+			using std::swap;
+			swap(a.budget_, b.budget_);
+			swap(a.writeback_, b.writeback_);
+			swap(a.numPages_, b.numPages_);
+		}
+
+		size_t numPages() const { return numPages_; }
+
+	private:
+		friend struct ServiceBudget;
+
+		Token(ServiceBudget *budget, bool writeback, size_t numPages)
+		: budget_{budget}, writeback_{writeback}, numPages_{numPages} { }
+
+		ServiceBudget *budget_ = nullptr;
+		bool writeback_ = false;
+		size_t numPages_ = 0;
+	};
+
+	explicit ServiceBudget(size_t numPages);
+
+	// Reserves budget for a request of the given length and returns a token that releases it.
+	// Requests are clamped to the maximal budget; hence, very large requests run alone.
+	async::result<Token> acquire(bool writeback, size_t length);
+
+private:
+	void release_(bool writeback, size_t numPages);
+
+	// Overall budget in pages.
+	size_t capacity_;
+	// Pages of the budget that writeback may occupy. Reads can always take the full budget.
+	size_t writebackCapacity_;
+	async::counting_semaphore semaphore_;
+	async::counting_semaphore writebackSemaphore_;
+};
+
+// One budget covers all servicing because no servicer waits for another one while holding budget.
+// This means that all metadata access must be done
+// *before* servicing budget is acquired for operations that rely on that metadata.
+ServiceBudget &servicingBudget();
+
+} // namespace blockfs

--- a/drivers/libblockfs/src/trace.hpp
+++ b/drivers/libblockfs/src/trace.hpp
@@ -89,6 +89,11 @@ inline constinit protocols::ostrace::UintAttribute ostAttrTimeLock{"timeLock"};
 inline constinit protocols::ostrace::UintAttribute ostAttrTimePin{"timePin"};
 // Importing the managed memory range into the DMA pool.
 inline constinit protocols::ostrace::UintAttribute ostAttrTimeImport{"timeImport"};
+// Waiting for servicing budget, i.e. for the memory that in-flight manage requests
+// pin to drop back below the per-thread limit.
+inline constinit protocols::ostrace::UintAttribute ostAttrTimeBudget{"timeBudget"};
+// Resolving the file range to runs of disk blocks, i.e. walking the block map.
+inline constinit protocols::ostrace::UintAttribute ostAttrTimeLookup{"timeLookup"};
 // Reading file data blocks off the device.
 inline constinit protocols::ostrace::UintAttribute ostAttrTimeRead{"timeRead"};
 // Assigning disk blocks to the file range that is being written back.
@@ -203,6 +208,8 @@ inline protocols::ostrace::Vocabulary ostVocabulary{
 	ostAttrTimeLock,
 	ostAttrTimePin,
 	ostAttrTimeImport,
+	ostAttrTimeBudget,
+	ostAttrTimeLookup,
 	ostAttrTimeRead,
 	ostAttrTimeAssign,
 	ostAttrTimeWrite,

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -1024,18 +1024,13 @@ namespace posix {
 				launchGdbServer(info.thread, _name, WorkQueue::generalQueue());
 				break;
 			}else if(interrupt == kIntrSuperCall + ::posix::superAnonAllocate) { // ANON_ALLOCATE.
-				// TODO: Use some always-zero memory for private anonymous mappings.
 				uintptr_t size;
 				auto readOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					size = *executor->arg0();
 				});
 				if(!readOutcome)
 					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
-				auto fileMemoryOutcome = AllocatedMemory::create(size);
-				if(!fileMemoryOutcome)
-					panicLogger() << "thor: Failed to create memory" << frg::endlog;
-				auto cowOutcome = CopyOnWriteMemory::create(
-						std::move(*fileMemoryOutcome), 0, size);
+				auto cowOutcome = CopyOnWriteMemory::create(getZeroMemory(), 0, size);
 				if(!cowOutcome)
 					panicLogger() << "thor: Failed to create copy-on-write memory" << frg::endlog;
 				auto sliceOutcome = MemorySlice::create(std::move(*cowOutcome), 0, size);


### PR DESCRIPTION
This PR changes the ext2 code to use one `MetadataCache` per block group instead of one `MetadataCache` per mount. This allows us to distribute the servicing coroutines over the `helix::DispatcherPool`. We previously distributed each individual servicing request but that turned out to be too fine-grained.

Since we now have a higher degree of parallelization, we also add a mechanism to limit memory usage: we only allow each thread to pin a limited number of pages in libblockfs-related DMA spaces at a time.