### PR TITLE
drivers/libblockfs: Perform block allocation lazily in ext2

### DIFF
--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -905,6 +905,18 @@ Inode::resizeFile(size_t newSize) {
 		// Shrink fileSize() last (after no initialization/writeback is in flight anymore).
 		setFileSize(newSize);
 		timeResizeMemory = timer.split();
+
+		// Zero the tail of the last page as it remains reachable by mmap().
+		// TODO: When we support (block size) > (page size), we have to guarantee that the tail
+		//       of the block is also zerod (either through an invariant or through explicit zeroing.
+		if (newSize < newMappingSize) {
+			// TODO: A dedicated zeroMemory() operation would be more efficient here.
+			static constexpr std::array<std::byte, 0x1000> zeroes{};
+			auto writeResult = co_await helix_ng::writeMemory(
+					helix::BorrowedDescriptor{frontalMemory},
+					newSize, newMappingSize - newSize, zeroes.data());
+			HEL_CHECK(writeResult.error());
+		}
 	} else {
 		// Nothing to do.
 		co_return frg::success;

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -10,7 +10,6 @@
 #include <linux/magic.h>
 
 #include <async/result.hpp>
-#include <core/align.hpp>
 #include <core/clock.hpp>
 #include <core/logging.hpp>
 #include <frg/scope_exit.hpp>
@@ -860,27 +859,11 @@ async::result<protocols::fs::Error> Inode::updateTimes(
 
 
 async::result<frg::expected<protocols::fs::Error>>
-Inode::ensureBackingBlocks(size_t offset, size_t length) {
-	auto [alignedOffset, alignedSize] = core::alignExtend({offset, length}, fs.blockSize);
-	size_t blockOffset = alignedOffset / fs.blockSize;
-	size_t blockCount = alignedSize / fs.blockSize;
-
-	{
-		co_await blockMapMutex.async_lock();
-		frg::unique_lock blockMapLock{frg::adopt_lock, blockMapMutex};
-		co_await fs.assignDataBlocks(this, blockOffset, blockCount);
-	}
-
-	co_return frg::success;
-}
-
-async::result<frg::expected<protocols::fs::Error>>
 Inode::resizeFile(size_t newSize) {
 	auto oldSize = fileSize();
 	auto newMappingSize = (newSize + 0xFFF) & ~size_t(0xFFF);
 
 	protocols::ostrace::Timer timer;
-	uint64_t timeEnsureBlocks = 0;
 	uint64_t timeResizeMemory = 0;
 	frg::scope_exit evtOnExit{[&] {
 		ostContext.emit(
@@ -888,18 +871,11 @@ Inode::resizeFile(size_t newSize) {
 			ostAttrTime(timer.elapsed()),
 			ostAttrOldSize(oldSize),
 			ostAttrNewSize(newSize),
-			ostAttrTimeEnsureBlocks(timeEnsureBlocks),
 			ostAttrTimeResizeMemory(timeResizeMemory)
 		);
 	}};
 
 	if (newSize > oldSize) {
-		// TODO(qookie): Technically we only need to assign 0
-		// blocks here, not allocate new ones. We also should
-		// zero out the new blocks.
-		FRG_CO_TRY(co_await ensureBackingBlocks(oldSize, newSize - oldSize));
-		timeEnsureBlocks = timer.split();
-
 		// Grow fileSize() first so the backing memory never covers a page beyond EOF.
 		setFileSize(newSize);
 

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -445,10 +445,6 @@ struct Inode final : BaseInode, std::enable_shared_from_this<Inode> {
 
 	// Callers must hold inodeMutex (exclusive).
 	async::result<frg::expected<protocols::fs::Error>>
-	ensureBackingBlocks(size_t offset, size_t length);
-
-	// Callers must hold inodeMutex (exclusive).
-	async::result<frg::expected<protocols::fs::Error>>
 	resizeFile(size_t newSize);
 
 	bool usesExtents;

--- a/drivers/libblockfs/src/trace.hpp
+++ b/drivers/libblockfs/src/trace.hpp
@@ -104,8 +104,6 @@ inline constinit protocols::ostrace::UintAttribute ostAttrTimeWrite{"timeWrite"}
 inline constinit protocols::ostrace::UintAttribute ostAttrTimeDevice{"timeDevice"};
 // Obtaining MetadataCache windows, summed over all accesses in the operation.
 inline constinit protocols::ostrace::UintAttribute ostAttrTimeAccess{"timeAccess"};
-// Allocating and assigning the blocks that back a file growth.
-inline constinit protocols::ostrace::UintAttribute ostAttrTimeEnsureBlocks{"timeEnsureBlocks"};
 // Resizing the page cache backing the file.
 inline constinit protocols::ostrace::UintAttribute ostAttrTimeResizeMemory{"timeResizeMemory"};
 // Waiting for readyEvent, i.e. for the inode to finish being initiated.
@@ -215,7 +213,6 @@ inline protocols::ostrace::Vocabulary ostVocabulary{
 	ostAttrTimeWrite,
 	ostAttrTimeDevice,
 	ostAttrTimeAccess,
-	ostAttrTimeEnsureBlocks,
 	ostAttrTimeResizeMemory,
 	ostAttrTimeReady,
 	ostAttrTimeResize,


### PR DESCRIPTION
This moves block allocation out of the write() path and gives a decent performance improvement for small writes.