### PR TITLE
virtio-block: Support multi-queue

### DIFF
--- a/core/virtio/include/core/virtio/core.hpp
+++ b/core/virtio/include/core/virtio/core.hpp
@@ -40,6 +40,7 @@ inline constexpr arch::scalar_register<uint32_t> PCI_DEVICE_FEATURE_SELECT(0);
 inline constexpr arch::scalar_register<uint32_t> PCI_DEVICE_FEATURE_WINDOW(4);
 inline constexpr arch::scalar_register<uint32_t> PCI_DRIVER_FEATURE_SELECT(8);
 inline constexpr arch::scalar_register<uint32_t> PCI_DRIVER_FEATURE_WINDOW(12);
+inline constexpr arch::scalar_register<uint16_t> PCI_CONFIG_MSIX_VECTOR(16);
 inline constexpr arch::scalar_register<uint8_t> PCI_DEVICE_STATUS(20);
 inline constexpr arch::scalar_register<uint16_t> PCI_QUEUE_SELECT(22);
 inline constexpr arch::scalar_register<uint16_t> PCI_QUEUE_SIZE(24);

--- a/core/virtio/include/core/virtio/core.hpp
+++ b/core/virtio/include/core/virtio/core.hpp
@@ -58,6 +58,9 @@ inline constexpr arch::scalar_register<uint32_t> PCI_QUEUE_USED[] = {
 
 inline constexpr arch::scalar_register<uint8_t> PCI_ISR(0);
 
+// Detaches a queue from any MSI-X vector.
+inline constexpr unsigned int VIRTIO_MSI_NO_VECTOR = 0xFFFF;
+
 enum {
 	PCI_L_DEVICE_SPECIFIC = 20
 };
@@ -139,6 +142,14 @@ struct QueueInfo {
 	ptrdiff_t notifyOffset;
 };
 
+// What a driver wants for the completion notifications of a virtq.
+enum class QueueIrq {
+	// One interrupt shared with every other queue that asks to share.
+	shared,
+	// An interrupt of its own, if the device has vectors to spare. Degrades to shared.
+	own
+};
+
 /* This class represents a virtio device.
  *
  * Usual initialization works as follows:
@@ -147,6 +158,7 @@ struct QueueInfo {
  * - Call Transport::finalizeFeatures().
  * - Call Transport::claimQueues().
  * - Call Transport::setupQueue() for each virtq.
+ * - Detach Queue::serviceQueue() for each virtq, on the thread that should run its completions.
  * - Call Transport::runDevice().
  *
  * Queues are thread-safe but this class is not:
@@ -166,6 +178,10 @@ struct Transport {
 
 	virtual protocols::hw::Device &hwDevice() = 0;
 
+	// Number of interrupts that this transport has available for virtqs.
+	// At least one, even if the transport does not use MSIs at all.
+	virtual unsigned int maxIrqsAvailableToQueues() = 0;
+
 	virtual uint8_t loadConfig8(size_t offset) = 0;
 	virtual uint16_t loadConfig16(size_t offset) = 0;
 	virtual uint32_t loadConfig32(size_t offset) = 0;
@@ -174,7 +190,15 @@ struct Transport {
 	virtual void acknowledgeDriverFeature(unsigned int feature) = 0;
 	virtual void finalizeFeatures() = 0;
 
-	virtual void claimQueues(unsigned int max_index) = 0;
+	// Fixes the number of virtqs. All of them share a single interrupt.
+	void claimQueues(unsigned int max_index) {
+		std::vector<QueueIrq> irqs(max_index, QueueIrq::shared);
+		claimQueues(irqs);
+	}
+
+	// Fixes the number of virtqs and the interrupt that each of them asks for.
+	// Which vectors these end up being is up to the transport.
+	virtual void claimQueues(std::span<const QueueIrq> irqs) = 0;
 
 	virtual async::result<Queue *> setupQueue(unsigned int index) = 0;
 
@@ -387,6 +411,10 @@ public:
 	// Processes interrupts for this virtq.
 	// Calls retrieveDescriptor() to complete individual requests.
 	void processInterrupt();
+
+	// Services the interrupt that delivers this queue's completions.
+	// Should be started on an appropriate thread to improve locality and reduce contention.
+	virtual async::result<void> serviceQueue() = 0;
 
 protected:
 	virtual void notifyTransport() = 0;

--- a/core/virtio/src/core.cpp
+++ b/core/virtio/src/core.cpp
@@ -1,5 +1,6 @@
 
 #include <assert.h>
+#include <algorithm>
 #include <atomic>
 #include <iostream>
 #include <unordered_map>
@@ -94,6 +95,10 @@ struct LegacyPciTransport : Transport {
 		return _hwDevice;
 	}
 
+	unsigned int maxIrqsAvailableToQueues() override {
+		return 1;
+	}
+
 	uint8_t loadConfig8(size_t offset) override;
 	uint16_t loadConfig16(size_t offset) override;
 	uint32_t loadConfig32(size_t offset) override;
@@ -102,7 +107,8 @@ struct LegacyPciTransport : Transport {
 	void acknowledgeDriverFeature(unsigned int feature) override;
 	void finalizeFeatures() override;
 
-	void claimQueues(unsigned int max_index) override;
+	using Transport::claimQueues;
+	void claimQueues(std::span<const QueueIrq> irqs) override;
 	async::result<Queue *> setupQueue(unsigned int index) override;
 
 	void runDevice() override;
@@ -127,6 +133,11 @@ struct LegacyPciQueue final : Queue {
 	LegacyPciQueue(LegacyPciTransport *transport,
 			unsigned int queue_index, size_t queue_size,
 			spec::Descriptor *table, spec::AvailableRing *available, spec::UsedRing *used);
+
+	// The legacy transport has no MSIs, so every queue is serviced by the IRQ loop.
+	async::result<void> serviceQueue() override {
+		co_return;
+	}
 
 protected:
 	void notifyTransport() override;
@@ -196,8 +207,8 @@ void LegacyPciTransport::finalizeFeatures() {
 	// Does nothing for now.
 }
 
-void LegacyPciTransport::claimQueues(unsigned int max_index) {
-	_queues.resize(max_index);
+void LegacyPciTransport::claimQueues(std::span<const QueueIrq> irqs) {
+	_queues.resize(irqs.size());
 }
 
 async::result<Queue *> LegacyPciTransport::setupQueue(unsigned int queue_index) {
@@ -314,11 +325,11 @@ struct StandardPciTransport : Transport {
 	friend struct StandardPciQueue;
 
 	StandardPciTransport(protocols::hw::Device hw_device,
-			bool useMsi,
+			unsigned int numMsis,
 			Mapping common_mapping, Mapping notify_mapping,
 			Mapping isr_mapping, Mapping device_mapping,
 			unsigned int notify_multiplier, helix::UniqueDescriptor irq,
-			helix::UniqueDescriptor queueMsi, helix::UniqueDescriptor dmaSpace, bool iommuActive);
+			helix::UniqueDescriptor dmaSpace, bool iommuActive);
 
 	bool isLegacy() override {
 		return false;
@@ -326,6 +337,10 @@ struct StandardPciTransport : Transport {
 
 	protocols::hw::Device &hwDevice() override {
 		return _hwDevice;
+	}
+
+	unsigned int maxIrqsAvailableToQueues() override {
+		return std::max(_numMsis, 1u);
 	}
 
 	uint8_t loadConfig8(size_t offset) override;
@@ -336,10 +351,14 @@ struct StandardPciTransport : Transport {
 	void acknowledgeDriverFeature(unsigned int feature) override;
 	void finalizeFeatures() override;
 
-	void claimQueues(unsigned int max_index) override;
+	using Transport::claimQueues;
+	void claimQueues(std::span<const QueueIrq> irqs) override;
 	async::result<Queue *> setupQueue(unsigned int index) override;
 
 	void runDevice() override;
+
+	// Backs StandardPciQueue::serviceQueue().
+	async::result<void> serviceVector(unsigned int queue_index);
 
 private:
 	arch::mem_space _commonSpace() { return arch::mem_space{_commonMapping.get()}; }
@@ -348,18 +367,25 @@ private:
 	arch::mem_space _deviceSpace() { return arch::mem_space{_deviceMapping.get()}; }
 
 	async::detached _processIrqs();
-	async::detached _processQueueMsi();
 
 	protocols::hw::Device _hwDevice;
-	bool _useMsi;
+	// Number of MSI vectors that the device offers. Zero if MSIs are unavailable.
+	unsigned int _numMsis;
 	Mapping _commonMapping;
 	Mapping _notifyMapping;
 	Mapping _isrMapping;
 	Mapping _deviceMapping;
 	unsigned int _notifyMultiplier;
 	helix::UniqueDescriptor _irq;
-	helix::UniqueDescriptor _queueMsi;
 
+	// MSI vectors that the device raises for virtq completions, indexed by vector.
+	std::vector<helix::UniqueDescriptor> _msis;
+	// Maps MSI vectors to one or more queues.
+	std::vector<std::vector<StandardPciQueue *>> _msiQueues;
+	// Whether a servicer was already started for each vector.
+	std::unique_ptr<std::atomic_flag[]> _msiServiced;
+	// MSI vector of each virtq, or VIRTIO_MSI_NO_VECTOR.
+	std::vector<unsigned int> _queueVectors;
 
 	std::vector<std::unique_ptr<StandardPciQueue>> _queues;
 };
@@ -380,6 +406,10 @@ struct StandardPciQueue final : Queue {
 		return _transport->dmaSpace_;
 	}
 
+	async::result<void> serviceQueue() override {
+		return _transport->serviceVector(queueIndex());
+	}
+
 protected:
 	void notifyTransport() override;
 
@@ -390,27 +420,25 @@ private:
 
 StandardPciTransport::StandardPciTransport(
     protocols::hw::Device hw_device,
-    bool useMsi,
+    unsigned int numMsis,
     Mapping common_mapping,
     Mapping notify_mapping,
     Mapping isr_mapping,
     Mapping device_mapping,
     unsigned int notify_multiplier,
     helix::UniqueDescriptor irq,
-    helix::UniqueDescriptor queueMsi,
     helix::UniqueDescriptor dmaSpace,
     bool iommuActive
 )
 : Transport(std::move(dmaSpace), iommuActive),
   _hwDevice{std::move(hw_device)},
-  _useMsi{useMsi},
+  _numMsis{numMsis},
   _commonMapping{std::move(common_mapping)},
   _notifyMapping{std::move(notify_mapping)},
   _isrMapping{std::move(isr_mapping)},
   _deviceMapping{std::move(device_mapping)},
   _notifyMultiplier{notify_multiplier},
-  _irq{std::move(irq)},
-  _queueMsi{std::move(queueMsi)} {}
+  _irq{std::move(irq)} {}
 
 uint8_t StandardPciTransport::loadConfig8(size_t offset) {
 	return _deviceSpace().load(arch::scalar_register<uint8_t>(offset));
@@ -452,8 +480,33 @@ void StandardPciTransport::finalizeFeatures() {
 	assert(confirm & FEATURES_OK);
 }
 
-void StandardPciTransport::claimQueues(unsigned int max_index) {
-	_queues.resize(max_index);
+void StandardPciTransport::claimQueues(std::span<const QueueIrq> irqs) {
+	_queues.resize(irqs.size());
+	_queueVectors.assign(irqs.size(), VIRTIO_MSI_NO_VECTOR);
+	if(!_numMsis)
+		return;
+
+	// Assign all MSI vectors.
+	// MSI-X suppresses the device's pin, so every queue needs a vector of some kind.
+	size_t numOwn = std::ranges::count(irqs, QueueIrq::own);
+	bool needShared = std::ranges::contains(irqs, QueueIrq::shared) || numOwn > _numMsis;
+	numOwn = std::min<size_t>(numOwn, _numMsis - (needShared ? 1 : 0));
+
+	unsigned int v = 0; // Next vector to allocate.
+	auto sharedVector = needShared ? v++ : VIRTIO_MSI_NO_VECTOR;
+	for(size_t i = 0; i < irqs.size(); ++i) {
+		if(irqs[i] == QueueIrq::own && numOwn) {
+			_queueVectors[i] = v++;
+			--numOwn;
+		}else{
+			_queueVectors[i] = sharedVector;
+		}
+	}
+	assert(v <= _numMsis);
+
+	_msis.resize(v);
+	_msiQueues.resize(v);
+	_msiServiced = std::make_unique<std::atomic_flag[]>(v);
 }
 
 async::result<Queue *> StandardPciTransport::setupQueue(unsigned int queue_index) {
@@ -510,10 +563,17 @@ async::result<Queue *> StandardPciTransport::setupQueue(unsigned int queue_index
 	_commonSpace().store(PCI_QUEUE_USED[0], used_physical);
 	_commonSpace().store(PCI_QUEUE_USED[1], used_physical >> 32);
 
-	// Setup MSI-X.
-	if(_useMsi) {
-		_commonSpace().store(PCI_QUEUE_MSIX_VECTOR, 0);
-		if(_commonSpace().load(PCI_QUEUE_MSIX_VECTOR) != 0)
+	auto vector = _queueVectors[queue_index];
+	if(vector != VIRTIO_MSI_NO_VECTOR) {
+		if(!_msis[vector])
+			_msis[vector] = co_await _hwDevice.installMsi(vector);
+		_msiQueues[vector].push_back(_queues[queue_index].get());
+	}
+
+	// Devices without MSI-X do not implement the vector register.
+	if(_numMsis) {
+		_commonSpace().store(PCI_QUEUE_MSIX_VECTOR, vector);
+		if(_commonSpace().load(PCI_QUEUE_MSIX_VECTOR) != vector)
 			throw std::runtime_error("Device failed to allocate MSI-X interrupt");
 	}
 
@@ -526,8 +586,6 @@ void StandardPciTransport::runDevice() {
 	// Finally set the DRIVER_OK bit to finish the configuration.
 	_commonSpace().store(PCI_DEVICE_STATUS, _commonSpace().load(PCI_DEVICE_STATUS) | DRIVER_OK);
 
-	if(_useMsi)
-		_processQueueMsi();
 	_processIrqs();
 }
 
@@ -637,16 +695,28 @@ async::detached StandardPciTransport::_processIrqs() {
 #endif
 }
 
-async::detached StandardPciTransport::_processQueueMsi() {
+async::result<void> StandardPciTransport::serviceVector(unsigned int queue_index) {
+	// setupQueue() appends to _msiQueues, so all queues must be set up before servicing starts.
+	assert(std::ranges::all_of(_queues, [] (auto &queue) { return static_cast<bool>(queue); }));
+
+	auto msiVector = _queueVectors[queue_index];
+	// Queues without a vector of their own are serviced by the device-wide IRQ loop.
+	if(msiVector == VIRTIO_MSI_NO_VECTOR)
+		co_return;
+	// Only the first caller services a vector. Queues sharing it are covered by it.
+	if(_msiServiced[msiVector].test_and_set(std::memory_order_acq_rel))
+		co_return;
+
 	uint64_t sequence = 0;
 	while(true) {
-		auto await = co_await helix_ng::awaitEvent(_queueMsi, sequence);
+		auto await = co_await helix_ng::awaitEvent(_msis[msiVector], sequence);
 		HEL_CHECK(await.error());
 		sequence = await.sequence();
 
-		HEL_CHECK(helAcknowledgeIrq(_queueMsi.getHandle(), kHelAckAcknowledge, sequence));
+		HEL_CHECK(helAcknowledgeIrq(_msis[msiVector].getHandle(),
+				kHelAckAcknowledge, sequence));
 
-		for(auto &queue : _queues)
+		for(auto queue : _msiQueues[msiVector])
 			queue->processInterrupt();
 	}
 }
@@ -744,13 +814,9 @@ discover(protocols::hw::Device hw_device, DiscoverMode mode) {
 			common_space.store(PCI_DEVICE_STATUS, 0);
 			assert(!common_space.load(PCI_DEVICE_STATUS));
 
-			helix::UniqueDescriptor queueMsi;
-
 			// Enable MSI-X.
-			if (info.numMsis) {
+			if (info.numMsis)
 				co_await hw_device.enableMsi();
-				queueMsi = co_await hw_device.installMsi(0);
-			}
 
 			// Set the ACKNOWLEDGE and DRIVER bits.
 			// The specification says this should be done in two steps
@@ -769,7 +835,6 @@ discover(protocols::hw::Device hw_device, DiscoverMode mode) {
 			    std::move(*device_mapping),
 			    notify_multiplier,
 			    std::move(irq),
-			    std::move(queueMsi),
 			    std::move(dmaSpace),
 			    iommuActive
 			);

--- a/core/virtio/src/core.cpp
+++ b/core/virtio/src/core.cpp
@@ -319,6 +319,13 @@ void LegacyPciQueue::notifyTransport() {
 
 namespace {
 
+// Reserve the first vector for configMsiVector.
+// The MSI vector allocator only allocates MSI vectors above numReservedMsis.
+constexpr unsigned int numReservedMsis = 1;
+
+// MSI vector that the device raises when its configuration changes.
+constexpr unsigned int configMsiVector = 0;
+
 struct StandardPciQueue;
 
 struct StandardPciTransport : Transport {
@@ -329,7 +336,8 @@ struct StandardPciTransport : Transport {
 			Mapping common_mapping, Mapping notify_mapping,
 			Mapping isr_mapping, Mapping device_mapping,
 			unsigned int notify_multiplier, helix::UniqueDescriptor irq,
-			helix::UniqueDescriptor dmaSpace, bool iommuActive);
+			helix::UniqueDescriptor configMsi, helix::UniqueDescriptor dmaSpace,
+			bool iommuActive);
 
 	bool isLegacy() override {
 		return false;
@@ -340,7 +348,9 @@ struct StandardPciTransport : Transport {
 	}
 
 	unsigned int maxIrqsAvailableToQueues() override {
-		return std::max(_numMsis, 1u);
+		if(!_numMsis)
+			return 1;
+		return _numMsis - numReservedMsis;
 	}
 
 	uint8_t loadConfig8(size_t offset) override;
@@ -367,6 +377,7 @@ private:
 	arch::mem_space _deviceSpace() { return arch::mem_space{_deviceMapping.get()}; }
 
 	async::detached _processIrqs();
+	async::detached _processConfigMsi();
 
 	protocols::hw::Device _hwDevice;
 	// Number of MSI vectors that the device offers. Zero if MSIs are unavailable.
@@ -377,6 +388,7 @@ private:
 	Mapping _deviceMapping;
 	unsigned int _notifyMultiplier;
 	helix::UniqueDescriptor _irq;
+	helix::UniqueDescriptor _configMsi;
 
 	// MSI vectors that the device raises for virtq completions, indexed by vector.
 	std::vector<helix::UniqueDescriptor> _msis;
@@ -427,6 +439,7 @@ StandardPciTransport::StandardPciTransport(
     Mapping device_mapping,
     unsigned int notify_multiplier,
     helix::UniqueDescriptor irq,
+    helix::UniqueDescriptor configMsi,
     helix::UniqueDescriptor dmaSpace,
     bool iommuActive
 )
@@ -438,7 +451,8 @@ StandardPciTransport::StandardPciTransport(
   _isrMapping{std::move(isr_mapping)},
   _deviceMapping{std::move(device_mapping)},
   _notifyMultiplier{notify_multiplier},
-  _irq{std::move(irq)} {}
+  _irq{std::move(irq)},
+  _configMsi{std::move(configMsi)} {}
 
 uint8_t StandardPciTransport::loadConfig8(size_t offset) {
 	return _deviceSpace().load(arch::scalar_register<uint8_t>(offset));
@@ -488,11 +502,12 @@ void StandardPciTransport::claimQueues(std::span<const QueueIrq> irqs) {
 
 	// Assign all MSI vectors.
 	// MSI-X suppresses the device's pin, so every queue needs a vector of some kind.
+	auto budget = _numMsis - numReservedMsis;
 	size_t numOwn = std::ranges::count(irqs, QueueIrq::own);
-	bool needShared = std::ranges::contains(irqs, QueueIrq::shared) || numOwn > _numMsis;
-	numOwn = std::min<size_t>(numOwn, _numMsis - (needShared ? 1 : 0));
+	bool needShared = std::ranges::contains(irqs, QueueIrq::shared) || numOwn > budget;
+	numOwn = std::min<size_t>(numOwn, budget - (needShared ? 1 : 0));
 
-	unsigned int v = 0; // Next vector to allocate.
+	unsigned int v = numReservedMsis; // Next vector to allocate.
 	auto sharedVector = needShared ? v++ : VIRTIO_MSI_NO_VECTOR;
 	for(size_t i = 0; i < irqs.size(); ++i) {
 		if(irqs[i] == QueueIrq::own && numOwn) {
@@ -583,10 +598,21 @@ async::result<Queue *> StandardPciTransport::setupQueue(unsigned int queue_index
 }
 
 void StandardPciTransport::runDevice() {
+	if(_numMsis) {
+		_commonSpace().store(PCI_CONFIG_MSIX_VECTOR, configMsiVector);
+		if(_commonSpace().load(PCI_CONFIG_MSIX_VECTOR) != configMsiVector)
+			throw std::runtime_error("Device failed to allocate MSI-X interrupt");
+	}
+
 	// Finally set the DRIVER_OK bit to finish the configuration.
 	_commonSpace().store(PCI_DEVICE_STATUS, _commonSpace().load(PCI_DEVICE_STATUS) | DRIVER_OK);
 
+	// The pin can be shared with other devices, so it always needs to be acked or nacked.
+	// MSI-X only suppresses this device's own use of it: the ISR register then stays clear
+	// and the IRQ loop does nothing but nack.
 	_processIrqs();
+	if(_numMsis)
+		_processConfigMsi();
 }
 
 async::detached StandardPciTransport::_processIrqs() {
@@ -693,6 +719,21 @@ async::detached StandardPciTransport::_processIrqs() {
 				queue->processInterrupt();
 	}
 #endif
+}
+
+async::detached StandardPciTransport::_processConfigMsi() {
+	uint64_t sequence = 0;
+	while(true) {
+		auto await = co_await helix_ng::awaitEvent(_configMsi, sequence);
+		HEL_CHECK(await.error());
+		sequence = await.sequence();
+
+		HEL_CHECK(helAcknowledgeIrq(_configMsi.getHandle(), kHelAckAcknowledge, sequence));
+
+		std::cout << "core-virtio: Configuration change" << std::endl;
+		auto status = _commonSpace().load(PCI_DEVICE_STATUS);
+		assert(!(status & DEVICE_NEEDS_RESET));
+	}
 }
 
 async::result<void> StandardPciTransport::serviceVector(unsigned int queue_index) {
@@ -815,8 +856,13 @@ discover(protocols::hw::Device hw_device, DiscoverMode mode) {
 			assert(!common_space.load(PCI_DEVICE_STATUS));
 
 			// Enable MSI-X.
-			if (info.numMsis)
+			// One vector is reserved for configuration changes, hence we need at least two vectors.
+			helix::UniqueDescriptor configMsi;
+			auto numMsis = info.numMsis >= (numReservedMsis + 1) ? info.numMsis : 0;
+			if (numMsis) {
 				co_await hw_device.enableMsi();
+				configMsi = co_await hw_device.installMsi(configMsiVector);
+			}
 
 			// Set the ACKNOWLEDGE and DRIVER bits.
 			// The specification says this should be done in two steps
@@ -828,13 +874,14 @@ discover(protocols::hw::Device hw_device, DiscoverMode mode) {
 			std::cout << "virtio: Using standard PCI transport" << std::endl;
 			co_return std::make_unique<StandardPciTransport>(
 			    std::move(hw_device),
-			    info.numMsis,
+			    numMsis,
 			    std::move(*common_mapping),
 			    std::move(*notify_mapping),
 			    std::move(*isr_mapping),
 			    std::move(*device_mapping),
 			    notify_multiplier,
 			    std::move(irq),
+			    std::move(configMsi),
 			    std::move(dmaSpace),
 			    iommuActive
 			);

--- a/drivers/block/virtio-blk/src/block.cpp
+++ b/drivers/block/virtio-blk/src/block.cpp
@@ -62,6 +62,7 @@ async::result<void> Device::runDevice() {
 	_transport->finalizeFeatures();
 	_transport->claimQueues(1);
 	_requestQueue = co_await _transport->setupQueue(0);
+	async::detach(_requestQueue->serviceQueue());
 
 	auto size = static_cast<uint64_t>(_transport->space().load(spec::regs::capacity[0]))
 			| (static_cast<uint64_t>(_transport->space().load(spec::regs::capacity[1])) << 32);

--- a/drivers/block/virtio-blk/src/block.cpp
+++ b/drivers/block/virtio-blk/src/block.cpp
@@ -21,12 +21,13 @@ uint64_t currentNs() {
 	return helix::getClock();
 }
 
-void emitRequestTrace(UserRequest *request) {
+void emitRequestTrace(UserRequest *request, unsigned int queueIndex) {
 	blockfs::ostContext.emit(
 		blockfs::ostEvtVirtioBlkRequest,
 		blockfs::ostAttrTime(request->completeTs - request->enqueueTs),
 		blockfs::ostAttrNumBytes(request->view.size()),
 		blockfs::ostAttrIsWrite(request->write),
+		blockfs::ostAttrQueueIndex(queueIndex),
 		blockfs::ostAttrTimeSetup(request->setupTime),
 		blockfs::ostAttrTimeObtain(request->obtainTime),
 		blockfs::ostAttrTimeDevice(request->completeTs - request->submitTs)
@@ -153,7 +154,7 @@ async::result<void> Device::readSectors(uint64_t sector, arch::dma_buffer_view v
 					<< static_cast<unsigned int>(*request.status) << std::endl;
 			abort();
 		}
-		emitRequestTrace(&request);
+		emitRequestTrace(&request, queue->queueIndex());
 	}
 
 	blockfs::ostContext.emit(
@@ -197,7 +198,7 @@ async::result<void> Device::writeSectors(uint64_t sector, arch::dma_buffer_view 
 					<< static_cast<unsigned int>(*request.status) << std::endl;
 			abort();
 		}
-		emitRequestTrace(&request);
+		emitRequestTrace(&request, queue->queueIndex());
 	}
 
 	blockfs::ostContext.emit(

--- a/drivers/block/virtio-blk/src/block.cpp
+++ b/drivers/block/virtio-blk/src/block.cpp
@@ -2,7 +2,9 @@
 #include <async/basic.hpp>
 #include <frg/scope_exit.hpp>
 #include <helix/clock.hpp>
+#include <helix/dispatcher-pool.hpp>
 #include <stdlib.h>
+#include <algorithm>
 #include <iostream>
 #include <list>
 
@@ -49,7 +51,6 @@ UserRequest::UserRequest(bool write_, uint64_t sector_, arch::dma_buffer_view vi
 Device::Device(std::unique_ptr<virtio_core::Transport> transport, int64_t parent_id)
 : blockfs::BlockDevice{512, parent_id, &transport->memoryPool_},
   _transport{std::move(transport)},
-  _requestQueue{nullptr},
   _size{0} {}
 
 async::result<void> Device::runDevice() {
@@ -59,10 +60,36 @@ async::result<void> Device::runDevice() {
 		_transport->acknowledgeDriverFeature(VIRTIO_BLK_F_FLUSH);
 		_hasFlush = true;
 	}
+
+	// Multi-queue lets each pool thread submit to a virtq of its own.
+	auto hasMq = _transport->checkDeviceFeature(VIRTIO_BLK_F_MQ);
+	if(hasMq)
+		_transport->acknowledgeDriverFeature(VIRTIO_BLK_F_MQ);
+
 	_transport->finalizeFeatures();
-	_transport->claimQueues(1);
-	_requestQueue = co_await _transport->setupQueue(0);
-	async::detach(_requestQueue->serviceQueue());
+
+	unsigned int numQueues = 1;
+	if(hasMq) {
+		auto maxQueues = _transport->space().load(spec::regs::numQueues);
+		auto maxThreads = helix::DispatcherPool::global().maxThreads();
+		numQueues = std::min({
+			static_cast<unsigned int>(maxQueues),
+			static_cast<unsigned int>(maxThreads),
+			_transport->maxIrqsAvailableToQueues()
+		});
+		assert(numQueues);
+	}
+	std::cout << "virtio: Using " << numQueues << " request queues" << std::endl;
+
+	// Each virtq is submitted to by a single thread, hence they all want their own interrupt.
+	std::vector<virtio_core::QueueIrq> irqs(numQueues, virtio_core::QueueIrq::own);
+	_transport->claimQueues(irqs);
+	for(unsigned int i = 0; i < numQueues; ++i)
+		_queues.push_back(co_await _transport->setupQueue(i));
+	_queueLive = std::make_unique<std::atomic_flag[]>(numQueues);
+
+	// Service queue 0 from here. It is also used by threads that are not DispatcherPool members.
+	_startServicer(0);
 
 	auto size = static_cast<uint64_t>(_transport->space().load(spec::regs::capacity[0]))
 			| (static_cast<uint64_t>(_transport->space().load(spec::regs::capacity[1])) << 32);
@@ -74,6 +101,24 @@ async::result<void> Device::runDevice() {
 	blockfs::runDevice(this);
 }
 
+void Device::_startServicer(unsigned int index) {
+	if(_queueLive[index].test_and_set(std::memory_order_acq_rel))
+		return;
+	async::detach(_queues[index]->serviceQueue());
+}
+
+virtio_core::Queue *Device::_pickQueue() {
+	// Threads outside DispatcherPool always pick queue zero.
+	// TODO: We could alternatively let them pick a random queue that is already is use,
+	//       but that requires more book keeping and there are no such threads right now anyway.
+	// TODO: The modulo causes some queues to be utilized more than others if #queues < #threads.
+	//       We could potentially use a better strategy in that situation.
+	auto index = helix::DispatcherPool::global().thisThread().value_or(0) % _queues.size();
+	if(!_queueLive[index].test(std::memory_order_acquire))
+		_startServicer(index);
+	return _queues[index];
+}
+
 async::result<void> Device::readSectors(uint64_t sector, arch::dma_buffer_view view) {
 	// Natural alignment makes sure a sector does not cross a page boundary.
 	assert(!((uintptr_t)view.data() % 512));
@@ -81,8 +126,10 @@ async::result<void> Device::readSectors(uint64_t sector, arch::dma_buffer_view v
 
 	protocols::ostrace::Timer timer;
 
+	auto queue = _pickQueue();
+
 	// Limit to ensure that we don't monopolize the device.
-	auto max_sectors = _requestQueue->numDescriptors() / 4;
+	auto max_sectors = queue->numDescriptors() / 4;
 	assert(max_sectors >= 1);
 	auto num_sectors = view.size() >> sectorShift;
 
@@ -95,7 +142,7 @@ async::result<void> Device::readSectors(uint64_t sector, arch::dma_buffer_view v
 		);
 		auto &request = requests.emplace_back(false, sector + progress, subview, pagePool);
 		request.enqueueTs = currentNs();
-		co_await _issueRequest(&request);
+		co_await _issueRequest(queue, &request);
 	}
 
 	for(auto &request : requests) {
@@ -123,8 +170,10 @@ async::result<void> Device::writeSectors(uint64_t sector, arch::dma_buffer_view 
 
 	protocols::ostrace::Timer timer;
 
+	auto queue = _pickQueue();
+
 	// Limit to ensure that we don't monopolize the device.
-	auto max_sectors = _requestQueue->numDescriptors() / 4;
+	auto max_sectors = queue->numDescriptors() / 4;
 	assert(max_sectors >= 1);
 	auto num_sectors = view.size() >> sectorShift;
 
@@ -137,7 +186,7 @@ async::result<void> Device::writeSectors(uint64_t sector, arch::dma_buffer_view 
 		);
 		auto &request = requests.emplace_back(true, sector + progress, subview, pagePool);
 		request.enqueueTs = currentNs();
-		co_await _issueRequest(&request);
+		co_await _issueRequest(queue, &request);
 	}
 
 	for(auto &request : requests) {
@@ -179,9 +228,12 @@ async::result<void> Device::flush() {
 
 	UserRequest request{false, 0, {}, pagePool};
 
+	// VIRTIO_BLK_T_FLUSH is device-wide, so any queue covers the writes of all of them.
+	auto queue = _pickQueue();
+
 	std::array<virtio_core::Handle, 2> handles;
 	setupTime += timer.split();
-	co_await _requestQueue->obtainDescriptors(handles);
+	co_await queue->obtainDescriptors(handles);
 	obtainTime = timer.split();
 	handles[0].setupLink(handles[1]);
 
@@ -195,13 +247,13 @@ async::result<void> Device::flush() {
 	setupTime += timer.split();
 	request.submitTs = currentNs();
 
-	_requestQueue->postDescriptor(handles.front(), &request,
+	queue->postDescriptor(handles.front(), &request,
 			[] (virtio_core::Request *base_request) {
 		auto request = static_cast<UserRequest *>(base_request);
 		request->completeTs = currentNs();
 		request->event.raise();
 	});
-	_requestQueue->notify();
+	queue->notify();
 
 	co_await request.event.wait();
 	deviceTime = request.completeTs - request.submitTs;
@@ -216,19 +268,19 @@ async::result<size_t> Device::getSize() {
 	co_return _size * 512;
 }
 
-async::result<void> Device::_issueRequest(UserRequest *request) {
+async::result<void> Device::_issueRequest(virtio_core::Queue *queue, UserRequest *request) {
 	assert(request->view.size());
 
 	protocols::ostrace::Timer setupTimer;
 
 	// Split the view into DMA-contiguous chunks (and not into individual sectors)
 	// since setupBuffer() only requires contiguity in DMA space per descriptor.
-	auto chunks = co_await _requestQueue->splitContiguous(request->view);
+	auto chunks = co_await queue->splitContiguous(request->view);
 
 	// Acquire all descriptors of the chain at once to avoid potential deadlocks.
 	std::vector<virtio_core::Handle> handles(2 + chunks.size());
 	request->setupTime += setupTimer.split();
-	co_await _requestQueue->obtainDescriptors(handles);
+	co_await queue->obtainDescriptors(handles);
 	request->obtainTime = setupTimer.split();
 
 	for(size_t i = 1; i < handles.size(); i++)
@@ -269,7 +321,7 @@ async::result<void> Device::_issueRequest(UserRequest *request) {
 	request->submitTs = currentNs();
 
 	// Submit the request to the device
-	_requestQueue->postDescriptor(handles.front(), request,
+	queue->postDescriptor(handles.front(), request,
 			[] (virtio_core::Request *base_request) {
 		auto request = static_cast<UserRequest *>(base_request);
 		if(logInitiateRetire)
@@ -278,7 +330,7 @@ async::result<void> Device::_issueRequest(UserRequest *request) {
 		request->completeTs = currentNs();
 		request->event.raise();
 	});
-	_requestQueue->notify();
+	queue->notify();
 }
 
 } } // namespace block::virtio

--- a/drivers/block/virtio-blk/src/block.hpp
+++ b/drivers/block/virtio-blk/src/block.hpp
@@ -1,5 +1,7 @@
 
+#include <atomic>
 #include <memory>
+#include <vector>
 
 #include <blockfs.hpp>
 #include <core/virtio/core.hpp>
@@ -27,7 +29,8 @@ enum {
 };
 
 enum {
-	VIRTIO_BLK_F_FLUSH = 9
+	VIRTIO_BLK_F_FLUSH = 9,
+	VIRTIO_BLK_F_MQ = 12,
 };
 
 enum {
@@ -40,6 +43,7 @@ namespace spec::regs {
 	inline constexpr arch::scalar_register<uint32_t> capacity[] = {
 			arch::scalar_register<uint32_t>{0},
 			arch::scalar_register<uint32_t>{4}};
+	inline constexpr arch::scalar_register<uint16_t> numQueues{34};
 }
 
 struct Device;
@@ -87,14 +91,23 @@ struct Device : blockfs::BlockDevice {
 	async::result<size_t> getSize() override;
 
 private:
-	// Sets up the descriptor chain of the request and posts it to the device.
+	// Returns the virtq that the calling thread submits to.
+	virtio_core::Queue *_pickQueue();
+
+	// Starts the completion servicer of a queue on the calling thread, at most once.
+	void _startServicer(unsigned int index);
+
+	// Sets up the descriptor chain of the request and posts it to the given queue.
 	// Returns after submission without waiting for the request's completion.
-	async::result<void> _issueRequest(UserRequest *request);
+	async::result<void> _issueRequest(virtio_core::Queue *queue, UserRequest *request);
 
 	std::unique_ptr<virtio_core::Transport> _transport;
 
-	// The single virtq of this device.
-	virtio_core::Queue *_requestQueue;
+	// The request virtqs of this device.
+	std::vector<virtio_core::Queue *> _queues;
+
+	// Whether the completion servicer of each virtq was already started.
+	std::unique_ptr<std::atomic_flag[]> _queueLive;
 
 	// The size of the disk
 	size_t _size;

--- a/drivers/gfx/virtio/src/main.cpp
+++ b/drivers/gfx/virtio/src/main.cpp
@@ -76,6 +76,10 @@ async::result<std::unique_ptr<drm_core::Configuration>> GfxDevice::initialize() 
 	_controlQ = co_await _transport->setupQueue(0);
 	_cursorQ = co_await _transport->setupQueue(1);
 
+	// This driver runs on a single thread, so both queues share one interrupt.
+	async::detach(_controlQ->serviceQueue());
+	async::detach(_cursorQ->serviceQueue());
+
 	_transport->runDevice();
 
 	std::vector<drm_core::Assignment> assignments;

--- a/drivers/libblockfs/include/blockfs.hpp
+++ b/drivers/libblockfs/include/blockfs.hpp
@@ -67,6 +67,7 @@ extern protocols::ostrace::Event ostEvtVirtioBlkFlush;
 extern protocols::ostrace::UintAttribute ostAttrTime;
 extern protocols::ostrace::UintAttribute ostAttrNumBytes;
 extern protocols::ostrace::UintAttribute ostAttrIsWrite;
+extern protocols::ostrace::UintAttribute ostAttrQueueIndex;
 extern protocols::ostrace::UintAttribute ostAttrTimeSetup;
 extern protocols::ostrace::UintAttribute ostAttrTimeObtain;
 extern protocols::ostrace::UintAttribute ostAttrTimeDevice;

--- a/drivers/libblockfs/src/trace.hpp
+++ b/drivers/libblockfs/src/trace.hpp
@@ -83,6 +83,8 @@ inline constinit protocols::ostrace::UintAttribute ostAttrIno{"ino"};
 inline constinit protocols::ostrace::UintAttribute ostAttrFound{"found"};
 // Whether the access was for writing (1) or reading (0).
 inline constinit protocols::ostrace::UintAttribute ostAttrIsWrite{"isWrite"};
+// Index of the device queue that the request was submitted to.
+inline constinit protocols::ostrace::UintAttribute ostAttrQueueIndex{"queueIndex"};
 // Waiting to acquire mutexes. Excludes page pinning, which is timePin.
 inline constinit protocols::ostrace::UintAttribute ostAttrTimeLock{"timeLock"};
 // Pinning pages into memory via LockMemoryView, i.e. faulting them in if absent.
@@ -205,6 +207,7 @@ inline protocols::ostrace::Vocabulary ostVocabulary{
 	ostAttrIno,
 	ostAttrFound,
 	ostAttrIsWrite,
+	ostAttrQueueIndex,
 	ostAttrTimeLock,
 	ostAttrTimePin,
 	ostAttrTimeImport,

--- a/drivers/nic/virtio/src/virtio.cpp
+++ b/drivers/nic/virtio/src/virtio.cpp
@@ -79,6 +79,10 @@ async::result<void> VirtioNic::initialize() {
 	receiveVq_ = co_await transport_->setupQueue(0);
 	transmitVq_ = co_await transport_->setupQueue(1);
 
+	// This driver runs on a single thread, so both queues share one interrupt.
+	async::detach(receiveVq_->serviceQueue());
+	async::detach(transmitVq_->serviceQueue());
+
 	promiscuous_ = true;
 	all_multicast_ = true;
 	multicast_ = true;

--- a/drivers/tty/virtio-console/src/console.cpp
+++ b/drivers/tty/virtio-console/src/console.cpp
@@ -71,6 +71,10 @@ async::detached Device::runDevice() {
 	rxQueue_ = co_await transport_->setupQueue(0);
 	txQueue_ = co_await transport_->setupQueue(1);
 
+	// This driver runs on a single thread, so both queues share one interrupt.
+	async::detach(rxQueue_->serviceQueue());
+	async::detach(txQueue_->serviceQueue());
+
 	auto maxPorts = transport_->space().load(spec::regs::maxPorts);
 	std::cout << "virtio-console: Device supports " << maxPorts << " ports" << std::endl;
 

--- a/hel/include/helix/dispatcher-pool.hpp
+++ b/hel/include/helix/dispatcher-pool.hpp
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <atomic>
 #include <concepts>
+#include <optional>
 #include <vector>
 
 #include <async/algorithm.hpp>
@@ -25,6 +26,12 @@ struct DispatcherPool {
 	DispatcherPool(const DispatcherPool &) = delete;
 
 	DispatcherPool &operator= (const DispatcherPool &) = delete;
+
+	// Index of the calling thread within the pool, or std::nullopt if the calling thread is not a pool member.
+	std::optional<size_t> thisThread();
+
+	// Maximal number of members that the pool can ever have.
+	size_t maxThreads();
 
 	// Fixes the number of pool threads.
 	// Must be called before the pool is brought up.

--- a/hel/src/dispatcher-pool.cpp
+++ b/hel/src/dispatcher-pool.cpp
@@ -2,6 +2,7 @@
 #include <bit>
 #include <future>
 #include <iostream>
+#include <optional>
 #include <thread>
 
 #include <hel.h>
@@ -24,7 +25,12 @@ size_t queryCpuCount() {
 	return count;
 }
 
-void workerMain(std::promise<async::run_queue *> promise) {
+// Index of the current thread within the pool. Absent on non-member threads.
+// FIXME: This assumes that there is a single global DispatcherPool.
+thread_local std::optional<size_t> memberIndex_;
+
+void workerMain(size_t index, std::promise<async::run_queue *> promise) {
+	memberIndex_ = index;
 	promise.set_value(Dispatcher::global().runQueue());
 	async::run_forever(currentDispatcher);
 	abort(); // We should never get here.
@@ -41,7 +47,18 @@ DispatcherPool::DispatcherPool() {
 	ownerContext_ = async::current_run_queue_context();
 
 	// Adopt the owner as the first member of this pool.
+	memberIndex_ = 0;
 	members_.push_back(Dispatcher::global().runQueue());
+}
+
+std::optional<size_t> DispatcherPool::thisThread() {
+	return memberIndex_;
+}
+
+size_t DispatcherPool::maxThreads() {
+	if(!live_.load(std::memory_order_relaxed))
+		abort();
+	return threadCount_;
 }
 
 void DispatcherPool::enter_() {
@@ -52,18 +69,19 @@ void DispatcherPool::enter_() {
 	if(live_.load(std::memory_order_relaxed))
 		return;
 
-	auto numThreads = threadCount_ ? threadCount_ : queryCpuCount();
-	std::cout << "helix: Running dispatcher pool on " << numThreads
+	if (!threadCount_)
+		threadCount_ = queryCpuCount();
+	std::cout << "helix: Running dispatcher pool on " << threadCount_
 			<< " threads" << std::endl;
 
 	assert(members_.size() == 1); // The owner is the first member.
-	for(size_t i = 1; i < numThreads; ++i) {
+	for(size_t i = 1; i < threadCount_; ++i) {
 		std::promise<async::run_queue *> promise;
 		auto future = promise.get_future();
 
 		// The workers are never joined for now to prevent UAF
 		// when there are still coroutines pointing to the helix::Dispatchers.
-		std::thread{workerMain, std::move(promise)}.detach();
+		std::thread{workerMain, i, std::move(promise)}.detach();
 
 		members_.push_back(future.get());
 	}


### PR DESCRIPTION
Add support for multiple MSIs to `core/virtio`. Then let virtio-block use one queue per thread of the `helix::DispatcherPool`.