### PR TITLE
drivers/libblockfs: Free ext2 data blocks on truncation

### DIFF
--- a/drivers/libblockfs/src/ext2/block-map-cache.cpp
+++ b/drivers/libblockfs/src/ext2/block-map-cache.cpp
@@ -109,5 +109,19 @@ void BlockMapCache::insertList(uint64_t fileBlock, const std::vector<uint32_t> &
 		insertLocked_(fileBlock + i, Run{.diskBlock = blocks[i], .size = 1, .hole = false});
 }
 
+void BlockMapCache::truncate(uint64_t fileBlock) {
+	std::lock_guard cacheGuard{mutex_};
+
+	// Trim a preceding run that extends past fileBlock.
+	auto it = runs_.lower_bound(fileBlock);
+	if(it != runs_.begin()) {
+		auto pred = std::prev(it);
+		if(pred->first + pred->second.size > fileBlock)
+			pred->second.size = fileBlock - pred->first;
+	}
+
+	runs_.erase(it, runs_.end());
+}
+
 } // namespace ext2fs
 } // namespace blockfs

--- a/drivers/libblockfs/src/ext2/block-map-cache.hpp
+++ b/drivers/libblockfs/src/ext2/block-map-cache.hpp
@@ -36,6 +36,9 @@ struct BlockMapCache {
 	// Inserts the disk blocks backing consecutive file blocks starting at fileBlock.
 	void insertList(uint64_t fileBlock, const std::vector<uint32_t> &blocks);
 
+	// Invalidates all cached runs at or after fileBlock, trimming a run that straddles it.
+	void truncate(uint64_t fileBlock);
+
 private:
 	// Callers must hold mutex_.
 	void insertLocked_(uint64_t fileBlock, Run run);

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1576,6 +1576,59 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 	assert(!"Failed to find zero-bit");
 }
 
+async::result<void> FileSystem::freeBlocks(std::vector<uint32_t> blocks) {
+	if(blocks.empty())
+		co_return;
+
+	protocols::ostrace::Timer timer;
+	uint64_t accessTime = 0;
+	unsigned int numGroups = 0;
+
+	// Group the blocks so that each block group's bitmap is accessed only once.
+	std::sort(blocks.begin(), blocks.end());
+
+	co_await allocationMutex.async_lock();
+	frg::unique_lock allocationLock{frg::adopt_lock, allocationMutex};
+	uint64_t lockDone = timer.elapsed();
+
+	size_t i = 0;
+	while(i < blocks.size()) {
+		auto bg = blocks[i] / blocksPerGroup;
+
+		assert(bgdt[bg].blockBitmap);
+		protocols::ostrace::Timer accessTimer;
+		auto bitmapWindow = co_await accessMetadata(bgdt[bg].blockBitmap, true);
+		accessTime += accessTimer.elapsed();
+		++numGroups;
+		auto words = reinterpret_cast<uint32_t *>(bitmapWindow.get());
+
+		for(; i < blocks.size() && blocks[i] / blocksPerGroup == bg; i++) {
+			auto block = blocks[i];
+			assert(block);
+			assert(block < blocksCount);
+
+			auto index = block % blocksPerGroup;
+			// Double free would imply that the block was allocated twice.
+			assert(words[index / 32] & (static_cast<uint32_t>(1) << (index % 32)));
+			words[index / 32] &= ~(static_cast<uint32_t>(1) << (index % 32));
+
+			bgdt[bg].freeBlocksCount++;
+		}
+
+		updateBlockBitmapChecksum(*this, &bgdt[bg], words, blockSize);
+		updateBlockGroupChecksum(*this, &bgdt[bg], bg);
+	}
+
+	ostContext.emit(
+		ostEvtExt2FreeBlocks,
+		ostAttrTime(timer.elapsed()),
+		ostAttrNumBlocks(blocks.size()),
+		ostAttrNumGroups(numGroups),
+		ostAttrTimeLock(lockDone),
+		ostAttrTimeAccess(accessTime)
+	);
+}
+
 async::result<uint32_t> FileSystem::allocateInode(uint32_t parentIno, bool directory) {
 	protocols::ostrace::Timer timer;
 	uint64_t accessTime = 0;

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -865,13 +865,15 @@ Inode::resizeFile(size_t newSize) {
 
 	protocols::ostrace::Timer timer;
 	uint64_t timeResizeMemory = 0;
+	uint64_t timeFreeBlocks = 0;
 	frg::scope_exit evtOnExit{[&] {
 		ostContext.emit(
 			ostEvtExt2ResizeFile,
 			ostAttrTime(timer.elapsed()),
 			ostAttrOldSize(oldSize),
 			ostAttrNewSize(newSize),
-			ostAttrTimeResizeMemory(timeResizeMemory)
+			ostAttrTimeResizeMemory(timeResizeMemory),
+			ostAttrTimeFreeBlocks(timeFreeBlocks)
 		);
 	}};
 
@@ -885,9 +887,6 @@ Inode::resizeFile(size_t newSize) {
 		HEL_CHECK(resizeResult.error());
 		timeResizeMemory = timer.split();
 	} else if (newSize < oldSize) {
-		// TODO(qookie): Deallocate blocks if they're no longer within the file.
-		std::println("libblockfs: Shrinking an Ext2 file does not free data blocks!");
-
 		// Shrink the memory object first so that no new pages appear beyond the new size.
 		auto resizeResult = co_await helix_ng::resizeMemory(
 				helix::BorrowedDescriptor{backingMemory}, newMappingSize);
@@ -904,7 +903,6 @@ Inode::resizeFile(size_t newSize) {
 
 		// Shrink fileSize() last (after no initialization/writeback is in flight anymore).
 		setFileSize(newSize);
-		timeResizeMemory = timer.split();
 
 		// Zero the tail of the last page as it remains reachable by mmap().
 		// TODO: When we support (block size) > (page size), we have to guarantee that the tail
@@ -917,6 +915,19 @@ Inode::resizeFile(size_t newSize) {
 					newSize, newMappingSize - newSize, zeroes.data());
 			HEL_CHECK(writeResult.error());
 		}
+		timeResizeMemory = timer.split();
+
+		// Only free the blocks once the invalidation above is done.
+		// Otherwise, in-flight writebacks may re-allocate new blocks.
+		{
+			co_await blockMapMutex.async_lock();
+			frg::unique_lock blockMapLock{frg::adopt_lock, blockMapMutex};
+
+			auto firstBlock = (newSize + fs.blockSize - 1) / fs.blockSize;
+			co_await fs.freeDataBlocks(this, firstBlock);
+			blockMapCache.truncate(firstBlock);
+		}
+		timeFreeBlocks = timer.split();
 	} else {
 		// Nothing to do.
 		co_return frg::success;

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -2503,6 +2503,126 @@ async::result<void> FileSystem::freeDataBlocksUsingExtents(Inode *inode, uint64_
 	);
 }
 
+async::result<void> FileSystem::freeDataBlocks(Inode *inode, uint64_t firstBlock) {
+	if(inode->usesExtents) {
+		co_await freeDataBlocksUsingExtents(inode, firstBlock);
+		co_await helix_ng::asyncNop();
+		co_return;
+	}
+
+	protocols::ostrace::Timer timer;
+
+	size_t per_indirect = blockSize / 4;
+	size_t per_single = per_indirect;
+	size_t per_double = per_indirect * per_indirect;
+
+	// Number of blocks that can be accessed by:
+	size_t i_range = 12; // Direct blocks only.
+	size_t s_range = i_range + per_single; // Plus the first single indirect block.
+	size_t d_range = s_range + per_double; // Plus the first double indirect block.
+
+	auto disk_inode = inode->diskInode();
+	size_t numFreed = 0;
+
+	// Releases the blocks that an indirect block points to, starting at the file block from,
+	// relative to the range that the indirection block covers.
+	// Level is 1/2/3 indicates single/double/triple indirect blocks.
+	// If drop is set, also release the indirect block itself.
+	auto drainIndirect = [&] (this auto &&self, uint32_t indirectBlock, unsigned int level,
+			size_t from, bool drop) -> async::result<void> {
+		// Each entry of the block covers 2^shift file blocks.
+		auto shift = (level - 1) * (blockShift - 2);
+		auto offset = from & ((size_t{1} << shift) - 1);
+
+		std::vector<uint32_t> entries;
+		uint32_t partial = 0;
+		{
+			auto indirectWindow = co_await accessMetadata(indirectBlock, !drop);
+			auto window = reinterpret_cast<uint32_t *>(indirectWindow.get());
+
+			auto i = from >> shift;
+			// The entry that from points into keeps its block and only loses its tail.
+			if(offset)
+				partial = window[i++];
+
+			for(; i < per_indirect; i++) {
+				if(!window[i])
+					continue;
+				entries.push_back(window[i]);
+				// No need to dirty the block if it gets dropped anyway.
+				if(!drop)
+					window[i] = 0;
+			}
+		}
+
+		if(partial)
+			co_await self(partial, level - 1, offset, false);
+
+		// Above the data blocks the entries are indirection blocks that release themselves.
+		if(level > 1) {
+			for(auto entry : entries)
+				co_await self(entry, level - 1, 0, true);
+			entries.clear();
+		}
+
+		if(drop) {
+			// Discard the block from the MetadataCache before freeing it.
+			co_await forgetMetadata(indirectBlock);
+			entries.push_back(indirectBlock);
+		}
+
+		numFreed += entries.size();
+		co_await freeBlocks(std::move(entries));
+	};
+
+	// Triple indirect blocks are not supported by lookupBlocksOnDisk() either.
+	assert(!disk_inode->data.blocks.tripleIndirect);
+
+	if(firstBlock < i_range) {
+		std::vector<uint32_t> batch;
+		for(size_t i = firstBlock; i < i_range; i++) {
+			if(!disk_inode->data.blocks.direct[i])
+				continue;
+			batch.push_back(disk_inode->data.blocks.direct[i]);
+			disk_inode->data.blocks.direct[i] = 0;
+		}
+		numFreed += batch.size();
+		co_await freeBlocks(std::move(batch));
+	}
+
+	if(firstBlock < s_range && disk_inode->data.blocks.singleIndirect) {
+		auto indirectBlock = disk_inode->data.blocks.singleIndirect;
+		auto from = firstBlock > i_range ? firstBlock - i_range : 0;
+
+		if(!from)
+			disk_inode->data.blocks.singleIndirect = 0;
+		co_await drainIndirect(indirectBlock, 1, from, !from);
+	}
+
+	if(firstBlock < d_range && disk_inode->data.blocks.doubleIndirect) {
+		auto doubleBlock = disk_inode->data.blocks.doubleIndirect;
+		auto from = firstBlock > s_range ? firstBlock - s_range : 0;
+
+		if(!from)
+			disk_inode->data.blocks.doubleIndirect = 0;
+		co_await drainIndirect(doubleBlock, 2, from, !from);
+	}
+
+	assert(disk_inode->blocks >= numFreed * (blockSize / 512));
+	disk_inode->blocks -= numFreed * (blockSize / 512);
+
+	updateInodeChecksum(*this, disk_inode, inode->number);
+
+	bgdtWriteback.raise();
+	inode->diskInodeWindow.markDirty();
+
+	ostContext.emit(
+		ostEvtExt2FreeDataBlocks,
+		ostAttrTime(timer.elapsed()),
+		ostAttrNumBlocks(numFreed)
+	);
+}
+
 async::result<void> FileSystem::readDataBlocks(const std::vector<BlockRange> &ranges,
 		arch::dma_buffer_view buf) {
 	assert(!(buf.size() & (blockSize - 1)));

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -2399,6 +2399,110 @@ async::result<void> FileSystem::assignDataBlocks(Inode *inode,
 	);
 }
 
+async::result<bool> FileSystem::removeExtentsFrom(Inode *inode, ExtentHeader *hdr,
+		std::optional<uint64_t> block, uint64_t fromBlock, size_t &numFreed) {
+	assert(hdr->magic == EXT4_EXTENT_MAGIC);
+
+	std::vector<uint32_t> batch;
+
+	if(!hdr->depth) {
+		auto extents = hdr->extents();
+
+		// Extents are ordered by file block, so walking backwards stops at the first
+		// extent that lies entirely before fromBlock.
+		while(hdr->entries) {
+			auto &extent = extents[hdr->entries - 1];
+			// TODO: Support uninitialized extents. A len above 32768 marks the extent as
+			// uninitialized and encodes the real length as len - 32768.
+			assert(extent.len <= 32768);
+			if(extent.block + extent.len <= fromBlock)
+				break;
+
+			uint64_t start = extent.start();
+			// An extent that straddles fromBlock only loses its tail.
+			size_t keep = extent.block < fromBlock ? fromBlock - extent.block : 0;
+
+			for(size_t i = keep; i < extent.len; i++)
+				batch.push_back(start + i);
+
+			if(keep) {
+				extent.len = keep;
+				break;
+			}
+			hdr->entries--;
+		}
+	}else{
+		auto indices = hdr->indices();
+
+		while(hdr->entries) {
+			auto &index = indices[hdr->entries - 1];
+			uint64_t child = index.leaf();
+			// Only the last child that starts before fromBlock can straddle it;
+			// every child after that one is removed in its entirety.
+			bool straddles = index.block < fromBlock;
+
+			bool empty;
+			{
+				// No need to dirty the child if it gets dropped below anyway.
+				auto childWindow = co_await accessMetadata(child, straddles);
+				auto childHdr = reinterpret_cast<ExtentHeader *>(childWindow.get());
+				empty = co_await removeExtentsFrom(inode, childHdr, child,
+						fromBlock, numFreed);
+			}
+
+			// A child that starts at or after fromBlock loses all of its extents.
+			assert(empty || straddles);
+
+			if(empty) {
+				// The block can be reallocated as file data right away, and a writeback
+				// that is still pending for it would then clobber that data.
+				co_await forgetMetadata(child);
+				batch.push_back(child);
+				hdr->entries--;
+			}
+
+			if(straddles || !empty)
+				break;
+		}
+	}
+
+	numFreed += batch.size();
+	co_await freeBlocks(std::move(batch));
+
+	// A node that is about to be freed itself does not need a valid checksum.
+	if(block && hdr->entries)
+		updateExtentChecksum(*this, inode, hdr);
+
+	co_return !hdr->entries;
+}
+
+async::result<void> FileSystem::freeDataBlocksUsingExtents(Inode *inode, uint64_t firstBlock) {
+	protocols::ostrace::Timer timer;
+
+	auto diskInode = inode->diskInode();
+	auto hdr = &diskInode->data.extents.hdr;
+	size_t numFreed = 0;
+
+	if(co_await removeExtentsFrom(inode, hdr, std::nullopt, firstBlock, numFreed)) {
+		// Leave the root as a valid empty tree that assignDataBlocksUsingExtents() can grow again.
+		hdr->depth = 0;
+	}
+
+	assert(diskInode->blocks >= numFreed * (blockSize / 512));
+	diskInode->blocks -= numFreed * (blockSize / 512);
+
+	updateInodeChecksum(*this, diskInode, inode->number);
+
+	bgdtWriteback.raise();
+	inode->diskInodeWindow.markDirty();
+
+	ostContext.emit(
+		ostEvtExt2FreeDataBlocks,
+		ostAttrTime(timer.elapsed()),
+		ostAttrNumBlocks(numFreed)
+	);
+}
+
 async::result<void> FileSystem::readDataBlocks(const std::vector<BlockRange> &ranges,
 		arch::dma_buffer_view buf) {
 	assert(!(buf.size() & (blockSize - 1)));

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1476,7 +1476,8 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 			auto bitmapWindow = co_await accessBitmap(bgdt[preferred_bg].blockBitmap);
 			auto words = reinterpret_cast<uint32_t *>(bitmapWindow.get());
 
-			for(unsigned int i = 0; i < (blocksPerGroup + 31) / 32; i++) {
+			for(unsigned int i = 0; i < (blocksPerGroup + 31) / 32
+					&& bgdt[preferred_bg].freeBlocksCount; i++) {
 				if(words[i] == 0xFFFFFFFF)
 					continue;
 				for(int j = 0; j < 32; j++) {
@@ -1484,6 +1485,10 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 						break;
 					if(words[i] & (static_cast<uint32_t>(1) << j))
 						continue;
+					// Never hand out more blocks than the group is accounted for, even if
+					// its bitmap has more of them: freeBlocksCount would wrap around.
+					if(!bgdt[preferred_bg].freeBlocksCount)
+						break;
 					// TODO: Make sure we never return reserved blocks.
 					// TODO: Make sure we never return blocks higher than the max. block in the SB.
 					auto block = preferred_bg * blocksPerGroup + i * 32 + j;
@@ -1525,7 +1530,8 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 		assert(bgdt[bg_idx].blockBitmap);
 		auto bitmapWindow = co_await accessBitmap(bgdt[bg_idx].blockBitmap);
 		auto words = reinterpret_cast<uint32_t *>(bitmapWindow.get());
-		for(unsigned int i = 0; i < (blocksPerGroup + 31) / 32; i++) {
+		for(unsigned int i = 0; i < (blocksPerGroup + 31) / 32
+				&& bgdt[bg_idx].freeBlocksCount; i++) {
 			if(words[i] == 0xFFFFFFFF)
 				continue;
 			for(int j = 0; j < 32; j++) {
@@ -1533,6 +1539,10 @@ async::result<std::vector<uint32_t>> FileSystem::allocateBlocks(size_t num, std:
 					break;
 				if(words[i] & (static_cast<uint32_t>(1) << j))
 					continue;
+				// Never hand out more blocks than the group is accounted for, even if
+				// its bitmap has more of them: freeBlocksCount would wrap around.
+				if(!bgdt[bg_idx].freeBlocksCount)
+					break;
 				// TODO: Make sure we never return reserved blocks.
 				// TODO: Make sure we never return blocks higher than the max. block in the SB.
 				auto block = bg_idx * blocksPerGroup + i * 32 + j;

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -1693,8 +1693,7 @@ async::result<std::vector<BlockRange>> FileSystem::lookupBlocksUsingExtent(Inode
 			size_t available = extent.len - startOffset;
 			size_t toAdd = std::min(available, num_blocks - progress);
 
-			uint64_t absoluteStartBlock = static_cast<uint64_t>(extent.startLow)
-					| (static_cast<uint64_t>(extent.startHigh) << 32);
+			uint64_t absoluteStartBlock = extent.start();
 
 			BlockRange range{
 				.relativeStartBlock = index,
@@ -1850,7 +1849,7 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 							else
 								newFirstBlock = info.extents[splitStart].block;
 
-							auto newExtents = reinterpret_cast<Extent *>(&newHdr[1]);
+							auto newExtents = newHdr->extents();
 							memmove(newExtents, info.extents + splitStart, entriesToMove * sizeof(Extent));
 						} else {
 							oldFirstBlock = info.indices[0].block;
@@ -1860,7 +1859,7 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 							else
 								newFirstBlock = info.indices[splitStart].block;
 
-							auto newIndices = reinterpret_cast<ExtentIndex *>(&newHdr[1]);
+							auto newIndices = newHdr->indices();
 							memmove(newIndices, info.indices + splitStart, entriesToMove * sizeof(ExtentIndex));
 						}
 
@@ -1892,7 +1891,7 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 							info.hdr->depth++;
 							assert(info.hdr->depth <= 4);
 
-							auto indices = reinterpret_cast<ExtentIndex *>(&info.hdr[1]);
+							auto indices = info.hdr->indices();
 							indices[0] = {
 								.block = oldFirstBlock,
 								.leafLow = static_cast<uint32_t>(newRoot[0] & 0xffffffff),
@@ -1934,10 +1933,10 @@ async::result<void> FileSystem::assignDataBlocksUsingExtents(Inode *inode,
 						}
 
 						if(info.hdr->depth == 0) {
-							info.extents = reinterpret_cast<Extent *>(&info.hdr[1]);
+							info.extents = info.hdr->extents();
 							info.indices = nullptr;
 						}else {
-							info.indices = reinterpret_cast<ExtentIndex *>(&info.hdr[1]);
+							info.indices = info.hdr->indices();
 							info.extents = nullptr;
 						}
 					}

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -546,6 +546,11 @@ struct FileSystem final : BaseFileSystem {
 	async::result<void> assignDataBlocks(Inode *inode,
 			uint64_t block_offset, size_t num_blocks);
 
+	// Releases the blocks backing the file blocks at or after firstBlock,
+	// including the indirection metadata that becomes unreachable.
+	// Callers must hold inode->blockMapMutex (exclusive).
+	async::result<void> freeDataBlocks(Inode *inode, uint64_t firstBlock);
+
 	// Resolves a range of file blocks to runs of disk blocks and holes.
 	// Callers must hold inode->blockMapMutex (shared or exclusive).
 	async::result<std::vector<BlockRange>> lookupBlocks(Inode *inode,

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -535,6 +535,11 @@ struct FileSystem final : BaseFileSystem {
 	// Allocate up to num blocks for the given inode.
 	// This function does not write back the BGDT, this is the caller's responsibility.
 	async::result<std::vector<uint32_t>> allocateBlocks(size_t num, std::optional<uint32_t> ino = std::nullopt);
+
+	// Release the given blocks back to the block bitmaps.
+	// This function does not write back the BGDT, this is the caller's responsibility.
+	async::result<void> freeBlocks(std::vector<uint32_t> blocks);
+
 	async::result<uint32_t> allocateInode(uint32_t parentIno = 0, bool directory = false);
 
 	// Callers must hold inode->blockMapMutex (exclusive).

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -573,6 +573,17 @@ struct FileSystem final : BaseFileSystem {
 	async::result<void> assignDataBlocksUsingExtents(Inode *inode,
 			uint64_t block_offset, size_t num_blocks);
 
+	// Callers must hold inode->blockMapMutex (exclusive).
+	async::result<void> freeDataBlocksUsingExtents(Inode *inode, uint64_t firstBlock);
+
+	// Removes all extents at or after fromBlock from the subtree rooted at hdr,
+	// freeing their disk blocks and the tree nodes that become empty.
+	// block is the disk block backing hdr, or nullopt for the inode-embedded root.
+	// Returns whether the node itself ended up empty.
+	// Callers must hold inode->blockMapMutex (exclusive).
+	async::result<bool> removeExtentsFrom(Inode *inode, ExtentHeader *hdr,
+			std::optional<uint64_t> block, uint64_t fromBlock, size_t &numFreed);
+
 	// Locks a metadata block and returns a window into it.
 	async::result<MetadataCache::BlockWindow> accessMetadata(uint64_t block, bool writable) {
 		return metadataCacheFor(block).access(block, writable);

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -578,6 +578,12 @@ struct FileSystem final : BaseFileSystem {
 		return metadataCacheFor(block).read(block, offset, length, buffer);
 	}
 
+	// Discard a cached metadata block without writeback.
+	// See MetadataCache::forget() for its preconditions.
+	async::result<void> forgetMetadata(uint64_t block) {
+		return metadataCacheFor(block).forget(block);
+	}
+
 	MetadataCache &metadataCacheFor(uint64_t block) {
 		auto index = block / blocksPerGroup;
 		assert(index < metadataCaches.size());

--- a/drivers/libblockfs/src/ext2/ext2fs.hpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.hpp
@@ -36,12 +36,19 @@ namespace ext2fs {
 using FlockManager = protocols::fs::FlockManager;
 using Flock = protocols::fs::Flock;
 
+struct ExtentIndex;
+struct Extent;
+
 struct ExtentHeader {
 	uint16_t magic;
 	uint16_t entries;
 	uint16_t max;
 	uint16_t depth;
 	uint32_t generation;
+
+	// The entries follow the header; a node holds indices unless its depth is zero.
+	Extent *extents();
+	ExtentIndex *indices();
 };
 static_assert(sizeof(ExtentHeader) == 12, "Bad ExtentHeader struct size");
 
@@ -54,6 +61,10 @@ struct ExtentIndex {
 	uint32_t leafLow;
 	uint16_t leafHigh;
 	uint16_t unused;
+
+	uint64_t leaf() const {
+		return static_cast<uint64_t>(leafLow) | (static_cast<uint64_t>(leafHigh) << 32);
+	}
 };
 static_assert(sizeof(ExtentIndex) == 12, "Bad ExtentIndex struct size");
 
@@ -62,8 +73,20 @@ struct Extent {
 	uint16_t len;
 	uint16_t startHigh;
 	uint32_t startLow;
+
+	uint64_t start() const {
+		return static_cast<uint64_t>(startLow) | (static_cast<uint64_t>(startHigh) << 32);
+	}
 };
 static_assert(sizeof(Extent) == 12, "Bad Extent struct size");
+
+inline Extent *ExtentHeader::extents() {
+	return reinterpret_cast<Extent *>(this + 1);
+}
+
+inline ExtentIndex *ExtentHeader::indices() {
+	return reinterpret_cast<ExtentIndex *>(this + 1);
+}
 
 union FileData {
 	struct Blocks {

--- a/drivers/libblockfs/src/ext2/extents.hpp
+++ b/drivers/libblockfs/src/ext2/extents.hpp
@@ -49,7 +49,7 @@ struct ExtentWalker {
 		while(hdr->depth != 0) {
 			assert(hdr->magic == EXT4_EXTENT_MAGIC);
 
-			auto indices = reinterpret_cast<ExtentIndex *>(&hdr[1]);
+			auto indices = hdr->indices();
 
 			uint32_t prevIndex = 0;
 
@@ -82,8 +82,7 @@ struct ExtentWalker {
 			co_await enter(path[pathCount - 1]);
 
 			auto &idx = indices[prevIndex];
-			uint64_t nextBlock = static_cast<uint64_t>(idx.leafLow)
-					| (static_cast<uint64_t>(idx.leafHigh) << 32);
+			uint64_t nextBlock = idx.leaf();
 
 			windows[pathCount] = co_await fs->accessMetadata(nextBlock, !lookup);
 			currentBlock = nextBlock;
@@ -92,7 +91,7 @@ struct ExtentWalker {
 
 		assert(hdr->magic == EXT4_EXTENT_MAGIC);
 
-		auto extents = reinterpret_cast<Extent *>(&hdr[1]);
+		auto extents = hdr->extents();
 
 		uint32_t prevIndex = 0;
 

--- a/drivers/libblockfs/src/metadata-cache.cpp
+++ b/drivers/libblockfs/src/metadata-cache.cpp
@@ -31,6 +31,7 @@ MetadataCache::MetadataCache(BlockDevice *device, uint64_t baseBlock, uint64_t n
 	HEL_CHECK(helCreateManagedMemory(numBlocks << blockPagesShift_,
 			0, &backing, &frontal));
 	frontal_ = helix::UniqueDescriptor{frontal};
+	backing_ = helix::UniqueDescriptor{backing};
 
 	// The mapping is lazy, i.e., its cost does not scale with the cache size.
 	mapping_ = helix::Mapping{frontal_, 0,
@@ -39,7 +40,7 @@ MetadataCache::MetadataCache(BlockDevice *device, uint64_t baseBlock, uint64_t n
 
 	// Distribute MetadataCache servicing coroutines over the helix::DispatcherPool,
 	// but keep manage_() and flushDirty_() on the same thread.
-	helix::DispatcherPool::global().detach(run_(helix::UniqueDescriptor{backing}));
+	helix::DispatcherPool::global().detach(run_());
 }
 
 void MetadataCache::CacheBlockPolicy::increment() const {
@@ -180,23 +181,62 @@ async::result<void> MetadataCache::read(uint64_t block, size_t offset, size_t le
 	);
 }
 
-async::result<void> MetadataCache::run_(helix::UniqueDescriptor backing) {
+async::result<void> MetadataCache::forget(uint64_t block) {
+	assert(block >= baseBlock_ && block - baseBlock_ < numBlocks_);
+
+	// The block is being freed, so its contents are of no interest anymore.
+	{
+		std::lock_guard dirtyLock{dirtyMutex_};
+		dirtyBlocks_.erase(block);
+	}
+
+	// Destroy the CacheBlock object pointing to the block to unpin the block's memory.
+	// If the block was still pinned, invalidateMemory() below would block on unpin.
+	{
+		CacheBlockPtr evicted; // Drop after the lock.
+		{
+			std::lock_guard cacheBlockLock{cacheBlockMutex_};
+
+			auto it = cacheBlocks_.find(block);
+			// Only the LRU may still reference the block: a live BlockWindow would keep
+			// it pinned and hang invalidateMemory() below.
+			assert(it == cacheBlocks_.end()
+					|| it->second->refCount.check_count() <= (it->second->inLru ? 1u : 0u));
+			if(it != cacheBlocks_.end() && it->second->inLru) {
+				auto *cacheBlock = it->second;
+				lru_.erase(lru_.iterator_to(cacheBlock));
+				cacheBlock->inLru = false;
+				--lruSize_;
+				evicted = CacheBlockPtr{smarter::adopt_rc, cacheBlock,
+						CacheBlockPolicy{cacheBlock}};
+			}
+		}
+	}
+
+	// Discard the page.
+	auto frameSize = size_t{1} << blockPagesShift_;
+	auto invalidate = co_await helix_ng::invalidateMemory(helix::BorrowedDescriptor{backing_},
+			blockOffset_(block), frameSize, kHelInvalidateNoWriteback);
+	HEL_CHECK(invalidate.error());
+}
+
+async::result<void> MetadataCache::run_() {
 	co_await async::when_all(
 		flushDirty_(),
-		manage_(std::move(backing))
+		manage_()
 	);
 }
 
-async::result<void> MetadataCache::manage_(helix::UniqueDescriptor backing) {
+async::result<void> MetadataCache::manage_() {
 	while(true) {
 		helix::ManageMemory manage;
-		auto &&submitManage = helix::submitManageMemory(backing,
+		auto &&submitManage = helix::submitManageMemory(helix::BorrowedDescriptor{backing_},
 				&manage, helix::Dispatcher::global());
 		co_await submitManage.async_wait();
 		HEL_CHECK(manage.error());
 
-		async::detach(serviceRequest_(backing, manage.type(), manage.offset(),
-				manage.length()));
+		async::detach(serviceRequest_(helix::BorrowedDescriptor{backing_}, manage.type(),
+				manage.offset(), manage.length()));
 	}
 }
 

--- a/drivers/libblockfs/src/metadata-cache.hpp
+++ b/drivers/libblockfs/src/metadata-cache.hpp
@@ -138,9 +138,13 @@ public:
 	// Reads bytes from the given block through the cache without mapping it.
 	async::result<void> read(uint64_t block, size_t offset, size_t length, void *buffer);
 
+	// Discards the given block without writeback.
+	// Precondition: no BlockWindow of the block is alive.
+	async::result<void> forget(uint64_t block);
+
 private:
-	async::result<void> run_(helix::UniqueDescriptor backing);
-	async::result<void> manage_(helix::UniqueDescriptor backing);
+	async::result<void> run_();
+	async::result<void> manage_();
 	async::result<void> serviceRequest_(helix::BorrowedDescriptor backing,
 			int type, uintptr_t offset, size_t length);
 	// Offset of the given block within this cache's mapping.
@@ -163,6 +167,7 @@ private:
 	uint32_t blockPagesShift_;
 	size_t sectorsPerBlock_;
 	helix::UniqueDescriptor frontal_;
+	helix::UniqueDescriptor backing_;
 	// Persistent mapping of the whole cache.
 	helix::Mapping mapping_;
 

--- a/drivers/libblockfs/src/trace.hpp
+++ b/drivers/libblockfs/src/trace.hpp
@@ -110,6 +110,8 @@ inline constinit protocols::ostrace::UintAttribute ostAttrTimeDevice{"timeDevice
 inline constinit protocols::ostrace::UintAttribute ostAttrTimeAccess{"timeAccess"};
 // Resizing the page cache backing the file.
 inline constinit protocols::ostrace::UintAttribute ostAttrTimeResizeMemory{"timeResizeMemory"};
+// Releasing the disk blocks past the new end of a shrunk file.
+inline constinit protocols::ostrace::UintAttribute ostAttrTimeFreeBlocks{"timeFreeBlocks"};
 // Waiting for readyEvent, i.e. for the inode to finish being initiated.
 inline constinit protocols::ostrace::UintAttribute ostAttrTimeReady{"timeReady"};
 // Growing the file so that the write fits.
@@ -221,6 +223,7 @@ inline protocols::ostrace::Vocabulary ostVocabulary{
 	ostAttrTimeDevice,
 	ostAttrTimeAccess,
 	ostAttrTimeResizeMemory,
+	ostAttrTimeFreeBlocks,
 	ostAttrTimeReady,
 	ostAttrTimeResize,
 	ostAttrTimeCopy,

--- a/drivers/libblockfs/src/trace.hpp
+++ b/drivers/libblockfs/src/trace.hpp
@@ -39,6 +39,7 @@ inline constinit protocols::ostrace::Event ostEvtExt2ResizeFile{"ext2.resizeFile
 inline constinit protocols::ostrace::Event ostEvtExt2InitializeFile{"ext2.initializeFile"};
 inline constinit protocols::ostrace::Event ostEvtExt2WritebackFile{"ext2.writebackFile"};
 inline constinit protocols::ostrace::Event ostEvtExt2AllocateBlocks{"ext2.allocateBlocks"};
+inline constinit protocols::ostrace::Event ostEvtExt2FreeBlocks{"ext2.freeBlocks"};
 inline constinit protocols::ostrace::Event ostEvtExt2AllocateInode{"ext2.allocateInode"};
 inline constinit protocols::ostrace::Event ostEvtExt2BgdtWriteback{"ext2.bgdtWriteback"};
 inline constinit protocols::ostrace::Event ostEvtVirtioBlkReadSectors{"virtio-blk.readSectors"};
@@ -182,6 +183,7 @@ inline protocols::ostrace::Vocabulary ostVocabulary{
 	ostEvtExt2InitializeFile,
 	ostEvtExt2WritebackFile,
 	ostEvtExt2AllocateBlocks,
+	ostEvtExt2FreeBlocks,
 	ostEvtExt2AllocateInode,
 	ostEvtExt2BgdtWriteback,
 	ostEvtVirtioBlkReadSectors,

--- a/drivers/libblockfs/src/trace.hpp
+++ b/drivers/libblockfs/src/trace.hpp
@@ -33,6 +33,7 @@ inline constinit protocols::ostrace::Event ostEvtExt2RemoveEntry{"ext2.removeEnt
 inline constinit protocols::ostrace::Event ostEvtExt2IsDirectoryEmpty{"ext2.isDirectoryEmpty"};
 inline constinit protocols::ostrace::Event ostEvtExt2UpdateDotDot{"ext2.updateDotDot"};
 inline constinit protocols::ostrace::Event ostEvtExt2AssignDataBlocks{"ext2.assignDataBlocks"};
+inline constinit protocols::ostrace::Event ostEvtExt2FreeDataBlocks{"ext2.freeDataBlocks"};
 inline constinit protocols::ostrace::Event ostEvtExt2ReadDataBlocks{"ext2.readDataBlocks"};
 inline constinit protocols::ostrace::Event ostEvtExt2WriteDataBlocks{"ext2.writeDataBlocks"};
 inline constinit protocols::ostrace::Event ostEvtExt2ResizeFile{"ext2.resizeFile"};
@@ -177,6 +178,7 @@ inline protocols::ostrace::Vocabulary ostVocabulary{
 	ostEvtExt2IsDirectoryEmpty,
 	ostEvtExt2UpdateDotDot,
 	ostEvtExt2AssignDataBlocks,
+	ostEvtExt2FreeDataBlocks,
 	ostEvtExt2ReadDataBlocks,
 	ostEvtExt2WriteDataBlocks,
 	ostEvtExt2ResizeFile,


### PR DESCRIPTION
This is a correctness fix. Linux assumes that a file has no blocks assigned past its EOF and it can return stale data after re-growth when this assumption is violated.