### PR TITLE
posix: Refactor VFS ownership semantics

### DIFF
--- a/posix/subsystem/src/cgroupfs.cpp
+++ b/posix/subsystem/src/cgroupfs.cpp
@@ -236,45 +236,41 @@ smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
 	auto link = makeFsShared<Link>(std::move(node));
-	the_node->_treeLink = link.get();
 
-	// the_node->directMkregular("cgroup.controllers", makeFsShared<ControllersNode>());
-	the_node->createCgroupFiles();
+	the_node->createCgroupFiles(link.get());
 
 	return link;
 }
 
 DirectoryNode::DirectoryNode()
-: FsNode{&cgroupfsSuperblock}, _treeLink{nullptr} { }
+: FsNode{&cgroupfsSuperblock} { }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkregular(std::string name,
+smarter::shared_ptr<Link> DirectoryNode::directMkregular(FsLink *parent, std::string name,
 		smarter::shared_ptr<RegularNode> regular) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = makeFsShared<Link>(treeLink(), name, std::move(regular));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(regular));
 	_entries.insert(link);
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
+smarter::shared_ptr<Link> DirectoryNode::directMkdir(FsLink *parent, std::string name) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = makeFsShared<DirectoryNode>();
-	auto the_node = node.get();
-	auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(node));
 	_entries.insert(link);
-	the_node->_treeLink = link.get();
 	return link;
 }
 
 async::result<std::variant<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::mkdir(FsLink *parent, Process *, std::string name, mode_t) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
-	auto link = createCgroupDirectory(name);
+	auto link = createCgroupDirectory(parent, name);
 	co_return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMknode(std::string name, smarter::shared_ptr<FsNode> node) {
+smarter::shared_ptr<Link> DirectoryNode::directMknode(FsLink *parent, std::string name, smarter::shared_ptr<FsNode> node) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	return link;
 }
@@ -306,11 +302,6 @@ async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 	stats.ctimeSecs = now.tv_sec;
 	stats.ctimeNanos = now.tv_nsec;
 	co_return stats;
-}
-
-smarter::shared_ptr<FsLink> DirectoryNode::treeLink() {
-	// TODO: Even the root should return a valid link.
-	return _treeLink ? _treeLink->sharedFromThis() : nullptr;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
@@ -345,18 +336,18 @@ async::result<frg::expected<Error>> DirectoryNode::unlink(std::string name) {
 	co_return frg::expected<Error>{};
 }
 
-smarter::shared_ptr<Link> DirectoryNode::createCgroupDirectory(std::string name) {
-	auto link = directMkdir(name);
+smarter::shared_ptr<Link> DirectoryNode::createCgroupDirectory(FsLink *parent, std::string name) {
+	auto link = directMkdir(parent, name);
 	auto cgroup_dir = static_cast<DirectoryNode*>(link->getTarget().get());
 
-	cgroup_dir->createCgroupFiles();
+	cgroup_dir->createCgroupFiles(link.get());
 
 	return link;
 }
 
-void DirectoryNode::createCgroupFiles() {
-	this->directMkregular("cgroup.procs", makeFsShared<ProcsNode>());
-	this->directMkregular("cgroup.controllers", makeFsShared<ControllersNode>());
+void DirectoryNode::createCgroupFiles(FsLink *parent) {
+	this->directMkregular(parent, "cgroup.procs", makeFsShared<ProcsNode>());
+	this->directMkregular(parent, "cgroup.controllers", makeFsShared<ControllersNode>());
 }
 
 async::result<std::string> ProcsNode::show() {

--- a/posix/subsystem/src/cgroupfs.cpp
+++ b/posix/subsystem/src/cgroupfs.cpp
@@ -144,13 +144,13 @@ helix::BorrowedDescriptor DirectoryFile::getPassthroughLane() {
 Link::Link(smarter::shared_ptr<FsNode> target)
 : _target{std::move(target)} { }
 
-Link::Link(smarter::shared_ptr<FsNode> owner, std::string name, smarter::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsLink> owner, std::string name, smarter::shared_ptr<FsNode> target)
 : _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 	assert(_owner);
 	assert(!_name.empty());
 }
 
-smarter::shared_ptr<FsNode> Link::getOwner() {
+smarter::shared_ptr<FsLink> Link::getParent() {
 	return _owner;
 }
 
@@ -250,7 +250,7 @@ DirectoryNode::DirectoryNode()
 smarter::shared_ptr<Link> DirectoryNode::directMkregular(std::string name,
 		smarter::shared_ptr<RegularNode> regular) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(regular));
+	auto link = makeFsShared<Link>(treeLink(), name, std::move(regular));
 	_entries.insert(link);
 	return link;
 }
@@ -259,7 +259,7 @@ smarter::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
-	auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(node));
 	_entries.insert(link);
 	the_node->_treeLink = link.get();
 	return link;
@@ -274,7 +274,7 @@ async::result<std::variant<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::m
 
 smarter::shared_ptr<Link> DirectoryNode::directMknode(std::string name, smarter::shared_ptr<FsNode> node) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
 	_entries.insert(link);
 	return link;
 }

--- a/posix/subsystem/src/cgroupfs.cpp
+++ b/posix/subsystem/src/cgroupfs.cpp
@@ -218,7 +218,7 @@ FutureMaybe<smarter::shared_ptr<FsNode>> SuperBlock::createRegular(Process *) {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-SuperBlock::rename(FsLink *, FsNode *, std::string) {
+SuperBlock::rename(FsLink *, FsLink *, std::string) {
 	co_return Error::noSuchFile;
 };
 
@@ -265,7 +265,7 @@ smarter::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
 	return link;
 }
 
-async::result<std::variant<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::mkdir(Process *, std::string name, mode_t) {
+async::result<std::variant<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::mkdir(FsLink *parent, Process *, std::string name, mode_t) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 	auto link = createCgroupDirectory(name);
@@ -283,7 +283,7 @@ VfsType DirectoryNode::getType() {
 	return VfsType::directory;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::link(std::string,
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::link(FsLink *, std::string,
 		smarter::shared_ptr<FsNode>) {
 	co_return Error::noSuchFile;
 }
@@ -330,7 +330,7 @@ DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(FsLink *, std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;

--- a/posix/subsystem/src/cgroupfs.hpp
+++ b/posix/subsystem/src/cgroupfs.hpp
@@ -79,15 +79,15 @@ private:
 struct Link final : FsLink {
 	explicit Link(smarter::shared_ptr<FsNode> target);
 
-	explicit Link(smarter::shared_ptr<FsNode> owner,
+	explicit Link(smarter::shared_ptr<FsLink> owner,
 			std::string name, smarter::shared_ptr<FsNode> target);
 
-	smarter::shared_ptr<FsNode> getOwner() override;
+	smarter::shared_ptr<FsLink> getParent() override;
 	std::string getName() override;
 	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
-	smarter::shared_ptr<FsNode> _owner;
+	smarter::shared_ptr<FsLink> _owner;
 	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
 };

--- a/posix/subsystem/src/cgroupfs.hpp
+++ b/posix/subsystem/src/cgroupfs.hpp
@@ -122,7 +122,7 @@ public:
 	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-			rename(FsLink *source, FsNode *directory, std::string name) override;
+			rename(FsLink *source, FsLink *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
 	std::string getFsType() override {
@@ -150,19 +150,19 @@ struct DirectoryNode final : FsNode {
 			smarter::shared_ptr<FsNode> node);
 	smarter::shared_ptr<Link> directMkdir(std::string name);
 	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-	mkdir(Process *, std::string name, mode_t mode) override;
+	mkdir(FsLink *parent, Process *, std::string name, mode_t mode) override;
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	smarter::shared_ptr<FsLink> treeLink() override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target) override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
 	async::result<frg::expected<Error>> unlink(std::string name) override;
 
 	async::result<Error> chmod(int) override {

--- a/posix/subsystem/src/cgroupfs.hpp
+++ b/posix/subsystem/src/cgroupfs.hpp
@@ -144,17 +144,16 @@ struct DirectoryNode final : FsNode {
 
 	DirectoryNode();
 
-	smarter::shared_ptr<Link> directMkregular(std::string name,
+	smarter::shared_ptr<Link> directMkregular(FsLink *parent, std::string name,
 			smarter::shared_ptr<RegularNode> regular);
-	smarter::shared_ptr<Link> directMknode(std::string name,
+	smarter::shared_ptr<Link> directMknode(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> node);
-	smarter::shared_ptr<Link> directMkdir(std::string name);
+	smarter::shared_ptr<Link> directMkdir(FsLink *parent, std::string name);
 	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
 	mkdir(FsLink *parent, Process *, std::string name, mode_t mode) override;
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
-	smarter::shared_ptr<FsLink> treeLink() override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target) override;
@@ -169,11 +168,10 @@ struct DirectoryNode final : FsNode {
 		co_return Error::success;
 	}
 
-	smarter::shared_ptr<Link> createCgroupDirectory(std::string name);
-	void createCgroupFiles();
+	smarter::shared_ptr<Link> createCgroupDirectory(FsLink *parent, std::string name);
+	void createCgroupFiles(FsLink *parent);
 
 private:
-	Link *_treeLink;
 	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
 };
 

--- a/posix/subsystem/src/coredump.cpp
+++ b/posix/subsystem/src/coredump.cpp
@@ -17,8 +17,8 @@ async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> creat
 	if (!resolveResult)
 		co_return resolveResult.error() | toPosixError;
 
-	auto directory = resolver.currentLink()->getTarget();
-	auto linkResult = co_await directory->getLinkOrCreate(proc, name, 0755);
+	auto directory = resolver.currentLink();
+	auto linkResult = co_await directory->getTarget()->getLinkOrCreate(directory.get(), proc, name, 0755);
 	if (!linkResult)
 		co_return linkResult.error();
 

--- a/posix/subsystem/src/coredump.cpp
+++ b/posix/subsystem/src/coredump.cpp
@@ -128,13 +128,13 @@ async::result<void> Process::coredump(TerminationState state) {
 
 	auto resizeResult = co_await file->truncate(memoryDumpOffset + memoryDumpSize);
 	if (!resizeResult) {
-		auto res[[maybe_unused]] = co_await file->associatedLink()->getOwner()->unlink(file->associatedLink()->getName());
+		auto res[[maybe_unused]] = co_await file->associatedLink()->getParentNode()->unlink(file->associatedLink()->getName());
 		co_return;
 	}
 
 	auto memory = co_await file->accessMemory();
 	if (!memory) {
-		auto res[[maybe_unused]] = co_await file->associatedLink()->getOwner()->unlink(file->associatedLink()->getName());
+		auto res[[maybe_unused]] = co_await file->associatedLink()->getParentNode()->unlink(file->associatedLink()->getName());
 		co_return;
 	}
 

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -81,11 +81,11 @@ smarter::shared_ptr<FsLink> getDevtmpfs() {
 
 async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id) {
 	size_t k = 0;
-	auto node = getDevtmpfs()->getTarget();
+	auto dirLink = getDevtmpfs();
 	while(true) {
 		size_t s = path.find('/', k);
 		if(s == std::string::npos) {
-			auto result = co_await node->mkdev(path.substr(k), type, id);
+			auto result = co_await dirLink->getTarget()->mkdev(dirLink.get(), path.substr(k), type, id);
 			assert(result);
 			break;
 		}else{
@@ -93,12 +93,12 @@ async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id
 			auto name = path.substr(k, s - k);
 			smarter::shared_ptr<FsLink> link;
 			while(true) {
-				auto linkResult = co_await node->getLink(name);
+				auto linkResult = co_await dirLink->getTarget()->getLink(dirLink.get(), name);
 				if(linkResult) {
 					link = linkResult.value();
 					break;
 				}
-				auto mkdirResult = co_await node->mkdir(nullptr, name, 0755);
+				auto mkdirResult = co_await dirLink->getTarget()->mkdir(dirLink.get(), nullptr, name, 0755);
 				if(auto linkp = std::get_if<smarter::shared_ptr<FsLink>>(&mkdirResult)) {
 					link = std::move(*linkp);
 					break;
@@ -107,7 +107,7 @@ async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id
 				assert(std::get<Error>(mkdirResult) == Error::alreadyExists);
 			}
 			k = s + 1;
-			node = link->getTarget();
+			dirLink = std::move(link);
 		}
 	}
 }

--- a/posix/subsystem/src/drvcore.cpp
+++ b/posix/subsystem/src/drvcore.cpp
@@ -95,7 +95,7 @@ Device::Device(std::shared_ptr<Device> parent, std::shared_ptr<sysfs::Object> pa
 
 std::string Device::getSysfsPath() {
 	std::string path = name();
-	auto link = directoryNode()->treeLink()->getParent();
+	auto link = dirLink()->getParent();
 	while(link->getParent()) {
 		path = link->getName() + '/' + path;
 		link = link->getParent();

--- a/posix/subsystem/src/drvcore.cpp
+++ b/posix/subsystem/src/drvcore.cpp
@@ -95,14 +95,10 @@ Device::Device(std::shared_ptr<Device> parent, std::shared_ptr<sysfs::Object> pa
 
 std::string Device::getSysfsPath() {
 	std::string path = name();
-	auto parent = directoryNode()->treeLink()->getOwner();
-	auto link = parent->treeLink().get();
-	while(true) {
-		auto owner = link->getOwner();
-		if(!owner)
-			break;
+	auto link = directoryNode()->treeLink()->getParent();
+	while(link->getParent()) {
 		path = link->getName() + '/' + path;
-		link = owner->treeLink().get();
+		link = link->getParent();
 	}
 
 	return path;

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -37,8 +37,8 @@ struct Superblock final : FsSuperblock {
 		return makedev(id.first, id.second);
 	}
 
-	smarter::shared_ptr<Node> internalizeStructural(uint64_t id, helix::UniqueLane lane);
-	smarter::shared_ptr<Node> internalizeStructural(FsLink *parent, std::string name,
+	smarter::shared_ptr<FsLink> internalizeStructural(uint64_t id, helix::UniqueLane lane);
+	smarter::shared_ptr<FsLink> internalizeStructural(FsLink *parent, std::string name,
 			uint64_t id, helix::UniqueLane lane);
 	smarter::shared_ptr<Node> internalizePeripheralNode(int64_t type, int id, helix::UniqueLane lane);
 	smarter::shared_ptr<FsLink> internalizePeripheralLink(FsLink *parent, std::string name,
@@ -496,9 +496,12 @@ private:
 		return VfsType::directory;
 	}
 
-	smarter::shared_ptr<FsLink> treeLink() override {
+public:
+	smarter::shared_ptr<FsLink> structuralLink() {
 		return smarter::shared_ptr<FsLink>{sharedFromThis(), &_treeLink};
 	}
+
+private:
 
 	bool hasTraverseLinks() override {
 		return true;
@@ -538,7 +541,7 @@ private:
 			if (resp.file_type() == managarm::fs::FileType::DIRECTORY) {
 				auto child = _sb->internalizeStructural(parent, name,
 						resp.id(), pull_node.descriptor());
-				co_return child->treeLink();
+				co_return child;
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
@@ -623,9 +626,9 @@ private:
 				auto child = _sb->internalizeStructural(parentLink.get(), path[i],
 						resp.ids()[i], pull_node.descriptor());
 				if (i != resp.ids().size() - 1)
-					parentLink = child->treeLink();
+					parentLink = child;
 				else
-					link = child->treeLink();
+					link = child;
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.ids()[i],
 						pull_node.descriptor());
@@ -667,7 +670,7 @@ private:
 
 			auto child = _sb->internalizeStructural(parent, name,
 					resp.id(), pullNode.descriptor());
-			co_return child->treeLink();
+			co_return child;
 		} else {
 			co_return resp.error() | toPosixError;
 		}
@@ -705,7 +708,7 @@ private:
 
 			auto child = _sb->internalizeStructural(parent, name,
 					resp.id(), pullNode.descriptor());
-			co_return child->treeLink();
+			co_return child;
 		} else {
 			co_return resp.error() | toPosixError;
 		}
@@ -747,7 +750,7 @@ private:
 			if(resp.file_type() == managarm::fs::FileType::DIRECTORY) {
 				auto child = _sb->internalizeStructural(parent, name,
 						resp.id(), pull_node.descriptor());
-				co_return child->treeLink();
+				co_return child;
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
@@ -786,7 +789,7 @@ private:
 			if(resp.file_type() == managarm::fs::FileType::DIRECTORY) {
 				auto child = _sb->internalizeStructural(parent, name,
 						resp.id(), pull_node.descriptor());
-				co_return child->treeLink();
+				co_return child;
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
@@ -983,28 +986,26 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 	co_return resp.error() | toPosixError;
 }
 
-smarter::shared_ptr<Node> Superblock::internalizeStructural(uint64_t id, helix::UniqueLane lane) {
+smarter::shared_ptr<FsLink> Superblock::internalizeStructural(uint64_t id, helix::UniqueLane lane) {
 	auto entry = &_activeStructural[id];
-	auto intern = entry->lock();
-	if(intern)
-		return intern;
+	if(auto intern = entry->lock(); intern)
+		return intern->structuralLink();
 
 	auto node = makeFsShared<DirectoryNode>(this, id, std::move(lane));
 	*entry = node;
-	return node;
+	return node->structuralLink();
 }
 
-smarter::shared_ptr<Node> Superblock::internalizeStructural(FsLink *parent,
+smarter::shared_ptr<FsLink> Superblock::internalizeStructural(FsLink *parent,
 		std::string name, uint64_t id, helix::UniqueLane lane) {
 	auto entry = &_activeStructural[id];
-	auto intern = entry->lock();
-	if(intern)
-		return intern;
+	if(auto intern = entry->lock(); intern)
+		return intern->structuralLink();
 
 	auto node = makeFsShared<DirectoryNode>(this, parent->sharedFromThis(),
 			std::move(name), id, std::move(lane));
 	*entry = node;
-	return node;
+	return node->structuralLink();
 }
 
 smarter::shared_ptr<Node> Superblock::internalizePeripheralNode(int64_t type,
@@ -1088,8 +1089,7 @@ async::result<frg::expected<Error, FsStats>> Superblock::getFsStats() {
 smarter::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device) {
 	auto sb = new Superblock{std::move(sb_lane), device};
 	// FIXME: 2 is the ext2fs root inode.
-	auto node = sb->internalizeStructural(2, std::move(lane));
-	return node->treeLink();
+	return sb->internalizeStructural(2, std::move(lane));
 }
 
 smarter::shared_ptr<File, FileHandle>

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -25,7 +25,7 @@ struct Superblock final : FsSuperblock {
 	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *process) override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-			rename(FsLink *source, FsNode *directory, std::string name) override;
+			rename(FsLink *source, FsLink *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
 	std::string getFsType() override {
@@ -38,10 +38,10 @@ struct Superblock final : FsSuperblock {
 	}
 
 	smarter::shared_ptr<Node> internalizeStructural(uint64_t id, helix::UniqueLane lane);
-	smarter::shared_ptr<Node> internalizeStructural(Node *owner, std::string name,
+	smarter::shared_ptr<Node> internalizeStructural(FsLink *parent, std::string name,
 			uint64_t id, helix::UniqueLane lane);
 	smarter::shared_ptr<Node> internalizePeripheralNode(int64_t type, int id, helix::UniqueLane lane);
-	smarter::shared_ptr<FsLink> internalizePeripheralLink(Node *parent, std::string name,
+	smarter::shared_ptr<FsLink> internalizePeripheralLink(FsLink *parent, std::string name,
 			smarter::shared_ptr<Node> target);
 
 private:
@@ -505,7 +505,8 @@ private:
 	}
 
 	async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
-	getLinkOrCreate(Process *process, std::string name, mode_t mode, bool exclusive) override {
+	getLinkOrCreate(FsLink *parent, Process *process, std::string name, mode_t mode,
+			bool exclusive) override {
 		assert(this->getType() == VfsType::directory);
 
 		managarm::fs::GetLinkOrCreateRequest req;
@@ -535,13 +536,13 @@ private:
 			HEL_CHECK(pull_node.error());
 
 			if (resp.file_type() == managarm::fs::FileType::DIRECTORY) {
-				auto child = _sb->internalizeStructural(this, name,
+				auto child = _sb->internalizeStructural(parent, name,
 						resp.id(), pull_node.descriptor());
 				co_return child->treeLink();
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
-				co_return _sb->internalizePeripheralLink(this, name, std::move(child));
+				co_return _sb->internalizePeripheralLink(parent, name, std::move(child));
 			}
 		} else {
 			co_return std::unexpected{resp.error() | toPosixError};
@@ -549,7 +550,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>>
-	traverseLinks(std::deque<std::string> path) override {
+	traverseLinks(FsLink *parent, std::deque<std::string> path) override {
 		managarm::fs::NodeTraverseLinksRequest req;
 		for (auto &i : path)
 			req.add_path_segments(i);
@@ -608,7 +609,7 @@ private:
 		assert(resp.links_traversed());
 		assert(resp.links_traversed() <= path.size());
 
-		auto parentNode = smarter::static_pointer_cast<Node>(sharedFromThis());
+		auto parentLink = parent->sharedFromThis();
 		for (size_t i = 0; i < resp.ids().size(); i++) {
 			auto [pull_node] = co_await helix_ng::exchangeMsgs(
 				pull_lane,
@@ -619,16 +620,16 @@ private:
 
 			if (i != resp.ids().size() - 1
 					|| resp.file_type() == managarm::fs::FileType::DIRECTORY) {
-				auto child = _sb->internalizeStructural(parentNode.get(), path[i],
+				auto child = _sb->internalizeStructural(parentLink.get(), path[i],
 						resp.ids()[i], pull_node.descriptor());
 				if (i != resp.ids().size() - 1)
-					parentNode = child;
+					parentLink = child->treeLink();
 				else
 					link = child->treeLink();
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.ids()[i],
 						pull_node.descriptor());
-				link = _sb->internalizePeripheralLink(parentNode.get(), path[i], std::move(child));
+				link = _sb->internalizePeripheralLink(parentLink.get(), path[i], std::move(child));
 			}
 		}
 
@@ -636,7 +637,7 @@ private:
 	}
 
 	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-	mkdir(Process *proc, std::string name, mode_t mode) override {
+	mkdir(FsLink *parent, Process *proc, std::string name, mode_t mode) override {
 		auto umask = proc ? proc->fsContext()->getUmask() : 0;
 
 		managarm::fs::MkdirRequest req;
@@ -664,7 +665,7 @@ private:
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pullNode.error());
 
-			auto child = _sb->internalizeStructural(this, name,
+			auto child = _sb->internalizeStructural(parent, name,
 					resp.id(), pullNode.descriptor());
 			co_return child->treeLink();
 		} else {
@@ -673,7 +674,7 @@ private:
 	}
 
 	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-	symlink(std::string name, std::string path) override {
+	symlink(FsLink *parent, std::string name, std::string path) override {
 		managarm::fs::CntRequest req;
 		req.set_req_type(managarm::fs::CntReqType::NODE_SYMLINK);
 		req.set_name_length(name.size());
@@ -702,7 +703,7 @@ private:
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pullNode.error());
 
-			auto child = _sb->internalizeStructural(this, name,
+			auto child = _sb->internalizeStructural(parent, name,
 					resp.id(), pullNode.descriptor());
 			co_return child->treeLink();
 		} else {
@@ -710,7 +711,8 @@ private:
 		}
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(std::string name, VfsType type, DeviceId id) override {
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(FsLink *parent, std::string name, VfsType type, DeviceId id) override {
+		(void)parent;
 		(void)name;
 		(void)type;
 		(void)id;
@@ -719,7 +721,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-			getLink(std::string name) override {
+			getLink(FsLink *parent, std::string name) override {
 		managarm::fs::GetLinkRequest req;
 		req.set_path(name);
 
@@ -743,20 +745,20 @@ private:
 			HEL_CHECK(pull_node.error());
 
 			if(resp.file_type() == managarm::fs::FileType::DIRECTORY) {
-				auto child = _sb->internalizeStructural(this, name,
+				auto child = _sb->internalizeStructural(parent, name,
 						resp.id(), pull_node.descriptor());
 				co_return child->treeLink();
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
-				co_return _sb->internalizePeripheralLink(this, name, std::move(child));
+				co_return _sb->internalizePeripheralLink(parent, name, std::move(child));
 			}
 		}else{
 			co_return resp.error() | toPosixError;
 		}
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target) override {
 		managarm::fs::LinkRequest req;
 		req.set_path(name);
@@ -782,13 +784,13 @@ private:
 			HEL_CHECK(pull_node.error());
 
 			if(resp.file_type() == managarm::fs::FileType::DIRECTORY) {
-				auto child = _sb->internalizeStructural(this, name,
+				auto child = _sb->internalizeStructural(parent, name,
 						resp.id(), pull_node.descriptor());
 				co_return child->treeLink();
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
-				co_return _sb->internalizePeripheralLink(this, name, std::move(child));
+				co_return _sb->internalizePeripheralLink(parent, name, std::move(child));
 			}
 		}else{
 			co_return resp.error() | toPosixError;
@@ -948,12 +950,12 @@ FutureMaybe<smarter::shared_ptr<FsNode>> Superblock::createRegular(Process *proc
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-		Superblock::rename(FsLink *source, FsNode *directory, std::string name) {
+		Superblock::rename(FsLink *source, FsLink *directory, std::string name) {
 
 	managarm::fs::RenameRequest req;
 	Link *slink = static_cast<Link *>(source);
 	Node *source_node = static_cast<Node *>(slink->getParentNode().get());
-	Node *target_node = static_cast<Node *>(directory);
+	Node *target_node = static_cast<Node *>(directory->getTarget().get());
 	smarter::shared_ptr<Node> shared_node = smarter::static_pointer_cast<Node>(source->getTarget());
 	req.set_inode_source(source_node->getInode());
 	req.set_inode_target(target_node->getInode());
@@ -977,7 +979,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 	recv_resp.reset();
 	if(resp.error() == managarm::fs::Errors::SUCCESS)
-		co_return internalizePeripheralLink(target_node, name, shared_node);
+		co_return internalizePeripheralLink(directory, name, shared_node);
 	co_return resp.error() | toPosixError;
 }
 
@@ -992,14 +994,14 @@ smarter::shared_ptr<Node> Superblock::internalizeStructural(uint64_t id, helix::
 	return node;
 }
 
-smarter::shared_ptr<Node> Superblock::internalizeStructural(Node *parent, std::string name,
-		uint64_t id, helix::UniqueLane lane) {
+smarter::shared_ptr<Node> Superblock::internalizeStructural(FsLink *parent,
+		std::string name, uint64_t id, helix::UniqueLane lane) {
 	auto entry = &_activeStructural[id];
 	auto intern = entry->lock();
 	if(intern)
 		return intern;
 
-	auto node = makeFsShared<DirectoryNode>(this, parent->treeLink(),
+	auto node = makeFsShared<DirectoryNode>(this, parent->sharedFromThis(),
 			std::move(name), id, std::move(lane));
 	*entry = node;
 	return node;
@@ -1027,14 +1029,15 @@ smarter::shared_ptr<Node> Superblock::internalizePeripheralNode(int64_t type,
 	return node;
 }
 
-smarter::shared_ptr<FsLink> Superblock::internalizePeripheralLink(Node *parent, std::string name,
-		smarter::shared_ptr<Node> target) {
-	auto entry = &_activePeripheralLinks[{parent->getInode(), name, target->getInode()}];
+smarter::shared_ptr<FsLink> Superblock::internalizePeripheralLink(FsLink *parent,
+		std::string name, smarter::shared_ptr<Node> target) {
+	auto parentInode = static_cast<Node *>(parent->getTarget().get())->getInode();
+	auto entry = &_activePeripheralLinks[{parentInode, name, target->getInode()}];
 	auto intern = entry->lock();
 	if(intern)
 		return intern;
 
-	auto link = makeFsShared<PeripheralLink>(parent->treeLink(),
+	auto link = makeFsShared<PeripheralLink>(parent->sharedFromThis(),
 			std::move(name), std::move(target));
 	*entry = link;
 	return link;

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -436,6 +436,12 @@ public:
 		return _target;
 	}
 
+	void renameTo(smarter::shared_ptr<FsLink> owner, std::string name) {
+		assert(_owner); // The root link is never renamed.
+		_owner = std::move(owner);
+		_name = std::move(name);
+	}
+
 private:
 	std::string getName() override {
 		assert(_owner);
@@ -943,9 +949,14 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 	managarm::fs::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 	recv_resp.reset();
-	if(resp.error() == managarm::fs::Errors::SUCCESS)
-		co_return internalizeLink(directory, name, shared_node);
-	co_return resp.error() | toPosixError;
+	if(resp.error() != managarm::fs::Errors::SUCCESS)
+		co_return resp.error() | toPosixError;
+
+	// _activeLinks is keyed by the owner and name, so the link has to be re-keyed.
+	_activeLinks.erase({source_node->getInode(), source->getName(), shared_node->getInode()});
+	slink->renameTo(directory->sharedFromThis(), name);
+	_activeLinks[{target_node->getInode(), name, shared_node->getInode()}] = source->sharedFromThis();
+	co_return source->sharedFromThis();
 }
 
 smarter::shared_ptr<FsLink> Superblock::internalizeRoot(uint64_t id, helix::UniqueLane lane) {

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -37,18 +37,19 @@ struct Superblock final : FsSuperblock {
 		return makedev(id.first, id.second);
 	}
 
-	smarter::shared_ptr<FsLink> internalizeStructural(uint64_t id, helix::UniqueLane lane);
+	smarter::shared_ptr<FsLink> internalizeRoot(uint64_t id, helix::UniqueLane lane);
 	smarter::shared_ptr<FsLink> internalizeStructural(FsLink *parent, std::string name,
 			uint64_t id, helix::UniqueLane lane);
+	smarter::shared_ptr<Node> internalizeDirectory(uint64_t id, helix::UniqueLane lane);
 	smarter::shared_ptr<Node> internalizePeripheralNode(int64_t type, int id, helix::UniqueLane lane);
-	smarter::shared_ptr<FsLink> internalizePeripheralLink(FsLink *parent, std::string name,
+	smarter::shared_ptr<FsLink> internalizeLink(FsLink *parent, std::string name,
 			smarter::shared_ptr<Node> target);
 
 private:
 	helix::UniqueLane _lane;
 	std::map<uint64_t, smarter::weak_ptr<DirectoryNode>> _activeStructural;
 	std::map<uint64_t, smarter::weak_ptr<Node>> _activePeripheralNodes;
-	std::map<std::tuple<uint64_t, std::string, uint64_t>, smarter::weak_ptr<FsLink>> _activePeripheralLinks;
+	std::map<std::tuple<uint64_t, std::string, uint64_t>, smarter::weak_ptr<FsLink>> _activeLinks;
 
 	std::shared_ptr<UnixDevice> device_;
 };
@@ -398,7 +399,7 @@ public:
 	: Node{inode, std::move(lane), sb} { }
 };
 
-struct Link : FsLink {
+struct Link final : FsLink {
 public:
 	smarter::shared_ptr<FsLink> getParent() override {
 		return _owner;
@@ -431,6 +432,10 @@ public:
 		co_return frg::success_tag{};
 	}
 
+	smarter::shared_ptr<FsNode> getTarget() override {
+		return _target;
+	}
+
 private:
 	std::string getName() override {
 		assert(_owner);
@@ -438,56 +443,19 @@ private:
 	}
 
 public:
-	Link() = default;
+	// Constructs the root link of the mount, which has neither an owner nor a name.
+	explicit Link(smarter::shared_ptr<FsNode> target)
+	: _target{std::move(target)} { }
 
-	Link(smarter::shared_ptr<FsLink> owner, std::string name)
-	: _owner{std::move(owner)}, _name{std::move(name)} {
+	Link(smarter::shared_ptr<FsLink> owner, std::string name, smarter::shared_ptr<FsNode> target)
+	: _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 		assert(_owner);
 	}
-
-protected:
-	~Link() = default;
 
 private:
 	smarter::shared_ptr<FsLink> _owner;
 	std::string _name;
-};
-
-// This class maintains a strong reference to the target.
-struct PeripheralLink final : Link {
-private:
-	smarter::shared_ptr<FsNode> getTarget() override {
-		return _target;
-	}
-
-public:
-	PeripheralLink(smarter::shared_ptr<FsLink> owner,
-			std::string name, smarter::shared_ptr<FsNode> target)
-	: Link{std::move(owner), std::move(name)}, _target{std::move(target)} { }
-
-private:
-	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
-};
-
-// This class is embedded in a DirectoryNode and share its lifetime.
-struct StructuralLink final : Link {
-private:
-	smarter::shared_ptr<FsNode> getTarget() override;
-
-public:
-	StructuralLink(DirectoryNode *target)
-	: _target{std::move(target)} {
-		assert(_target);
-	}
-
-	StructuralLink(smarter::shared_ptr<FsLink> owner, DirectoryNode *target, std::string name)
-	: Link{std::move(owner), std::move(name)}, _target{std::move(target)} {
-		assert(_target);
-	}
-
-private:
-	DirectoryNode *_target;
 };
 
 struct DirectoryNode final : Node {
@@ -496,12 +464,6 @@ private:
 		return VfsType::directory;
 	}
 
-public:
-	smarter::shared_ptr<FsLink> structuralLink() {
-		return smarter::shared_ptr<FsLink>{sharedFromThis(), &_treeLink};
-	}
-
-private:
 
 	bool hasTraverseLinks() override {
 		return true;
@@ -545,7 +507,7 @@ private:
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
-				co_return _sb->internalizePeripheralLink(parent, name, std::move(child));
+				co_return _sb->internalizeLink(parent, name, std::move(child));
 			}
 		} else {
 			co_return std::unexpected{resp.error() | toPosixError};
@@ -572,8 +534,6 @@ private:
 		HEL_CHECK(send_head.error());
 		HEL_CHECK(send_tail.error());
 		HEL_CHECK(recv_resp.error());
-
-		smarter::shared_ptr<FsLink> link = nullptr;
 
 		auto preamble = bragi::read_preamble(recv_resp);
 		if (preamble.error()) {
@@ -612,7 +572,10 @@ private:
 		assert(resp.links_traversed());
 		assert(resp.links_traversed() <= path.size());
 
-		auto parentLink = parent->sharedFromThis();
+		// The reply only reports inodes, so we cannot immediately tell which link they correspond to.
+		// We replay the resolution rules to associate each link with the proper parent.
+		smarter::shared_ptr<FsLink> link = nullptr;
+		std::vector<smarter::shared_ptr<FsLink>> dirStack{parent->sharedFromThis()};
 		for (size_t i = 0; i < resp.ids().size(); i++) {
 			auto [pull_node] = co_await helix_ng::exchangeMsgs(
 				pull_lane,
@@ -621,19 +584,29 @@ private:
 
 			HEL_CHECK(pull_node.error());
 
-			if (i != resp.ids().size() - 1
-					|| resp.file_type() == managarm::fs::FileType::DIRECTORY) {
-				auto child = _sb->internalizeStructural(parentLink.get(), path[i],
+			bool last = i == resp.ids().size() - 1;
+
+			if (path[i] == ".") {
+				link = dirStack.back();
+				continue;
+			}else if (path[i] == "..") {
+				assert(dirStack.size() > 1); // The server does not ascend past parent.
+				dirStack.pop_back();
+				link = dirStack.back();
+				continue;
+			}
+
+			if (!last || resp.file_type() == managarm::fs::FileType::DIRECTORY) {
+				link = _sb->internalizeStructural(dirStack.back().get(), path[i],
 						resp.ids()[i], pull_node.descriptor());
-				if (i != resp.ids().size() - 1)
-					parentLink = child;
-				else
-					link = child;
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.ids()[i],
 						pull_node.descriptor());
-				link = _sb->internalizePeripheralLink(parentLink.get(), path[i], std::move(child));
+				link = _sb->internalizeLink(dirStack.back().get(), path[i], std::move(child));
 			}
+
+			if (!last)
+				dirStack.push_back(link);
 		}
 
 		co_return std::make_pair(link, resp.links_traversed());
@@ -754,7 +727,7 @@ private:
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
-				co_return _sb->internalizePeripheralLink(parent, name, std::move(child));
+				co_return _sb->internalizeLink(parent, name, std::move(child));
 			}
 		}else{
 			co_return resp.error() | toPosixError;
@@ -793,7 +766,7 @@ private:
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
-				co_return _sb->internalizePeripheralLink(parent, name, std::move(child));
+				co_return _sb->internalizeLink(parent, name, std::move(child));
 			}
 		}else{
 			co_return resp.error() | toPosixError;
@@ -901,22 +874,11 @@ private:
 
 public:
 	DirectoryNode(Superblock *sb, uint64_t inode, helix::UniqueLane lane)
-	: Node{inode, std::move(lane), sb}, _sb{sb},
-			_treeLink{this} { }
-
-	DirectoryNode(Superblock *sb, smarter::shared_ptr<FsLink> owner, std::string name,
-			uint64_t inode, helix::UniqueLane lane)
-	: Node{inode, std::move(lane), sb}, _sb{sb},
-			_treeLink{std::move(owner), this, std::move(name)} { }
+	: Node{inode, std::move(lane), sb}, _sb{sb} { }
 
 private:
 	Superblock *_sb;
-	StructuralLink _treeLink;
 };
-
-smarter::shared_ptr<FsNode> StructuralLink::getTarget() {
-	return _target->sharedFromThis();
-}
 
 Superblock::Superblock(helix::UniqueLane lane, std::shared_ptr<UnixDevice> device)
 : _lane{std::move(lane)}, device_{device} { }
@@ -982,30 +944,28 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 	recv_resp.reset();
 	if(resp.error() == managarm::fs::Errors::SUCCESS)
-		co_return internalizePeripheralLink(directory, name, shared_node);
+		co_return internalizeLink(directory, name, shared_node);
 	co_return resp.error() | toPosixError;
 }
 
-smarter::shared_ptr<FsLink> Superblock::internalizeStructural(uint64_t id, helix::UniqueLane lane) {
+smarter::shared_ptr<FsLink> Superblock::internalizeRoot(uint64_t id, helix::UniqueLane lane) {
+	return makeFsShared<Link>(internalizeDirectory(id, std::move(lane)));
+}
+
+smarter::shared_ptr<Node> Superblock::internalizeDirectory(uint64_t id, helix::UniqueLane lane) {
 	auto entry = &_activeStructural[id];
 	if(auto intern = entry->lock(); intern)
-		return intern->structuralLink();
+		return intern;
 
 	auto node = makeFsShared<DirectoryNode>(this, id, std::move(lane));
 	*entry = node;
-	return node->structuralLink();
+	return node;
 }
 
 smarter::shared_ptr<FsLink> Superblock::internalizeStructural(FsLink *parent,
 		std::string name, uint64_t id, helix::UniqueLane lane) {
-	auto entry = &_activeStructural[id];
-	if(auto intern = entry->lock(); intern)
-		return intern->structuralLink();
-
-	auto node = makeFsShared<DirectoryNode>(this, parent->sharedFromThis(),
-			std::move(name), id, std::move(lane));
-	*entry = node;
-	return node->structuralLink();
+	return internalizeLink(parent, std::move(name),
+			internalizeDirectory(id, std::move(lane)));
 }
 
 smarter::shared_ptr<Node> Superblock::internalizePeripheralNode(int64_t type,
@@ -1030,16 +990,14 @@ smarter::shared_ptr<Node> Superblock::internalizePeripheralNode(int64_t type,
 	return node;
 }
 
-smarter::shared_ptr<FsLink> Superblock::internalizePeripheralLink(FsLink *parent,
+smarter::shared_ptr<FsLink> Superblock::internalizeLink(FsLink *parent,
 		std::string name, smarter::shared_ptr<Node> target) {
 	auto parentInode = static_cast<Node *>(parent->getTarget().get())->getInode();
-	auto entry = &_activePeripheralLinks[{parentInode, name, target->getInode()}];
-	auto intern = entry->lock();
-	if(intern)
+	auto entry = &_activeLinks[{parentInode, name, target->getInode()}];
+	if(auto intern = entry->lock(); intern)
 		return intern;
 
-	auto link = makeFsShared<PeripheralLink>(parent->sharedFromThis(),
-			std::move(name), std::move(target));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(target));
 	*entry = link;
 	return link;
 }
@@ -1089,7 +1047,7 @@ async::result<frg::expected<Error, FsStats>> Superblock::getFsStats() {
 smarter::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device) {
 	auto sb = new Superblock{std::move(sb_lane), device};
 	// FIXME: 2 is the ext2fs root inode.
-	return sb->internalizeStructural(2, std::move(lane));
+	return sb->internalizeRoot(2, std::move(lane));
 }
 
 smarter::shared_ptr<File, FileHandle>

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -400,7 +400,7 @@ public:
 
 struct Link : FsLink {
 public:
-	smarter::shared_ptr<FsNode> getOwner() override {
+	smarter::shared_ptr<FsLink> getParent() override {
 		return _owner;
 	}
 
@@ -409,7 +409,7 @@ public:
 		managarm::fs::ObstructLinkRequest req;
 		req.set_link_name(_name);
 
-		auto lane = static_cast<Node *>(_owner.get())->getLane();
+		auto lane = static_cast<Node *>(_owner->getTarget().get())->getLane();
 
 		auto [offer, send_req, send_tail, recv_resp] = co_await helix_ng::exchangeMsgs(
 			lane,
@@ -440,7 +440,7 @@ private:
 public:
 	Link() = default;
 
-	Link(smarter::shared_ptr<FsNode> owner, std::string name)
+	Link(smarter::shared_ptr<FsLink> owner, std::string name)
 	: _owner{std::move(owner)}, _name{std::move(name)} {
 		assert(_owner);
 	}
@@ -449,7 +449,7 @@ protected:
 	~Link() = default;
 
 private:
-	smarter::shared_ptr<FsNode> _owner;
+	smarter::shared_ptr<FsLink> _owner;
 	std::string _name;
 };
 
@@ -461,7 +461,7 @@ private:
 	}
 
 public:
-	PeripheralLink(smarter::shared_ptr<FsNode> owner,
+	PeripheralLink(smarter::shared_ptr<FsLink> owner,
 			std::string name, smarter::shared_ptr<FsNode> target)
 	: Link{std::move(owner), std::move(name)}, _target{std::move(target)} { }
 
@@ -481,7 +481,7 @@ public:
 		assert(_target);
 	}
 
-	StructuralLink(smarter::shared_ptr<FsNode> owner, DirectoryNode *target, std::string name)
+	StructuralLink(smarter::shared_ptr<FsLink> owner, DirectoryNode *target, std::string name)
 	: Link{std::move(owner), std::move(name)}, _target{std::move(target)} {
 		assert(_target);
 	}
@@ -899,7 +899,7 @@ public:
 	: Node{inode, std::move(lane), sb}, _sb{sb},
 			_treeLink{this} { }
 
-	DirectoryNode(Superblock *sb, smarter::shared_ptr<FsNode> owner, std::string name,
+	DirectoryNode(Superblock *sb, smarter::shared_ptr<FsLink> owner, std::string name,
 			uint64_t inode, helix::UniqueLane lane)
 	: Node{inode, std::move(lane), sb}, _sb{sb},
 			_treeLink{std::move(owner), this, std::move(name)} { }
@@ -952,7 +952,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 
 	managarm::fs::RenameRequest req;
 	Link *slink = static_cast<Link *>(source);
-	Node *source_node = static_cast<Node *>(slink->getOwner().get());
+	Node *source_node = static_cast<Node *>(slink->getParentNode().get());
 	Node *target_node = static_cast<Node *>(directory);
 	smarter::shared_ptr<Node> shared_node = smarter::static_pointer_cast<Node>(source->getTarget());
 	req.set_inode_source(source_node->getInode());
@@ -999,7 +999,7 @@ smarter::shared_ptr<Node> Superblock::internalizeStructural(Node *parent, std::s
 	if(intern)
 		return intern;
 
-	auto node = makeFsShared<DirectoryNode>(this, parent->sharedFromThis(),
+	auto node = makeFsShared<DirectoryNode>(this, parent->treeLink(),
 			std::move(name), id, std::move(lane));
 	*entry = node;
 	return node;
@@ -1034,7 +1034,7 @@ smarter::shared_ptr<FsLink> Superblock::internalizePeripheralLink(Node *parent, 
 	if(intern)
 		return intern;
 
-	auto link = makeFsShared<PeripheralLink>(parent->sharedFromThis(),
+	auto link = makeFsShared<PeripheralLink>(parent->treeLink(),
 			std::move(name), std::move(target));
 	*entry = link;
 	return link;

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -59,8 +59,8 @@ id_allocator<unsigned int> &getUnnamedDeviceIdAllocator() {
 // --------------------------------------------------------
 
 async::result<frg::expected<Error>> FsLink::obstruct() {
-	if(getOwner())
-		assert(!getOwner()->hasTraverseLinks() && "Node has traverseLinks but no obstruct?");
+	if(auto parent = getParentNode(); parent)
+		assert(!parent->hasTraverseLinks() && "Node has traverseLinks but no obstruct?");
 	co_return Error::illegalOperationTarget;
 }
 

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -18,7 +18,7 @@ struct AnonymousSuperblock : FsSuperblock {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-	rename(FsLink *, FsNode *, std::string) override {
+	rename(FsLink *, FsLink *, std::string) override {
 		co_return Error::noSuchFile;
 	}
 
@@ -99,39 +99,39 @@ void FsNode::removeObserver(FsObserver *observer) {
 }
 
 async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
-FsNode::getLinkOrCreate(Process *, std::string, mode_t, bool) {
+FsNode::getLinkOrCreate(FsLink *, Process *, std::string, mode_t, bool) {
 	std::println("posix: getLink() is not implemented for this FsNode");
 	co_return std::unexpected{Error::illegalOperationTarget};
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::getLink(std::string) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::getLink(FsLink *, std::string) {
 	std::cout << "posix: getLink() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::link(std::string, smarter::shared_ptr<FsNode>) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::link(FsLink *, std::string, smarter::shared_ptr<FsNode>) {
 	std::cout << "posix: link() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
 async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-FsNode::mkdir(Process *, std::string, mode_t) {
+FsNode::mkdir(FsLink *, Process *, std::string, mode_t) {
 	std::cout << "posix: mkdir() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
 async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-FsNode::symlink(std::string, std::string) {
+FsNode::symlink(FsLink *, std::string, std::string) {
 	std::cout << "posix: symlink() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mkdev(std::string, VfsType, DeviceId) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mkdev(FsLink *, std::string, VfsType, DeviceId) {
 	std::cout << "posix: mkdev() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mkfifo(std::string, mode_t) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mkfifo(FsLink *, std::string, mode_t) {
 	std::cout << "posix: mkfifo() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
@@ -165,7 +165,7 @@ bool FsNode::hasTraverseLinks() {
 	return false;
 }
 
-async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>> FsNode::traverseLinks(std::deque<std::string>) {
+async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>> FsNode::traverseLinks(FsLink *, std::deque<std::string>) {
 	std::cout << "posix: traverseLinks() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
@@ -192,7 +192,7 @@ async::result<Error> FsNode::utimensat(std::optional<timespec> atime, std::optio
 	co_return Error::accessDenied;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mksocket(FsLink *, std::string name, mode_t mode, uid_t uid, gid_t gid) {
 	(void) name;
 	(void) mode;
 	(void) uid;

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -77,10 +77,6 @@ async::result<frg::expected<Error, FileStats>> FsNode::getStats() {
 	co_return Error::illegalOperationTarget;
 }
 
-smarter::shared_ptr<FsLink> FsNode::treeLink() {
-	throw std::runtime_error("treeLink() is not implemented for this FsNode");
-}
-
 void FsNode::addObserver(std::shared_ptr<FsObserver> observer) {
 	if(!(_defaultOps & defaultSupportsObservers))
 		std::cout << "\e[31m" "posix: FsNode does not support observers" "\e[39m" << std::endl;

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -115,7 +115,7 @@ public:
 	virtual FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) = 0;
 
 	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-			rename(FsLink *source, FsNode *directory, std::string name) = 0;
+			rename(FsLink *source, FsLink *directory, std::string name) = 0;
 	virtual async::result<frg::expected<Error, FsStats>> getFsStats() = 0;
 	virtual std::string getFsType() = 0;
 	virtual dev_t deviceNumber() = 0;
@@ -191,28 +191,29 @@ public:
 
 	//! Get an existing link or create one (directories only).
 	virtual async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
-	getLinkOrCreate(Process *, std::string name, mode_t mode, bool exclusive = false);
+	getLinkOrCreate(FsLink *parent, Process *, std::string name, mode_t mode,
+			bool exclusive = false);
 
 	//! Resolves a file in a directory (directories only).
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name);
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name);
 
 	//! Links an existing node to this directory (directories only).
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(std::string name,
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target);
 
 	//! Creates a new directory (directories only).
 	virtual async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-	mkdir(Process *, std::string name, mode_t mode);
+	mkdir(FsLink *parent, Process *, std::string name, mode_t mode);
 
 	//! Creates a new symlink (directories only).
 	virtual async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-	symlink(std::string name, std::string path);
+	symlink(FsLink *parent, std::string name, std::string path);
 
 	//! Creates a new device file (directories only).
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(std::string name,
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(FsLink *parent, std::string name,
 			VfsType type, DeviceId id);
 
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkfifo(std::string name, mode_t mode);
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkfifo(FsLink *parent, std::string name, mode_t mode);
 
 	virtual async::result<frg::expected<Error>> unlink(std::string name);
 
@@ -241,11 +242,11 @@ public:
 	virtual async::result<Error> utimensat(std::optional<timespec> atime, std::optional<timespec> mtime, timespec ctime);
 
 	// Creates an socket
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid);
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mksocket(FsLink *parent, std::string name, mode_t mode, uid_t uid, gid_t gid);
 
 	// Recursive path traversal
 	virtual bool hasTraverseLinks();
-	virtual async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>> traverseLinks(std::deque<std::string> path);
+	virtual async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>> traverseLinks(FsLink *parent, std::deque<std::string> path);
 
 	void notifyObservers(uint32_t inotifyEvents, const std::string &name, uint32_t cookie, bool isDir = false);
 

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -181,10 +181,6 @@ public:
 	// TODO: This should be async.
 	virtual async::result<frg::expected<Error, FileStats>> getStats();
 
-	// For directories only: Returns a pointer to the link
-	// that links this directory from its parent.
-	virtual smarter::shared_ptr<FsLink> treeLink();
-
 	virtual void addObserver(std::shared_ptr<FsObserver> observer);
 
 	virtual void removeObserver(FsObserver *observer);

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -63,16 +63,34 @@ struct ViewPath;
 // FsLink class.
 // ----------------------------------------------------------------------------
 
-// Represents a directory entry on an actual file system (i.e. not in the VFS).
+// Represents a directory entry on an actual file system.
+// FsLinks know their parent FsLink. Hence, FsLinks form a rooted directory tree.
+// The chain of parents terminates at the root of the superblock, not at the root of the VFS.
 struct FsLink {
 protected:
 	~FsLink() = default;
 
 public:
-	virtual smarter::shared_ptr<FsNode> getOwner() = 0;
+	// Returns the link of the directory that this link lives in.
+	// Null for the root of a mount and for anonymous links.
+	virtual smarter::shared_ptr<FsLink> getParent() = 0;
+
+	// Name of the link. Empty for the root link.
 	virtual std::string getName() = 0;
+
+	// Target of the link:
+	// directory entry (getParent(), getName()) points to getTarget().
 	virtual smarter::shared_ptr<FsNode> getTarget() = 0;
+
 	virtual async::result<frg::expected<Error>> obstruct();
+
+	smarter::shared_ptr<FsNode> getParentNode() {
+		auto parent = getParent();
+		if(!parent)
+			return nullptr;
+		return parent->getTarget();
+	}
+
 	virtual std::optional<std::string> getProcFsDescription();
 
 	// Only to be called by makeFsShared().
@@ -284,7 +302,7 @@ public:
 		return {sharedFromThis(), &embeddedNode_};
 	}
 
-	smarter::shared_ptr<FsNode> getOwner() override {
+	smarter::shared_ptr<FsLink> getParent() override {
 		return nullptr;
 	}
 

--- a/posix/subsystem/src/main.cpp
+++ b/posix/subsystem/src/main.cpp
@@ -186,7 +186,7 @@ async::result<void> enumerateKerncfg() {
 	affinityMaskSize = (numCpuResp->num_cpu() + 7) / 8;
 
 	auto procfsRoot = smarter::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
-	procfsRoot->directMkregular("cmdline", makeFsShared<CmdlineNode>());
+	procfsRoot->directMkregular(getProcfs().get(), "cmdline", makeFsShared<CmdlineNode>());
 }
 
 async::result<void> enumeratePm() {

--- a/posix/subsystem/src/memfd.hpp
+++ b/posix/subsystem/src/memfd.hpp
@@ -87,7 +87,7 @@ public:
 		return {sharedFromThis(), &embeddedNode_};
 	}
 
-	smarter::shared_ptr<FsNode> getOwner() override {
+	smarter::shared_ptr<FsLink> getParent() override {
 		return nullptr;
 	}
 

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -1378,7 +1378,7 @@ async::result<std::shared_ptr<ThreadGroup>> Process::init(std::string path) {
 	HEL_CHECK(helGetCredentials(process->_threadDescriptor.getHandle(), 0, process->credentials_.data()));
 
 	auto procfs_root = smarter::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
-	process->procfsTaskLink_ = procfs_root->createProcTaskDirectory(process.get());
+	process->procfsTaskLink_ = procfs_root->createProcTaskDirectory(getProcfs().get(), process.get());
 
 	auto generation = std::make_shared<Generation>();
 	process->_currentGeneration = generation;
@@ -1447,7 +1447,7 @@ async::result<std::shared_ptr<Process>> Process::fork(std::shared_ptr<Process> o
 	process->threadGroup()->didExecute_ = false;
 
 	auto procfs_root = smarter::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
-	process->procfsTaskLink_ = procfs_root->createProcTaskDirectory(process.get());
+	process->procfsTaskLink_ = procfs_root->createProcTaskDirectory(getProcfs().get(), process.get());
 
 	HelHandle new_thread;
 	HEL_CHECK(helCreateThread(process->fileContext()->getUniverse().getHandle(),
@@ -1582,7 +1582,7 @@ Process::clone(std::shared_ptr<Process> original, void *ip, void *sp, posix::sup
 	process->threadGroup()->didExecute_ = false;
 
 	auto procfs_root = smarter::static_pointer_cast<procfs::DirectoryNode>(getProcfs()->getTarget());
-	process->procfsTaskLink_ = procfs_root->createProcTaskDirectory(process.get());
+	process->procfsTaskLink_ = procfs_root->createProcTaskDirectory(getProcfs().get(), process.get());
 
 	HelHandle new_thread;
 	HEL_CHECK(helCreateThread(process->fileContext()->getUniverse().getHandle(),

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -1268,15 +1268,15 @@ void Process::dumpRegisters() {
 					traversed = vp;
 				}
 
-				auto owner = traversed.second->getOwner();
-				if(!owner) { // We did not reach the root.
+				auto parentLink = traversed.second->getParent();
+				if(!parentLink) { // We did not reach the root.
 					// TODO: Can we get rid of this case?
 					path = "?" + path;
 					break;
 				}
 
 				path = "/" + traversed.second->getName() + path;
-				vp = ViewPath{traversed.first, owner->treeLink()};
+				vp = ViewPath{traversed.first, std::move(parentLink)};
 			}
 		}else{
 			path = "anon";

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -178,13 +178,13 @@ helix::BorrowedDescriptor DirectoryFile::getPassthroughLane() {
 Link::Link(smarter::shared_ptr<FsNode> target)
 : _target{std::move(target)} { }
 
-Link::Link(smarter::shared_ptr<FsNode> owner, std::string name, smarter::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsLink> owner, std::string name, smarter::shared_ptr<FsNode> target)
 : _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 	assert(_owner);
 	assert(!_name.empty());
 }
 
-smarter::shared_ptr<FsNode> Link::getOwner() {
+smarter::shared_ptr<FsLink> Link::getParent() {
 	return _owner;
 }
 
@@ -201,7 +201,7 @@ smarter::shared_ptr<FsNode> Link::getTarget() {
 void Link::unlinkSelf() {
 	assert(_target->getType() == VfsType::directory);
 
-	auto node = smarter::static_pointer_cast<DirectoryNode>(_owner);
+	auto node = smarter::static_pointer_cast<DirectoryNode>(_owner->getTarget());
 	auto err = node->directUnlink(_name);
 	assert(err == Error::success);
 }
@@ -299,10 +299,10 @@ smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 	auto link = makeFsShared<Link>(std::move(node));
 	the_node->_treeLink = link.get();
 
-	auto self_link = makeFsShared<Link>(the_node->sharedFromThis(), "self", makeFsShared<SelfLink>());
+	auto self_link = makeFsShared<Link>(the_node->treeLink(), "self", makeFsShared<SelfLink>());
 	the_node->_entries.insert(std::move(self_link));
 
-	auto self_thread_link = makeFsShared<Link>(the_node->sharedFromThis(), "thread-self", makeFsShared<SelfThreadLink>());
+	auto self_thread_link = makeFsShared<Link>(the_node->treeLink(), "thread-self", makeFsShared<SelfThreadLink>());
 	the_node->_entries.insert(std::move(self_thread_link));
 
 	the_node->directMkregular("uptime", makeFsShared<UptimeNode>());
@@ -331,7 +331,7 @@ DirectoryNode::DirectoryNode()
 smarter::shared_ptr<Link> DirectoryNode::directMkregular(std::string name,
 		smarter::shared_ptr<RegularNode> regular) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(regular));
+	auto link = makeFsShared<Link>(treeLink(), name, std::move(regular));
 	_entries.insert(link);
 	return link;
 }
@@ -340,7 +340,7 @@ smarter::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
-	auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(node));
 	_entries.insert(link);
 	the_node->_treeLink = link.get();
 	return link;
@@ -351,7 +351,7 @@ requires requires (T t) { {t._treeLink} -> std::same_as<Link *&>; }
 smarter::shared_ptr<Link> DirectoryNode::directMknodeDir(std::string name, smarter::shared_ptr<T> dirnode) {
 	assert(_entries.find(name) == _entries.end());
 	auto dirnodePtr = dirnode.get();
-	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(dirnode));
+	auto link = makeFsShared<Link>(treeLink(), name, std::move(dirnode));
 	dirnodePtr->_treeLink = link.get();
 	_entries.insert(link);
 	return link;
@@ -359,7 +359,7 @@ smarter::shared_ptr<Link> DirectoryNode::directMknodeDir(std::string name, smart
 
 smarter::shared_ptr<Link> DirectoryNode::directMknode(std::string name, smarter::shared_ptr<FsNode> node) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
 	_entries.insert(link);
 	return link;
 }
@@ -1237,7 +1237,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdDirectoryNode
 		if(name != std::to_string(fdnum))
 			continue;
 		auto pointee = makeFsShared<SymlinkNode>(p.get(), fd.file->associatedMount(), fd.file->associatedLink());
-		co_return makeFsShared<Link>(sharedFromThis(), name, pointee);
+		co_return makeFsShared<Link>(treeLink(), name, pointee);
 	}
 	co_return Error::noSuchFile;
 }
@@ -1446,7 +1446,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdInfoDirectory
 	if(p->fileContext()->fileTable().contains(nameNum)) {
 		auto file = p->fileContext()->fileTable().at(nameNum).file;
 		auto pointee = makeFsShared<FdInfoNode>(file->associatedMount(), file);
-		co_return makeFsShared<Link>(sharedFromThis(), name, pointee);
+		co_return makeFsShared<Link>(treeLink(), name, pointee);
 	}
 
 	co_return Error::noSuchFile;

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -279,7 +279,7 @@ FutureMaybe<smarter::shared_ptr<FsNode>> SuperBlock::createRegular(Process *) {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-SuperBlock::rename(FsLink *, FsNode *, std::string) {
+SuperBlock::rename(FsLink *, FsLink *, std::string) {
 	co_return Error::noSuchFile;
 };
 
@@ -417,7 +417,7 @@ VfsType DirectoryNode::getType() {
 	return VfsType::directory;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::link(std::string,
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::link(FsLink *, std::string,
 		smarter::shared_ptr<FsNode>) {
 	co_return Error::noSuchFile;
 }
@@ -451,7 +451,7 @@ DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(FsLink *, std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;
@@ -1228,7 +1228,7 @@ FdDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shar
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdDirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdDirectoryNode::getLink(FsLink *parent, std::string name) {
 	auto p = _process.lock();
 	if (!p)
 		co_return Error::noSuchProcess;
@@ -1237,7 +1237,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdDirectoryNode
 		if(name != std::to_string(fdnum))
 			continue;
 		auto pointee = makeFsShared<SymlinkNode>(p.get(), fd.file->associatedMount(), fd.file->associatedLink());
-		co_return makeFsShared<Link>(treeLink(), name, pointee);
+		co_return makeFsShared<Link>(parent->sharedFromThis(), name, pointee);
 	}
 	co_return Error::noSuchFile;
 }
@@ -1434,7 +1434,7 @@ FdInfoDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdInfoDirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdInfoDirectoryNode::getLink(FsLink *parent, std::string name) {
 	if(!std::all_of(name.begin(), name.end(), isdigit))
 		co_return Error::noSuchFile;
 
@@ -1446,7 +1446,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdInfoDirectory
 	if(p->fileContext()->fileTable().contains(nameNum)) {
 		auto file = p->fileContext()->fileTable().at(nameNum).file;
 		auto pointee = makeFsShared<FdInfoNode>(file->associatedMount(), file);
-		co_return makeFsShared<Link>(treeLink(), name, pointee);
+		co_return makeFsShared<Link>(parent->sharedFromThis(), name, pointee);
 	}
 
 	co_return Error::noSuchFile;

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -297,102 +297,88 @@ smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
 	auto link = makeFsShared<Link>(std::move(node));
-	the_node->_treeLink = link.get();
 
-	auto self_link = makeFsShared<Link>(the_node->treeLink(), "self", makeFsShared<SelfLink>());
+	auto self_link = makeFsShared<Link>(link, "self", makeFsShared<SelfLink>());
 	the_node->_entries.insert(std::move(self_link));
 
-	auto self_thread_link = makeFsShared<Link>(the_node->treeLink(), "thread-self", makeFsShared<SelfThreadLink>());
+	auto self_thread_link = makeFsShared<Link>(link, "thread-self", makeFsShared<SelfThreadLink>());
 	the_node->_entries.insert(std::move(self_thread_link));
 
-	the_node->directMkregular("uptime", makeFsShared<UptimeNode>());
-	the_node->directMknode("mounts", makeFsShared<MountsLink>());
+	the_node->directMkregular(link.get(), "uptime", makeFsShared<UptimeNode>());
+	the_node->directMknode(link.get(), "mounts", makeFsShared<MountsLink>());
 
-	auto sysLink = the_node->directMkdir("sys");
+	auto sysLink = the_node->directMkdir(link.get(), "sys");
 	auto sys = smarter::static_pointer_cast<DirectoryNode>(sysLink->getTarget());
-	auto kernelLink = sys->directMkdir("kernel");
+	auto kernelLink = sys->directMkdir(sysLink.get(), "kernel");
 	auto kernel = smarter::static_pointer_cast<DirectoryNode>(kernelLink->getTarget());
-	auto randomLink = kernel->directMkdir("random");
+	auto randomLink = kernel->directMkdir(kernelLink.get(), "random");
 	auto random = smarter::static_pointer_cast<DirectoryNode>(randomLink->getTarget());
 
-	kernel->directMkregular("ostype", makeFsShared<OstypeNode>());
-	kernel->directMkregular("osrelease", makeFsShared<OsreleaseNode>());
-	kernel->directMkregular("arch", makeFsShared<ArchNode>());
-	kernel->directMkregular("hostname", makeFsShared<HostnameNode>());
+	kernel->directMkregular(kernelLink.get(), "ostype", makeFsShared<OstypeNode>());
+	kernel->directMkregular(kernelLink.get(), "osrelease", makeFsShared<OsreleaseNode>());
+	kernel->directMkregular(kernelLink.get(), "arch", makeFsShared<ArchNode>());
+	kernel->directMkregular(kernelLink.get(), "hostname", makeFsShared<HostnameNode>());
 
-	random->directMkregular("boot_id", makeFsShared<BootIdNode>());
+	random->directMkregular(randomLink.get(), "boot_id", makeFsShared<BootIdNode>());
 
 	return link;
 }
 
 DirectoryNode::DirectoryNode()
-: FsNode{&procfsSuperblock}, _treeLink{nullptr} { }
+: FsNode{&procfsSuperblock} { }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkregular(std::string name,
+smarter::shared_ptr<Link> DirectoryNode::directMkregular(FsLink *parent, std::string name,
 		smarter::shared_ptr<RegularNode> regular) {
 	assert(_entries.find(name) == _entries.end());
-	auto link = makeFsShared<Link>(treeLink(), name, std::move(regular));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(regular));
 	_entries.insert(link);
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
+smarter::shared_ptr<Link> DirectoryNode::directMkdir(FsLink *parent, std::string name) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = makeFsShared<DirectoryNode>();
-	auto the_node = node.get();
-	auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(node));
 	_entries.insert(link);
-	the_node->_treeLink = link.get();
 	return link;
 }
 
-template<typename T>
-requires requires (T t) { {t._treeLink} -> std::same_as<Link *&>; }
-smarter::shared_ptr<Link> DirectoryNode::directMknodeDir(std::string name, smarter::shared_ptr<T> dirnode) {
+smarter::shared_ptr<Link> DirectoryNode::directMknode(FsLink *parent, std::string name, smarter::shared_ptr<FsNode> node) {
 	assert(_entries.find(name) == _entries.end());
-	auto dirnodePtr = dirnode.get();
-	auto link = makeFsShared<Link>(treeLink(), name, std::move(dirnode));
-	dirnodePtr->_treeLink = link.get();
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMknode(std::string name, smarter::shared_ptr<FsNode> node) {
-	assert(_entries.find(name) == _entries.end());
-	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
-	_entries.insert(link);
-	return link;
-}
-
-smarter::shared_ptr<Link> DirectoryNode::createProcDirectory(Process *process) {
-	auto link = directMkdir(std::to_string(process->pid()));
+smarter::shared_ptr<Link> DirectoryNode::createProcDirectory(FsLink *parent, Process *process) {
+	auto link = directMkdir(parent, std::to_string(process->pid()));
 	auto proc_dir = static_cast<DirectoryNode*>(link->getTarget().get());
 
-	proc_dir->directMknode("exe", makeFsShared<ExeLink>(process));
-	proc_dir->directMknode("root", makeFsShared<RootLink>(process));
-	proc_dir->directMknode("cwd", makeFsShared<CwdLink>(process));
-	proc_dir->directMknodeDir("fd", makeFsShared<FdDirectoryNode>(process));
-	proc_dir->directMknodeDir("fdinfo", makeFsShared<FdInfoDirectoryNode>(process));
-	proc_dir->directMkregular("maps", makeFsShared<MapNode>(process));
-	proc_dir->directMkregular("comm", makeFsShared<CommNode>(process));
-	proc_dir->directMkregular("stat", makeFsShared<StatNode>(process));
-	proc_dir->directMkregular("statm", makeFsShared<StatmNode>(process));
-	proc_dir->directMkregular("status", makeFsShared<ProcessStatusNode>(process->threadGroup()->weak_from_this()));
-	proc_dir->directMkregular("cgroup", makeFsShared<CgroupNode>(process));
-	proc_dir->directMkregular("mounts", makeFsShared<MountsNode>(process));
-	proc_dir->directMkregular("mountinfo", makeFsShared<MountInfoNode>(process));
+	proc_dir->directMknode(link.get(), "exe", makeFsShared<ExeLink>(process));
+	proc_dir->directMknode(link.get(), "root", makeFsShared<RootLink>(process));
+	proc_dir->directMknode(link.get(), "cwd", makeFsShared<CwdLink>(process));
+	proc_dir->directMknode(link.get(), "fd", makeFsShared<FdDirectoryNode>(process));
+	proc_dir->directMknode(link.get(), "fdinfo", makeFsShared<FdInfoDirectoryNode>(process));
+	proc_dir->directMkregular(link.get(), "maps", makeFsShared<MapNode>(process));
+	proc_dir->directMkregular(link.get(), "comm", makeFsShared<CommNode>(process));
+	proc_dir->directMkregular(link.get(), "stat", makeFsShared<StatNode>(process));
+	proc_dir->directMkregular(link.get(), "statm", makeFsShared<StatmNode>(process));
+	proc_dir->directMkregular(link.get(), "status", makeFsShared<ProcessStatusNode>(process->threadGroup()->weak_from_this()));
+	proc_dir->directMkregular(link.get(), "cgroup", makeFsShared<CgroupNode>(process));
+	proc_dir->directMkregular(link.get(), "mounts", makeFsShared<MountsNode>(process));
+	proc_dir->directMkregular(link.get(), "mountinfo", makeFsShared<MountInfoNode>(process));
 
-	proc_dir->directMkdir("task");
+	proc_dir->directMkdir(link.get(), "task");
 
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::createProcTaskDirectory(Process *process) {
+smarter::shared_ptr<Link> DirectoryNode::createProcTaskDirectory(FsLink *parent, Process *process) {
 	auto pidProcfsLink = process->threadGroup()->procfsLink();
 	// Create /proc/[pid] on demand to minimize observable states of /proc/[pid] being visible
 	// without any /proc/[pid]/task/[tid] attached.
 	if (!pidProcfsLink) {
-		pidProcfsLink = createProcDirectory(process);
+		pidProcfsLink = createProcDirectory(parent, process);
 		process->threadGroup()->setProcfsLink(pidProcfsLink);
 	}
 
@@ -404,11 +390,11 @@ smarter::shared_ptr<Link> DirectoryNode::createProcTaskDirectory(Process *proces
 	assert(taskLinkIt != proc_dir->_entries.end());
 	auto task_dir = static_cast<DirectoryNode *>(((*taskLinkIt)->getTarget()).get());
 
-	auto tid_link = task_dir->directMkdir(std::to_string(process->tid()));
+	auto tid_link = task_dir->directMkdir(taskLinkIt->get(), std::to_string(process->tid()));
 	auto tid_dir = static_cast<DirectoryNode *>(tid_link->getTarget().get());
 
-	tid_dir->directMkregular("comm", makeFsShared<CommNode>(process));
-	tid_dir->directMkregular("status", makeFsShared<StatusNode>(process->weak_from_this()));
+	tid_dir->directMkregular(tid_link.get(), "comm", makeFsShared<CommNode>(process));
+	tid_dir->directMkregular(tid_link.get(), "status", makeFsShared<StatusNode>(process->weak_from_this()));
 
 	return tid_link;
 }
@@ -425,13 +411,6 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::
 async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 	std::cout << "\e[31mposix: Fix procfs Directory::getStats()\e[39m" << std::endl;
 	co_return FileStats{};
-}
-
-smarter::shared_ptr<FsLink> DirectoryNode::treeLink() {
-	assert(_treeLink);
-	auto s = _treeLink->sharedFromThis();
-	assert(s);
-	return s;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
@@ -1200,13 +1179,6 @@ async::result<frg::expected<Error, FileStats>> FdDirectoryNode::getStats() {
 	co_return FileStats{};
 }
 
-smarter::shared_ptr<FsLink> FdDirectoryNode::treeLink() {
-	assert(_treeLink);
-	auto s = _treeLink->sharedFromThis();
-	assert(s);
-	return s;
-}
-
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 FdDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 		SemanticFlags semantic_flags) {
@@ -1404,13 +1376,6 @@ VfsType FdInfoDirectoryNode::getType() {
 async::result<frg::expected<Error, FileStats>> FdInfoDirectoryNode::getStats() {
 	std::cout << "\e[31mposix: Fix procfs FdInfoDirectoryNode::getStats()\e[39m" << std::endl;
 	co_return FileStats{};
-}
-
-smarter::shared_ptr<FsLink> FdInfoDirectoryNode::treeLink() {
-	assert(_treeLink);
-	auto s = _treeLink->sharedFromThis();
-	assert(s);
-	return s;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -150,22 +150,17 @@ struct DirectoryNode final : FsNode {
 
 	DirectoryNode();
 
-	smarter::shared_ptr<Link> directMkregular(std::string name,
+	smarter::shared_ptr<Link> directMkregular(FsLink *parent, std::string name,
 			smarter::shared_ptr<RegularNode> regular);
 
-	template<typename T>
-	requires requires (T t) { {t._treeLink} -> std::same_as<Link *&>; }
-	smarter::shared_ptr<Link> directMknodeDir(std::string name, smarter::shared_ptr<T> node);
-
-	smarter::shared_ptr<Link> directMknode(std::string name,
+	smarter::shared_ptr<Link> directMknode(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> node);
-	smarter::shared_ptr<Link> directMkdir(std::string name);
+	smarter::shared_ptr<Link> directMkdir(FsLink *parent, std::string name);
 
-	smarter::shared_ptr<Link> createProcTaskDirectory(Process *process);
+	smarter::shared_ptr<Link> createProcTaskDirectory(FsLink *parent, Process *process);
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
-	smarter::shared_ptr<FsLink> treeLink() override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target) override;
@@ -179,9 +174,8 @@ struct DirectoryNode final : FsNode {
 	Error directUnlink(std::string name);
 
 private:
-	smarter::shared_ptr<Link> createProcDirectory(Process *process);
+	smarter::shared_ptr<Link> createProcDirectory(FsLink *parent, Process *process);
 
-	Link *_treeLink;
 	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
 };
 
@@ -408,11 +402,9 @@ public:
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	smarter::shared_ptr<FsLink> treeLink() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
 private:
 	std::weak_ptr<Process> _process;
-	Link *_treeLink;
 };
 
 struct SymlinkNode final : LinkNode {
@@ -462,11 +454,9 @@ public:
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	smarter::shared_ptr<FsLink> treeLink() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
 private:
 	std::weak_ptr<Process> _process;
-	Link *_treeLink;
 };
 
 struct FdInfoDirectoryFile final : FileWithDefaults {

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -86,16 +86,16 @@ private:
 struct Link final : FsLink {
 	explicit Link(smarter::shared_ptr<FsNode> target);
 
-	explicit Link(smarter::shared_ptr<FsNode> owner,
+	explicit Link(smarter::shared_ptr<FsLink> owner,
 			std::string name, smarter::shared_ptr<FsNode> target);
 
-	smarter::shared_ptr<FsNode> getOwner() override;
+	smarter::shared_ptr<FsLink> getParent() override;
 	std::string getName() override;
 	smarter::shared_ptr<FsNode> getTarget() override;
 	void unlinkSelf();
 
 private:
-	smarter::shared_ptr<FsNode> _owner;
+	smarter::shared_ptr<FsLink> _owner;
 	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
 };

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -128,7 +128,7 @@ public:
 	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-			rename(FsLink *source, FsNode *directory, std::string name) override;
+			rename(FsLink *source, FsLink *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
 	std::string getFsType() override {
@@ -167,13 +167,13 @@ struct DirectoryNode final : FsNode {
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	smarter::shared_ptr<FsLink> treeLink() override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target) override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
 	async::result<frg::expected<Error>> unlink(std::string name) override;
 
 	Error directUnlink(std::string name);
@@ -409,7 +409,7 @@ public:
 	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 	smarter::shared_ptr<FsLink> treeLink() override;
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
 private:
 	std::weak_ptr<Process> _process;
 	Link *_treeLink;
@@ -463,7 +463,7 @@ public:
 	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
 	smarter::shared_ptr<FsLink> treeLink() override;
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
 private:
 	std::weak_ptr<Process> _process;
 	Link *_treeLink;

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -617,13 +617,10 @@ public:
 		return VfsType::directory;
 	}
 
-	void linkDevice(std::string name, smarter::shared_ptr<DeviceNode> node) {
-		auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
+	void linkDevice(FsLink *parent, std::string name,
+			smarter::shared_ptr<DeviceNode> node) {
+		auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
 		_entries.insert(std::move(link));
-	}
-
-	smarter::shared_ptr<FsLink> treeLink() override {
-		return globalRootLink;
 	}
 
 	async::result<frg::expected<Error, FileStats>> getStats() override {
@@ -919,7 +916,7 @@ MasterFile::MasterFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsL
 	auto slave_device = std::make_shared<SlaveDevice>(_channel);
 	charRegistry.install(std::move(slave_device));
 
-	globalRootLink->rootNode()->linkDevice(std::to_string(_channel->ptsIndex),
+	globalRootLink->rootNode()->linkDevice(globalRootLink.get(), std::to_string(_channel->ptsIndex),
 			makeFsShared<DeviceNode>(DeviceId{136, _channel->ptsIndex}));
 }
 

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -509,18 +509,18 @@ private:
 
 struct Link final : FsLink {
 public:
-	explicit Link(smarter::shared_ptr<FsNode> root, std::string name,
+	explicit Link(smarter::shared_ptr<FsLink> root, std::string name,
 			smarter::shared_ptr<DeviceNode> device)
 	: _root{std::move(root)}, _name{std::move(name)}, _device{std::move(device)} { }
 
-	smarter::shared_ptr<FsNode> getOwner() override;
+	smarter::shared_ptr<FsLink> getParent() override;
 
 	std::string getName() override;
 
 	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
-	smarter::shared_ptr<FsNode> _root;
+	smarter::shared_ptr<FsLink> _root;
 	std::string _name;
 	smarter::shared_ptr<DeviceNode> _device;
 };
@@ -532,8 +532,8 @@ struct RootLink final : FsLink {
 		return _root.get();
 	}
 
-	smarter::shared_ptr<FsNode> getOwner() override {
-		throw std::logic_error("posix: pts RootLink has no owner");
+	smarter::shared_ptr<FsLink> getParent() override {
+		return nullptr;
 	}
 
 	std::string getName() override {
@@ -618,7 +618,7 @@ public:
 	}
 
 	void linkDevice(std::string name, smarter::shared_ptr<DeviceNode> node) {
-		auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
+		auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
 		_entries.insert(std::move(link));
 	}
 
@@ -1528,7 +1528,7 @@ void SlaveFile::handleClose() {
 // Link and RootLink implementation.
 //-----------------------------------------------------------------------------
 
-smarter::shared_ptr<FsNode> Link::getOwner() {
+smarter::shared_ptr<FsLink> Link::getParent() {
 	return _root;
 }
 

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -509,8 +509,9 @@ private:
 
 struct Link final : FsLink {
 public:
-	explicit Link(RootNode *root, std::string name, smarter::shared_ptr<DeviceNode> device)
-	: _root{root}, _name{std::move(name)}, _device{std::move(device)} { }
+	explicit Link(smarter::shared_ptr<FsNode> root, std::string name,
+			smarter::shared_ptr<DeviceNode> device)
+	: _root{std::move(root)}, _name{std::move(name)}, _device{std::move(device)} { }
 
 	smarter::shared_ptr<FsNode> getOwner() override;
 
@@ -519,7 +520,7 @@ public:
 	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
-	RootNode *_root;
+	smarter::shared_ptr<FsNode> _root;
 	std::string _name;
 	smarter::shared_ptr<DeviceNode> _device;
 };
@@ -617,7 +618,7 @@ public:
 	}
 
 	void linkDevice(std::string name, smarter::shared_ptr<DeviceNode> node) {
-		auto link = makeFsShared<Link>(this, name, std::move(node));
+		auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
 		_entries.insert(std::move(link));
 	}
 
@@ -1528,7 +1529,7 @@ void SlaveFile::handleClose() {
 //-----------------------------------------------------------------------------
 
 smarter::shared_ptr<FsNode> Link::getOwner() {
-	return _root->sharedFromThis();
+	return _root;
 }
 
 std::string Link::getName() {

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -298,7 +298,7 @@ public:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-			rename(FsLink *, FsNode *, std::string) override {
+			rename(FsLink *, FsLink *, std::string) override {
 		co_return Error::noSuchFile;
 	}
 
@@ -632,7 +632,7 @@ public:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-	getLink(std::string name) override {
+	getLink(FsLink *, std::string name) override {
 		auto it = _entries.find(name);
 		if(it != _entries.end())
 			co_return *it;

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -250,14 +250,16 @@ HandleRequest::operator()(managarm::posix::MkdirAtRequest &&req,
 		co_return {};
 	}
 
-	auto parent = resolver.currentLink()->getTarget();
-	auto existsResult = co_await parent->getLink(resolver.nextComponent());
+	auto parentLink = resolver.currentLink();
+	auto parent = parentLink->getTarget();
+	auto existsResult = co_await parent->getLink(parentLink.get(), resolver.nextComponent());
 	if (existsResult) {
 		co_await sendErrorResponse<managarm::posix::MkdirAtResponse>(conversation, managarm::posix::Errors::ALREADY_EXISTS);
 		co_return {};
 	}
 
 	auto result = co_await parent->mkdir(
+		parentLink.get(),
 	    self.get(),
 	    resolver.nextComponent(),
 	    req.mode()
@@ -316,13 +318,15 @@ HandleRequest::operator()(managarm::posix::MkfifoAtRequest &&req,
 		co_return {};
 	}
 
-	auto parent = resolver.currentLink()->getTarget();
-	if(co_await parent->getLink(resolver.nextComponent())) {
+	auto parentLink = resolver.currentLink();
+	auto parent = parentLink->getTarget();
+	if(co_await parent->getLink(parentLink.get(), resolver.nextComponent())) {
 		co_await sendErrorResponse<managarm::posix::MkfifoAtResponse>(conversation, managarm::posix::Errors::ALREADY_EXISTS);
 		co_return {};
 	}
 
 	auto result = co_await parent->mkfifo(
+		parentLink.get(),
 		resolver.nextComponent(),
 		req.mode() & ~self->fsContext()->getUmask()
 	);
@@ -419,12 +423,13 @@ HandleRequest::operator()(managarm::posix::LinkAtRequest &&req,
 	}
 
 	auto target = resolver.currentLink()->getTarget();
-	auto directory = new_resolver.currentLink()->getTarget();
+	auto directoryLink = new_resolver.currentLink();
+	auto directory = directoryLink->getTarget();
 	if(target->superblock() != directory->superblock()) {
 		co_await sendErrorResponse<managarm::posix::LinkAtResponse>(conversation, managarm::posix::Errors::CROSS_DEVICE_LINK);
 		co_return {};
 	}
-	auto result = co_await directory->link(new_resolver.nextComponent(), target);
+	auto result = co_await directory->link(directoryLink.get(), new_resolver.nextComponent(), target);
 	if(!result) {
 		co_await sendErrorResponse<managarm::posix::LinkAtResponse>(conversation, result.error() | toPosixProtoError);
 		co_return {};
@@ -482,8 +487,9 @@ HandleRequest::operator()(managarm::posix::SymlinkAtRequest &&req,
 		resolver.nextComponent(),
 		req.target_path());
 
-	auto parent = resolver.currentLink()->getTarget();
-	auto result = co_await parent->symlink(resolver.nextComponent(), req.target_path());
+	auto parentLink = resolver.currentLink();
+	auto parent = parentLink->getTarget();
+	auto result = co_await parent->symlink(parentLink.get(), resolver.nextComponent(), req.target_path());
 	if(auto error = std::get_if<Error>(&result); error) {
 		if(*error == Error::alreadyExists) {
 			co_await sendErrorResponse<managarm::posix::SymlinkAtResponse>(conversation, managarm::posix::Errors::ALREADY_EXISTS);
@@ -689,13 +695,14 @@ HandleRequest::operator()(managarm::posix::RenameAtRequest &&req,
 		new_resolver.nextComponent());
 
 	auto superblock = resolver.currentLink()->getTarget()->superblock();
-	auto directory = new_resolver.currentLink()->getTarget();
+	auto directoryLink = new_resolver.currentLink();
+	auto directory = directoryLink->getTarget();
 	if(superblock != directory->superblock()) {
 		co_await sendErrorResponse<managarm::posix::RenameAtResponse>(conversation, managarm::posix::Errors::CROSS_DEVICE_LINK);
 		co_return {};
 	}
 	auto result = co_await superblock->rename(resolver.currentLink().get(),
-			directory.get(), new_resolver.nextComponent());
+			directoryLink.get(), new_resolver.nextComponent());
 	if(!result) {
 		co_await sendErrorResponse<managarm::posix::RenameAtResponse>(conversation, result.error() | toPosixProtoError);
 		co_return {};
@@ -1402,9 +1409,10 @@ HandleRequest::operator()(managarm::posix::OpenAtRequest &&req,
 			co_return {};
 		}
 
-		auto directory = resolver.currentLink()->getTarget();
+		auto directoryLink = resolver.currentLink();
+		auto directory = directoryLink->getTarget();
 
-		auto linkResult = co_await directory->getLinkOrCreate(self.get(), resolver.nextComponent(),
+		auto linkResult = co_await directory->getLinkOrCreate(directoryLink.get(), self.get(), resolver.nextComponent(),
 			req.mode() & ~self->fsContext()->getUmask(), req.flags() & managarm::posix::OpenFlags::OF_EXCLUSIVE);
 		if (!linkResult) {
 			co_await sendErrorResponse<managarm::posix::OpenAtResponse>(conversation, linkResult.error() | toPosixProtoError);
@@ -1589,8 +1597,9 @@ HandleRequest::operator()(managarm::posix::MknodAtRequest &&req,
 		co_return {};
 	}
 
-	auto parent = resolver.currentLink()->getTarget();
-	auto existsResult = co_await parent->getLink(resolver.nextComponent());
+	auto parentLink = resolver.currentLink();
+	auto parent = parentLink->getTarget();
+	auto existsResult = co_await parent->getLink(parentLink.get(), resolver.nextComponent());
 	if (existsResult) {
 		co_await sendErrorResponse<managarm::posix::MknodAtResponse>(conversation, managarm::posix::Errors::ALREADY_EXISTS);
 		co_return {};
@@ -1621,7 +1630,7 @@ HandleRequest::operator()(managarm::posix::MknodAtRequest &&req,
 		dev.first = major(req.device());
 		dev.second = minor(req.device());
 
-		auto result = co_await parent->mkdev(resolver.nextComponent(), type, dev);
+		auto result = co_await parent->mkdev(parentLink.get(), resolver.nextComponent(), type, dev);
 		if(!result) {
 			if(result.error() == Error::illegalOperationTarget) {
 				co_await sendErrorResponse<managarm::posix::MknodAtResponse>(conversation, managarm::posix::Errors::ILLEGAL_ARGUMENTS);
@@ -1633,6 +1642,7 @@ HandleRequest::operator()(managarm::posix::MknodAtRequest &&req,
 		}
 	} else if(type == VfsType::fifo) {
 		auto result = co_await parent->mkfifo(
+			parentLink.get(),
 			resolver.nextComponent(),
 			req.mode() & ~self->fsContext()->getUmask()
 		);
@@ -1646,7 +1656,7 @@ HandleRequest::operator()(managarm::posix::MknodAtRequest &&req,
 			}
 		}
 	} else if(type == VfsType::socket) {
-		auto result = co_await parent->mksocket(resolver.nextComponent(), (req.mode() & ~self->fsContext()->getUmask()), self->threadGroup()->uid(), self->threadGroup()->gid());
+		auto result = co_await parent->mksocket(parentLink.get(), resolver.nextComponent(), (req.mode() & ~self->fsContext()->getUmask()), self->threadGroup()->uid(), self->threadGroup()->gid());
 		if(!result) {
 			if(result.error() == Error::illegalOperationTarget) {
 				co_await sendErrorResponse<managarm::posix::MknodAtResponse>(conversation, managarm::posix::Errors::ILLEGAL_ARGUMENTS);

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -766,7 +766,7 @@ HandleRequest::operator()(managarm::posix::UnlinkAtRequest &&req,
 
 	target_link = resolver.currentLink();
 
-	auto owner = target_link->getOwner();
+	auto owner = target_link->getParentNode();
 	if(!owner) {
 		co_await sendErrorResponse<managarm::posix::UnlinkAtResponse>(conversation, managarm::posix::Errors::RESOURCE_IN_USE);
 		co_return {};
@@ -826,7 +826,7 @@ HandleRequest::operator()(managarm::posix::RmdirRequest &&req,
 
 	target_link = resolver.currentLink();
 
-	auto owner = target_link->getOwner();
+	auto owner = target_link->getParentNode();
 	auto result = co_await owner->rmdir(target_link->getName());
 	if(!result) {
 		co_await sendErrorResponse<managarm::posix::RmdirResponse>(conversation, result.error() | toPosixProtoError);

--- a/posix/subsystem/src/subsystem/input.cpp
+++ b/posix/subsystem/src/subsystem/input.cpp
@@ -177,12 +177,12 @@ async::detached run() {
 			drvcore::installDevice(device);
 
 			// TODO: Do this before the device becomes visible in sysfs!
-			auto link = device->directoryNode()->directMkdir("capabilities");
+			auto link = device->directoryNode()->directMkdir(device->dirLink().get(), "capabilities");
 			auto caps = static_cast<sysfs::DirectoryNode *>(link->getTarget().get());
-			caps->directMkattr(device.get(), &evCapability);
-			caps->directMkattr(device.get(), &keyCapability);
-			caps->directMkattr(device.get(), &relCapability);
-			caps->directMkattr(device.get(), &absCapability);
+			caps->directMkattr(link.get(), device.get(), &evCapability);
+			caps->directMkattr(link.get(), device.get(), &keyCapability);
+			caps->directMkattr(link.get(), device.get(), &relCapability);
+			caps->directMkattr(link.get(), device.get(), &absCapability);
 		}
 	}
 }

--- a/posix/subsystem/src/subsystem/pci.cpp
+++ b/posix/subsystem/src/subsystem/pci.cpp
@@ -323,7 +323,8 @@ async::detached bind(mbus_ng::Entity entity, mbus_ng::Properties properties) {
 
 async::detached run() {
 	sysfsSubsystem = new drvcore::BusSubsystem{"pci"};
-	sysfsSubsystem->object()->directoryNode()->directMkdir("slots");
+	sysfsSubsystem->object()->directoryNode()->directMkdir(
+			sysfsSubsystem->object()->dirLink().get(), "slots");
 
 	auto filter = mbus_ng::Conjunction({
 		mbus_ng::EqualsFilter{"unix.subsystem", "pci"}

--- a/posix/subsystem/src/sysfs.cpp
+++ b/posix/subsystem/src/sysfs.cpp
@@ -210,13 +210,13 @@ helix::BorrowedDescriptor DirectoryFile::getPassthroughLane() {
 Link::Link(smarter::shared_ptr<FsNode> target)
 : _target{std::move(target)} { }
 
-Link::Link(smarter::shared_ptr<FsNode> owner, std::string name, smarter::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsLink> owner, std::string name, smarter::shared_ptr<FsNode> target)
 : _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 	assert(_owner);
 	assert(!_name.empty());
 }
 
-smarter::shared_ptr<FsNode> Link::getOwner() {
+smarter::shared_ptr<FsLink> Link::getParent() {
 	return _owner;
 }
 
@@ -308,24 +308,12 @@ expected<std::string> SymlinkNode::readSymlink(FsLink *link, Process *) {
 	std::string path;
 
 	// Walk from the target to the root to discover the path.
-	auto ref = object->directoryNode();
-	while(true) {
-		auto link = ref->treeLink();
-		if(!link->getOwner())
-			break;
-		path = path.empty() ? link->getName() : link->getName() + "/" + path;
-		ref = smarter::static_pointer_cast<DirectoryNode>(link->getOwner());
-	}
+	for(auto ref = object->directoryNode()->treeLink(); ref->getParent(); ref = ref->getParent())
+		path = path.empty() ? ref->getName() : ref->getName() + "/" + path;
 
 	// Walk from the symlink to the root to discover the number of ../ prefixes.
-	ref = smarter::static_pointer_cast<DirectoryNode>(link->getOwner());
-	while(true) {
-		auto link = ref->treeLink();
-		if(!link->getOwner())
-			break;
+	for(auto ref = link->getParent(); ref->getParent(); ref = ref->getParent())
 		path = "../" + path;
-		ref = smarter::static_pointer_cast<DirectoryNode>(link->getOwner());
-	}
 
 	co_return path;
 }
@@ -350,7 +338,7 @@ DirectoryNode::DirectoryNode()
 smarter::shared_ptr<Link> DirectoryNode::directMkattr(Object *object, Attribute *attr) {
 	assert(_entries.find(attr->name()) == _entries.end());
 	auto node = makeFsShared<AttributeNode>(object, attr);
-	auto link = makeFsShared<Link>(sharedFromThis(), attr->name(), std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), attr->name(), std::move(node));
 	_entries.insert(link);
 	return link;
 }
@@ -358,7 +346,7 @@ smarter::shared_ptr<Link> DirectoryNode::directMkattr(Object *object, Attribute 
 smarter::shared_ptr<Link> DirectoryNode::directMklink(std::string name, std::weak_ptr<Object> target) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = makeFsShared<SymlinkNode>(std::move(target));
-	auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(node));
 	_entries.insert(link);
 	return link;
 }
@@ -370,7 +358,7 @@ smarter::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
 	}
 	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
-	auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(node));
 	_entries.insert(link);
 	the_node->_treeLink = link.get();
 	return link;

--- a/posix/subsystem/src/sysfs.cpp
+++ b/posix/subsystem/src/sysfs.cpp
@@ -308,7 +308,7 @@ expected<std::string> SymlinkNode::readSymlink(FsLink *link, Process *) {
 	std::string path;
 
 	// Walk from the target to the root to discover the path.
-	for(auto ref = object->directoryNode()->treeLink(); ref->getParent(); ref = ref->getParent())
+	for(smarter::shared_ptr<FsLink> ref = object->dirLink(); ref->getParent(); ref = ref->getParent())
 		path = path.empty() ? ref->getName() : ref->getName() + "/" + path;
 
 	// Walk from the symlink to the root to discover the number of ../ prefixes.
@@ -324,43 +324,39 @@ expected<std::string> SymlinkNode::readSymlink(FsLink *link, Process *) {
 
 smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 	auto node = makeFsShared<DirectoryNode>();
-	auto the_node = node.get();
 	auto link = makeFsShared<Link>(std::move(node));
-	the_node->_treeLink = link.get();
 	return link;
 }
 
 DirectoryNode::DirectoryNode()
-: FsNode(&sysfsSuperblock), _treeLink{nullptr} {
+: FsNode(&sysfsSuperblock) {
 	inode_ = static_cast<SysfsSuperblock *>(superblock())->inodeAllocator().allocate();
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkattr(Object *object, Attribute *attr) {
+smarter::shared_ptr<Link> DirectoryNode::directMkattr(FsLink *parent, Object *object, Attribute *attr) {
 	assert(_entries.find(attr->name()) == _entries.end());
 	auto node = makeFsShared<AttributeNode>(object, attr);
-	auto link = makeFsShared<Link>(treeLink(), attr->name(), std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), attr->name(), std::move(node));
 	_entries.insert(link);
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMklink(std::string name, std::weak_ptr<Object> target) {
+smarter::shared_ptr<Link> DirectoryNode::directMklink(FsLink *parent, std::string name, std::weak_ptr<Object> target) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = makeFsShared<SymlinkNode>(std::move(target));
-	auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(node));
 	_entries.insert(link);
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkdir(std::string name) {
+smarter::shared_ptr<Link> DirectoryNode::directMkdir(FsLink *parent, std::string name) {
 	auto preexisting = _entries.find(name);
 	if(preexisting != _entries.end()) {
 		return *preexisting;
 	}
 	auto node = makeFsShared<DirectoryNode>();
-	auto the_node = node.get();
-	auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(node));
 	_entries.insert(link);
-	the_node->_treeLink = link.get();
 	return link;
 }
 
@@ -377,13 +373,6 @@ async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 	fs.uid = 0;
 	fs.gid = 0;
 	co_return fs;
-}
-
-smarter::shared_ptr<FsLink> DirectoryNode::treeLink() {
-	assert(_treeLink);
-	auto s = _treeLink->sharedFromThis();
-	assert(s);
-	return s;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
@@ -434,13 +423,13 @@ smarter::shared_ptr<DirectoryNode> Object::directoryNode() {
 void Object::realizeAttribute(Attribute *attr) {
 	assert(_dirLink);
 	auto dir = static_cast<DirectoryNode *>(_dirLink->getTarget().get());
-	dir->directMkattr(this, attr);
+	dir->directMkattr(_dirLink.get(), this, attr);
 }
 
 void Object::createSymlink(std::string name, std::shared_ptr<Object> target) {
 	assert(_dirLink);
 	auto dir = static_cast<DirectoryNode *>(_dirLink->getTarget().get());
-	dir->directMklink(std::move(name), std::move(target));
+	dir->directMklink(_dirLink.get(), std::move(name), std::move(target));
 }
 
 std::optional<std::string> Object::getClassPath() {
@@ -451,10 +440,10 @@ void Object::addObject() {
 	if(_parent) {
 		assert(_parent->_dirLink);
 		auto parent_dir = static_cast<DirectoryNode *>(_parent->_dirLink->getTarget().get());
-		_dirLink = parent_dir->directMkdir(_name);
+		_dirLink = parent_dir->directMkdir(_parent->_dirLink.get(), _name);
 	}else{
 		auto parent_dir = static_cast<DirectoryNode *>(getSysfs()->getTarget().get());
-		_dirLink = parent_dir->directMkdir(_name);
+		_dirLink = parent_dir->directMkdir(getSysfs().get(), _name);
 	}
 }
 

--- a/posix/subsystem/src/sysfs.cpp
+++ b/posix/subsystem/src/sysfs.cpp
@@ -23,7 +23,7 @@ FutureMaybe<smarter::shared_ptr<FsNode>> SysfsSuperblock::createRegular(Process 
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-SysfsSuperblock::rename(FsLink *, FsNode *, std::string) {
+SysfsSuperblock::rename(FsLink *, FsLink *, std::string) {
 	co_return Error::noSuchFile;
 };
 
@@ -403,7 +403,7 @@ DirectoryNode::open(Process *, std::shared_ptr<MountView> mount,
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(FsLink *, std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;

--- a/posix/subsystem/src/sysfs.hpp
+++ b/posix/subsystem/src/sysfs.hpp
@@ -33,7 +33,7 @@ public:
 	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-			rename(FsLink *source, FsNode *directory, std::string name) override;
+			rename(FsLink *source, FsLink *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
 	std::string getFsType() override {
@@ -188,7 +188,7 @@ struct DirectoryNode final : FsNode {
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
 
 private:
 	Link *_treeLink;

--- a/posix/subsystem/src/sysfs.hpp
+++ b/posix/subsystem/src/sysfs.hpp
@@ -119,15 +119,15 @@ private:
 struct Link final : FsLink {
 	explicit Link(smarter::shared_ptr<FsNode> target);
 
-	explicit Link(smarter::shared_ptr<FsNode> owner,
+	explicit Link(smarter::shared_ptr<FsLink> owner,
 			std::string name, smarter::shared_ptr<FsNode> target);
 
-	smarter::shared_ptr<FsNode> getOwner() override;
+	smarter::shared_ptr<FsLink> getParent() override;
 	std::string getName() override;
 	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
-	smarter::shared_ptr<FsNode> _owner;
+	smarter::shared_ptr<FsLink> _owner;
 	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
 };

--- a/posix/subsystem/src/sysfs.hpp
+++ b/posix/subsystem/src/sysfs.hpp
@@ -177,13 +177,12 @@ struct DirectoryNode final : FsNode {
 		static_cast<SysfsSuperblock *>(superblock())->inodeAllocator().free(inode_);
 	}
 
-	smarter::shared_ptr<Link> directMkattr(Object *object, Attribute *attr);
-	smarter::shared_ptr<Link> directMklink(std::string name, std::weak_ptr<Object> target);
-	smarter::shared_ptr<Link> directMkdir(std::string name);
+	smarter::shared_ptr<Link> directMkattr(FsLink *parent, Object *object, Attribute *attr);
+	smarter::shared_ptr<Link> directMklink(FsLink *parent, std::string name, std::weak_ptr<Object> target);
+	smarter::shared_ptr<Link> directMkdir(FsLink *parent, std::string name);
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
-	smarter::shared_ptr<FsLink> treeLink() override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
@@ -191,7 +190,6 @@ struct DirectoryNode final : FsNode {
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
 
 private:
-	Link *_treeLink;
 	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
 	uint64_t inode_;
 };
@@ -241,6 +239,10 @@ struct Object {
 	}
 
 	smarter::shared_ptr<DirectoryNode> directoryNode();
+
+	const smarter::shared_ptr<Link> &dirLink() {
+		return _dirLink;
+	}
 
 	void realizeAttribute(Attribute *attr);
 	void createSymlink(std::string name, std::shared_ptr<Object> target);

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -233,13 +233,13 @@ public:
 	explicit Link(smarter::shared_ptr<FsNode> target)
 	: _target(std::move(target)) { }
 
-	explicit Link(smarter::shared_ptr<FsNode> owner, std::string name, smarter::shared_ptr<FsNode> target)
+	explicit Link(smarter::shared_ptr<FsLink> owner, std::string name, smarter::shared_ptr<FsNode> target)
 	: _owner(std::move(owner)), _name(std::move(name)), _target(std::move(target)) {
 		assert(_owner);
 		assert(!_name.empty());
 	}
 
-	smarter::shared_ptr<FsNode> getOwner() override {
+	smarter::shared_ptr<FsLink> getParent() override {
 		return _owner;
 	}
 
@@ -254,7 +254,7 @@ public:
 	}
 
 private:
-	smarter::shared_ptr<FsNode> _owner;
+	smarter::shared_ptr<FsLink> _owner;
 	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
 };
@@ -347,7 +347,7 @@ private:
 		if(!(_entries.find(name) == _entries.end()))
 			co_return Error::alreadyExists;
 		static_cast<Node *>(target.get())->adjustLinkCount(1);
-		auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(target));
+		auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(target));
 		_entries.insert(link);
 		co_return link;
 	}
@@ -584,7 +584,7 @@ struct Superblock final : FsSuperblock {
 			co_return Error::notDirectory;
 		auto dest_dir = static_cast<DirectoryNode *>(dest_fs_dir);
 
-		auto src_dir = static_cast<DirectoryNode *>(src_link->getOwner().get());
+		auto src_dir = static_cast<DirectoryNode *>(src_link->getParentNode().get());
 		auto it = src_dir->_entries.find(src_link->getName());
 		if(it == src_dir->_entries.end() || it->get() != src_link)
 			co_return Error::alreadyExists;
@@ -614,7 +614,7 @@ struct Superblock final : FsSuperblock {
 			dest_dir->_entries.erase(dest_it);
 		}
 
-		auto new_link = makeFsShared<Link>(dest_dir->sharedFromThis(),
+		auto new_link = makeFsShared<Link>(dest_dir->treeLink(),
 				std::move(dest_name), target);
 		src_dir->_entries.erase(it);
 		dest_dir->_entries.insert(new_link);
@@ -824,7 +824,7 @@ DirectoryFile::readEntries() {
 	// '.' and '..' are not stored in _entries; synthesize them before iterating.
 	if(_dots != DotEntriesPhase::done) {
 		// The parent of the root directory is the root itself.
-		auto owner = _node->treeLink()->getOwner();
+		auto owner = _node->treeLink()->getParentNode();
 		auto parent = owner ? static_cast<Node *>(owner.get()) : static_cast<Node *>(_node);
 		if(auto entry = nextDotEntry(_dots, _node->inodeNumber(), parent->inodeNumber()); entry)
 			co_return *entry;
@@ -946,7 +946,7 @@ DirectoryNode::getLinkOrCreate(Process *, std::string name, mode_t mode, bool ex
 
 	auto node = makeFsShared<MemoryNode>(static_cast<Superblock *>(superblock()));
 	co_await node->chmod(mode);
-	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0, false);
 	co_return link;
@@ -963,7 +963,7 @@ DirectoryNode::mkdir(Process *proc, std::string name, mode_t mode) {
 
 	auto node = makeFsShared<DirectoryNode>(static_cast<Superblock *>(superblock()), mode & ~umask, uid, gid);
 	auto the_node = node.get();
-	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
 	the_node->_treeLink = link;
 	_entries.insert(link);
 	// Account for the new subdirectory's '..' backlink.
@@ -978,7 +978,7 @@ DirectoryNode::symlink(std::string name, std::string path) {
 		co_return Error::alreadyExists;
 	auto node = makeFsShared<SymlinkNode>(static_cast<Superblock *>(superblock()),
 			std::move(path));
-	auto link = makeFsShared<Link>(sharedFromThis(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(node));
 	_entries.insert(link);
 	co_return link;
 }
@@ -989,7 +989,7 @@ DirectoryNode::mkdev(std::string name, VfsType type, DeviceId id) {
 		co_return Error::alreadyExists;
 	auto node = makeFsShared<DeviceNode>(static_cast<Superblock *>(superblock()),
 			type, id);
-	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0);
 	co_return link;
@@ -1000,7 +1000,7 @@ DirectoryNode::mkfifo(std::string name, mode_t mode) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 	auto node = makeFsShared<FifoNode>(static_cast<Superblock *>(superblock()), mode);
-	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0);
 	co_return link;
@@ -1010,7 +1010,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 	auto node = makeFsShared<SocketNode>(static_cast<Superblock *>(superblock()), mode, uid, gid);
-	auto link = makeFsShared<Link>(sharedFromThis(), name, std::move(node));
+	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0);
 	co_return link;

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -333,35 +333,36 @@ private:
 	}
 
 	async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
-	getLinkOrCreate(Process *process, std::string name, mode_t mode, bool exclusive) override;
+	getLinkOrCreate(FsLink *parent, Process *process, std::string name, mode_t mode,
+			bool exclusive) override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(std::string name) override {
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *, std::string name) override {
 		auto it = _entries.find(name);
 		if(it != _entries.end())
 			co_return *it;
 		co_return Error::noSuchFile;
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target) override {
 		if(!(_entries.find(name) == _entries.end()))
 			co_return Error::alreadyExists;
 		static_cast<Node *>(target.get())->adjustLinkCount(1);
-		auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(target));
+		auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(target));
 		_entries.insert(link);
 		co_return link;
 	}
 
 	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-	mkdir(Process *p, std::string name, mode_t mode) override;
+	mkdir(FsLink *parent, Process *p, std::string name, mode_t mode) override;
 
 	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-	symlink(std::string name, std::string path) override;
+	symlink(FsLink *parent, std::string name, std::string path) override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(FsLink *parent, std::string name,
 			VfsType type, DeviceId id) override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkfifo(std::string name, mode_t mode) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkfifo(FsLink *parent, std::string name, mode_t mode) override;
 
 	async::result<frg::expected<Error>> unlink(std::string name) override {
 		auto it = _entries.find(name);
@@ -379,7 +380,7 @@ private:
 		co_return {};
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mksocket(FsLink *parent, std::string name, mode_t mode, uid_t uid, gid_t gid) override;
 
 	async::result<frg::expected<Error>> rmdir(std::string name) override {
 		auto it = _entries.find(name);
@@ -577,12 +578,13 @@ struct Superblock final : FsSuperblock {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> rename(FsLink *src_fs_link,
-			FsNode *dest_fs_dir, std::string dest_name) override {
+			FsLink *dest_fs_link, std::string dest_name) override {
 		auto src_link = static_cast<Link *>(src_fs_link);
 
+		auto dest_fs_dir = dest_fs_link->getTarget();
 		if(dest_fs_dir->getType() != VfsType::directory)
 			co_return Error::notDirectory;
-		auto dest_dir = static_cast<DirectoryNode *>(dest_fs_dir);
+		auto dest_dir = static_cast<DirectoryNode *>(dest_fs_dir.get());
 
 		auto src_dir = static_cast<DirectoryNode *>(src_link->getParentNode().get());
 		auto it = src_dir->_entries.find(src_link->getName());
@@ -614,7 +616,7 @@ struct Superblock final : FsSuperblock {
 			dest_dir->_entries.erase(dest_it);
 		}
 
-		auto new_link = makeFsShared<Link>(dest_dir->treeLink(),
+		auto new_link = makeFsShared<Link>(dest_fs_link->sharedFromThis(),
 				std::move(dest_name), target);
 		src_dir->_entries.erase(it);
 		dest_dir->_entries.insert(new_link);
@@ -937,8 +939,9 @@ DirectoryNode::DirectoryNode(Superblock *superblock, int mode, uid_t uid, gid_t 
 }
 
 async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
-DirectoryNode::getLinkOrCreate(Process *, std::string name, mode_t mode, bool exclusive) {
-	auto linkResult = co_await getLink(name);
+DirectoryNode::getLinkOrCreate(FsLink *parent, Process *, std::string name, mode_t mode,
+		bool exclusive) {
+	auto linkResult = co_await getLink(parent, name);
 	if (linkResult && !exclusive)
 		co_return linkResult.value();
 	else if (linkResult && exclusive)
@@ -946,14 +949,14 @@ DirectoryNode::getLinkOrCreate(Process *, std::string name, mode_t mode, bool ex
 
 	auto node = makeFsShared<MemoryNode>(static_cast<Superblock *>(superblock()));
 	co_await node->chmod(mode);
-	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0, false);
 	co_return link;
 }
 
 async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-DirectoryNode::mkdir(Process *proc, std::string name, mode_t mode) {
+DirectoryNode::mkdir(FsLink *parent, Process *proc, std::string name, mode_t mode) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 
@@ -963,7 +966,7 @@ DirectoryNode::mkdir(Process *proc, std::string name, mode_t mode) {
 
 	auto node = makeFsShared<DirectoryNode>(static_cast<Superblock *>(superblock()), mode & ~umask, uid, gid);
 	auto the_node = node.get();
-	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
 	the_node->_treeLink = link;
 	_entries.insert(link);
 	// Account for the new subdirectory's '..' backlink.
@@ -973,44 +976,44 @@ DirectoryNode::mkdir(Process *proc, std::string name, mode_t mode) {
 }
 
 async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
-DirectoryNode::symlink(std::string name, std::string path) {
+DirectoryNode::symlink(FsLink *parent, std::string name, std::string path) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 	auto node = makeFsShared<SymlinkNode>(static_cast<Superblock *>(superblock()),
 			std::move(path));
-	auto link = makeFsShared<Link>(treeLink(), std::move(name), std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(node));
 	_entries.insert(link);
 	co_return link;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-DirectoryNode::mkdev(std::string name, VfsType type, DeviceId id) {
+DirectoryNode::mkdev(FsLink *parent, std::string name, VfsType type, DeviceId id) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 	auto node = makeFsShared<DeviceNode>(static_cast<Superblock *>(superblock()),
 			type, id);
-	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0);
 	co_return link;
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
-DirectoryNode::mkfifo(std::string name, mode_t mode) {
+DirectoryNode::mkfifo(FsLink *parent, std::string name, mode_t mode) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 	auto node = makeFsShared<FifoNode>(static_cast<Superblock *>(superblock()), mode);
-	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0);
 	co_return link;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::mksocket(std::string name, mode_t mode, uid_t uid, gid_t gid) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::mksocket(FsLink *parent, std::string name, mode_t mode, uid_t uid, gid_t gid) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 	auto node = makeFsShared<SocketNode>(static_cast<Superblock *>(superblock()), mode, uid, gid);
-	auto link = makeFsShared<Link>(treeLink(), name, std::move(node));
+	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	notifyObservers(FsObserver::createEvent, name, 0);
 	co_return link;

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -312,11 +312,6 @@ private:
 		return VfsType::directory;
 	}
 
-	smarter::shared_ptr<FsLink> treeLink() override {
-		assert(_treeLink);
-		return _treeLink;
-	}
-
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
 			SemanticFlags semantic_flags) override {
@@ -411,7 +406,6 @@ public:
 
 private:
 	// TODO: This creates a circular reference -- fix this.
-	smarter::shared_ptr<Link> _treeLink;
 	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
 };
 
@@ -622,8 +616,7 @@ struct Superblock final : FsSuperblock {
 		dest_dir->_entries.insert(new_link);
 
 		if(target->getType() == VfsType::directory) {
-			// The moved directory's tree link and '..' backlink follow it to dest_dir.
-			static_cast<DirectoryNode *>(target.get())->_treeLink = new_link;
+			// Account for the moved directory's '..' backlink.
 			if(src_dir != dest_dir) {
 				src_dir->adjustLinkCount(-1);
 				dest_dir->adjustLinkCount(1);
@@ -826,7 +819,7 @@ DirectoryFile::readEntries() {
 	// '.' and '..' are not stored in _entries; synthesize them before iterating.
 	if(_dots != DotEntriesPhase::done) {
 		// The parent of the root directory is the root itself.
-		auto owner = _node->treeLink()->getParentNode();
+		auto owner = associatedLink()->getParentNode();
 		auto parent = owner ? static_cast<Node *>(owner.get()) : static_cast<Node *>(_node);
 		if(auto entry = nextDotEntry(_dots, _node->inodeNumber(), parent->inodeNumber()); entry)
 			co_return *entry;
@@ -924,9 +917,7 @@ SocketNode::SocketNode(Superblock *superblock, mode_t mode, uid_t uid, gid_t gid
 
 smarter::shared_ptr<Link> DirectoryNode::createRootDirectory(Superblock *superblock, int mode, uid_t uid, gid_t gid) {
 	auto node = makeFsShared<DirectoryNode>(superblock, mode, uid, gid);
-	auto the_node = node.get();
 	auto link = makeFsShared<Link>(std::move(node));
-	the_node->_treeLink = link;
 	return link;
 }
 
@@ -965,9 +956,7 @@ DirectoryNode::mkdir(FsLink *parent, Process *proc, std::string name, mode_t mod
 	auto gid = proc ? proc->threadGroup()->gid() : 0;
 
 	auto node = makeFsShared<DirectoryNode>(static_cast<Superblock *>(superblock()), mode & ~umask, uid, gid);
-	auto the_node = node.get();
 	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
-	the_node->_treeLink = link;
 	_entries.insert(link);
 	// Account for the new subdirectory's '..' backlink.
 	adjustLinkCount(1);

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -253,6 +253,12 @@ public:
 		return _target;
 	}
 
+	void renameTo(smarter::shared_ptr<FsLink> owner, std::string name) {
+		assert(_owner); // The root link is never renamed.
+		_owner = std::move(owner);
+		_name = std::move(name);
+	}
+
 private:
 	smarter::shared_ptr<FsLink> _owner;
 	std::string _name;
@@ -610,10 +616,11 @@ struct Superblock final : FsSuperblock {
 			dest_dir->_entries.erase(dest_it);
 		}
 
-		auto new_link = makeFsShared<Link>(dest_fs_link->sharedFromThis(),
-				std::move(dest_name), target);
+		// _entries is ordered by name, so the link has to leave the set before it is renamed.
+		auto link = *it;
 		src_dir->_entries.erase(it);
-		dest_dir->_entries.insert(new_link);
+		link->renameTo(dest_fs_link->sharedFromThis(), std::move(dest_name));
+		dest_dir->_entries.insert(link);
 
 		if(target->getType() == VfsType::directory) {
 			// Account for the moved directory's '..' backlink.
@@ -622,7 +629,7 @@ struct Superblock final : FsSuperblock {
 				dest_dir->adjustLinkCount(1);
 			}
 		}
-		co_return new_link;
+		co_return link;
 	}
 
 	async::result<frg::expected<Error, FsStats>> getFsStats() override {

--- a/posix/subsystem/src/un-socket.cpp
+++ b/posix/subsystem/src/un-socket.cpp
@@ -586,8 +586,9 @@ public:
 			if(!resolver.currentLink())
 				co_return protocols::fs::Error::fileNotFound;
 
-			auto parentNode = resolver.currentLink()->getTarget();
-			auto nodeResult = co_await parentNode->mksocket(resolver.nextComponent(), (0666 & ~process->fsContext()->getUmask()), process->threadGroup()->uid(), process->threadGroup()->gid());
+			auto parentLink = resolver.currentLink();
+			auto nodeResult = co_await parentLink->getTarget()->mksocket(parentLink.get(),
+					resolver.nextComponent(), (0666 & ~process->fsContext()->getUmask()), process->threadGroup()->uid(), process->threadGroup()->gid());
 			if(!nodeResult) {
 				co_return protocols::fs::Error::alreadyExists;
 			}

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -492,8 +492,8 @@ async::result<frg::expected<protocols::fs::Error, void>> PathResolver::resolve(R
 
 std::string ViewPath::getPath(ViewPath root) const {
 	// Strategy: from the current ViewPath, we build up the path by traversing upwards through
-	// its parents. This relies on the fact that we guarantee that directories provide a valid
-	// treeLink(), so that we can traverse further.
+	// its parents. This relies on the fact that every link knows the link of its parent
+	// directory, so that we can traverse further.
 
 	// Determine if we want a trailing slash
 	std::string path = this->second->getTarget()->getType() == VfsType::directory ? "/" : "";

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -76,24 +76,24 @@ async::result<void> populateRootView() {
 	auto tree = tmp_fs::createRoot(nullptr, {}).value();
 	rootView = MountView::createRoot(tree);
 
-	co_await tree->getTarget()->mkdir(nullptr, "realfs", 0555);
+	co_await tree->getTarget()->mkdir(tree.get(), nullptr, "realfs", 0555);
 
 	// TODO: Check for errors from mkdir().
-	auto dev = std::get<smarter::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir(nullptr, "dev", 0755));
+	auto dev = std::get<smarter::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir(tree.get(), nullptr, "dev", 0755));
 	co_await rootView->mount(std::move(dev), getDevtmpfs());
 
-	auto sys = std::get<smarter::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir(nullptr, "sys", 0755));
+	auto sys = std::get<smarter::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir(tree.get(), nullptr, "sys", 0755));
 	co_await rootView->mount(std::move(sys), getSysfs());
 
 	// Populate the tmpfs from the fs we are running on.
 	std::vector<
 		std::pair<
-			smarter::shared_ptr<FsNode>,
+			smarter::shared_ptr<FsLink>,
 			std::string
 		>
 	> stack;
 
-	stack.push_back({tree->getTarget(), std::string{""}});
+	stack.push_back({tree, std::string{""}});
 
 	while(!stack.empty()) {
 		auto item = stack.back();
@@ -158,15 +158,15 @@ async::result<void> populateRootView() {
 			if(resp.file_type() == managarm::fs::FileType::DIRECTORY) {
 				// TODO: Check for errors from mkdir().
 				auto link = std::get<smarter::shared_ptr<FsLink>>(
-				    co_await item.first->mkdir(nullptr, resp.path(), 0755)
+				    co_await item.first->getTarget()->mkdir(item.first.get(), nullptr, resp.path(), 0755)
 				);
-				stack.push_back({link->getTarget(), item.second + "/" + resp.path()});
+				stack.push_back({link, item.second + "/" + resp.path()});
 			}else{
 				assert(resp.file_type() == managarm::fs::FileType::REGULAR);
 
 				auto file_path = "/" + item.second + "/" + resp.path();
 				auto node = tmp_fs::createMemoryNode(std::move(file_path));
-				auto result = co_await item.first->link(resp.path(), node);
+				auto result = co_await item.first->getTarget()->link(item.first.get(), resp.path(), node);
 				assert(result);
 			}
 		}
@@ -309,7 +309,7 @@ async::result<frg::expected<protocols::fs::Error, void>> PathResolver::resolve(R
 					_components.pop_back();
 				}
 
-				auto result = co_await _currentPath.second->getTarget()->traverseLinks(_components);
+				auto result = co_await _currentPath.second->getTarget()->traverseLinks(_currentPath.second.get(), _components);
 
 				if (!result) {
 					assert(result.error() == Error::illegalOperationTarget
@@ -386,7 +386,7 @@ async::result<frg::expected<protocols::fs::Error, void>> PathResolver::resolve(R
 					_currentPath = std::move(next);
 				}
 			} else {
-				auto childResult = co_await _currentPath.second->getTarget()->getLink(std::move(name));
+				auto childResult = co_await _currentPath.second->getTarget()->getLink(_currentPath.second.get(), std::move(name));
 				if(!childResult) {
 					assert(childResult.error() == Error::notDirectory
 							|| childResult.error() == Error::illegalOperationTarget
@@ -472,7 +472,7 @@ async::result<frg::expected<protocols::fs::Error, void>> PathResolver::resolve(R
 			if(flags & resolveOpenCreate)
 				co_return protocols::fs::Error::isDirectory;
 			if((flags & resolveCreatesNonDirectory) && !_components.empty()) {
-				auto childResult = co_await _currentPath.second->getTarget()->getLink(_components.front());
+				auto childResult = co_await _currentPath.second->getTarget()->getLink(_currentPath.second.get(), _components.front());
 				if(childResult && childResult.value())
 					co_return protocols::fs::Error::alreadyExists;
 				co_return protocols::fs::Error::fileNotFound;

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -286,18 +286,18 @@ async::result<frg::expected<protocols::fs::Error, void>> PathResolver::resolve(R
 				if(auto parent = _currentPath.first->getParent(); parent) {
 					auto anchor = _currentPath.first->getAnchor();
 					assert(anchor); // Non-root mounts must have anchors in their parents.
-					auto owner = anchor->getOwner();
+					auto anchorParent = anchor->getParent();
 					// TODO: We have to decide if the following is something we want to support:
-					assert(owner && "FS mounted over root of parent mount");
-					_currentPath = ViewPath{parent, owner->treeLink()};
+					assert(anchorParent && "FS mounted over root of parent mount");
+					_currentPath = ViewPath{parent, std::move(anchorParent)};
 				}else{
 					// We are at the root -- do not modify _currentPath at all.
 				}
 			}else{
-				auto owner = _currentPath.second->getOwner();
-				assert(owner && "VFS resolution crosses root directory of non-root"
+				auto parentLink = _currentPath.second->getParent();
+				assert(parentLink && "VFS resolution crosses root directory of non-root"
 							" mount! (Mount configuration broken?)");
-				_currentPath = ViewPath{_currentPath.first, owner->treeLink()};
+				_currentPath = ViewPath{_currentPath.first, std::move(parentLink)};
 			}
 		}else{
 			if (_currentPath.second->getTarget()->hasTraverseLinks()) {
@@ -380,7 +380,7 @@ async::result<frg::expected<protocols::fs::Error, void>> PathResolver::resolve(R
 					if(!link.isRelative())
 						_currentPath = _rootPath;
 					else
-						_currentPath = ViewPath{_currentPath.first, next.second->getOwner()->treeLink()};
+						_currentPath = ViewPath{_currentPath.first, next.second->getParent()};
 					_components.insert(_components.begin(), link.begin(), link.end());
 				}else{
 					_currentPath = std::move(next);
@@ -514,11 +514,11 @@ std::string ViewPath::getPath(ViewPath root) const {
 			traversed = dir;
 		}
 
-		auto owner = traversed.second->getOwner();
-		assert(owner); // Otherwise, we would have been at the root.
+		auto parentLink = traversed.second->getParent();
+		assert(parentLink); // Otherwise, we would have been at the root.
 		path = "/" + traversed.second->getName() + path;
 
-		dir = ViewPath{traversed.first, owner->treeLink()};
+		dir = ViewPath{traversed.first, std::move(parentLink)};
 	}
 
 	return path;


### PR DESCRIPTION
This PR removes the `treeLink()` function in favor of a `FsLink::getParent()` function that returns the parent link (not the parent node) of the link.

This simplifies the lifetime handling in the VFS. Before, we had strong references from `FsNode`s to their parent `FsLink`s (as returned by `treeLink()`). Now ownership only goes from links to nodes: `FsLink` has a strong reference to its parent link and to its target node. `FsNode` doesn't necessarily have any strong reference to other links or nodes anymore (but in the case of tmpfs, the `FsNode` owns its children `FsLink`s until they are `unlink()`ed).

This change also simplifies extern_fs: both the `StructuralLink` (link to directories) and `PeripheralLink` (link to everything else) now collapse to a single `Link` class because we don't have to carefully work around potential reference cycles anymore.