### PR TITLE
posix: Migrate FsLink/FsNode smart pointers to smarter::shared_ptr

### DIFF
--- a/posix/subsystem/src/cgroupfs.cpp
+++ b/posix/subsystem/src/cgroupfs.cpp
@@ -17,15 +17,15 @@ SuperBlock cgroupfsSuperblock;
 // LinkCompare implementation.
 // ----------------------------------------------------------------------------
 
-bool LinkCompare::operator() (const std::shared_ptr<Link> &a, const std::shared_ptr<Link> &b) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const {
 	return a->getName() < b->getName();
 }
 
-bool LinkCompare::operator() (const std::shared_ptr<Link> &link, const std::string &name) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const {
 	return link->getName() < name;
 }
 
-bool LinkCompare::operator() (const std::string &name, const std::shared_ptr<Link> &link) const {
+bool LinkCompare::operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const {
 	return name < link->getName();
 }
 
@@ -42,7 +42,7 @@ void RegularFile::serve(smarter::shared_ptr<RegularFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-RegularFile::RegularFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+RegularFile::RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("cgroupfs.file"), std::move(mount), std::move(link)},
 		_cached{false}, _offset{0} { }
 
@@ -105,7 +105,7 @@ void DirectoryFile::serve(smarter::shared_ptr<DirectoryFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("cgroupfs.dir"), std::move(mount), std::move(link)},
 		_node{static_cast<DirectoryNode *>(associatedLink()->getTarget().get())},
 		_iter{_node->_entries.begin()} { }
@@ -141,16 +141,16 @@ helix::BorrowedDescriptor DirectoryFile::getPassthroughLane() {
 // Link implementation.
 // ----------------------------------------------------------------------------
 
-Link::Link(std::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsNode> target)
 : _target{std::move(target)} { }
 
-Link::Link(std::shared_ptr<FsNode> owner, std::string name, std::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsNode> owner, std::string name, smarter::shared_ptr<FsNode> target)
 : _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 	assert(_owner);
 	assert(!_name.empty());
 }
 
-std::shared_ptr<FsNode> Link::getOwner() {
+smarter::shared_ptr<FsNode> Link::getOwner() {
 	return _owner;
 }
 
@@ -160,7 +160,7 @@ std::string Link::getName() {
 	return _name;
 }
 
-std::shared_ptr<FsNode> Link::getTarget() {
+smarter::shared_ptr<FsNode> Link::getTarget() {
 	return _target;
 }
 
@@ -196,7 +196,7 @@ async::result<frg::expected<Error, FileStats>> RegularNode::getStats() {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-RegularNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+RegularNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: cgroupfs RegularNode open() received illegal arguments:"
@@ -212,12 +212,12 @@ RegularNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<F
 	co_return File::constructHandle(std::move(file));
 }
 
-FutureMaybe<std::shared_ptr<FsNode>> SuperBlock::createRegular(Process *) {
+FutureMaybe<smarter::shared_ptr<FsNode>> SuperBlock::createRegular(Process *) {
 	std::cout << "posix: createRegular on cgroupfs Superblock unsupported" << std::endl;
 	co_return nullptr;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 SuperBlock::rename(FsLink *, FsNode *, std::string) {
 	co_return Error::noSuchFile;
 };
@@ -232,13 +232,13 @@ async::result<frg::expected<Error, FsStats>> SuperBlock::getFsStats() {
 // DirectoryNode implementation.
 // ----------------------------------------------------------------------------
 
-std::shared_ptr<Link> DirectoryNode::createRootDirectory() {
-	auto node = std::make_shared<DirectoryNode>();
+smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
+	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
-	auto link = std::make_shared<Link>(std::move(node));
+	auto link = makeFsShared<Link>(std::move(node));
 	the_node->_treeLink = link.get();
 
-	// the_node->directMkregular("cgroup.controllers", std::make_shared<ControllersNode>());
+	// the_node->directMkregular("cgroup.controllers", makeFsShared<ControllersNode>());
 	the_node->createCgroupFiles();
 
 	return link;
@@ -247,34 +247,34 @@ std::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 DirectoryNode::DirectoryNode()
 : FsNode{&cgroupfsSuperblock}, _treeLink{nullptr} { }
 
-std::shared_ptr<Link> DirectoryNode::directMkregular(std::string name,
-		std::shared_ptr<RegularNode> regular) {
+smarter::shared_ptr<Link> DirectoryNode::directMkregular(std::string name,
+		smarter::shared_ptr<RegularNode> regular) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(regular));
+	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(regular));
 	_entries.insert(link);
 	return link;
 }
 
-std::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
+smarter::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
 	assert(_entries.find(name) == _entries.end());
-	auto node = std::make_shared<DirectoryNode>();
+	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
-	auto link = std::make_shared<Link>(shared_from_this(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(node));
 	_entries.insert(link);
 	the_node->_treeLink = link.get();
 	return link;
 }
 
-async::result<std::variant<Error, std::shared_ptr<FsLink>>> DirectoryNode::mkdir(Process *, std::string name, mode_t) {
+async::result<std::variant<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::mkdir(Process *, std::string name, mode_t) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 	auto link = createCgroupDirectory(name);
 	co_return link;
 }
 
-std::shared_ptr<Link> DirectoryNode::directMknode(std::string name, std::shared_ptr<FsNode> node) {
+smarter::shared_ptr<Link> DirectoryNode::directMknode(std::string name, smarter::shared_ptr<FsNode> node) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(node));
+	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	return link;
 }
@@ -283,8 +283,8 @@ VfsType DirectoryNode::getType() {
 	return VfsType::directory;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> DirectoryNode::link(std::string,
-		std::shared_ptr<FsNode>) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::link(std::string,
+		smarter::shared_ptr<FsNode>) {
 	co_return Error::noSuchFile;
 }
 
@@ -308,13 +308,13 @@ async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 	co_return stats;
 }
 
-std::shared_ptr<FsLink> DirectoryNode::treeLink() {
+smarter::shared_ptr<FsLink> DirectoryNode::treeLink() {
 	// TODO: Even the root should return a valid link.
-	return _treeLink ? _treeLink->shared_from_this() : nullptr;
+	return _treeLink ? _treeLink->sharedFromThis() : nullptr;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: cgroup DirectoryNode open() received illegal arguments:"
@@ -330,7 +330,7 @@ DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;
@@ -345,7 +345,7 @@ async::result<frg::expected<Error>> DirectoryNode::unlink(std::string name) {
 	co_return frg::expected<Error>{};
 }
 
-std::shared_ptr<Link> DirectoryNode::createCgroupDirectory(std::string name) {
+smarter::shared_ptr<Link> DirectoryNode::createCgroupDirectory(std::string name) {
 	auto link = directMkdir(name);
 	auto cgroup_dir = static_cast<DirectoryNode*>(link->getTarget().get());
 
@@ -355,8 +355,8 @@ std::shared_ptr<Link> DirectoryNode::createCgroupDirectory(std::string name) {
 }
 
 void DirectoryNode::createCgroupFiles() {
-	this->directMkregular("cgroup.procs", std::make_shared<ProcsNode>());
-	this->directMkregular("cgroup.controllers", std::make_shared<ControllersNode>());
+	this->directMkregular("cgroup.procs", makeFsShared<ProcsNode>());
+	this->directMkregular("cgroup.controllers", makeFsShared<ControllersNode>());
 }
 
 async::result<std::string> ProcsNode::show() {
@@ -394,7 +394,7 @@ LinkNode::LinkNode()
 
 } // namespace cgroupfs
 
-std::shared_ptr<FsLink> getCgroupfs() {
-	static std::shared_ptr<FsLink> cgroupfs = cgroupfs::DirectoryNode::createRootDirectory();
+smarter::shared_ptr<FsLink> getCgroupfs() {
+	static smarter::shared_ptr<FsLink> cgroupfs = cgroupfs::DirectoryNode::createRootDirectory();
 	return cgroupfs;
 }

--- a/posix/subsystem/src/cgroupfs.hpp
+++ b/posix/subsystem/src/cgroupfs.hpp
@@ -22,16 +22,16 @@ struct DirectoryNode;
 struct LinkCompare {
 	struct is_transparent { };
 
-	bool operator() (const std::shared_ptr<Link> &a, const std::shared_ptr<Link> &b) const;
-	bool operator() (const std::shared_ptr<Link> &link, const std::string &name) const;
-	bool operator() (const std::string &name, const std::shared_ptr<Link> &link) const;
+	bool operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const;
+	bool operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const;
+	bool operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const;
 };
 
 struct RegularFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<RegularFile> file);
 
-	explicit RegularFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link);
+	explicit RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
 
 	void handleClose() override;
 
@@ -58,7 +58,7 @@ struct DirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<DirectoryFile> file);
 
-	explicit DirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link);
+	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
 
 	void handleClose() override;
 
@@ -73,26 +73,26 @@ private:
 	async::cancellation_event _cancelServe;
 
 	DotEntriesPhase _dots = DotEntriesPhase::dot;
-	std::set<std::shared_ptr<Link>, LinkCompare>::iterator _iter;
+	std::set<smarter::shared_ptr<Link>, LinkCompare>::iterator _iter;
 };
 
-struct Link final : FsLink, std::enable_shared_from_this<Link> {
-	explicit Link(std::shared_ptr<FsNode> target);
+struct Link final : FsLink {
+	explicit Link(smarter::shared_ptr<FsNode> target);
 
-	explicit Link(std::shared_ptr<FsNode> owner,
-			std::string name, std::shared_ptr<FsNode> target);
+	explicit Link(smarter::shared_ptr<FsNode> owner,
+			std::string name, smarter::shared_ptr<FsNode> target);
 
-	std::shared_ptr<FsNode> getOwner() override;
+	smarter::shared_ptr<FsNode> getOwner() override;
 	std::string getName() override;
-	std::shared_ptr<FsNode> getTarget() override;
+	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
-	std::shared_ptr<FsNode> _owner;
+	smarter::shared_ptr<FsNode> _owner;
 	std::string _name;
-	std::shared_ptr<FsNode> _target;
+	smarter::shared_ptr<FsNode> _target;
 };
 
-struct RegularNode : FsNode, std::enable_shared_from_this<RegularNode> {
+struct RegularNode : FsNode {
 	friend struct RegularFile;
 
 	RegularNode();
@@ -101,7 +101,7 @@ struct RegularNode : FsNode, std::enable_shared_from_this<RegularNode> {
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 
 	async::result<Error> chmod(int) override {
@@ -119,9 +119,9 @@ public:
 		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
 	}
 
-	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override;
+	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override;
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 			rename(FsLink *source, FsNode *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
@@ -137,44 +137,44 @@ private:
 	unsigned int deviceMinor_;
 };
 
-struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode> {
+struct DirectoryNode final : FsNode {
 	friend struct DirectoryFile;
 
-	static std::shared_ptr<Link> createRootDirectory();
+	static smarter::shared_ptr<Link> createRootDirectory();
 
 	DirectoryNode();
 
-	std::shared_ptr<Link> directMkregular(std::string name,
-			std::shared_ptr<RegularNode> regular);
-	std::shared_ptr<Link> directMknode(std::string name,
-			std::shared_ptr<FsNode> node);
-	std::shared_ptr<Link> directMkdir(std::string name);
-	async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+	smarter::shared_ptr<Link> directMkregular(std::string name,
+			smarter::shared_ptr<RegularNode> regular);
+	smarter::shared_ptr<Link> directMknode(std::string name,
+			smarter::shared_ptr<FsNode> node);
+	smarter::shared_ptr<Link> directMkdir(std::string name);
+	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 	mkdir(Process *, std::string name, mode_t mode) override;
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
-	std::shared_ptr<FsLink> treeLink() override;
+	smarter::shared_ptr<FsLink> treeLink() override;
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> link(std::string name,
-			std::shared_ptr<FsNode> target) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(std::string name,
+			smarter::shared_ptr<FsNode> target) override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override;
 	async::result<frg::expected<Error>> unlink(std::string name) override;
 
 	async::result<Error> chmod(int) override {
 		co_return Error::success;
 	}
 
-	std::shared_ptr<Link> createCgroupDirectory(std::string name);
+	smarter::shared_ptr<Link> createCgroupDirectory(std::string name);
 	void createCgroupFiles();
 
 private:
 	Link *_treeLink;
-	std::set<std::shared_ptr<Link>, LinkCompare> _entries;
+	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
 };
 
 struct ProcsNode final : RegularNode {
@@ -195,7 +195,7 @@ private:
 	// Process *_process;
 };
 
-struct LinkNode : FsNode, std::enable_shared_from_this<LinkNode> {
+struct LinkNode : FsNode {
 	LinkNode();
 
 	async::result<frg::expected<Error, FileStats>> getStats() override {
@@ -211,4 +211,4 @@ struct LinkNode : FsNode, std::enable_shared_from_this<LinkNode> {
 
 } // namespace cgroupfs
 
-std::shared_ptr<FsLink> getCgroupfs();
+smarter::shared_ptr<FsLink> getCgroupfs();

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -23,7 +23,7 @@ UnixDeviceRegistry blockRegistry;
 // UnixDevice
 // --------------------------------------------------------
 
-FutureMaybe<std::shared_ptr<FsLink>> UnixDevice::mount(std::string) {
+FutureMaybe<smarter::shared_ptr<FsLink>> UnixDevice::mount(std::string) {
 	// TODO: Return an error.
 	throw std::logic_error("Device cannot be mounted!");
 }
@@ -53,7 +53,7 @@ std::shared_ptr<UnixDevice> UnixDeviceRegistry::get(DeviceId id) {
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 openDevice(Process *process, VfsType type, DeviceId id, std::shared_ptr<MountView> mount,
-	std::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
+	smarter::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
 	if(type == VfsType::charDevice) {
 		auto device = charRegistry.get(id);
 		if(device == nullptr)
@@ -74,8 +74,8 @@ openDevice(Process *process, VfsType type, DeviceId id, std::shared_ptr<MountVie
 // devtmpfs functions.
 // --------------------------------------------------------
 
-std::shared_ptr<FsLink> getDevtmpfs() {
-	static std::shared_ptr<FsLink> devtmpfs = tmp_fs::createDevTmpFsRoot();
+smarter::shared_ptr<FsLink> getDevtmpfs() {
+	static smarter::shared_ptr<FsLink> devtmpfs = tmp_fs::createDevTmpFsRoot();
 	return devtmpfs;
 }
 
@@ -91,7 +91,7 @@ async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id
 		}else{
 			assert(s > k);
 			auto name = path.substr(k, s - k);
-			std::shared_ptr<FsLink> link;
+			smarter::shared_ptr<FsLink> link;
 			while(true) {
 				auto linkResult = co_await node->getLink(name);
 				if(linkResult) {
@@ -99,7 +99,7 @@ async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id
 					break;
 				}
 				auto mkdirResult = co_await node->mkdir(nullptr, name, 0755);
-				if(auto linkp = std::get_if<std::shared_ptr<FsLink>>(&mkdirResult)) {
+				if(auto linkp = std::get_if<smarter::shared_ptr<FsLink>>(&mkdirResult)) {
 					link = std::move(*linkp);
 					break;
 				}
@@ -208,7 +208,7 @@ private:
 
 public:
 	DeviceFile(helix::UniqueLane control, helix::UniqueLane lane,
-			std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+			std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			helix::Mapping status_mapping)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("devicefile"), std::move(mount), std::move(link)},
 			_control{std::move(control)}, _file{std::move(lane)},
@@ -237,7 +237,7 @@ private:
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 openExternalDevice(helix::BorrowedLane lane,
-		std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+		std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite | semanticAppend)){
 		std::cout << "\e[31mposix: openExternalDevice() received illegal arguments:"
@@ -380,7 +380,7 @@ async::result<void> serveServerLane(helix::UniqueDescriptor lane) {
 	}
 }
 
-FutureMaybe<std::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lane, std::shared_ptr<UnixDevice> device, std::string fs_type) {
+FutureMaybe<smarter::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lane, std::shared_ptr<UnixDevice> device, std::string fs_type) {
 	managarm::fs::MountRequest req;
 	req.set_fs_type(fs_type);
 

--- a/posix/subsystem/src/device.hpp
+++ b/posix/subsystem/src/device.hpp
@@ -31,10 +31,10 @@ public:
 	virtual std::string nodePath() = 0;
 
 	virtual async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) = 0;
 
-	virtual FutureMaybe<std::shared_ptr<FsLink>> mount(std::string fs_type);
+	virtual FutureMaybe<smarter::shared_ptr<FsLink>> mount(std::string fs_type);
 
 private:
 	VfsType _type;
@@ -73,14 +73,14 @@ extern UnixDeviceRegistry charRegistry;
 extern UnixDeviceRegistry blockRegistry;
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-openDevice(Process *, VfsType type, DeviceId id, std::shared_ptr<MountView> mont, std::shared_ptr<FsLink> link,
+openDevice(Process *, VfsType type, DeviceId id, std::shared_ptr<MountView> mont, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags);
 
 // --------------------------------------------------------
 // devtmpfs functions.
 // --------------------------------------------------------
 
-std::shared_ptr<FsLink> getDevtmpfs();
+smarter::shared_ptr<FsLink> getDevtmpfs();
 
 async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id);
 
@@ -90,9 +90,9 @@ async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 openExternalDevice(helix::BorrowedLane lane,
-		std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+		std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags);
 
-FutureMaybe<std::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lane, std::shared_ptr<UnixDevice> device, std::string fs_type);
+FutureMaybe<smarter::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lane, std::shared_ptr<UnixDevice> device, std::string fs_type);
 
 async::result<void> serveServerLane(helix::UniqueDescriptor lane);

--- a/posix/subsystem/src/devices/full.cpp
+++ b/posix/subsystem/src/devices/full.cpp
@@ -39,7 +39,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	FullFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	FullFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("full-file"), std::move(mount), std::move(link)} { }
 };
 
@@ -54,7 +54,7 @@ struct FullDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: FullFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/helout.cpp
+++ b/posix/subsystem/src/devices/helout.cpp
@@ -43,7 +43,7 @@ private:
 	}
 
 public:
-	HeloutFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	HeloutFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("helout"), std::move(mount), std::move(link),
 			File::defaultIsTerminal} { }
 };
@@ -59,7 +59,7 @@ struct HeloutDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: HeloutFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/kmsg.cpp
+++ b/posix/subsystem/src/devices/kmsg.cpp
@@ -145,7 +145,7 @@ public:
 				file, &fileOperations, file->cancelServe_));
 	}
 
-	KmsgFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, helix::UniqueLane lane, bool nonblock)
+	KmsgFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, helix::UniqueLane lane, bool nonblock)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("kmsg-file"), std::move(mount), std::move(link)},
 		lane_{std::move(lane)}, nonBlock_{nonblock} {}
 };
@@ -161,7 +161,7 @@ struct KmsgDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags flags) override {
 		bool nonblock = flags & semanticNonBlock;
 

--- a/posix/subsystem/src/devices/null.cpp
+++ b/posix/subsystem/src/devices/null.cpp
@@ -42,7 +42,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	NullFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	NullFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("null-file"), std::move(mount), std::move(link)} { }
 };
 
@@ -57,7 +57,7 @@ struct NullDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: NullFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/random.cpp
+++ b/posix/subsystem/src/devices/random.cpp
@@ -53,7 +53,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	RandomFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	RandomFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("random-file"), std::move(mount), std::move(link)} { }
 };
 
@@ -68,7 +68,7 @@ struct RandomDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: RandomFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/tty.cpp
+++ b/posix/subsystem/src/devices/tty.cpp
@@ -14,7 +14,7 @@ struct TtyDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *process, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags flags) override {
 		if (!process)
 			co_return Error::noBackingDevice;

--- a/posix/subsystem/src/devices/tty0.cpp
+++ b/posix/subsystem/src/devices/tty0.cpp
@@ -15,7 +15,7 @@ struct TTY0Device final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *process, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		co_return co_await openDevice(process, VfsType::charDevice, {4, 1}, mount, link, semantic_flags);
 	}

--- a/posix/subsystem/src/devices/ttyn.cpp
+++ b/posix/subsystem/src/devices/ttyn.cpp
@@ -297,7 +297,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	TTYNFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	TTYNFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("tty1-file"), std::move(mount), std::move(link), File::defaultIsTerminal | File::defaultPipeLikeSeek} {
 		memset(&_activeSettings, 0, sizeof(struct termios));
 		// cflag: Linux also stores a baud rate here.
@@ -336,7 +336,7 @@ struct TTYNDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: TTYNFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/urandom.cpp
+++ b/posix/subsystem/src/devices/urandom.cpp
@@ -60,7 +60,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	UrandomFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	UrandomFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("urandom-file"), std::move(mount), std::move(link)} { }
 };
 
@@ -75,7 +75,7 @@ struct UrandomDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: UrandomFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/zero.cpp
+++ b/posix/subsystem/src/devices/zero.cpp
@@ -40,7 +40,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	ZeroFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	ZeroFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("zero-file"), std::move(mount), std::move(link),
 			defaultMapsAnonymously} { }
 };
@@ -56,7 +56,7 @@ struct ZeroDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: ZeroFile open() received illegal arguments:"

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -22,9 +22,9 @@ struct DirectoryNode;
 struct Superblock final : FsSuperblock {
 	Superblock(helix::UniqueLane lane, std::shared_ptr<UnixDevice> device);
 
-	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *process) override;
+	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *process) override;
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 			rename(FsLink *source, FsNode *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
@@ -37,18 +37,18 @@ struct Superblock final : FsSuperblock {
 		return makedev(id.first, id.second);
 	}
 
-	std::shared_ptr<Node> internalizeStructural(uint64_t id, helix::UniqueLane lane);
-	std::shared_ptr<Node> internalizeStructural(Node *owner, std::string name,
+	smarter::shared_ptr<Node> internalizeStructural(uint64_t id, helix::UniqueLane lane);
+	smarter::shared_ptr<Node> internalizeStructural(Node *owner, std::string name,
 			uint64_t id, helix::UniqueLane lane);
-	std::shared_ptr<Node> internalizePeripheralNode(int64_t type, int id, helix::UniqueLane lane);
-	std::shared_ptr<FsLink> internalizePeripheralLink(Node *parent, std::string name,
-			std::shared_ptr<Node> target);
+	smarter::shared_ptr<Node> internalizePeripheralNode(int64_t type, int id, helix::UniqueLane lane);
+	smarter::shared_ptr<FsLink> internalizePeripheralLink(Node *parent, std::string name,
+			smarter::shared_ptr<Node> target);
 
 private:
 	helix::UniqueLane _lane;
-	std::map<uint64_t, std::weak_ptr<DirectoryNode>> _activeStructural;
-	std::map<uint64_t, std::weak_ptr<Node>> _activePeripheralNodes;
-	std::map<std::tuple<uint64_t, std::string, uint64_t>, std::weak_ptr<FsLink>> _activePeripheralLinks;
+	std::map<uint64_t, smarter::weak_ptr<DirectoryNode>> _activeStructural;
+	std::map<uint64_t, smarter::weak_ptr<Node>> _activePeripheralNodes;
+	std::map<std::tuple<uint64_t, std::string, uint64_t>, smarter::weak_ptr<FsLink>> _activePeripheralLinks;
 
 	std::shared_ptr<UnixDevice> device_;
 };
@@ -200,16 +200,7 @@ public:
 		return _lane;
 	}
 
-	void setupWeakNode(std::weak_ptr<Node> self) {
-		_self = std::move(self);
-	}
-
-	std::weak_ptr<Node> weakNode() {
-		return _self;
-	}
-
 private:
-	std::weak_ptr<Node> _self;
 	uint64_t _inode;
 	helix::UniqueLane _lane;
 };
@@ -270,7 +261,7 @@ private:
 
 public:
 	OpenFile(helix::UniqueLane control, helix::UniqueLane lane,
-			std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+			std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 	: File{FileKind::unknown, StructName::get("externfs.file"), std::move(mount), std::move(link)},
 			_control{std::move(control)}, _file{std::move(lane)} { }
 
@@ -318,7 +309,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		// Regular files do not support O_NONBLOCK.
 		semantic_flags &= ~semanticNonBlock;
@@ -409,7 +400,7 @@ public:
 
 struct Link : FsLink {
 public:
-	std::shared_ptr<FsNode> getOwner() override {
+	smarter::shared_ptr<FsNode> getOwner() override {
 		return _owner;
 	}
 
@@ -449,7 +440,7 @@ private:
 public:
 	Link() = default;
 
-	Link(std::shared_ptr<FsNode> owner, std::string name)
+	Link(smarter::shared_ptr<FsNode> owner, std::string name)
 	: _owner{std::move(owner)}, _name{std::move(name)} {
 		assert(_owner);
 	}
@@ -458,31 +449,31 @@ protected:
 	~Link() = default;
 
 private:
-	std::shared_ptr<FsNode> _owner;
+	smarter::shared_ptr<FsNode> _owner;
 	std::string _name;
 };
 
 // This class maintains a strong reference to the target.
 struct PeripheralLink final : Link {
 private:
-	std::shared_ptr<FsNode> getTarget() override {
+	smarter::shared_ptr<FsNode> getTarget() override {
 		return _target;
 	}
 
 public:
-	PeripheralLink(std::shared_ptr<FsNode> owner,
-			std::string name, std::shared_ptr<FsNode> target)
+	PeripheralLink(smarter::shared_ptr<FsNode> owner,
+			std::string name, smarter::shared_ptr<FsNode> target)
 	: Link{std::move(owner), std::move(name)}, _target{std::move(target)} { }
 
 private:
 	std::string _name;
-	std::shared_ptr<FsNode> _target;
+	smarter::shared_ptr<FsNode> _target;
 };
 
 // This class is embedded in a DirectoryNode and share its lifetime.
 struct StructuralLink final : Link {
 private:
-	std::shared_ptr<FsNode> getTarget() override;
+	smarter::shared_ptr<FsNode> getTarget() override;
 
 public:
 	StructuralLink(DirectoryNode *target)
@@ -490,7 +481,7 @@ public:
 		assert(_target);
 	}
 
-	StructuralLink(std::shared_ptr<FsNode> owner, DirectoryNode *target, std::string name)
+	StructuralLink(smarter::shared_ptr<FsNode> owner, DirectoryNode *target, std::string name)
 	: Link{std::move(owner), std::move(name)}, _target{std::move(target)} {
 		assert(_target);
 	}
@@ -505,16 +496,15 @@ private:
 		return VfsType::directory;
 	}
 
-	std::shared_ptr<FsLink> treeLink() override {
-		auto self = std::shared_ptr<FsNode>{weakNode()};
-		return std::shared_ptr<FsLink>{std::move(self), &_treeLink};
+	smarter::shared_ptr<FsLink> treeLink() override {
+		return smarter::shared_ptr<FsLink>{sharedFromThis(), &_treeLink};
 	}
 
 	bool hasTraverseLinks() override {
 		return true;
 	}
 
-	async::result<std::expected<std::shared_ptr<FsLink>, Error>>
+	async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
 	getLinkOrCreate(Process *process, std::string name, mode_t mode, bool exclusive) override {
 		assert(this->getType() == VfsType::directory);
 
@@ -558,7 +548,7 @@ private:
 		}
 	}
 
-	async::result<frg::expected<Error, std::pair<std::shared_ptr<FsLink>, size_t>>>
+	async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>>
 	traverseLinks(std::deque<std::string> path) override {
 		managarm::fs::NodeTraverseLinksRequest req;
 		for (auto &i : path)
@@ -579,7 +569,7 @@ private:
 		HEL_CHECK(send_tail.error());
 		HEL_CHECK(recv_resp.error());
 
-		std::shared_ptr<FsLink> link = nullptr;
+		smarter::shared_ptr<FsLink> link = nullptr;
 
 		auto preamble = bragi::read_preamble(recv_resp);
 		if (preamble.error()) {
@@ -618,7 +608,7 @@ private:
 		assert(resp.links_traversed());
 		assert(resp.links_traversed() <= path.size());
 
-		std::shared_ptr<Node> parentNode{weakNode()};
+		auto parentNode = smarter::static_pointer_cast<Node>(sharedFromThis());
 		for (size_t i = 0; i < resp.ids().size(); i++) {
 			auto [pull_node] = co_await helix_ng::exchangeMsgs(
 				pull_lane,
@@ -645,7 +635,7 @@ private:
 		co_return std::make_pair(link, resp.links_traversed());
 	}
 
-	async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 	mkdir(Process *proc, std::string name, mode_t mode) override {
 		auto umask = proc ? proc->fsContext()->getUmask() : 0;
 
@@ -682,7 +672,7 @@ private:
 		}
 	}
 
-	async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 	symlink(std::string name, std::string path) override {
 		managarm::fs::CntRequest req;
 		req.set_req_type(managarm::fs::CntReqType::NODE_SYMLINK);
@@ -720,7 +710,7 @@ private:
 		}
 	}
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkdev(std::string name, VfsType type, DeviceId id) override {
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(std::string name, VfsType type, DeviceId id) override {
 		(void)name;
 		(void)type;
 		(void)id;
@@ -728,7 +718,7 @@ private:
 		__builtin_unreachable();
 	}
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 			getLink(std::string name) override {
 		managarm::fs::GetLinkRequest req;
 		req.set_path(name);
@@ -766,8 +756,8 @@ private:
 		}
 	}
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> link(std::string name,
-			std::shared_ptr<FsNode> target) override {
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(std::string name,
+			smarter::shared_ptr<FsNode> target) override {
 		managarm::fs::LinkRequest req;
 		req.set_path(name);
 		req.set_fd(static_cast<Node *>(target.get())->getInode());
@@ -857,7 +847,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		// Regular files do not support O_NONBLOCK.
 		semantic_flags &= ~semanticNonBlock;
@@ -909,7 +899,7 @@ public:
 	: Node{inode, std::move(lane), sb}, _sb{sb},
 			_treeLink{this} { }
 
-	DirectoryNode(Superblock *sb, std::shared_ptr<Node> owner, std::string name,
+	DirectoryNode(Superblock *sb, smarter::shared_ptr<FsNode> owner, std::string name,
 			uint64_t inode, helix::UniqueLane lane)
 	: Node{inode, std::move(lane), sb}, _sb{sb},
 			_treeLink{std::move(owner), this, std::move(name)} { }
@@ -919,14 +909,14 @@ private:
 	StructuralLink _treeLink;
 };
 
-std::shared_ptr<FsNode> StructuralLink::getTarget() {
-	return std::shared_ptr<Node>{_target->weakNode()};
+smarter::shared_ptr<FsNode> StructuralLink::getTarget() {
+	return _target->sharedFromThis();
 }
 
 Superblock::Superblock(helix::UniqueLane lane, std::shared_ptr<UnixDevice> device)
 : _lane{std::move(lane)}, device_{device} { }
 
-FutureMaybe<std::shared_ptr<FsNode>> Superblock::createRegular(Process *process) {
+FutureMaybe<smarter::shared_ptr<FsNode>> Superblock::createRegular(Process *process) {
 	managarm::fs::CntRequest req;
 	req.set_req_type(managarm::fs::CntReqType::SB_CREATE_REGULAR);
 	req.set_uid(process->threadGroup()->uid());
@@ -957,14 +947,14 @@ FutureMaybe<std::shared_ptr<FsNode>> Superblock::createRegular(Process *process)
 	}
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 		Superblock::rename(FsLink *source, FsNode *directory, std::string name) {
 
 	managarm::fs::RenameRequest req;
 	Link *slink = static_cast<Link *>(source);
 	Node *source_node = static_cast<Node *>(slink->getOwner().get());
 	Node *target_node = static_cast<Node *>(directory);
-	std::shared_ptr<Node> shared_node = std::static_pointer_cast<Node>(source->getTarget());
+	smarter::shared_ptr<Node> shared_node = smarter::static_pointer_cast<Node>(source->getTarget());
 	req.set_inode_source(source_node->getInode());
 	req.set_inode_target(target_node->getInode());
 	req.set_old_name(source->getName());
@@ -991,64 +981,60 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
 	co_return resp.error() | toPosixError;
 }
 
-std::shared_ptr<Node> Superblock::internalizeStructural(uint64_t id, helix::UniqueLane lane) {
+smarter::shared_ptr<Node> Superblock::internalizeStructural(uint64_t id, helix::UniqueLane lane) {
 	auto entry = &_activeStructural[id];
 	auto intern = entry->lock();
 	if(intern)
 		return intern;
 
-	auto node = std::make_shared<DirectoryNode>(this, id, std::move(lane));
-	node->setupWeakNode(node);
+	auto node = makeFsShared<DirectoryNode>(this, id, std::move(lane));
 	*entry = node;
 	return node;
 }
 
-std::shared_ptr<Node> Superblock::internalizeStructural(Node *parent, std::string name,
+smarter::shared_ptr<Node> Superblock::internalizeStructural(Node *parent, std::string name,
 		uint64_t id, helix::UniqueLane lane) {
 	auto entry = &_activeStructural[id];
 	auto intern = entry->lock();
 	if(intern)
 		return intern;
 
-	auto owner = std::shared_ptr<Node>{parent->weakNode()};
-	auto node = std::make_shared<DirectoryNode>(this, owner, std::move(name), id, std::move(lane));
-	node->setupWeakNode(node);
+	auto node = makeFsShared<DirectoryNode>(this, parent->sharedFromThis(),
+			std::move(name), id, std::move(lane));
 	*entry = node;
 	return node;
 }
 
-std::shared_ptr<Node> Superblock::internalizePeripheralNode(int64_t type,
+smarter::shared_ptr<Node> Superblock::internalizePeripheralNode(int64_t type,
 		int id, helix::UniqueLane lane) {
 	auto entry = &_activePeripheralNodes[id];
 	auto intern = entry->lock();
 	if(intern)
 		return intern;
 
-	std::shared_ptr<Node> node;
+	smarter::shared_ptr<Node> node;
 	switch(type) {
 	case managarm::fs::FileType::REGULAR:
-		node = std::make_shared<RegularNode>(this, id, std::move(lane));
+		node = makeFsShared<RegularNode>(this, id, std::move(lane));
 		break;
 	case managarm::fs::FileType::SYMLINK:
-		node = std::make_shared<SymlinkNode>(this, id, std::move(lane));
+		node = makeFsShared<SymlinkNode>(this, id, std::move(lane));
 		break;
 	default:
 		throw std::runtime_error("extern_fs: Unexpected file type");
 	}
-	node->setupWeakNode(node);
 	*entry = node;
 	return node;
 }
 
-std::shared_ptr<FsLink> Superblock::internalizePeripheralLink(Node *parent, std::string name,
-		std::shared_ptr<Node> target) {
+smarter::shared_ptr<FsLink> Superblock::internalizePeripheralLink(Node *parent, std::string name,
+		smarter::shared_ptr<Node> target) {
 	auto entry = &_activePeripheralLinks[{parent->getInode(), name, target->getInode()}];
 	auto intern = entry->lock();
 	if(intern)
 		return intern;
 
-	auto owner = std::shared_ptr<Node>{parent->weakNode()};
-	auto link = std::make_shared<PeripheralLink>(std::move(owner),
+	auto link = makeFsShared<PeripheralLink>(parent->sharedFromThis(),
 			std::move(name), std::move(target));
 	*entry = link;
 	return link;
@@ -1096,7 +1082,7 @@ async::result<frg::expected<Error, FsStats>> Superblock::getFsStats() {
 
 } // anonymous namespace
 
-std::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device) {
+smarter::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device) {
 	auto sb = new Superblock{std::move(sb_lane), device};
 	// FIXME: 2 is the ext2fs root inode.
 	auto node = sb->internalizeStructural(2, std::move(lane));
@@ -1104,7 +1090,7 @@ std::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane 
 }
 
 smarter::shared_ptr<File, FileHandle>
-createFile(helix::UniqueLane lane, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link) {
+createFile(helix::UniqueLane lane, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link) {
 	auto file = smarter::make_shared<OpenFile>(helix::UniqueLane{},
 			std::move(lane), std::move(mount), std::move(link));
 	file->setupWeakFile(file);

--- a/posix/subsystem/src/extern_fs.hpp
+++ b/posix/subsystem/src/extern_fs.hpp
@@ -5,9 +5,9 @@
 
 namespace extern_fs {
 
-std::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device);
+smarter::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device);
 
 smarter::shared_ptr<File, FileHandle>
-createFile(helix::UniqueLane lane, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link);
+createFile(helix::UniqueLane lane, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
 
 } // namespace extern_fs

--- a/posix/subsystem/src/fifo.cpp
+++ b/posix/subsystem/src/fifo.cpp
@@ -58,7 +58,7 @@ public:
 				smarter::shared_ptr<File>{file}, &File::fileOperations));
 	}
 
-	OpenFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	OpenFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		bool isReader, bool isWriter, bool nonBlock = false)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("fifo"), mount, link, File::defaultPipeLikeSeek},
 		isReader_{isReader}, isWriter_{isWriter}, nonBlock_{nonBlock} { }
@@ -312,7 +312,7 @@ void unlinkNamedChannel(FsNode *node) {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-openNamedChannel(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, FsNode *node, SemanticFlags flags) {
+openNamedChannel(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, FsNode *node, SemanticFlags flags) {
 	if (globalChannelMap.find(node) == globalChannelMap.end())
 		co_return nullptr;
 

--- a/posix/subsystem/src/fifo.hpp
+++ b/posix/subsystem/src/fifo.hpp
@@ -8,7 +8,7 @@ namespace fifo {
 void createNamedChannel(FsNode *node);
 void unlinkNamedChannel(FsNode *node);
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-openNamedChannel(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, FsNode *node, SemanticFlags flags);
+openNamedChannel(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, FsNode *node, SemanticFlags flags);
 
 std::array<smarter::shared_ptr<File, FileHandle>, 2> createPair(bool nonBlock);
 

--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -471,7 +471,7 @@ public:
 	File(FileKind kind, StructName struct_name, DefaultOps default_ops = 0)
 	: kind_{kind}, _structName{struct_name}, _defaultOps{default_ops}, _isOpen{true} { }
 
-	File(FileKind kind, StructName struct_name, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	File(FileKind kind, StructName struct_name, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			DefaultOps default_ops = 0)
 	: _link{std::move(link)}, kind_{kind}, _structName{struct_name}, _mount{std::move(mount)},
 			_defaultOps{default_ops}, _isOpen{true} { }
@@ -519,7 +519,7 @@ public:
 	// This is the link that was used to open the file.
 	// Note that this might not be the only link that can be used
 	// to reach the file's inode.
-	std::shared_ptr<FsLink> associatedLink() {
+	smarter::shared_ptr<FsLink> associatedLink() {
 		if(!_link)
 			std::cout << "posix \e[1;34m" << structName()
 					<< "\e[0m: Object does not support associatedLink()" << std::endl;
@@ -623,7 +623,7 @@ public:
 	virtual async::result<protocols::fs::Error> flock(int flags);
 
 protected:
-	const std::shared_ptr<FsLink> _link;
+	const smarter::shared_ptr<FsLink> _link;
 
 private:
 	smarter::counter _fileCtr;
@@ -641,7 +641,7 @@ struct FileWithDefaults : File {
 	FileWithDefaults(FileKind kind, StructName struct_name, DefaultOps default_ops = 0)
 	: File{kind, struct_name, default_ops} { }
 
-	FileWithDefaults(FileKind kind, StructName struct_name, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	FileWithDefaults(FileKind kind, StructName struct_name, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			DefaultOps default_ops = 0)
 	: File{kind, struct_name, std::move(mount), std::move(link), default_ops} { }
 
@@ -662,7 +662,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	DummyFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, DefaultOps default_ops = 0)
+	DummyFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, DefaultOps default_ops = 0)
 	: FileWithDefaults{FileKind::unknown, StructName::get("dummy-file"), std::move(mount), std::move(link), default_ops | defaultPipeLikeSeek} { }
 
 	helix::BorrowedDescriptor getPassthroughLane() override {

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -12,12 +12,12 @@ struct AnonymousSuperblock : FsSuperblock {
 		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
 	}
 
-	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override {
+	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override {
 		std::cout << "posix: createRegular on AnonymousSuperblock unsupported" << std::endl;
 		co_return nullptr;
 	}
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 	rename(FsLink *, FsNode *, std::string) override {
 		co_return Error::noSuchFile;
 	}
@@ -59,7 +59,7 @@ id_allocator<unsigned int> &getUnnamedDeviceIdAllocator() {
 // --------------------------------------------------------
 
 async::result<frg::expected<Error>> FsLink::obstruct() {
-	if(getOwner() != nullptr)
+	if(getOwner())
 		assert(!getOwner()->hasTraverseLinks() && "Node has traverseLinks but no obstruct?");
 	co_return Error::illegalOperationTarget;
 }
@@ -77,7 +77,7 @@ async::result<frg::expected<Error, FileStats>> FsNode::getStats() {
 	co_return Error::illegalOperationTarget;
 }
 
-std::shared_ptr<FsLink> FsNode::treeLink() {
+smarter::shared_ptr<FsLink> FsNode::treeLink() {
 	throw std::runtime_error("treeLink() is not implemented for this FsNode");
 }
 
@@ -98,40 +98,40 @@ void FsNode::removeObserver(FsObserver *observer) {
 	_observers.erase(it);
 }
 
-async::result<std::expected<std::shared_ptr<FsLink>, Error>>
+async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
 FsNode::getLinkOrCreate(Process *, std::string, mode_t, bool) {
 	std::println("posix: getLink() is not implemented for this FsNode");
 	co_return std::unexpected{Error::illegalOperationTarget};
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::getLink(std::string) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::getLink(std::string) {
 	std::cout << "posix: getLink() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::link(std::string, std::shared_ptr<FsNode>) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::link(std::string, smarter::shared_ptr<FsNode>) {
 	std::cout << "posix: link() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 FsNode::mkdir(Process *, std::string, mode_t) {
 	std::cout << "posix: mkdir() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 FsNode::symlink(std::string, std::string) {
 	std::cout << "posix: symlink() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::mkdev(std::string, VfsType, DeviceId) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mkdev(std::string, VfsType, DeviceId) {
 	std::cout << "posix: mkdev() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::mkfifo(std::string, mode_t) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mkfifo(std::string, mode_t) {
 	std::cout << "posix: mkfifo() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
@@ -148,7 +148,7 @@ async::result<frg::expected<Error>> FsNode::rmdir(std::string) {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-FsNode::open(Process *, std::shared_ptr<MountView>, std::shared_ptr<FsLink>, SemanticFlags) {
+FsNode::open(Process *, std::shared_ptr<MountView>, smarter::shared_ptr<FsLink>, SemanticFlags) {
 	std::cout << "posix: open() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
@@ -165,7 +165,7 @@ bool FsNode::hasTraverseLinks() {
 	return false;
 }
 
-async::result<frg::expected<Error, std::pair<std::shared_ptr<FsLink>, size_t>>> FsNode::traverseLinks(std::deque<std::string>) {
+async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>> FsNode::traverseLinks(std::deque<std::string>) {
 	std::cout << "posix: traverseLinks() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
@@ -192,7 +192,7 @@ async::result<Error> FsNode::utimensat(std::optional<timespec> atime, std::optio
 	co_return Error::accessDenied;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FsNode::mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid) {
 	(void) name;
 	(void) mode;
 	(void) uid;

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <iostream>
 #include <set>
 #include <deque>
@@ -9,6 +10,7 @@
 #include <core/id-allocator.hpp>
 #include <frg/container_of.hpp>
 #include <hel.h>
+#include <smarter.hpp>
 #include <sys/types.h>
 
 #include <fcntl.h>
@@ -67,11 +69,24 @@ protected:
 	~FsLink() = default;
 
 public:
-	virtual std::shared_ptr<FsNode> getOwner() = 0;
+	virtual smarter::shared_ptr<FsNode> getOwner() = 0;
 	virtual std::string getName() = 0;
-	virtual std::shared_ptr<FsNode> getTarget() = 0;
+	virtual smarter::shared_ptr<FsNode> getTarget() = 0;
 	virtual async::result<frg::expected<Error>> obstruct();
 	virtual std::optional<std::string> getProcFsDescription();
+
+	// Only to be called by makeFsShared().
+	void setupSelfPtr(smarter::borrowed_ptr<FsLink> ptr) {
+		selfPtr_ = ptr;
+	}
+
+	smarter::shared_ptr<FsLink> sharedFromThis() {
+		assert(selfPtr_);
+		return selfPtr_.lock();
+	}
+
+private:
+	smarter::borrowed_ptr<FsLink> selfPtr_;
 };
 
 struct FsSuperblock {
@@ -79,9 +94,9 @@ protected:
 	~FsSuperblock() = default;
 
 public:
-	virtual FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) = 0;
+	virtual FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) = 0;
 
-	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 			rename(FsLink *source, FsNode *directory, std::string name) = 0;
 	virtual async::result<frg::expected<Error, FsStats>> getFsStats() = 0;
 	virtual std::string getFsType() = 0;
@@ -150,36 +165,36 @@ public:
 
 	// For directories only: Returns a pointer to the link
 	// that links this directory from its parent.
-	virtual std::shared_ptr<FsLink> treeLink();
+	virtual smarter::shared_ptr<FsLink> treeLink();
 
 	virtual void addObserver(std::shared_ptr<FsObserver> observer);
 
 	virtual void removeObserver(FsObserver *observer);
 
 	//! Get an existing link or create one (directories only).
-	virtual async::result<std::expected<std::shared_ptr<FsLink>, Error>>
+	virtual async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
 	getLinkOrCreate(Process *, std::string name, mode_t mode, bool exclusive = false);
 
 	//! Resolves a file in a directory (directories only).
-	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name);
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name);
 
 	//! Links an existing node to this directory (directories only).
-	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> link(std::string name,
-			std::shared_ptr<FsNode> target);
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(std::string name,
+			smarter::shared_ptr<FsNode> target);
 
 	//! Creates a new directory (directories only).
-	virtual async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+	virtual async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 	mkdir(Process *, std::string name, mode_t mode);
 
 	//! Creates a new symlink (directories only).
-	virtual async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+	virtual async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 	symlink(std::string name, std::string path);
 
 	//! Creates a new device file (directories only).
-	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkdev(std::string name,
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(std::string name,
 			VfsType type, DeviceId id);
 
-	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkfifo(std::string name, mode_t mode);
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkfifo(std::string name, mode_t mode);
 
 	virtual async::result<frg::expected<Error>> unlink(std::string name);
 
@@ -188,7 +203,7 @@ public:
 	//! Opens the file (regular files only).
 	// TODO: Move this to the link instead of the inode?
 	virtual async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *process, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags);
 
 	// Reads the target of a symlink (symlinks only).
@@ -208,17 +223,28 @@ public:
 	virtual async::result<Error> utimensat(std::optional<timespec> atime, std::optional<timespec> mtime, timespec ctime);
 
 	// Creates an socket
-	virtual async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid);
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid);
 
 	// Recursive path traversal
 	virtual bool hasTraverseLinks();
-	virtual async::result<frg::expected<Error, std::pair<std::shared_ptr<FsLink>, size_t>>> traverseLinks(std::deque<std::string> path);
+	virtual async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>> traverseLinks(std::deque<std::string> path);
 
 	void notifyObservers(uint32_t inotifyEvents, const std::string &name, uint32_t cookie, bool isDir = false);
+
+	// Only to be called by makeFsShared().
+	void setupSelfPtr(smarter::borrowed_ptr<FsNode> ptr) {
+		selfPtr_ = ptr;
+	}
+
+	smarter::shared_ptr<FsNode> sharedFromThis() {
+		assert(selfPtr_);
+		return selfPtr_.lock();
+	}
 
 	protocols::fs::FlockManager flockManager;
 
 private:
+	smarter::borrowed_ptr<FsNode> selfPtr_;
 	FsSuperblock *_superblock;
 	DefaultOps _defaultOps;
 
@@ -226,30 +252,39 @@ private:
 	std::unordered_map<FsObserver *, std::shared_ptr<FsObserver>> _observers;
 };
 
+// Allocates an FsLink or FsNode and installs the self-pointer that sharedFromThis() returns.
+template<typename T, typename... Args>
+requires std::derived_from<T, FsLink> || std::derived_from<T, FsNode>
+smarter::shared_ptr<T> makeFsShared(Args &&...args) {
+	auto ptr = smarter::make_shared<T>(std::forward<Args>(args)...);
+	ptr->setupSelfPtr(ptr);
+	return ptr;
+}
+
 // ----------------------------------------------------------------------------
 // SpecialLink class.
 // ----------------------------------------------------------------------------
 
 // This class can be used to construct FsLinks for anonymous special files
 // such as epoll, signalfd, timerfd, etc.
-struct SpecialLink final : FsLink, std::enable_shared_from_this<SpecialLink> {
+struct SpecialLink final : FsLink {
 private:
 	struct PrivateTag { }; // To tag-dispatch to private methods.
 
 public:
-	static std::shared_ptr<SpecialLink> makeSpecialLink(VfsType fileType, int mode) {
-		return std::make_shared<SpecialLink>(PrivateTag{}, fileType, mode);
+	static smarter::shared_ptr<SpecialLink> makeSpecialLink(VfsType fileType, int mode) {
+		return makeFsShared<SpecialLink>(PrivateTag{}, fileType, mode);
 	}
 
 	SpecialLink(PrivateTag, VfsType fileType, int mode)
 	: fileType_{fileType}, mode_{mode} { }
 
 public:
-	std::shared_ptr<FsNode> getTarget() override {
-		return {shared_from_this(), &embeddedNode_};
+	smarter::shared_ptr<FsNode> getTarget() override {
+		return {sharedFromThis(), &embeddedNode_};
 	}
 
-	std::shared_ptr<FsNode> getOwner() override {
+	smarter::shared_ptr<FsNode> getOwner() override {
 		return nullptr;
 	}
 

--- a/posix/subsystem/src/inotify.cpp
+++ b/posix/subsystem/src/inotify.cpp
@@ -32,7 +32,7 @@ public:
 	};
 
 	struct Watch final : FsObserver {
-		Watch(smarter::weak_ptr<File> file_, int descriptor, uint32_t mask, std::weak_ptr<FsNode> node)
+		Watch(smarter::weak_ptr<File> file_, int descriptor, uint32_t mask, smarter::weak_ptr<FsNode> node)
 		: file{file_}, descriptor{descriptor}, mask{mask}, node{node} { }
 
 		void observeNotification(uint32_t events,
@@ -79,7 +79,7 @@ public:
 		smarter::weak_ptr<File> file;
 		int descriptor;
 		uint32_t mask;
-		std::weak_ptr<FsNode> node;
+		smarter::weak_ptr<FsNode> node;
 	};
 
 	static void serve(smarter::shared_ptr<OpenFile> file) {
@@ -189,7 +189,7 @@ public:
 		return _passthrough;
 	}
 
-	int addWatch(std::shared_ptr<FsNode> node, uint32_t mask) {
+	int addWatch(smarter::shared_ptr<FsNode> node, uint32_t mask) {
 		if(mask & ~supportedFlags)
 			std::println("posix: inotify mask {:#x} is partially ignored", mask);
 
@@ -292,7 +292,7 @@ smarter::shared_ptr<File, FileHandle> createFile(bool nonBlock) {
 	return File::constructHandle(std::move(file));
 }
 
-int addWatch(File *base, std::shared_ptr<FsNode> node, uint32_t mask) {
+int addWatch(File *base, smarter::shared_ptr<FsNode> node, uint32_t mask) {
 	auto file = static_cast<OpenFile *>(base);
 	return file->addWatch(std::move(node), mask);
 }

--- a/posix/subsystem/src/inotify.hpp
+++ b/posix/subsystem/src/inotify.hpp
@@ -5,7 +5,7 @@
 namespace inotify {
 
 smarter::shared_ptr<File, FileHandle> createFile(bool nonBlock);
-int addWatch(File *file, std::shared_ptr<FsNode> node, uint32_t mask);
+int addWatch(File *file, smarter::shared_ptr<FsNode> node, uint32_t mask);
 bool removeWatch(File *file, int wd);
 
 } // namespace inotify

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -185,8 +185,8 @@ async::result<void> enumerateKerncfg() {
 	auto numCpuResp = bragi::parse_head_only<managarm::kerncfg::GetNumCpuResponse>(recvResp);
 	affinityMaskSize = (numCpuResp->num_cpu() + 7) / 8;
 
-	auto procfsRoot = std::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
-	procfsRoot->directMkregular("cmdline", std::make_shared<CmdlineNode>());
+	auto procfsRoot = smarter::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
+	procfsRoot->directMkregular("cmdline", makeFsShared<CmdlineNode>());
 }
 
 async::result<void> enumeratePm() {

--- a/posix/subsystem/src/memfd.hpp
+++ b/posix/subsystem/src/memfd.hpp
@@ -14,7 +14,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	MemoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, bool allowSealing)
+	MemoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, bool allowSealing)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("memfd-file"), mount, link}, _offset{0} {
 		if(!allowSealing) {
 			_seals = F_SEAL_SEAL;
@@ -66,13 +66,13 @@ private:
 // MemoryFileLink class.
 // ----------------------------------------------------------------------------
 
-struct MemoryFileLink final : FsLink, std::enable_shared_from_this<MemoryFileLink> {
+struct MemoryFileLink final : FsLink {
 private:
 	struct PrivateTag { }; // To tag-dispatch to private methods.
 
 public:
-	static std::shared_ptr<MemoryFileLink> makeMemoryFileLink(int mode) {
-		return std::make_shared<MemoryFileLink>(PrivateTag{}, mode);
+	static smarter::shared_ptr<MemoryFileLink> makeMemoryFileLink(int mode) {
+		return makeFsShared<MemoryFileLink>(PrivateTag{}, mode);
 	}
 
 	MemoryFileLink(PrivateTag, int mode)
@@ -83,11 +83,11 @@ public:
 	}
 
 public:
-	std::shared_ptr<FsNode> getTarget() override {
-		return {shared_from_this(), &embeddedNode_};
+	smarter::shared_ptr<FsNode> getTarget() override {
+		return {sharedFromThis(), &embeddedNode_};
 	}
 
-	std::shared_ptr<FsNode> getOwner() override {
+	smarter::shared_ptr<FsNode> getOwner() override {
 		return nullptr;
 	}
 

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -1258,7 +1258,7 @@ void Process::dumpRegisters() {
 
 				// If we are at the origin of a mount point, traverse that mount point.
 				ViewPath traversed;
-				if(vp.second == vp.first->getOrigin()) {
+				if(vp.second.get() == vp.first->getOrigin().get()) {
 					if(!vp.first->getParent())
 						break;
 					auto anchor = vp.first->getAnchor();
@@ -1377,7 +1377,7 @@ async::result<std::shared_ptr<ThreadGroup>> Process::init(std::string path) {
 
 	HEL_CHECK(helGetCredentials(process->_threadDescriptor.getHandle(), 0, process->credentials_.data()));
 
-	auto procfs_root = std::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
+	auto procfs_root = smarter::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
 	process->procfsTaskLink_ = procfs_root->createProcTaskDirectory(process.get());
 
 	auto generation = std::make_shared<Generation>();
@@ -1446,7 +1446,7 @@ async::result<std::shared_ptr<Process>> Process::fork(std::shared_ptr<Process> o
 	process->getTidHull()->initializeThreadGroup(threadGroup);
 	process->threadGroup()->didExecute_ = false;
 
-	auto procfs_root = std::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
+	auto procfs_root = smarter::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
 	process->procfsTaskLink_ = procfs_root->createProcTaskDirectory(process.get());
 
 	HelHandle new_thread;
@@ -1581,7 +1581,7 @@ Process::clone(std::shared_ptr<Process> original, void *ip, void *sp, posix::sup
 
 	process->threadGroup()->didExecute_ = false;
 
-	auto procfs_root = std::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
+	auto procfs_root = smarter::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
 	process->procfsTaskLink_ = procfs_root->createProcTaskDirectory(process.get());
 
 	HelHandle new_thread;

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -724,7 +724,7 @@ private:
 	std::shared_ptr<FsContext> _fsContext;
 	std::shared_ptr<FileContext> _fileContext;
 
-	std::shared_ptr<procfs::Link> procfsTaskLink_;
+	smarter::shared_ptr<procfs::Link> procfsTaskLink_;
 
 	std::shared_ptr<ThreadGroup> tgPointer_;
 	frg::default_list_hook<Process> tgHook_;
@@ -898,11 +898,11 @@ struct ThreadGroup : std::enable_shared_from_this<ThreadGroup> {
 		return _childrenUsage;
 	}
 
-	void setProcfsLink(std::shared_ptr<procfs::Link> link) {
+	void setProcfsLink(smarter::shared_ptr<procfs::Link> link) {
 		procfsLink_ = link;
 	}
 
-	std::shared_ptr<procfs::Link> procfsLink() const {
+	smarter::shared_ptr<procfs::Link> procfsLink() const {
 		return procfsLink_;
 	}
 
@@ -1046,7 +1046,7 @@ private:
 	> _notifyQueue;
 	async::recurring_event _notifyBell;
 
-	std::shared_ptr<procfs::Link> procfsLink_;
+	smarter::shared_ptr<procfs::Link> procfsLink_;
 
 	uint64_t currentSignalSeq_ = 1;
 	// ThreadGroup-wide signal queue for signals with no thread to accept them.

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -23,15 +23,15 @@ SuperBlock procfsSuperblock;
 // LinkCompare implementation.
 // ----------------------------------------------------------------------------
 
-bool LinkCompare::operator() (const std::shared_ptr<Link> &a, const std::shared_ptr<Link> &b) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const {
 	return a->getName() < b->getName();
 }
 
-bool LinkCompare::operator() (const std::shared_ptr<Link> &link, const std::string &name) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const {
 	return link->getName() < name;
 }
 
-bool LinkCompare::operator() (const std::string &name, const std::shared_ptr<Link> &link) const {
+bool LinkCompare::operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const {
 	return name < link->getName();
 }
 
@@ -48,7 +48,7 @@ void RegularFile::serve(smarter::shared_ptr<RegularFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-RegularFile::RegularFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+RegularFile::RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("procfs.attr"), std::move(mount), std::move(link)},
 		_cached{false}, _offset{0} { }
 
@@ -139,7 +139,7 @@ void DirectoryFile::serve(smarter::shared_ptr<DirectoryFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("procfs.dir"), std::move(mount), std::move(link)},
 		_node{static_cast<DirectoryNode *>(associatedLink()->getTarget().get())},
 		_iter{_node->_entries.begin()} { }
@@ -175,16 +175,16 @@ helix::BorrowedDescriptor DirectoryFile::getPassthroughLane() {
 // Link implementation.
 // ----------------------------------------------------------------------------
 
-Link::Link(std::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsNode> target)
 : _target{std::move(target)} { }
 
-Link::Link(std::shared_ptr<FsNode> owner, std::string name, std::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsNode> owner, std::string name, smarter::shared_ptr<FsNode> target)
 : _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 	assert(_owner);
 	assert(!_name.empty());
 }
 
-std::shared_ptr<FsNode> Link::getOwner() {
+smarter::shared_ptr<FsNode> Link::getOwner() {
 	return _owner;
 }
 
@@ -194,14 +194,14 @@ std::string Link::getName() {
 	return _name;
 }
 
-std::shared_ptr<FsNode> Link::getTarget() {
+smarter::shared_ptr<FsNode> Link::getTarget() {
 	return _target;
 }
 
 void Link::unlinkSelf() {
 	assert(_target->getType() == VfsType::directory);
 
-	auto node = std::static_pointer_cast<DirectoryNode>(_owner);
+	auto node = smarter::static_pointer_cast<DirectoryNode>(_owner);
 	auto err = node->directUnlink(_name);
 	assert(err == Error::success);
 }
@@ -257,7 +257,7 @@ async::result<frg::expected<Error, FileStats>> RegularNode::getStatsInternal(Thr
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-RegularNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+RegularNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: procfs RegularNode open() received illegal arguments:"
@@ -273,12 +273,12 @@ RegularNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<F
 	co_return File::constructHandle(std::move(file));
 }
 
-FutureMaybe<std::shared_ptr<FsNode>> SuperBlock::createRegular(Process *) {
+FutureMaybe<smarter::shared_ptr<FsNode>> SuperBlock::createRegular(Process *) {
 	std::cout << "posix: createRegular on procfs Superblock unsupported" << std::endl;
 	co_return nullptr;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 SuperBlock::rename(FsLink *, FsNode *, std::string) {
 	co_return Error::noSuchFile;
 };
@@ -293,34 +293,34 @@ async::result<frg::expected<Error, FsStats>> SuperBlock::getFsStats() {
 // DirectoryNode implementation.
 // ----------------------------------------------------------------------------
 
-std::shared_ptr<Link> DirectoryNode::createRootDirectory() {
-	auto node = std::make_shared<DirectoryNode>();
+smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
+	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
-	auto link = std::make_shared<Link>(std::move(node));
+	auto link = makeFsShared<Link>(std::move(node));
 	the_node->_treeLink = link.get();
 
-	auto self_link = std::make_shared<Link>(the_node->shared_from_this(), "self", std::make_shared<SelfLink>());
+	auto self_link = makeFsShared<Link>(the_node->sharedFromThis(), "self", makeFsShared<SelfLink>());
 	the_node->_entries.insert(std::move(self_link));
 
-	auto self_thread_link = std::make_shared<Link>(the_node->shared_from_this(), "thread-self", std::make_shared<SelfThreadLink>());
+	auto self_thread_link = makeFsShared<Link>(the_node->sharedFromThis(), "thread-self", makeFsShared<SelfThreadLink>());
 	the_node->_entries.insert(std::move(self_thread_link));
 
-	the_node->directMkregular("uptime", std::make_shared<UptimeNode>());
-	the_node->directMknode("mounts", std::make_shared<MountsLink>());
+	the_node->directMkregular("uptime", makeFsShared<UptimeNode>());
+	the_node->directMknode("mounts", makeFsShared<MountsLink>());
 
 	auto sysLink = the_node->directMkdir("sys");
-	auto sys = std::static_pointer_cast<DirectoryNode>(sysLink->getTarget());
+	auto sys = smarter::static_pointer_cast<DirectoryNode>(sysLink->getTarget());
 	auto kernelLink = sys->directMkdir("kernel");
-	auto kernel = std::static_pointer_cast<DirectoryNode>(kernelLink->getTarget());
+	auto kernel = smarter::static_pointer_cast<DirectoryNode>(kernelLink->getTarget());
 	auto randomLink = kernel->directMkdir("random");
-	auto random = std::static_pointer_cast<DirectoryNode>(randomLink->getTarget());
+	auto random = smarter::static_pointer_cast<DirectoryNode>(randomLink->getTarget());
 
-	kernel->directMkregular("ostype", std::make_shared<OstypeNode>());
-	kernel->directMkregular("osrelease", std::make_shared<OsreleaseNode>());
-	kernel->directMkregular("arch", std::make_shared<ArchNode>());
-	kernel->directMkregular("hostname", std::make_shared<HostnameNode>());
+	kernel->directMkregular("ostype", makeFsShared<OstypeNode>());
+	kernel->directMkregular("osrelease", makeFsShared<OsreleaseNode>());
+	kernel->directMkregular("arch", makeFsShared<ArchNode>());
+	kernel->directMkregular("hostname", makeFsShared<HostnameNode>());
 
-	random->directMkregular("boot_id", std::make_shared<BootIdNode>());
+	random->directMkregular("boot_id", makeFsShared<BootIdNode>());
 
 	return link;
 }
@@ -328,19 +328,19 @@ std::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 DirectoryNode::DirectoryNode()
 : FsNode{&procfsSuperblock}, _treeLink{nullptr} { }
 
-std::shared_ptr<Link> DirectoryNode::directMkregular(std::string name,
-		std::shared_ptr<RegularNode> regular) {
+smarter::shared_ptr<Link> DirectoryNode::directMkregular(std::string name,
+		smarter::shared_ptr<RegularNode> regular) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(regular));
+	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(regular));
 	_entries.insert(link);
 	return link;
 }
 
-std::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
+smarter::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
 	assert(_entries.find(name) == _entries.end());
-	auto node = std::make_shared<DirectoryNode>();
+	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
-	auto link = std::make_shared<Link>(shared_from_this(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(node));
 	_entries.insert(link);
 	the_node->_treeLink = link.get();
 	return link;
@@ -348,46 +348,46 @@ std::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
 
 template<typename T>
 requires requires (T t) { {t._treeLink} -> std::same_as<Link *&>; }
-std::shared_ptr<Link> DirectoryNode::directMknodeDir(std::string name, std::shared_ptr<T> dirnode) {
+smarter::shared_ptr<Link> DirectoryNode::directMknodeDir(std::string name, smarter::shared_ptr<T> dirnode) {
 	assert(_entries.find(name) == _entries.end());
 	auto dirnodePtr = dirnode.get();
-	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(dirnode));
+	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(dirnode));
 	dirnodePtr->_treeLink = link.get();
 	_entries.insert(link);
 	return link;
 }
 
-std::shared_ptr<Link> DirectoryNode::directMknode(std::string name, std::shared_ptr<FsNode> node) {
+smarter::shared_ptr<Link> DirectoryNode::directMknode(std::string name, smarter::shared_ptr<FsNode> node) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(node));
+	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	return link;
 }
 
-std::shared_ptr<Link> DirectoryNode::createProcDirectory(Process *process) {
+smarter::shared_ptr<Link> DirectoryNode::createProcDirectory(Process *process) {
 	auto link = directMkdir(std::to_string(process->pid()));
 	auto proc_dir = static_cast<DirectoryNode*>(link->getTarget().get());
 
-	proc_dir->directMknode("exe", std::make_shared<ExeLink>(process));
-	proc_dir->directMknode("root", std::make_shared<RootLink>(process));
-	proc_dir->directMknode("cwd", std::make_shared<CwdLink>(process));
-	proc_dir->directMknodeDir("fd", std::make_shared<FdDirectoryNode>(process));
-	proc_dir->directMknodeDir("fdinfo", std::make_shared<FdInfoDirectoryNode>(process));
-	proc_dir->directMkregular("maps", std::make_shared<MapNode>(process));
-	proc_dir->directMkregular("comm", std::make_shared<CommNode>(process));
-	proc_dir->directMkregular("stat", std::make_shared<StatNode>(process));
-	proc_dir->directMkregular("statm", std::make_shared<StatmNode>(process));
-	proc_dir->directMkregular("status", std::make_shared<ProcessStatusNode>(process->threadGroup()->weak_from_this()));
-	proc_dir->directMkregular("cgroup", std::make_shared<CgroupNode>(process));
-	proc_dir->directMkregular("mounts", std::make_shared<MountsNode>(process));
-	proc_dir->directMkregular("mountinfo", std::make_shared<MountInfoNode>(process));
+	proc_dir->directMknode("exe", makeFsShared<ExeLink>(process));
+	proc_dir->directMknode("root", makeFsShared<RootLink>(process));
+	proc_dir->directMknode("cwd", makeFsShared<CwdLink>(process));
+	proc_dir->directMknodeDir("fd", makeFsShared<FdDirectoryNode>(process));
+	proc_dir->directMknodeDir("fdinfo", makeFsShared<FdInfoDirectoryNode>(process));
+	proc_dir->directMkregular("maps", makeFsShared<MapNode>(process));
+	proc_dir->directMkregular("comm", makeFsShared<CommNode>(process));
+	proc_dir->directMkregular("stat", makeFsShared<StatNode>(process));
+	proc_dir->directMkregular("statm", makeFsShared<StatmNode>(process));
+	proc_dir->directMkregular("status", makeFsShared<ProcessStatusNode>(process->threadGroup()->weak_from_this()));
+	proc_dir->directMkregular("cgroup", makeFsShared<CgroupNode>(process));
+	proc_dir->directMkregular("mounts", makeFsShared<MountsNode>(process));
+	proc_dir->directMkregular("mountinfo", makeFsShared<MountInfoNode>(process));
 
 	proc_dir->directMkdir("task");
 
 	return link;
 }
 
-std::shared_ptr<Link> DirectoryNode::createProcTaskDirectory(Process *process) {
+smarter::shared_ptr<Link> DirectoryNode::createProcTaskDirectory(Process *process) {
 	auto pidProcfsLink = process->threadGroup()->procfsLink();
 	// Create /proc/[pid] on demand to minimize observable states of /proc/[pid] being visible
 	// without any /proc/[pid]/task/[tid] attached.
@@ -407,8 +407,8 @@ std::shared_ptr<Link> DirectoryNode::createProcTaskDirectory(Process *process) {
 	auto tid_link = task_dir->directMkdir(std::to_string(process->tid()));
 	auto tid_dir = static_cast<DirectoryNode *>(tid_link->getTarget().get());
 
-	tid_dir->directMkregular("comm", std::make_shared<CommNode>(process));
-	tid_dir->directMkregular("status", std::make_shared<StatusNode>(process->weak_from_this()));
+	tid_dir->directMkregular("comm", makeFsShared<CommNode>(process));
+	tid_dir->directMkregular("status", makeFsShared<StatusNode>(process->weak_from_this()));
 
 	return tid_link;
 }
@@ -417,8 +417,8 @@ VfsType DirectoryNode::getType() {
 	return VfsType::directory;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> DirectoryNode::link(std::string,
-		std::shared_ptr<FsNode>) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::link(std::string,
+		smarter::shared_ptr<FsNode>) {
 	co_return Error::noSuchFile;
 }
 
@@ -427,15 +427,15 @@ async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 	co_return FileStats{};
 }
 
-std::shared_ptr<FsLink> DirectoryNode::treeLink() {
+smarter::shared_ptr<FsLink> DirectoryNode::treeLink() {
 	assert(_treeLink);
-	auto s = _treeLink->shared_from_this();
+	auto s = _treeLink->sharedFromThis();
 	assert(s);
 	return s;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: procfs DirectoryNode open() received illegal arguments:"
@@ -451,7 +451,7 @@ DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;
@@ -1159,7 +1159,7 @@ void FdDirectoryFile::serve(smarter::shared_ptr<FdDirectoryFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-FdDirectoryFile::FdDirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, Process *process)
+FdDirectoryFile::FdDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, Process *process)
 : FileWithDefaults{FileKind::unknown,  StructName::get("procfs.fddir"), std::move(mount), std::move(link)},
 		_process{process->weak_from_this()}, _fileTable{process->fileContext()->fileTable()}, _iter{_fileTable.begin()} {}
 
@@ -1200,15 +1200,15 @@ async::result<frg::expected<Error, FileStats>> FdDirectoryNode::getStats() {
 	co_return FileStats{};
 }
 
-std::shared_ptr<FsLink> FdDirectoryNode::treeLink() {
+smarter::shared_ptr<FsLink> FdDirectoryNode::treeLink() {
 	assert(_treeLink);
-	auto s = _treeLink->shared_from_this();
+	auto s = _treeLink->sharedFromThis();
 	assert(s);
 	return s;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-FdDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+FdDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: procfs FdDirectoryNode open() received illegal arguments:"
@@ -1228,7 +1228,7 @@ FdDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_p
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FdDirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdDirectoryNode::getLink(std::string name) {
 	auto p = _process.lock();
 	if (!p)
 		co_return Error::noSuchProcess;
@@ -1236,13 +1236,13 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FdDirectoryNode::ge
 	for(const auto &[fdnum, fd] : p->fileContext()->fileTable()) {
 		if(name != std::to_string(fdnum))
 			continue;
-		auto pointee = std::make_shared<SymlinkNode>(p.get(), fd.file->associatedMount(), fd.file->associatedLink());
-		co_return std::make_shared<Link>(shared_from_this(), name, pointee);
+		auto pointee = makeFsShared<SymlinkNode>(p.get(), fd.file->associatedMount(), fd.file->associatedLink());
+		co_return makeFsShared<Link>(sharedFromThis(), name, pointee);
 	}
 	co_return Error::noSuchFile;
 }
 
-SymlinkNode::SymlinkNode(Process* proc, std::shared_ptr<MountView> mount, std::weak_ptr<FsLink> link)
+SymlinkNode::SymlinkNode(Process* proc, std::shared_ptr<MountView> mount, smarter::weak_ptr<FsLink> link)
 : _process{proc->weak_from_this()}, _mount{std::move(mount)}, _link{std::move(link)} { }
 
 expected<std::string> SymlinkNode::readSymlink(FsLink *, Process *process) {
@@ -1406,15 +1406,15 @@ async::result<frg::expected<Error, FileStats>> FdInfoDirectoryNode::getStats() {
 	co_return FileStats{};
 }
 
-std::shared_ptr<FsLink> FdInfoDirectoryNode::treeLink() {
+smarter::shared_ptr<FsLink> FdInfoDirectoryNode::treeLink() {
 	assert(_treeLink);
-	auto s = _treeLink->shared_from_this();
+	auto s = _treeLink->sharedFromThis();
 	assert(s);
 	return s;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-FdInfoDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+FdInfoDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: procfs FdInfoDirectoryNode open() received illegal arguments:"
@@ -1434,7 +1434,7 @@ FdInfoDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, std::shar
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FdInfoDirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdInfoDirectoryNode::getLink(std::string name) {
 	if(!std::all_of(name.begin(), name.end(), isdigit))
 		co_return Error::noSuchFile;
 
@@ -1445,8 +1445,8 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>> FdInfoDirectoryNode
 	auto nameNum = std::stoi(name);
 	if(p->fileContext()->fileTable().contains(nameNum)) {
 		auto file = p->fileContext()->fileTable().at(nameNum).file;
-		auto pointee = std::make_shared<FdInfoNode>(file->associatedMount(), file);
-		co_return std::make_shared<Link>(shared_from_this(), name, pointee);
+		auto pointee = makeFsShared<FdInfoNode>(file->associatedMount(), file);
+		co_return makeFsShared<Link>(sharedFromThis(), name, pointee);
 	}
 
 	co_return Error::noSuchFile;
@@ -1459,7 +1459,7 @@ void FdInfoDirectoryFile::serve(smarter::shared_ptr<FdInfoDirectoryFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-FdInfoDirectoryFile::FdInfoDirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, Process* process)
+FdInfoDirectoryFile::FdInfoDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, Process* process)
 : FileWithDefaults{FileKind::unknown,  StructName::get("procfs.fdinfodir"), std::move(mount), std::move(link)},
 		_process{process->weak_from_this()}, _fileTable{process->fileContext()->fileTable()}, _iter{_fileTable.begin()} {}
 
@@ -1505,7 +1505,7 @@ async::result<void> FdInfoNode::store(std::string) {
 
 } // namespace procfs
 
-std::shared_ptr<FsLink> getProcfs() {
-	static std::shared_ptr<FsLink> procfs = procfs::DirectoryNode::createRootDirectory();
+smarter::shared_ptr<FsLink> getProcfs() {
+	static smarter::shared_ptr<FsLink> procfs = procfs::DirectoryNode::createRootDirectory();
 	return procfs;
 }

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -23,16 +23,16 @@ struct DirectoryNode;
 struct LinkCompare {
 	struct is_transparent { };
 
-	bool operator() (const std::shared_ptr<Link> &a, const std::shared_ptr<Link> &b) const;
-	bool operator() (const std::shared_ptr<Link> &link, const std::string &name) const;
-	bool operator() (const std::string &name, const std::shared_ptr<Link> &link) const;
+	bool operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const;
+	bool operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const;
+	bool operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const;
 };
 
 struct RegularFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<RegularFile> file);
 
-	explicit RegularFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link);
+	explicit RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
 
 	void handleClose() override;
 
@@ -65,7 +65,7 @@ struct DirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<DirectoryFile> file);
 
-	explicit DirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link);
+	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
 
 	void handleClose() override;
 
@@ -80,27 +80,27 @@ private:
 	async::cancellation_event _cancelServe;
 
 	DotEntriesPhase _dots = DotEntriesPhase::dot;
-	std::set<std::shared_ptr<Link>, LinkCompare>::iterator _iter;
+	std::set<smarter::shared_ptr<Link>, LinkCompare>::iterator _iter;
 };
 
-struct Link final : FsLink, std::enable_shared_from_this<Link> {
-	explicit Link(std::shared_ptr<FsNode> target);
+struct Link final : FsLink {
+	explicit Link(smarter::shared_ptr<FsNode> target);
 
-	explicit Link(std::shared_ptr<FsNode> owner,
-			std::string name, std::shared_ptr<FsNode> target);
+	explicit Link(smarter::shared_ptr<FsNode> owner,
+			std::string name, smarter::shared_ptr<FsNode> target);
 
-	std::shared_ptr<FsNode> getOwner() override;
+	smarter::shared_ptr<FsNode> getOwner() override;
 	std::string getName() override;
-	std::shared_ptr<FsNode> getTarget() override;
+	smarter::shared_ptr<FsNode> getTarget() override;
 	void unlinkSelf();
 
 private:
-	std::shared_ptr<FsNode> _owner;
+	smarter::shared_ptr<FsNode> _owner;
 	std::string _name;
-	std::shared_ptr<FsNode> _target;
+	smarter::shared_ptr<FsNode> _target;
 };
 
-struct RegularNode : FsNode, std::enable_shared_from_this<RegularNode> {
+struct RegularNode : FsNode {
 	friend struct RegularFile;
 
 	RegularNode();
@@ -109,7 +109,7 @@ struct RegularNode : FsNode, std::enable_shared_from_this<RegularNode> {
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 
 protected:
@@ -125,9 +125,9 @@ public:
 		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
 	}
 
-	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override;
+	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override;
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 			rename(FsLink *source, FsNode *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
@@ -143,49 +143,49 @@ private:
 	unsigned int deviceMinor_;
 };
 
-struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode> {
+struct DirectoryNode final : FsNode {
 	friend struct DirectoryFile;
 
-	static std::shared_ptr<Link> createRootDirectory();
+	static smarter::shared_ptr<Link> createRootDirectory();
 
 	DirectoryNode();
 
-	std::shared_ptr<Link> directMkregular(std::string name,
-			std::shared_ptr<RegularNode> regular);
+	smarter::shared_ptr<Link> directMkregular(std::string name,
+			smarter::shared_ptr<RegularNode> regular);
 
 	template<typename T>
 	requires requires (T t) { {t._treeLink} -> std::same_as<Link *&>; }
-	std::shared_ptr<Link> directMknodeDir(std::string name, std::shared_ptr<T> node);
+	smarter::shared_ptr<Link> directMknodeDir(std::string name, smarter::shared_ptr<T> node);
 
-	std::shared_ptr<Link> directMknode(std::string name,
-			std::shared_ptr<FsNode> node);
-	std::shared_ptr<Link> directMkdir(std::string name);
+	smarter::shared_ptr<Link> directMknode(std::string name,
+			smarter::shared_ptr<FsNode> node);
+	smarter::shared_ptr<Link> directMkdir(std::string name);
 
-	std::shared_ptr<Link> createProcTaskDirectory(Process *process);
+	smarter::shared_ptr<Link> createProcTaskDirectory(Process *process);
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
-	std::shared_ptr<FsLink> treeLink() override;
+	smarter::shared_ptr<FsLink> treeLink() override;
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> link(std::string name,
-			std::shared_ptr<FsNode> target) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(std::string name,
+			smarter::shared_ptr<FsNode> target) override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override;
 	async::result<frg::expected<Error>> unlink(std::string name) override;
 
 	Error directUnlink(std::string name);
 
 private:
-	std::shared_ptr<Link> createProcDirectory(Process *process);
+	smarter::shared_ptr<Link> createProcDirectory(Process *process);
 
 	Link *_treeLink;
-	std::set<std::shared_ptr<Link>, LinkCompare> _entries;
+	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
 };
 
-struct LinkNode : FsNode, std::enable_shared_from_this<LinkNode> {
+struct LinkNode : FsNode {
 	LinkNode();
 
 	VfsType getType() override {
@@ -196,7 +196,7 @@ protected:
 	async::result<frg::expected<Error, FileStats>> getStatsInternal(Process *);
 };
 
-struct SelfLink final : LinkNode, std::enable_shared_from_this<SelfLink> {
+struct SelfLink final : LinkNode {
 	SelfLink() = default;
 
 	expected<std::string> readSymlink(FsLink *link, Process *process) override;
@@ -204,7 +204,7 @@ struct SelfLink final : LinkNode, std::enable_shared_from_this<SelfLink> {
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 };
 
-struct SelfThreadLink final : LinkNode, std::enable_shared_from_this<SelfThreadLink> {
+struct SelfThreadLink final : LinkNode {
 	SelfThreadLink() = default;
 
 	expected<std::string> readSymlink(FsLink *link, Process *process) override;
@@ -212,7 +212,7 @@ struct SelfThreadLink final : LinkNode, std::enable_shared_from_this<SelfThreadL
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 };
 
-struct ExeLink final : LinkNode, std::enable_shared_from_this<ExeLink> {
+struct ExeLink final : LinkNode {
 	ExeLink(Process *process);
 
 	expected<std::string> readSymlink(FsLink *link, Process *process) override;
@@ -222,7 +222,7 @@ private:
 	std::weak_ptr<Process> _process;
 };
 
-struct RootLink final : LinkNode, std::enable_shared_from_this<RootLink> {
+struct RootLink final : LinkNode {
 	RootLink(Process *process);
 
 	expected<std::string> readSymlink(FsLink *link, Process *process) override;
@@ -232,7 +232,7 @@ private:
 	std::weak_ptr<Process> _process;
 };
 
-struct CwdLink final : LinkNode, std::enable_shared_from_this<CwdLink> {
+struct CwdLink final : LinkNode {
 	CwdLink(Process *process);
 
 	expected<std::string> readSymlink(FsLink *link, Process *process) override;
@@ -242,7 +242,7 @@ private:
 	std::weak_ptr<Process> _process;
 };
 
-struct MountsLink final : LinkNode, std::enable_shared_from_this<MountsLink> {
+struct MountsLink final : LinkNode {
 	MountsLink() = default;
 
 	expected<std::string> readSymlink(FsLink *link, Process *process) override;
@@ -368,7 +368,7 @@ struct FdDirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<FdDirectoryFile> file);
 
-	explicit FdDirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, Process *process);
+	explicit FdDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, Process *process);
 
 	void handleClose() override;
 
@@ -397,7 +397,7 @@ private:
 	std::weak_ptr<Process> _process;
 };
 
-struct FdDirectoryNode final : FsNode, std::enable_shared_from_this<FdDirectoryNode> {
+struct FdDirectoryNode final : FsNode {
 public:
 	friend DirectoryNode;
 
@@ -406,17 +406,17 @@ public:
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	std::shared_ptr<FsLink> treeLink() override;
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override;
+	smarter::shared_ptr<FsLink> treeLink() override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override;
 private:
 	std::weak_ptr<Process> _process;
 	Link *_treeLink;
 };
 
-struct SymlinkNode final : LinkNode, std::enable_shared_from_this<SymlinkNode> {
-	SymlinkNode(Process *, std::shared_ptr<MountView>, std::weak_ptr<FsLink>);
+struct SymlinkNode final : LinkNode {
+	SymlinkNode(Process *, std::shared_ptr<MountView>, smarter::weak_ptr<FsLink>);
 
 	expected<std::string> readSymlink(FsLink *link, Process *process) override;
 
@@ -424,7 +424,7 @@ struct SymlinkNode final : LinkNode, std::enable_shared_from_this<SymlinkNode> {
 private:
 	std::weak_ptr<Process> _process;
 	std::shared_ptr<MountView> _mount;
-	std::weak_ptr<FsLink> _link;
+	smarter::weak_ptr<FsLink> _link;
 };
 
 struct MountsNode final : RegularNode {
@@ -451,7 +451,7 @@ private:
 	std::weak_ptr<Process> _process;
 };
 
-struct FdInfoDirectoryNode final : FsNode, std::enable_shared_from_this<FdInfoDirectoryNode> {
+struct FdInfoDirectoryNode final : FsNode {
 public:
 	friend DirectoryNode;
 
@@ -460,10 +460,10 @@ public:
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	std::shared_ptr<FsLink> treeLink() override;
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override;
+	smarter::shared_ptr<FsLink> treeLink() override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override;
 private:
 	std::weak_ptr<Process> _process;
 	Link *_treeLink;
@@ -473,7 +473,7 @@ struct FdInfoDirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<FdInfoDirectoryFile> file);
 
-	explicit FdInfoDirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, Process* process);
+	explicit FdInfoDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, Process* process);
 
 	void handleClose() override;
 
@@ -504,4 +504,4 @@ private:
 
 } // namespace procfs
 
-std::shared_ptr<FsLink> getProcfs();
+smarter::shared_ptr<FsLink> getProcfs();

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -34,7 +34,7 @@ bool logAttrs = false;
 
 int nextPtsIndex = 0;
 
-extern std::shared_ptr<RootLink> globalRootLink;
+extern smarter::shared_ptr<RootLink> globalRootLink;
 
 //-----------------------------------------------------------------------------
 
@@ -292,12 +292,12 @@ public:
 		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
 	}
 
-	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override {
+	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override {
 		std::cout << "posix: createRegular on PtsSuperblock unsupported" << std::endl;
 		co_return nullptr;
 	}
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 			rename(FsLink *, FsNode *, std::string) override {
 		co_return Error::noSuchFile;
 	}
@@ -339,7 +339,7 @@ struct MasterDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 };
 
@@ -351,7 +351,7 @@ struct SlaveDevice final : UnixDevice, std::enable_shared_from_this<SlaveDevice>
 	}
 
 	async::result<frg::expected<Error, SharedFilePtr>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 
 private:
@@ -373,7 +373,7 @@ public:
 				file, &File::fileOperations, file->cancelServe_));
 	}
 
-	MasterFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	MasterFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			bool nonBlocking);
 
 	async::result<std::expected<size_t, Error>>
@@ -444,7 +444,7 @@ public:
 				file, &File::fileOperations, file->cancelServe_));
 	}
 
-	SlaveFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	SlaveFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			std::shared_ptr<Channel> channel, bool nonBlock, bool read, bool write);
 
 	async::result<std::expected<size_t, Error>>
@@ -509,19 +509,19 @@ private:
 
 struct Link final : FsLink {
 public:
-	explicit Link(RootNode *root, std::string name, std::shared_ptr<DeviceNode> device)
+	explicit Link(RootNode *root, std::string name, smarter::shared_ptr<DeviceNode> device)
 	: _root{root}, _name{std::move(name)}, _device{std::move(device)} { }
 
-	std::shared_ptr<FsNode> getOwner() override;
+	smarter::shared_ptr<FsNode> getOwner() override;
 
 	std::string getName() override;
 
-	std::shared_ptr<FsNode> getTarget() override;
+	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
 	RootNode *_root;
 	std::string _name;
-	std::shared_ptr<DeviceNode> _device;
+	smarter::shared_ptr<DeviceNode> _device;
 };
 
 struct RootLink final : FsLink {
@@ -531,7 +531,7 @@ struct RootLink final : FsLink {
 		return _root.get();
 	}
 
-	std::shared_ptr<FsNode> getOwner() override {
+	smarter::shared_ptr<FsNode> getOwner() override {
 		throw std::logic_error("posix: pts RootLink has no owner");
 	}
 
@@ -539,23 +539,23 @@ struct RootLink final : FsLink {
 		throw std::logic_error("posix: pts RootLink has no name");
 	}
 
-	std::shared_ptr<FsNode> getTarget() override;
+	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
-	std::shared_ptr<RootNode> _root;
+	smarter::shared_ptr<RootNode> _root;
 };
 
 struct LinkCompare {
 	struct is_transparent { };
 
-	bool operator() (const std::shared_ptr<Link> &link, const std::string &name) const {
+	bool operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const {
 		return link->getName() < name;
 	}
-	bool operator() (const std::string &name, const std::shared_ptr<Link> &link) const {
+	bool operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const {
 		return name < link->getName();
 	}
 
-	bool operator() (const std::shared_ptr<Link> &a, const std::shared_ptr<Link> &b) const {
+	bool operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const {
 		return a->getName() < b->getName();
 	}
 };
@@ -583,7 +583,7 @@ public:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *process, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		return openDevice(process, _type, _id, std::move(mount), std::move(link), semantic_flags);
 	}
@@ -605,7 +605,7 @@ private:
 	gid_t gid_ = 0;
 };
 
-struct RootNode final : FsNode, std::enable_shared_from_this<RootNode> {
+struct RootNode final : FsNode {
 	friend struct Superblock;
 	friend struct DirectoryFile;
 
@@ -616,12 +616,12 @@ public:
 		return VfsType::directory;
 	}
 
-	void linkDevice(std::string name, std::shared_ptr<DeviceNode> node) {
-		auto link = std::make_shared<Link>(this, name, std::move(node));
+	void linkDevice(std::string name, smarter::shared_ptr<DeviceNode> node) {
+		auto link = makeFsShared<Link>(this, name, std::move(node));
 		_entries.insert(std::move(link));
 	}
 
-	std::shared_ptr<FsLink> treeLink() override {
+	smarter::shared_ptr<FsLink> treeLink() override {
 		return globalRootLink;
 	}
 
@@ -630,7 +630,7 @@ public:
 		co_return FileStats{};
 	}
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 	getLink(std::string name) override {
 		auto it = _entries.find(name);
 		if(it != _entries.end())
@@ -639,7 +639,7 @@ public:
 	}
 
 private:
-	std::set<std::shared_ptr<Link>, LinkCompare> _entries;
+	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
 };
 
 async::result<void>
@@ -894,7 +894,7 @@ Channel::commonIoctl(managarm::fs::GenericIoctlRequest req, helix::BorrowedDescr
 //-----------------------------------------------------------------------------
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-MasterDevice::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+MasterDevice::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: pts MasterDevice open() received illegal arguments:"
@@ -911,7 +911,7 @@ MasterDevice::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<
 	co_return File::constructHandle(std::move(file));
 }
 
-MasterFile::MasterFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+MasterFile::MasterFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		bool nonBlocking)
 : FileWithDefaults{FileKind::unknown,  StructName::get("pts.master"), std::move(mount), std::move(link), File::defaultPipeLikeSeek},
 		_channel{std::make_shared<Channel>(nextPtsIndex++)}, _nonBlocking{nonBlocking} {
@@ -919,7 +919,7 @@ MasterFile::MasterFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink>
 	charRegistry.install(std::move(slave_device));
 
 	globalRootLink->rootNode()->linkDevice(std::to_string(_channel->ptsIndex),
-			std::make_shared<DeviceNode>(DeviceId{136, _channel->ptsIndex}));
+			makeFsShared<DeviceNode>(DeviceId{136, _channel->ptsIndex}));
 }
 
 async::result<std::expected<size_t, Error>>
@@ -1169,7 +1169,7 @@ SlaveDevice::SlaveDevice(std::shared_ptr<Channel> channel)
 }
 
 async::result<frg::expected<Error, SharedFilePtr>>
-SlaveDevice::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+SlaveDevice::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: pts SlaveDevice open() received illegal arguments:"
@@ -1188,7 +1188,7 @@ SlaveDevice::open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<F
 	co_return File::constructHandle(std::move(file));
 }
 
-SlaveFile::SlaveFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+SlaveFile::SlaveFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		std::shared_ptr<Channel> channel, bool nonBlock, bool read, bool write)
 : FileWithDefaults{FileKind::unknown,  StructName::get("pts.slave"), std::move(mount), std::move(link),
 		File::defaultIsTerminal | File::defaultPipeLikeSeek},
@@ -1502,7 +1502,7 @@ async::result<void> SlaveFile::ioctl(Process *, uint32_t, helix_ng::RecvInlineRe
 
 async::result<frg::expected<Error, std::string>>
 SlaveFile::ttyname() {
-	std::shared_ptr<FsLink> me = associatedLink();
+	smarter::shared_ptr<FsLink> me = associatedLink();
 	std::string name;
 	if(!isTerminal())
 		co_return Error::notTerminal;
@@ -1527,26 +1527,26 @@ void SlaveFile::handleClose() {
 // Link and RootLink implementation.
 //-----------------------------------------------------------------------------
 
-std::shared_ptr<FsNode> Link::getOwner() {
-	return _root->shared_from_this();
+smarter::shared_ptr<FsNode> Link::getOwner() {
+	return _root->sharedFromThis();
 }
 
 std::string Link::getName() {
 	return _name;
 }
 
-std::shared_ptr<FsNode> Link::getTarget() {
+smarter::shared_ptr<FsNode> Link::getTarget() {
 	return _device;
 }
 
 RootLink::RootLink()
-: _root(std::make_shared<RootNode>()) { }
+: _root(makeFsShared<RootNode>()) { }
 
-std::shared_ptr<FsNode> RootLink::getTarget() {
-	return _root->shared_from_this();
+smarter::shared_ptr<FsNode> RootLink::getTarget() {
+	return _root->sharedFromThis();
 }
 
-std::shared_ptr<RootLink> globalRootLink = std::make_shared<RootLink>();
+smarter::shared_ptr<RootLink> globalRootLink = makeFsShared<RootLink>();
 
 } // anonymous namespace
 
@@ -1554,7 +1554,7 @@ std::shared_ptr<UnixDevice> createMasterDevice() {
 	return std::make_shared<MasterDevice>();
 }
 
-std::shared_ptr<FsLink> getFsRoot() {
+smarter::shared_ptr<FsLink> getFsRoot() {
 	return globalRootLink;
 }
 

--- a/posix/subsystem/src/pts.hpp
+++ b/posix/subsystem/src/pts.hpp
@@ -6,6 +6,6 @@ namespace pts {
 
 std::shared_ptr<UnixDevice> createMasterDevice();
 
-std::shared_ptr<FsLink> getFsRoot();
+smarter::shared_ptr<FsLink> getFsRoot();
 
 } // namespace pts

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -291,7 +291,7 @@ HandleRequest::operator()(managarm::posix::MkfifoAtRequest &&req,
 
 	ViewPath relative_to;
 	smarter::shared_ptr<File, FileHandle> file;
-	std::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink> target_link;
 
 	if (req.fd() == AT_FDCWD) {
 		relative_to = self->fsContext()->getWorkingDirectory();
@@ -718,7 +718,7 @@ HandleRequest::operator()(managarm::posix::UnlinkAtRequest &&req,
 
 	ViewPath relative_to;
 	smarter::shared_ptr<File, FileHandle> file;
-	std::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink> target_link;
 
 	if(req.flags() & ~AT_REMOVEDIR) {
 		std::cout << "posix: UNLINKAT flag handling unimplemented with unknown flag: " << req.flags() << std::endl;
@@ -800,7 +800,7 @@ HandleRequest::operator()(managarm::posix::RmdirRequest &&req,
 		co_return std::unexpected(tailRes.error());
 	logBragiRequest(req);
 
-	std::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink> target_link;
 
 	PathResolver resolver;
 	resolver.setup(self->fsContext()->getRoot(), self->fsContext()->getWorkingDirectory(),
@@ -858,7 +858,7 @@ HandleRequest::operator()(managarm::posix::FstatAtRequest &&req,
 
 	ViewPath relative_to;
 	smarter::shared_ptr<File, FileHandle> file;
-	std::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink> target_link;
 	std::shared_ptr<MountView> target_mount;
 
 	if (req.fd() == AT_FDCWD) {
@@ -906,7 +906,7 @@ HandleRequest::operator()(managarm::posix::FstatAtRequest &&req,
 
 	// This catches cases where associatedLink is called on a file, but the file doesn't implement that.
 	// Instead of blowing up, return ENOENT.
-	if(target_link == nullptr) {
+	if(!target_link) {
 		co_await sendErrorResponse<managarm::posix::FstatAtResponse>(conversation, managarm::posix::Errors::FILE_NOT_FOUND);
 		co_return {};
 	}
@@ -917,7 +917,7 @@ HandleRequest::operator()(managarm::posix::FstatAtRequest &&req,
 	if (statsResult) {
 		constexpr int statxAttrMask = STATX_ATTR_MOUNT_ROOT;
 		int attr = 0;
-		if(target_mount && target_link == target_mount->getOrigin())
+		if(target_mount && target_link.get() == target_mount->getOrigin().get())
 			attr |= STATX_ATTR_MOUNT_ROOT;
 		auto stats = statsResult.value();
 		assert((attr & ~statxAttrMask) == 0);
@@ -1003,7 +1003,7 @@ HandleRequest::operator()(managarm::posix::FstatfsRequest &&req,
 	logRequest(logRequests, self, "FSTATFS");
 
 	smarter::shared_ptr<File, FileHandle> file;
-	std::shared_ptr<FsLink> targetLink;
+	smarter::shared_ptr<FsLink> targetLink;
 	managarm::posix::FstatfsResponse resp;
 
 	if(req.fd() >= 0) {
@@ -1019,7 +1019,7 @@ HandleRequest::operator()(managarm::posix::FstatfsRequest &&req,
 		// This catches cases where associatedLink is called on a file, but the file doesn't implement that.
 		// Instead of blowing up, return ENOENT.
 		// TODO: fstatfs can't return ENOENT, verify this is needed
-		if(targetLink == nullptr) {
+		if(!targetLink) {
 			co_await sendErrorResponse<managarm::posix::FstatfsResponse>(conversation, managarm::posix::Errors::FILE_NOT_FOUND);
 			co_return {};
 		}
@@ -1091,7 +1091,7 @@ HandleRequest::operator()(managarm::posix::FchmodAtRequest &&req,
 
 	ViewPath relative_to;
 	smarter::shared_ptr<File, FileHandle> file;
-	std::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink> target_link;
 
 	if(req.fd() == AT_FDCWD) {
 		relative_to = self->fsContext()->getWorkingDirectory();
@@ -1162,7 +1162,7 @@ HandleRequest::operator()(managarm::posix::FchownAtRequest &&req,
 
 	ViewPath relativeTo;
 	smarter::shared_ptr<File, FileHandle> file;
-	std::shared_ptr<FsLink> targetLink;
+	smarter::shared_ptr<FsLink> targetLink;
 
 	if(req.fd() == AT_FDCWD) {
 		relativeTo = self->fsContext()->getWorkingDirectory();
@@ -1236,7 +1236,7 @@ HandleRequest::operator()(managarm::posix::UtimensAtRequest &&req,
 
 	ViewPath relativeTo;
 	smarter::shared_ptr<File, FileHandle> file;
-	std::shared_ptr<FsNode> target = nullptr;
+	smarter::shared_ptr<FsNode> target = nullptr;
 
 	if(!req.path().size() && (req.flags() & AT_EMPTY_PATH)) {
 		target = self->fileContext()->getFile(req.fd())->associatedLink()->getTarget();
@@ -1363,7 +1363,7 @@ HandleRequest::operator()(managarm::posix::OpenAtRequest &&req,
 
 	ViewPath relative_to;
 	smarter::shared_ptr<File, FileHandle> file;
-	std::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink> target_link;
 
 	if(req.fd() == AT_FDCWD) {
 		relative_to = self->fsContext()->getWorkingDirectory();

--- a/posix/subsystem/src/subsystem/block.cpp
+++ b/posix/subsystem/src/subsystem/block.cpp
@@ -43,12 +43,12 @@ struct Device final : UnixDevice, drvcore::BlockDevice, std::enable_shared_from_
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
 	}
 
-	FutureMaybe<std::shared_ptr<FsLink>> mount(std::string fs_type) override {
+	FutureMaybe<smarter::shared_ptr<FsLink>> mount(std::string fs_type) override {
 		return mountExternalDevice(_lane, shared_from_this(), fs_type);
 	}
 

--- a/posix/subsystem/src/subsystem/drm.cpp
+++ b/posix/subsystem/src/subsystem/drm.cpp
@@ -27,7 +27,7 @@ struct Device final : UnixDevice, drvcore::ClassDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
 	}
@@ -58,7 +58,7 @@ struct RenderDevice final : UnixDevice, drvcore::ClassDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
 	}

--- a/posix/subsystem/src/subsystem/generic.cpp
+++ b/posix/subsystem/src/subsystem/generic.cpp
@@ -24,12 +24,12 @@ struct Device final : UnixDevice, std::enable_shared_from_this<Device> {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
 	}
 
-	FutureMaybe<std::shared_ptr<FsLink>> mount(std::string fs_type) override {
+	FutureMaybe<smarter::shared_ptr<FsLink>> mount(std::string fs_type) override {
 		return mountExternalDevice(_lane, shared_from_this(), fs_type);
 	}
 

--- a/posix/subsystem/src/subsystem/input.cpp
+++ b/posix/subsystem/src/subsystem/input.cpp
@@ -48,7 +48,7 @@ struct EventDevice final : UnixDevice, drvcore::ClassDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
 	}

--- a/posix/subsystem/src/subsystem/sound.cpp
+++ b/posix/subsystem/src/subsystem/sound.cpp
@@ -45,7 +45,7 @@ struct ControlDevice final : UnixDevice, drvcore::ClassDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(lane_, std::move(mount), std::move(link), semantic_flags);
 	}
@@ -81,7 +81,7 @@ struct PcmDevice final : UnixDevice, drvcore::ClassDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(lane_, std::move(mount), std::move(link), semantic_flags);
 	}

--- a/posix/subsystem/src/sysfs.cpp
+++ b/posix/subsystem/src/sysfs.cpp
@@ -17,12 +17,12 @@ sysfs::SysfsSuperblock sysfsSuperblock{};
 
 namespace sysfs {
 
-FutureMaybe<std::shared_ptr<FsNode>> SysfsSuperblock::createRegular(Process *) {
+FutureMaybe<smarter::shared_ptr<FsNode>> SysfsSuperblock::createRegular(Process *) {
 	std::cout << "posix: createRegular on SysfsSuperblock unsupported" << std::endl;
 	co_return nullptr;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 SysfsSuperblock::rename(FsLink *, FsNode *, std::string) {
 	co_return Error::noSuchFile;
 };
@@ -37,15 +37,15 @@ async::result<frg::expected<Error, FsStats>> SysfsSuperblock::getFsStats() {
 // LinkCompare implementation.
 // ----------------------------------------------------------------------------
 
-bool LinkCompare::operator() (const std::shared_ptr<Link> &a, const std::shared_ptr<Link> &b) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const {
 	return a->getName() < b->getName();
 }
 
-bool LinkCompare::operator() (const std::shared_ptr<Link> &link, const std::string &name) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const {
 	return link->getName() < name;
 }
 
-bool LinkCompare::operator() (const std::string &name, const std::shared_ptr<Link> &link) const {
+bool LinkCompare::operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const {
 	return name < link->getName();
 }
 
@@ -74,7 +74,7 @@ void AttributeFile::serve(smarter::shared_ptr<AttributeFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-AttributeFile::AttributeFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+AttributeFile::AttributeFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("sysfs.attr"), std::move(mount), std::move(link)},
 		_cached{false}, _offset{0} { }
 
@@ -166,7 +166,7 @@ void DirectoryFile::serve(smarter::shared_ptr<DirectoryFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("sysfs.dir"), std::move(mount), std::move(link)},
 		_node{static_cast<DirectoryNode *>(associatedLink()->getTarget().get())},
 		_iter{_node->_entries.begin()} { }
@@ -207,16 +207,16 @@ helix::BorrowedDescriptor DirectoryFile::getPassthroughLane() {
 // Link implementation.
 // ----------------------------------------------------------------------------
 
-Link::Link(std::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsNode> target)
 : _target{std::move(target)} { }
 
-Link::Link(std::shared_ptr<FsNode> owner, std::string name, std::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsNode> owner, std::string name, smarter::shared_ptr<FsNode> target)
 : _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 	assert(_owner);
 	assert(!_name.empty());
 }
 
-std::shared_ptr<FsNode> Link::getOwner() {
+smarter::shared_ptr<FsNode> Link::getOwner() {
 	return _owner;
 }
 
@@ -226,7 +226,7 @@ std::string Link::getName() {
 	return _name;
 }
 
-std::shared_ptr<FsNode> Link::getTarget() {
+smarter::shared_ptr<FsNode> Link::getTarget() {
 	return _target;
 }
 
@@ -265,7 +265,7 @@ async::result<frg::expected<Error, FileStats>> AttributeNode::getStats() {
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 AttributeNode::open(Process *, std::shared_ptr<MountView> mount,
-		std::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
+		smarter::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: sysfs AttributeNode open() received illegal arguments:"
 			<< std::bitset<32>(semantic_flags)
@@ -314,17 +314,17 @@ expected<std::string> SymlinkNode::readSymlink(FsLink *link, Process *) {
 		if(!link->getOwner())
 			break;
 		path = path.empty() ? link->getName() : link->getName() + "/" + path;
-		ref = std::static_pointer_cast<DirectoryNode>(link->getOwner());
+		ref = smarter::static_pointer_cast<DirectoryNode>(link->getOwner());
 	}
 
 	// Walk from the symlink to the root to discover the number of ../ prefixes.
-	ref = std::static_pointer_cast<DirectoryNode>(link->getOwner());
+	ref = smarter::static_pointer_cast<DirectoryNode>(link->getOwner());
 	while(true) {
 		auto link = ref->treeLink();
 		if(!link->getOwner())
 			break;
 		path = "../" + path;
-		ref = std::static_pointer_cast<DirectoryNode>(link->getOwner());
+		ref = smarter::static_pointer_cast<DirectoryNode>(link->getOwner());
 	}
 
 	co_return path;
@@ -334,10 +334,10 @@ expected<std::string> SymlinkNode::readSymlink(FsLink *link, Process *) {
 // DirectoryNode implementation.
 // ----------------------------------------------------------------------------
 
-std::shared_ptr<Link> DirectoryNode::createRootDirectory() {
-	auto node = std::make_shared<DirectoryNode>();
+smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
+	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
-	auto link = std::make_shared<Link>(std::move(node));
+	auto link = makeFsShared<Link>(std::move(node));
 	the_node->_treeLink = link.get();
 	return link;
 }
@@ -347,30 +347,30 @@ DirectoryNode::DirectoryNode()
 	inode_ = static_cast<SysfsSuperblock *>(superblock())->inodeAllocator().allocate();
 }
 
-std::shared_ptr<Link> DirectoryNode::directMkattr(Object *object, Attribute *attr) {
+smarter::shared_ptr<Link> DirectoryNode::directMkattr(Object *object, Attribute *attr) {
 	assert(_entries.find(attr->name()) == _entries.end());
-	auto node = std::make_shared<AttributeNode>(object, attr);
-	auto link = std::make_shared<Link>(shared_from_this(), attr->name(), std::move(node));
+	auto node = makeFsShared<AttributeNode>(object, attr);
+	auto link = makeFsShared<Link>(sharedFromThis(), attr->name(), std::move(node));
 	_entries.insert(link);
 	return link;
 }
 
-std::shared_ptr<Link> DirectoryNode::directMklink(std::string name, std::weak_ptr<Object> target) {
+smarter::shared_ptr<Link> DirectoryNode::directMklink(std::string name, std::weak_ptr<Object> target) {
 	assert(_entries.find(name) == _entries.end());
-	auto node = std::make_shared<SymlinkNode>(std::move(target));
-	auto link = std::make_shared<Link>(shared_from_this(), std::move(name), std::move(node));
+	auto node = makeFsShared<SymlinkNode>(std::move(target));
+	auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(node));
 	_entries.insert(link);
 	return link;
 }
 
-std::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
+smarter::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
 	auto preexisting = _entries.find(name);
 	if(preexisting != _entries.end()) {
 		return *preexisting;
 	}
-	auto node = std::make_shared<DirectoryNode>();
+	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
-	auto link = std::make_shared<Link>(shared_from_this(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(node));
 	_entries.insert(link);
 	the_node->_treeLink = link.get();
 	return link;
@@ -391,16 +391,16 @@ async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 	co_return fs;
 }
 
-std::shared_ptr<FsLink> DirectoryNode::treeLink() {
+smarter::shared_ptr<FsLink> DirectoryNode::treeLink() {
 	assert(_treeLink);
-	auto s = _treeLink->shared_from_this();
+	auto s = _treeLink->sharedFromThis();
 	assert(s);
 	return s;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 DirectoryNode::open(Process *, std::shared_ptr<MountView> mount,
-		std::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
+		smarter::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: sysfs DirectoryNode open() received illegal arguments:"
 			<< std::bitset<32>(semantic_flags)
@@ -415,7 +415,7 @@ DirectoryNode::open(Process *, std::shared_ptr<MountView> mount,
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;
@@ -439,8 +439,8 @@ Attribute::Attribute(std::string name, bool writable, size_t size)
 Object::Object(std::shared_ptr<Object> parent, std::string name)
 : _parent{std::move(parent)}, _name{std::move(name)} { }
 
-std::shared_ptr<DirectoryNode> Object::directoryNode() {
-	return std::static_pointer_cast<DirectoryNode>(_dirLink->getTarget());
+smarter::shared_ptr<DirectoryNode> Object::directoryNode() {
+	return smarter::static_pointer_cast<DirectoryNode>(_dirLink->getTarget());
 }
 
 void Object::realizeAttribute(Attribute *attr) {
@@ -472,8 +472,8 @@ void Object::addObject() {
 
 } // namespace sysfs
 
-std::shared_ptr<FsLink> getSysfs() {
-	static std::shared_ptr<FsLink> sysfs = sysfs::DirectoryNode::createRootDirectory();
+smarter::shared_ptr<FsLink> getSysfs() {
+	static smarter::shared_ptr<FsLink> sysfs = sysfs::DirectoryNode::createRootDirectory();
 	return sysfs;
 }
 

--- a/posix/subsystem/src/sysfs.hpp
+++ b/posix/subsystem/src/sysfs.hpp
@@ -30,9 +30,9 @@ public:
 		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
 	}
 
-	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override;
+	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override;
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 			rename(FsLink *source, FsNode *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
@@ -56,16 +56,16 @@ private:
 struct LinkCompare {
 	struct is_transparent { };
 
-	bool operator() (const std::shared_ptr<Link> &a, const std::shared_ptr<Link> &b) const;
-	bool operator() (const std::shared_ptr<Link> &link, const std::string &name) const;
-	bool operator() (const std::string &name, const std::shared_ptr<Link> &link) const;
+	bool operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const;
+	bool operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const;
+	bool operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const;
 };
 
 struct AttributeFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<AttributeFile> file);
 
-	explicit AttributeFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link);
+	explicit AttributeFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
 
 	void handleClose() override;
 
@@ -97,7 +97,7 @@ struct DirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<DirectoryFile> file);
 
-	explicit DirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link);
+	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
 
 	void handleClose() override;
 
@@ -113,26 +113,26 @@ private:
 	async::cancellation_event _cancelServe;
 
 	DotEntriesPhase _dots = DotEntriesPhase::dot;
-	std::set<std::shared_ptr<Link>, LinkCompare>::iterator _iter;
+	std::set<smarter::shared_ptr<Link>, LinkCompare>::iterator _iter;
 };
 
-struct Link final : FsLink, std::enable_shared_from_this<Link> {
-	explicit Link(std::shared_ptr<FsNode> target);
+struct Link final : FsLink {
+	explicit Link(smarter::shared_ptr<FsNode> target);
 
-	explicit Link(std::shared_ptr<FsNode> owner,
-			std::string name, std::shared_ptr<FsNode> target);
+	explicit Link(smarter::shared_ptr<FsNode> owner,
+			std::string name, smarter::shared_ptr<FsNode> target);
 
-	std::shared_ptr<FsNode> getOwner() override;
+	smarter::shared_ptr<FsNode> getOwner() override;
 	std::string getName() override;
-	std::shared_ptr<FsNode> getTarget() override;
+	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
-	std::shared_ptr<FsNode> _owner;
+	smarter::shared_ptr<FsNode> _owner;
 	std::string _name;
-	std::shared_ptr<FsNode> _target;
+	smarter::shared_ptr<FsNode> _target;
 };
 
-struct AttributeNode final : FsNode, std::enable_shared_from_this<AttributeNode> {
+struct AttributeNode final : FsNode {
 	friend struct AttributeFile;
 
 	AttributeNode(Object *object, Attribute *attr);
@@ -143,7 +143,7 @@ struct AttributeNode final : FsNode, std::enable_shared_from_this<AttributeNode>
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 
 private:
@@ -152,7 +152,7 @@ private:
 	uint64_t inode_;
 };
 
-struct SymlinkNode final : FsNode, std::enable_shared_from_this<SymlinkNode> {
+struct SymlinkNode final : FsNode {
 	SymlinkNode(std::weak_ptr<Object> target);
 	~SymlinkNode()  {
 		static_cast<SysfsSuperblock *>(superblock())->inodeAllocator().free(inode_);
@@ -167,32 +167,32 @@ private:
 	uint64_t inode_;
 };
 
-struct DirectoryNode final : FsNode, std::enable_shared_from_this<DirectoryNode> {
+struct DirectoryNode final : FsNode {
 	friend struct DirectoryFile;
 
-	static std::shared_ptr<Link> createRootDirectory();
+	static smarter::shared_ptr<Link> createRootDirectory();
 
 	DirectoryNode();
 	~DirectoryNode() {
 		static_cast<SysfsSuperblock *>(superblock())->inodeAllocator().free(inode_);
 	}
 
-	std::shared_ptr<Link> directMkattr(Object *object, Attribute *attr);
-	std::shared_ptr<Link> directMklink(std::string name, std::weak_ptr<Object> target);
-	std::shared_ptr<Link> directMkdir(std::string name);
+	smarter::shared_ptr<Link> directMkattr(Object *object, Attribute *attr);
+	smarter::shared_ptr<Link> directMklink(std::string name, std::weak_ptr<Object> target);
+	smarter::shared_ptr<Link> directMkdir(std::string name);
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
-	std::shared_ptr<FsLink> treeLink() override;
+	smarter::shared_ptr<FsLink> treeLink() override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override;
 
 private:
 	Link *_treeLink;
-	std::set<std::shared_ptr<Link>, LinkCompare> _entries;
+	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
 	uint64_t inode_;
 };
 
@@ -240,7 +240,7 @@ struct Object {
 		return _name;
 	}
 
-	std::shared_ptr<DirectoryNode> directoryNode();
+	smarter::shared_ptr<DirectoryNode> directoryNode();
 
 	void realizeAttribute(Attribute *attr);
 	void createSymlink(std::string name, std::shared_ptr<Object> target);
@@ -255,7 +255,7 @@ private:
 	std::shared_ptr<Object> _parent;
 	std::string _name;
 
-	std::shared_ptr<Link> _dirLink;
+	smarter::shared_ptr<Link> _dirLink;
 
 	std::unordered_map<std::string, std::shared_ptr<sysfs::Object>> classDirectories_;
 };
@@ -267,4 +267,4 @@ struct Hierarchy {
 
 } // namespace sysfs
 
-std::shared_ptr<FsLink> getSysfs();
+smarter::shared_ptr<FsLink> getSysfs();

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -185,7 +185,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> open(Process *process, std::shared_ptr<MountView> mount,
-			std::shared_ptr<FsLink> link, SemanticFlags semantic_flags) override {
+			smarter::shared_ptr<FsLink> link, SemanticFlags semantic_flags) override {
 		return openDevice(process, _type, _id, std::move(mount), std::move(link), semantic_flags);
 	}
 
@@ -212,7 +212,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> open(Process *, std::shared_ptr<MountView> mount,
-			std::shared_ptr<FsLink> link, SemanticFlags semantic_flags) override {
+			smarter::shared_ptr<FsLink> link, SemanticFlags semantic_flags) override {
 		co_return co_await fifo::openNamedChannel(mount, link, this, semantic_flags);
 	}
 
@@ -230,16 +230,16 @@ public:
 
 struct Link final : FsLink {
 public:
-	explicit Link(std::shared_ptr<FsNode> target)
+	explicit Link(smarter::shared_ptr<FsNode> target)
 	: _target(std::move(target)) { }
 
-	explicit Link(std::shared_ptr<FsNode> owner, std::string name, std::shared_ptr<FsNode> target)
+	explicit Link(smarter::shared_ptr<FsNode> owner, std::string name, smarter::shared_ptr<FsNode> target)
 	: _owner(std::move(owner)), _name(std::move(name)), _target(std::move(target)) {
 		assert(_owner);
 		assert(!_name.empty());
 	}
 
-	std::shared_ptr<FsNode> getOwner() override {
+	smarter::shared_ptr<FsNode> getOwner() override {
 		return _owner;
 	}
 
@@ -249,28 +249,28 @@ public:
 		return _name;
 	}
 
-	std::shared_ptr<FsNode> getTarget() override {
+	smarter::shared_ptr<FsNode> getTarget() override {
 		return _target;
 	}
 
 private:
-	std::shared_ptr<FsNode> _owner;
+	smarter::shared_ptr<FsNode> _owner;
 	std::string _name;
-	std::shared_ptr<FsNode> _target;
+	smarter::shared_ptr<FsNode> _target;
 };
 
 struct LinkCompare {
 	struct is_transparent { };
 
-	bool operator() (const std::shared_ptr<Link> &link, const std::string &name) const {
+	bool operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const {
 		return link->getName() < name;
 	}
 
-	bool operator() (const std::string &name, const std::shared_ptr<Link> &link) const {
+	bool operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const {
 		return name < link->getName();
 	}
 
-	bool operator() (const std::shared_ptr<Link> &a, const std::shared_ptr<Link> &b) const {
+	bool operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const {
 		return a->getName() < b->getName();
 	}
 };
@@ -281,7 +281,7 @@ struct DirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<DirectoryFile> file);
 
-	explicit DirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link);
+	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
 
 	void handleClose() override;
 
@@ -298,27 +298,27 @@ private:
 	// The '.' and '..' entries are synthesized before iterating _entries.
 	DotEntriesPhase _dots = DotEntriesPhase::dot;
 
-	std::set<std::shared_ptr<Link>, LinkCompare>::iterator _iter;
+	std::set<smarter::shared_ptr<Link>, LinkCompare>::iterator _iter;
 };
 
-struct DirectoryNode final : Node, std::enable_shared_from_this<DirectoryNode> {
+struct DirectoryNode final : Node {
 	friend struct Superblock;
 	friend struct DirectoryFile;
 
-	static std::shared_ptr<Link> createRootDirectory(Superblock *superblock, int mode, uid_t uid, gid_t gid);
+	static smarter::shared_ptr<Link> createRootDirectory(Superblock *superblock, int mode, uid_t uid, gid_t gid);
 
 private:
 	VfsType getType() override {
 		return VfsType::directory;
 	}
 
-	std::shared_ptr<FsLink> treeLink() override {
+	smarter::shared_ptr<FsLink> treeLink() override {
 		assert(_treeLink);
 		return _treeLink;
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		// we silently ignore semanticAppend for directories
 		if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite | semanticAppend)){
@@ -332,36 +332,36 @@ private:
 		co_return File::constructHandle(std::move(file));
 	}
 
-	async::result<std::expected<std::shared_ptr<FsLink>, Error>>
+	async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
 	getLinkOrCreate(Process *process, std::string name, mode_t mode, bool exclusive) override;
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> getLink(std::string name) override {
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override {
 		auto it = _entries.find(name);
 		if(it != _entries.end())
 			co_return *it;
 		co_return Error::noSuchFile;
 	}
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> link(std::string name,
-			std::shared_ptr<FsNode> target) override {
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(std::string name,
+			smarter::shared_ptr<FsNode> target) override {
 		if(!(_entries.find(name) == _entries.end()))
 			co_return Error::alreadyExists;
 		static_cast<Node *>(target.get())->adjustLinkCount(1);
-		auto link = std::make_shared<Link>(shared_from_this(), std::move(name), std::move(target));
+		auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(target));
 		_entries.insert(link);
 		co_return link;
 	}
 
-	async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 	mkdir(Process *p, std::string name, mode_t mode) override;
 
-	async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 	symlink(std::string name, std::string path) override;
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkdev(std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(std::string name,
 			VfsType type, DeviceId id) override;
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mkfifo(std::string name, mode_t mode) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkfifo(std::string name, mode_t mode) override;
 
 	async::result<frg::expected<Error>> unlink(std::string name) override {
 		auto it = _entries.find(name);
@@ -379,7 +379,7 @@ private:
 		co_return {};
 	}
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid) override;
 
 	async::result<frg::expected<Error>> rmdir(std::string name) override {
 		auto it = _entries.find(name);
@@ -410,8 +410,8 @@ public:
 
 private:
 	// TODO: This creates a circular reference -- fix this.
-	std::shared_ptr<Link> _treeLink;
-	std::set<std::shared_ptr<Link>, LinkCompare> _entries;
+	smarter::shared_ptr<Link> _treeLink;
+	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
 };
 
 // TODO: Remove this class in favor of MemoryNode.
@@ -422,7 +422,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: tmp_fs open() received illegal arguments:"
@@ -456,7 +456,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	MemoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link, SemanticFlags flags)
+	MemoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, SemanticFlags flags)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("tmpfs.regular"), std::move(mount), std::move(link)},
 	flags_{flags}, _offset{0} { }
 
@@ -507,7 +507,7 @@ struct MemoryNode final : Node {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite | semanticAppend)){
 			std::cout << "\e[31mposix: MemoryNode open() received illegal arguments:"
@@ -571,12 +571,12 @@ struct Superblock final : FsSuperblock {
 		deviceMinor_ = getUnnamedDeviceIdAllocator().allocate();
 	}
 
-	FutureMaybe<std::shared_ptr<FsNode>> createRegular(Process *) override {
-		auto node = std::make_shared<MemoryNode>(this);
+	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override {
+		auto node = makeFsShared<MemoryNode>(this);
 		co_return std::move(node);
 	}
 
-	async::result<frg::expected<Error, std::shared_ptr<FsLink>>> rename(FsLink *src_fs_link,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> rename(FsLink *src_fs_link,
 			FsNode *dest_fs_dir, std::string dest_name) override {
 		auto src_link = static_cast<Link *>(src_fs_link);
 
@@ -614,7 +614,7 @@ struct Superblock final : FsSuperblock {
 			dest_dir->_entries.erase(dest_it);
 		}
 
-		auto new_link = std::make_shared<Link>(dest_dir->shared_from_this(),
+		auto new_link = makeFsShared<Link>(dest_dir->sharedFromThis(),
 				std::move(dest_name), target);
 		src_dir->_entries.erase(it);
 		dest_dir->_entries.insert(new_link);
@@ -813,7 +813,7 @@ void DirectoryFile::handleClose() {
 	_cancelServe.cancel();
 }
 
-DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("tmpfs.dir"), std::move(mount), std::move(link)},
 		_node{static_cast<DirectoryNode *>(associatedLink()->getTarget().get())},
 		_iter{_node->_entries.begin()} { }
@@ -920,10 +920,10 @@ SocketNode::SocketNode(Superblock *superblock, mode_t mode, uid_t uid, gid_t gid
 // DirectoryNode implementation.
 // ----------------------------------------------------------------------------
 
-std::shared_ptr<Link> DirectoryNode::createRootDirectory(Superblock *superblock, int mode, uid_t uid, gid_t gid) {
-	auto node = std::make_shared<DirectoryNode>(superblock, mode, uid, gid);
+smarter::shared_ptr<Link> DirectoryNode::createRootDirectory(Superblock *superblock, int mode, uid_t uid, gid_t gid) {
+	auto node = makeFsShared<DirectoryNode>(superblock, mode, uid, gid);
 	auto the_node = node.get();
-	auto link = std::make_shared<Link>(std::move(node));
+	auto link = makeFsShared<Link>(std::move(node));
 	the_node->_treeLink = link;
 	return link;
 }
@@ -936,7 +936,7 @@ DirectoryNode::DirectoryNode(Superblock *superblock, int mode, uid_t uid, gid_t 
 	adjustLinkCount(1);
 }
 
-async::result<std::expected<std::shared_ptr<FsLink>, Error>>
+async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
 DirectoryNode::getLinkOrCreate(Process *, std::string name, mode_t mode, bool exclusive) {
 	auto linkResult = co_await getLink(name);
 	if (linkResult && !exclusive)
@@ -944,15 +944,15 @@ DirectoryNode::getLinkOrCreate(Process *, std::string name, mode_t mode, bool ex
 	else if (linkResult && exclusive)
 		co_return std::unexpected{Error::alreadyExists};
 
-	auto node = std::make_shared<MemoryNode>(static_cast<Superblock *>(superblock()));
+	auto node = makeFsShared<MemoryNode>(static_cast<Superblock *>(superblock()));
 	co_await node->chmod(mode);
-	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(node));
+	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0, false);
 	co_return link;
 }
 
-async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 DirectoryNode::mkdir(Process *proc, std::string name, mode_t mode) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
@@ -961,9 +961,9 @@ DirectoryNode::mkdir(Process *proc, std::string name, mode_t mode) {
 	auto uid = proc ? proc->threadGroup()->uid() : 0;
 	auto gid = proc ? proc->threadGroup()->gid() : 0;
 
-	auto node = std::make_shared<DirectoryNode>(static_cast<Superblock *>(superblock()), mode & ~umask, uid, gid);
+	auto node = makeFsShared<DirectoryNode>(static_cast<Superblock *>(superblock()), mode & ~umask, uid, gid);
 	auto the_node = node.get();
-	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(node));
+	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
 	the_node->_treeLink = link;
 	_entries.insert(link);
 	// Account for the new subdirectory's '..' backlink.
@@ -972,45 +972,45 @@ DirectoryNode::mkdir(Process *proc, std::string name, mode_t mode) {
 	co_return link;
 }
 
-async::result<std::variant<Error, std::shared_ptr<FsLink>>>
+async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 DirectoryNode::symlink(std::string name, std::string path) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
-	auto node = std::make_shared<SymlinkNode>(static_cast<Superblock *>(superblock()),
+	auto node = makeFsShared<SymlinkNode>(static_cast<Superblock *>(superblock()),
 			std::move(path));
-	auto link = std::make_shared<Link>(shared_from_this(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(node));
 	_entries.insert(link);
 	co_return link;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 DirectoryNode::mkdev(std::string name, VfsType type, DeviceId id) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
-	auto node = std::make_shared<DeviceNode>(static_cast<Superblock *>(superblock()),
+	auto node = makeFsShared<DeviceNode>(static_cast<Superblock *>(superblock()),
 			type, id);
-	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(node));
+	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0);
 	co_return link;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 DirectoryNode::mkfifo(std::string name, mode_t mode) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
-	auto node = std::make_shared<FifoNode>(static_cast<Superblock *>(superblock()), mode);
-	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(node));
+	auto node = makeFsShared<FifoNode>(static_cast<Superblock *>(superblock()), mode);
+	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0);
 	co_return link;
 }
 
-async::result<frg::expected<Error, std::shared_ptr<FsLink>>> DirectoryNode::mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
-	auto node = std::make_shared<SocketNode>(static_cast<Superblock *>(superblock()), mode, uid, gid);
-	auto link = std::make_shared<Link>(shared_from_this(), name, std::move(node));
+	auto node = makeFsShared<SocketNode>(static_cast<Superblock *>(superblock()), mode, uid, gid);
+	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0);
 	co_return link;
@@ -1019,11 +1019,11 @@ async::result<frg::expected<Error, std::shared_ptr<FsLink>>> DirectoryNode::mkso
 } // anonymous namespace
 
 // Ironically, this function does not create a MemoryNode.
-std::shared_ptr<FsNode> createMemoryNode(std::string path) {
-	return std::make_shared<InheritedNode>(new Superblock{}, std::move(path));
+smarter::shared_ptr<FsNode> createMemoryNode(std::string path) {
+	return makeFsShared<InheritedNode>(new Superblock{}, std::move(path));
 }
 
-std::expected<std::shared_ptr<FsLink>, Error> createRoot(Process *p, std::string options) {
+std::expected<smarter::shared_ptr<FsLink>, Error> createRoot(Process *p, std::string options) {
 	std::optional<uid_t> uid = std::nullopt;
 	std::optional<gid_t> gid = std::nullopt;
 	std::optional<mode_t> mode = std::nullopt;
@@ -1080,7 +1080,7 @@ std::expected<std::shared_ptr<FsLink>, Error> createRoot(Process *p, std::string
 	return dir;
 }
 
-std::shared_ptr<FsLink> createDevTmpFsRoot() {
+smarter::shared_ptr<FsLink> createDevTmpFsRoot() {
 	return DirectoryNode::createRootDirectory(new Superblock{"devtmpfs"}, 01777, 0, 0);
 }
 

--- a/posix/subsystem/src/tmp_fs.hpp
+++ b/posix/subsystem/src/tmp_fs.hpp
@@ -4,9 +4,9 @@
 
 namespace tmp_fs {
 
-std::shared_ptr<FsNode> createMemoryNode(std::string path);
+smarter::shared_ptr<FsNode> createMemoryNode(std::string path);
 
-std::expected<std::shared_ptr<FsLink>, Error> createRoot(Process *p, std::string options);
-std::shared_ptr<FsLink> createDevTmpFsRoot();
+std::expected<smarter::shared_ptr<FsLink>, Error> createRoot(Process *p, std::string options);
+smarter::shared_ptr<FsLink> createDevTmpFsRoot();
 
 } // namespace tmp_fs

--- a/posix/subsystem/src/un-socket.cpp
+++ b/posix/subsystem/src/un-socket.cpp
@@ -38,9 +38,8 @@ static constexpr bool logSockets = false;
 struct OpenFile;
 
 // This map associates bound sockets with FS nodes.
-// TODO: Use plain pointers instead of weak_ptrs and store a shared_ptr inside the OpenFile.
-std::map<std::weak_ptr<FsNode>, OpenFile *,
-		std::owner_less<std::weak_ptr<FsNode>>> globalBindMap;
+// TODO: Store a shared_ptr to the node inside the OpenFile.
+std::map<FsNode *, OpenFile *> globalBindMap;
 std::unordered_map<std::string, OpenFile *> abstractSocketsBindMap;
 
 std::array<int, 3> supportedSocketTypes = {
@@ -425,7 +424,7 @@ public:
 
 					// Lookup the socket associated with the node.
 					auto node = resolver.currentLink()->getTarget();
-					remote = globalBindMap.at(node);
+					remote = globalBindMap.at(node.get());
 				}
 
 			}
@@ -595,7 +594,7 @@ public:
 			assert(nodeResult);
 			auto node = nodeResult.value();
 			// Associate the current socket with the node.
-			auto res = globalBindMap.insert({std::weak_ptr<FsNode>{node->getTarget()}, this});
+			auto res = globalBindMap.insert({node->getTarget().get(), this});
 			if(!res.second)
 				co_return protocols::fs::Error::addressInUse;
 			co_return protocols::fs::Error::none;
@@ -679,7 +678,7 @@ public:
 
 			// Lookup the socket associated with the node.
 			auto node = resolver.currentLink()->getTarget();
-			auto server = globalBindMap.at(node);
+			auto server = globalBindMap.at(node.get());
 			if(socktype_ == SOCK_STREAM) {
 				server->_acceptQueue.push_back(this);
 				server->_inSeq = ++server->_currentSeq;

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -30,7 +30,7 @@ id_allocator<uint64_t> mountIdAllocator;
 // MountView implementation.
 // --------------------------------------------------------
 
-std::shared_ptr<MountView> MountView::createRoot(std::shared_ptr<FsLink> origin) {
+std::shared_ptr<MountView> MountView::createRoot(smarter::shared_ptr<FsLink> origin) {
 	return std::make_shared<MountView>(mountIdAllocator.allocate(), nullptr, nullptr, std::move(origin), ViewPath{});
 }
 
@@ -38,15 +38,15 @@ std::shared_ptr<MountView> MountView::getParent() const {
 	return _parent;
 }
 
-std::shared_ptr<FsLink> MountView::getAnchor() const {
+smarter::shared_ptr<FsLink> MountView::getAnchor() const {
 	return _anchor;
 }
 
-std::shared_ptr<FsLink> MountView::getOrigin() const {
+smarter::shared_ptr<FsLink> MountView::getOrigin() const {
 	return _origin;
 }
 
-async::result<void> MountView::mount(std::shared_ptr<FsLink> anchor, std::shared_ptr<FsLink> origin, ViewPath deviceLink) {
+async::result<void> MountView::mount(smarter::shared_ptr<FsLink> anchor, smarter::shared_ptr<FsLink> origin, ViewPath deviceLink) {
 	if (anchor) {
 		auto result = co_await anchor->obstruct();
 		(void)result;
@@ -58,7 +58,7 @@ async::result<void> MountView::mount(std::shared_ptr<FsLink> anchor, std::shared
 	// TODO: check insert return value
 }
 
-std::shared_ptr<MountView> MountView::getMount(std::shared_ptr<FsLink> link) const {
+std::shared_ptr<MountView> MountView::getMount(smarter::shared_ptr<FsLink> link) const {
 	auto it = _mounts.find(link);
 	if(it == _mounts.end())
 		return nullptr;
@@ -79,16 +79,16 @@ async::result<void> populateRootView() {
 	co_await tree->getTarget()->mkdir(nullptr, "realfs", 0555);
 
 	// TODO: Check for errors from mkdir().
-	auto dev = std::get<std::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir(nullptr, "dev", 0755));
+	auto dev = std::get<smarter::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir(nullptr, "dev", 0755));
 	co_await rootView->mount(std::move(dev), getDevtmpfs());
 
-	auto sys = std::get<std::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir(nullptr, "sys", 0755));
+	auto sys = std::get<smarter::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir(nullptr, "sys", 0755));
 	co_await rootView->mount(std::move(sys), getSysfs());
 
 	// Populate the tmpfs from the fs we are running on.
 	std::vector<
 		std::pair<
-			std::shared_ptr<FsNode>,
+			smarter::shared_ptr<FsNode>,
 			std::string
 		>
 	> stack;
@@ -157,7 +157,7 @@ async::result<void> populateRootView() {
 
 			if(resp.file_type() == managarm::fs::FileType::DIRECTORY) {
 				// TODO: Check for errors from mkdir().
-				auto link = std::get<std::shared_ptr<FsLink>>(
+				auto link = std::get<smarter::shared_ptr<FsLink>>(
 				    co_await item.first->mkdir(nullptr, resp.path(), 0755)
 				);
 				stack.push_back({link->getTarget(), item.second + "/" + resp.path()});
@@ -282,7 +282,7 @@ async::result<frg::expected<protocols::fs::Error, void>> PathResolver::resolve(R
 		}else if(name == "..") {
 			if(_currentPath == _rootPath) {
 				// We are at the root -- do not modify _currentPath at all.
-			}else if(_currentPath.second == _currentPath.first->getOrigin()) {
+			}else if(_currentPath.second.get() == _currentPath.first->getOrigin().get()) {
 				if(auto parent = _currentPath.first->getParent(); parent) {
 					auto anchor = _currentPath.first->getAnchor();
 					assert(anchor); // Non-root mounts must have anchors in their parents.
@@ -504,7 +504,7 @@ std::string ViewPath::getPath(ViewPath root) const {
 
 		// If we are at the origin of a mount point, traverse that mount point.
 		ViewPath traversed;
-		if(dir.second == dir.first->getOrigin()) {
+		if(dir.second.get() == dir.first->getOrigin().get()) {
 			if(!dir.first->getParent())
 				break;
 			auto anchor = dir.first->getAnchor();

--- a/posix/subsystem/src/vfs.hpp
+++ b/posix/subsystem/src/vfs.hpp
@@ -40,13 +40,18 @@ inline constexpr ResolveFlags resolveOpenCreate = (1 << 5);
 // If the last component does not exist, resolution fails with ENOENT. Otherwise, it fails with EEXIST.
 inline constexpr ResolveFlags resolveCreatesNonDirectory = (1 << 6);
 
-using ViewPathPair = std::pair<std::shared_ptr<MountView>, std::shared_ptr<FsLink>>;
+using ViewPathPair = std::pair<std::shared_ptr<MountView>, smarter::shared_ptr<FsLink>>;
 
 struct ViewPath : public ViewPathPair {
 	ViewPath() = default;
 
-	ViewPath(std::shared_ptr<MountView> mount, std::shared_ptr<FsLink> link)
+	ViewPath(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
 	: ViewPathPair(mount, link) {}
+
+	// smarter::shared_ptr does not compare, hence std::pair's operator== does not apply.
+	bool operator== (const ViewPath &other) const {
+		return first == other.first && second.get() == other.second.get();
+	}
 
 	std::string getPath(ViewPath root) const;
 };
@@ -54,11 +59,11 @@ struct ViewPath : public ViewPathPair {
 //! Represents a virtual view of the file system.
 //! We handle all mount point related logic in this class.
 struct MountView : std::enable_shared_from_this<MountView> {
-	static std::shared_ptr<MountView> createRoot(std::shared_ptr<FsLink> origin);
+	static std::shared_ptr<MountView> createRoot(smarter::shared_ptr<FsLink> origin);
 
 	// TODO: This is an implementation detail that could be hidden.
-	explicit MountView(uint64_t mountId, std::shared_ptr<MountView> parent, std::shared_ptr<FsLink> anchor,
-			std::shared_ptr<FsLink> origin, ViewPath deviceLink)
+	explicit MountView(uint64_t mountId, std::shared_ptr<MountView> parent, smarter::shared_ptr<FsLink> anchor,
+			smarter::shared_ptr<FsLink> origin, ViewPath deviceLink)
 	: mountId_{mountId}, _parent{std::move(parent)}, _anchor{std::move(anchor)}, _origin{std::move(origin)},
 		deviceLink_{std::move(deviceLink)}
 	{ }
@@ -68,31 +73,31 @@ struct MountView : std::enable_shared_from_this<MountView> {
 	}
 
 	std::shared_ptr<MountView> getParent() const;
-	std::shared_ptr<FsLink> getAnchor() const;
-	std::shared_ptr<FsLink> getOrigin() const;
+	smarter::shared_ptr<FsLink> getAnchor() const;
+	smarter::shared_ptr<FsLink> getOrigin() const;
 	ViewPath getDevice() const {
 		return deviceLink_;
 	}
 
-	async::result<void> mount(std::shared_ptr<FsLink> anchor, std::shared_ptr<FsLink> origin, ViewPath deviceLink = {});
+	async::result<void> mount(smarter::shared_ptr<FsLink> anchor, smarter::shared_ptr<FsLink> origin, ViewPath deviceLink = {});
 
-	std::shared_ptr<MountView> getMount(std::shared_ptr<FsLink> link) const;
+	std::shared_ptr<MountView> getMount(smarter::shared_ptr<FsLink> link) const;
 
 	struct Compare {
 		struct is_transparent { };
 
 		bool operator() (const std::shared_ptr<MountView> &a,
-				const std::shared_ptr<FsLink> &b) const {
-			return a->getAnchor() < b;
+				const smarter::shared_ptr<FsLink> &b) const {
+			return a->getAnchor().get() < b.get();
 		}
-		bool operator() (const std::shared_ptr<FsLink> &a,
+		bool operator() (const smarter::shared_ptr<FsLink> &a,
 				const std::shared_ptr<MountView> &b) const {
-			return a < b->getAnchor();
+			return a.get() < b->getAnchor().get();
 		}
 
 		bool operator() (const std::shared_ptr<MountView> &a,
 				const std::shared_ptr<MountView> &b) const {
-			return a->getAnchor() < b->getAnchor();
+			return a->getAnchor().get() < b->getAnchor().get();
 		}
 	};
 
@@ -104,8 +109,8 @@ private:
 
 	uint64_t mountId_;
 	std::shared_ptr<MountView> _parent;
-	std::shared_ptr<FsLink> _anchor;
-	std::shared_ptr<FsLink> _origin;
+	smarter::shared_ptr<FsLink> _anchor;
+	smarter::shared_ptr<FsLink> _origin;
 	ViewPath deviceLink_;
 	std::set<std::shared_ptr<MountView>, Compare> _mounts;
 };
@@ -128,7 +133,7 @@ struct PathResolver {
 		return _currentPath.first;
 	}
 
-	std::shared_ptr<FsLink> currentLink() {
+	smarter::shared_ptr<FsLink> currentLink() {
 		return _currentPath.second;
 	}
 


### PR DESCRIPTION
Mechanical refactoring. Using `smarter::shared_ptr` instead of `std::shared_ptr` allows us to manually increment / decrement the refcount which is useful if we want to add caching to `extern_fs`.