### PR TITLE
posix: Add namecache to extern_fs

### DIFF
--- a/drivers/libblockfs/src/btrfs/ops.cpp
+++ b/drivers/libblockfs/src/btrfs/ops.cpp
@@ -68,7 +68,8 @@ getLink(std::shared_ptr<void> object, std::string name) {
 	assert(!name.empty() && name != "." && name != "..");
 	auto entry = FRG_CO_TRY(co_await self->findEntry(name));
 	if (!entry)
-		co_return protocols::fs::GetLinkResult{nullptr, -1, protocols::fs::FileType::unknown};
+		co_return protocols::fs::GetLinkResult{nullptr, -1, protocols::fs::FileType::unknown,
+				self->dirSerial};
 
 	protocols::fs::FileType type;
 	switch (entry->fileType) {
@@ -86,7 +87,8 @@ getLink(std::shared_ptr<void> object, std::string name) {
 	}
 
 	assert(entry->inode);
-	co_return protocols::fs::GetLinkResult{self->fs.accessInode(entry->inode), entry->inode, type};
+	co_return protocols::fs::GetLinkResult{self->fs.accessInode(entry->inode), entry->inode, type,
+			self->dirSerial};
 }
 
 async::result<std::expected<protocols::fs::GetLinkResult, protocols::fs::Error>>
@@ -98,7 +100,7 @@ link(std::shared_ptr<void> object, std::string name, int64_t ino) {
 	co_return std::unexpected{protocols::fs::Error::internalError};
 }
 
-async::result<std::expected<void, protocols::fs::Error>>
+async::result<std::expected<uint64_t, protocols::fs::Error>>
 unlink(std::shared_ptr<void> object, std::string name) {
 	(void)object;
 	(void)name;
@@ -217,7 +219,8 @@ async::result<std::expected<protocols::fs::GetLinkResult, protocols::fs::Error>>
 		default:
 			throw std::runtime_error("Unexpected file type");
 		}
-		co_return protocols::fs::GetLinkResult{self->fs.accessInode(e.inode), e.inode, type};
+		co_return protocols::fs::GetLinkResult{self->fs.accessInode(e.inode), e.inode, type,
+				self->dirSerial};
 	}
 
 	(void)mode;

--- a/drivers/libblockfs/src/common-ops.hpp
+++ b/drivers/libblockfs/src/common-ops.hpp
@@ -343,8 +343,7 @@ doTraverseLinks(std::shared_ptr<void> object, std::deque<std::string> components
 	std::optional<DirEntry> entry;
 	size_t allComponents = components.size();
 
-	// (inode, inode number) pair for all resolved path components.
-	std::vector<std::pair<std::shared_ptr<void>, int64_t>> nodes;
+	std::vector<protocols::fs::TraversedLink> nodes;
 
 	protocols::ostrace::Timer timer;
 	uint64_t timeLock = 0;
@@ -370,7 +369,8 @@ doTraverseLinks(std::shared_ptr<void> object, std::deque<std::string> components
 
 		if (component == ".") {
 			components.pop_front();
-			nodes.push_back({dirStack.back().first, dirStack.back().second});
+			// "." and ".." are not entries that a client may cache, so they carry no serial.
+			nodes.push_back({dirStack.back().first, dirStack.back().second, 0});
 		} else if (component == "..") {
 			// Break before popping the component: we must not ascend past the initial directory.
 			if (dirStack.size() == 1)
@@ -379,9 +379,10 @@ doTraverseLinks(std::shared_ptr<void> object, std::deque<std::string> components
 			dirStack.pop_back();
 
 			components.pop_front();
-			nodes.push_back({dirStack.back().first, dirStack.back().second});
+			nodes.push_back({dirStack.back().first, dirStack.back().second, 0});
 		} else {
 			auto parent = dirStack.back().first;
+			uint64_t serial;
 			{
 				protocols::ostrace::Timer lockTimer;
 				co_await parent->inodeMutex.async_lock_shared();
@@ -389,17 +390,22 @@ doTraverseLinks(std::shared_ptr<void> object, std::deque<std::string> components
 				timeLock += lockTimer.elapsed();
 
 				protocols::ostrace::Timer findTimer;
-				entry = FRG_CO_TRY(co_await parent->findEntry(component));
+				auto found = co_await parent->findEntry(component);
 				timeFind += findTimer.elapsed();
+				if (!found)
+					co_return std::unexpected{protocols::fs::TraverseLinksError{found.error()}};
+				entry = found.value();
+				serial = parent->dirSerial;
 			}
 
 			if (!entry) {
-				co_return protocols::fs::Error::fileNotFound;
+				co_return std::unexpected{protocols::fs::TraverseLinksError{
+						protocols::fs::Error::fileNotFound, serial}};
 			}
 			assert(entry->inode);
 
 			components.pop_front();
-			nodes.push_back({self->fs.accessInode(entry->inode), entry->inode});
+			nodes.push_back({self->fs.accessInode(entry->inode), entry->inode, serial});
 
 			if (!components.empty()) {
 				bool obstructed;
@@ -417,7 +423,8 @@ doTraverseLinks(std::shared_ptr<void> object, std::deque<std::string> components
 					break;
 
 				if (entry->fileType != kTypeDirectory)
-					co_return protocols::fs::Error::notDirectory;
+					co_return std::unexpected{protocols::fs::TraverseLinksError{
+							protocols::fs::Error::notDirectory}};
 
 				// Push the directory that we just entered.
 				dirStack.push_back({std::static_pointer_cast<Inode>(ino), entry->inode});
@@ -426,7 +433,7 @@ doTraverseLinks(std::shared_ptr<void> object, std::deque<std::string> components
 	}
 
 	if (!entry)
-		co_return protocols::fs::Error::fileNotFound;
+		co_return std::unexpected{protocols::fs::TraverseLinksError{protocols::fs::Error::fileNotFound}};
 
 	protocols::fs::FileType type;
 	switch (entry->fileType) {

--- a/drivers/libblockfs/src/ext2/ext2fs.cpp
+++ b/drivers/libblockfs/src/ext2/ext2fs.cpp
@@ -471,6 +471,7 @@ async::result<frg::expected<protocols::fs::Error>> Inode::removeEntry(std::strin
 				diskInodeWindow.markDirty();
 			}
 
+			fs.recordMutation({this});
 			co_return {};
 		}
 
@@ -600,6 +601,7 @@ async::result<frg::expected<protocols::fs::Error>> Inode::updateDotDot(uint32_t 
 			HEL_CHECK(syncDir.error());
 			cleanDirTime += cleanDirTimer.elapsed();
 
+			fs.recordMutation({this});
 			co_return {};
 		}
 
@@ -647,6 +649,7 @@ Inode::link(std::string name, int64_t ino, blockfs::FileType type) {
 	auto result = co_await insertEntry(name, ino, type);
 	if(!result)
 		co_return std::unexpected{result.error()};
+	fs.recordMutation({this});
 	co_return result.value();
 }
 
@@ -730,6 +733,7 @@ async::result<std::expected<DirEntry, protocols::fs::Error>> Inode::mkdir(std::s
 	auto result = co_await insertEntry(name, dirNode->number, kTypeDirectory);
 	if(!result)
 		co_return std::unexpected{result.error()};
+	fs.recordMutation({this});
 	co_return result.value();
 }
 
@@ -807,6 +811,7 @@ async::result<std::expected<DirEntry, protocols::fs::Error>> Inode::symlink(std:
 	auto result = co_await insertEntry(name, newNode->number, kTypeSymlink);
 	if(!result)
 		co_return std::unexpected{result.error()};
+	fs.recordMutation({this});
 	co_return result.value();
 }
 

--- a/drivers/libblockfs/src/ext2/ops.cpp
+++ b/drivers/libblockfs/src/ext2/ops.cpp
@@ -182,7 +182,8 @@ async::result<std::expected<uint64_t, protocols::fs::Error>> unlink(std::shared_
 	co_return self->dirSerial;
 }
 
-async::result<std::expected<uint64_t, protocols::fs::Error>> rmdir(std::shared_ptr<void> object, std::string name) {
+async::result<std::expected<protocols::fs::RmdirResult, protocols::fs::Error>>
+rmdir(std::shared_ptr<void> object, std::string name) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
 
 	protocols::ostrace::Timer timer;
@@ -222,7 +223,7 @@ async::result<std::expected<uint64_t, protocols::fs::Error>> rmdir(std::shared_p
 	auto result = co_await self->removeEntry(std::move(name));
 	if (!result)
 		co_return std::unexpected{result.error()};
-	co_return self->dirSerial;
+	co_return protocols::fs::RmdirResult{target->number, self->dirSerial};
 }
 
 async::result<protocols::fs::FileStats>

--- a/drivers/libblockfs/src/ext2/ops.cpp
+++ b/drivers/libblockfs/src/ext2/ops.cpp
@@ -77,7 +77,7 @@ getLink(std::shared_ptr<void> object,
 	found = entry.has_value();
 	if(!entry)
 		co_return protocols::fs::GetLinkResult{nullptr, -1,
-				protocols::fs::FileType::unknown};
+				protocols::fs::FileType::unknown, self->dirSerial};
 
 	protocols::fs::FileType type;
 	switch(entry->fileType) {
@@ -95,7 +95,8 @@ getLink(std::shared_ptr<void> object,
 	}
 
 	assert(entry->inode);
-	co_return protocols::fs::GetLinkResult{self->fs.accessInode(entry->inode), entry->inode, type};
+	co_return protocols::fs::GetLinkResult{self->fs.accessInode(entry->inode), entry->inode, type,
+			self->dirSerial};
 }
 
 async::result<std::expected<protocols::fs::GetLinkResult, protocols::fs::Error>> link(std::shared_ptr<void> object,
@@ -138,10 +139,11 @@ async::result<std::expected<protocols::fs::GetLinkResult, protocols::fs::Error>>
 	}
 
 	assert(entry->inode);
-	co_return protocols::fs::GetLinkResult{self->fs.accessInode(entry->inode), entry->inode, type};
+	co_return protocols::fs::GetLinkResult{self->fs.accessInode(entry->inode), entry->inode, type,
+			self->dirSerial};
 }
 
-async::result<std::expected<void, protocols::fs::Error>> unlink(std::shared_ptr<void> object, std::string name) {
+async::result<std::expected<uint64_t, protocols::fs::Error>> unlink(std::shared_ptr<void> object, std::string name) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
 
 	protocols::ostrace::Timer timer;
@@ -177,10 +179,10 @@ async::result<std::expected<void, protocols::fs::Error>> unlink(std::shared_ptr<
 	auto result = co_await self->removeEntry(std::move(name));
 	if (!result)
 		co_return std::unexpected{result.error()};
-	co_return {};
+	co_return self->dirSerial;
 }
 
-async::result<std::expected<void, protocols::fs::Error>> rmdir(std::shared_ptr<void> object, std::string name) {
+async::result<std::expected<uint64_t, protocols::fs::Error>> rmdir(std::shared_ptr<void> object, std::string name) {
 	auto self = std::static_pointer_cast<ext2fs::Inode>(object);
 
 	protocols::ostrace::Timer timer;
@@ -220,7 +222,7 @@ async::result<std::expected<void, protocols::fs::Error>> rmdir(std::shared_ptr<v
 	auto result = co_await self->removeEntry(std::move(name));
 	if (!result)
 		co_return std::unexpected{result.error()};
-	co_return {};
+	co_return self->dirSerial;
 }
 
 async::result<protocols::fs::FileStats>
@@ -310,7 +312,8 @@ mkdir(std::shared_ptr<void> object, std::string name, uid_t uid, gid_t gid, mode
 		co_return std::unexpected{entry.error()};
 
 	assert(entry->inode);
-	co_return protocols::fs::MkdirResult{self->fs.accessInode(entry->inode), entry->inode};
+	co_return protocols::fs::MkdirResult{self->fs.accessInode(entry->inode), entry->inode,
+			self->dirSerial};
 }
 
 async::result<std::expected<protocols::fs::SymlinkResult, protocols::fs::Error>>
@@ -340,7 +343,8 @@ symlink(std::shared_ptr<void> object, std::string name, std::string target) {
 		co_return std::unexpected{entry.error()};
 
 	assert(entry->inode);
-	co_return protocols::fs::SymlinkResult{self->fs.accessInode(entry->inode), entry->inode};
+	co_return protocols::fs::SymlinkResult{self->fs.accessInode(entry->inode), entry->inode,
+			self->dirSerial};
 }
 
 async::result<protocols::fs::Error> chmod(std::shared_ptr<void> object, int mode) {
@@ -423,7 +427,8 @@ getLinkOrCreate(std::shared_ptr<void> object, std::string name, mode_t mode, boo
 		default:
 			throw std::runtime_error("Unexpected file type");
 		}
-		co_return protocols::fs::GetLinkResult{self->fs.accessInode(e.inode), e.inode, type};
+		co_return protocols::fs::GetLinkResult{self->fs.accessInode(e.inode), e.inode, type,
+				self->dirSerial};
 	}
 
 	auto baseInode = co_await self->fs.createRegular(uid, gid, self->number);
@@ -443,7 +448,8 @@ getLinkOrCreate(std::shared_ptr<void> object, std::string name, mode_t mode, boo
 	if (!linkResult)
 		co_return std::unexpected{protocols::fs::Error::internalError};
 
-	co_return protocols::fs::GetLinkResult{inode, inode->number, protocols::fs::FileType::regular};
+	co_return protocols::fs::GetLinkResult{inode, inode->number, protocols::fs::FileType::regular,
+			self->dirSerial};
 }
 
 } // namespace anonymous

--- a/drivers/libblockfs/src/fs.hpp
+++ b/drivers/libblockfs/src/fs.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "common.hpp"
+#include <atomic>
+#include <initializer_list>
 #include <memory>
 #include <mutex>
 #include <unordered_set>
@@ -50,6 +52,11 @@ struct BaseInode {
 
 	// Protected by obstructedLinksMutex.
 	std::unordered_set<std::string> obstructedLinks;
+
+	// Serial of the last mutation of this directory's entries.
+	// Updated to BaseFileSystem::mutationSerial_ on any mutation.
+	// Protected by inodeMutex.
+	uint64_t dirSerial = 0;
 };
 
 struct BaseFile {
@@ -94,12 +101,24 @@ struct BaseFileSystem {
 	// Ordered after BaseFile::mutex.
 	async::shared_mutex topologyMutex;
 
+	// Assigns a fresh mutation serial to the given directories and returns it.
+	// Callers must hold the inodeMutex of each directory (exclusive).
+	uint64_t recordMutation(std::initializer_list<BaseInode *> dirs) {
+		auto serial = mutationSerial_.fetch_add(1, std::memory_order_relaxed) + 1;
+		for(auto dir : dirs)
+			dir->dirSerial = serial;
+		return serial;
+	}
+
 	BaseFileSystem(const BaseFileSystem &) = delete;
 	BaseFileSystem(BaseFileSystem &&) = delete;
 	BaseFileSystem &operator=(const BaseFileSystem &) = delete;
 	BaseFileSystem &operator=(BaseFileSystem &&) = delete;
 
 	virtual ~BaseFileSystem() = default;
+
+private:
+	std::atomic<uint64_t> mutationSerial_{0};
 };
 
 template <typename T>

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -415,6 +415,8 @@ struct HandlePartition {
 					old_file.value().inode, old_file.value().fileType);
 			linkTime += linkTimer.elapsed();
 			if(!link_result) {
+				// We already mutated the directory, so report a serial.
+				resp.set_serial(fs->recordMutation({oldInode.get(), newInode.get()}));
 				resp.set_error(link_result.error() | protocols::fs::toFsError);
 
 				auto ser = resp.SerializeAsString();
@@ -431,6 +433,8 @@ struct HandlePartition {
 					&& oldInode->number != newInode->number) {
 				auto reparent = co_await movedInode->updateDotDot(newInode->number);
 				if(!reparent) {
+					// We already mutated the directory, so report a serial.
+					resp.set_serial(fs->recordMutation({oldInode.get(), newInode.get()}));
 					resp.set_error(reparent.error() | protocols::fs::toFsError);
 
 					auto ser = resp.SerializeAsString();
@@ -454,6 +458,8 @@ struct HandlePartition {
 		auto result = co_await oldInode->removeEntry(req.old_name());
 		removeTime += removeOldTimer.elapsed();
 		if(!result) {
+			// We already mutated the directory, so report a serial.
+			resp.set_serial(fs->recordMutation({oldInode.get(), newInode.get()}));
 			resp.set_error(result.error() | protocols::fs::toFsError);
 
 			auto ser = resp.SerializeAsString();
@@ -462,6 +468,9 @@ struct HandlePartition {
 			HEL_CHECK(send_resp.error());
 			co_return {};
 		}
+		// Report one serial for both directories, so that the client can order this
+		// rename against the mutations it observes on either directory.
+		resp.set_serial(fs->recordMutation({oldInode.get(), newInode.get()}));
 		resp.set_error(managarm::fs::Errors::SUCCESS);
 
 		auto ser = resp.SerializeAsString();

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -114,7 +114,7 @@ struct HandlePartition {
 			fs = std::make_unique<btrfs::FileSystem>(partition);
 			co_await static_cast<btrfs::FileSystem *>(fs.get())->init();
 		} else {
-			managarm::fs::SvrResponse resp;
+			managarm::fs::MountResponse resp;
 			resp.set_error(managarm::fs::Errors::NO_BACKING_DEVICE);
 
 			auto ser = resp.SerializeAsString();
@@ -131,8 +131,9 @@ struct HandlePartition {
 		protocols::fs::serveNode(std::move(local_lane), fs->accessRoot(),
 				fs->nodeOps());
 
-		managarm::fs::SvrResponse resp;
+		managarm::fs::MountResponse resp;
 		resp.set_error(managarm::fs::Errors::SUCCESS);
+		resp.set_caps(managarm::fs::MountCaps::MC_CLIENT_EXCLUSIVE_NAMESPACE);
 
 		auto ser = resp.SerializeAsString();
 		auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
@@ -621,7 +622,7 @@ struct HandleDevice {
 		if(!tailRes)
 			co_return std::unexpected(tailRes.error());
 
-		managarm::fs::SvrResponse resp;
+		managarm::fs::MountResponse resp;
 		resp.set_error(managarm::fs::Errors::ILLEGAL_OPERATION_TARGET);
 
 		auto ser = resp.SerializeAsString();

--- a/drivers/libblockfs/src/libblockfs.cpp
+++ b/drivers/libblockfs/src/libblockfs.cpp
@@ -259,6 +259,8 @@ struct HandlePartition {
 		std::shared_ptr<ext2fs::Inode> movedInode, victimInode;
 		// These locks are taken below for the moved and victim inodes.
 		std::optional<frg::unique_lock<async::shared_mutex>> thirdLock, fourthLock;
+		// Entry that the rename replaces, reported once the rename succeeded.
+		std::optional<ext2fs::DirEntry> replacedEntry;
 
 		if(old_file) {
 			// Reject moving a directory into itself or one of its own
@@ -410,6 +412,7 @@ struct HandlePartition {
 				HEL_CHECK(send_resp.error());
 				co_return {};
 			}
+			replacedEntry = new_entry.value();
 			protocols::ostrace::Timer linkTimer;
 			auto link_result = co_await newInode->link(req.new_name(),
 					old_file.value().inode, old_file.value().fileType);
@@ -467,6 +470,23 @@ struct HandlePartition {
 				helix_ng::sendBuffer(ser.data(), ser.size()));
 			HEL_CHECK(send_resp.error());
 			co_return {};
+		}
+		// Report the replaced entry so that the client can drop its state for it.
+		if(replacedEntry) {
+			resp.set_id(replacedEntry->inode);
+			switch(replacedEntry->fileType) {
+			case kTypeDirectory:
+				resp.set_file_type(managarm::fs::FileType::DIRECTORY);
+				break;
+			case kTypeRegular:
+				resp.set_file_type(managarm::fs::FileType::REGULAR);
+				break;
+			case kTypeSymlink:
+				resp.set_file_type(managarm::fs::FileType::SYMLINK);
+				break;
+			default:
+				throw std::runtime_error("Unexpected file type");
+			}
 		}
 		// Report one serial for both directories, so that the client can order this
 		// rename against the mutations it observes on either directory.

--- a/posix/subsystem/meson.build
+++ b/posix/subsystem/meson.build
@@ -29,6 +29,7 @@ src = [
 	'src/gdbserver.cpp',
 	'src/inotify.cpp',
 	'src/interval-timer.cpp',
+	'src/link-rc.cpp',
 	'src/main.cpp',
 	'src/memfd.cpp',
 	'src/net.cpp',

--- a/posix/subsystem/src/cgroupfs.cpp
+++ b/posix/subsystem/src/cgroupfs.cpp
@@ -17,15 +17,15 @@ SuperBlock cgroupfsSuperblock;
 // LinkCompare implementation.
 // ----------------------------------------------------------------------------
 
-bool LinkCompare::operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link, LinkRc> &a, const smarter::shared_ptr<Link, LinkRc> &b) const {
 	return a->getName() < b->getName();
 }
 
-bool LinkCompare::operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link, LinkRc> &link, const std::string &name) const {
 	return link->getName() < name;
 }
 
-bool LinkCompare::operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const {
+bool LinkCompare::operator() (const std::string &name, const smarter::shared_ptr<Link, LinkRc> &link) const {
 	return name < link->getName();
 }
 
@@ -42,7 +42,7 @@ void RegularFile::serve(smarter::shared_ptr<RegularFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-RegularFile::RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+RegularFile::RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("cgroupfs.file"), std::move(mount), std::move(link)},
 		_cached{false}, _offset{0} { }
 
@@ -105,7 +105,7 @@ void DirectoryFile::serve(smarter::shared_ptr<DirectoryFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("cgroupfs.dir"), std::move(mount), std::move(link)},
 		_node{static_cast<DirectoryNode *>(associatedLink()->getTarget().get())},
 		_iter{_node->_entries.begin()} { }
@@ -144,13 +144,13 @@ helix::BorrowedDescriptor DirectoryFile::getPassthroughLane() {
 Link::Link(smarter::shared_ptr<FsNode> target)
 : _target{std::move(target)} { }
 
-Link::Link(smarter::shared_ptr<FsLink> owner, std::string name, smarter::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsLink, LinkRc> owner, std::string name, smarter::shared_ptr<FsNode> target)
 : _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 	assert(_owner);
 	assert(!_name.empty());
 }
 
-smarter::shared_ptr<FsLink> Link::getParent() {
+smarter::shared_ptr<FsLink, LinkRc> Link::getParent() {
 	return _owner;
 }
 
@@ -196,7 +196,7 @@ async::result<frg::expected<Error, FileStats>> RegularNode::getStats() {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-RegularNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+RegularNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: cgroupfs RegularNode open() received illegal arguments:"
@@ -217,7 +217,7 @@ FutureMaybe<smarter::shared_ptr<FsNode>> SuperBlock::createRegular(Process *) {
 	co_return nullptr;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 SuperBlock::rename(FsLink *, FsLink *, std::string) {
 	co_return Error::noSuchFile;
 };
@@ -232,7 +232,7 @@ async::result<frg::expected<Error, FsStats>> SuperBlock::getFsStats() {
 // DirectoryNode implementation.
 // ----------------------------------------------------------------------------
 
-smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::createRootDirectory() {
 	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
 	auto link = makeFsShared<Link>(std::move(node));
@@ -245,7 +245,7 @@ smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 DirectoryNode::DirectoryNode()
 : FsNode{&cgroupfsSuperblock} { }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkregular(FsLink *parent, std::string name,
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::directMkregular(FsLink *parent, std::string name,
 		smarter::shared_ptr<RegularNode> regular) {
 	assert(_entries.find(name) == _entries.end());
 	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(regular));
@@ -253,7 +253,7 @@ smarter::shared_ptr<Link> DirectoryNode::directMkregular(FsLink *parent, std::st
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkdir(FsLink *parent, std::string name) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::directMkdir(FsLink *parent, std::string name) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = makeFsShared<DirectoryNode>();
 	auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(node));
@@ -261,14 +261,14 @@ smarter::shared_ptr<Link> DirectoryNode::directMkdir(FsLink *parent, std::string
 	return link;
 }
 
-async::result<std::variant<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::mkdir(FsLink *parent, Process *, std::string name, mode_t) {
+async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>> DirectoryNode::mkdir(FsLink *parent, Process *, std::string name, mode_t) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 	auto link = createCgroupDirectory(parent, name);
 	co_return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMknode(FsLink *parent, std::string name, smarter::shared_ptr<FsNode> node) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::directMknode(FsLink *parent, std::string name, smarter::shared_ptr<FsNode> node) {
 	assert(_entries.find(name) == _entries.end());
 	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
@@ -279,7 +279,7 @@ VfsType DirectoryNode::getType() {
 	return VfsType::directory;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::link(FsLink *, std::string,
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> DirectoryNode::link(FsLink *, std::string,
 		smarter::shared_ptr<FsNode>) {
 	co_return Error::noSuchFile;
 }
@@ -305,7 +305,7 @@ async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: cgroup DirectoryNode open() received illegal arguments:"
@@ -321,7 +321,7 @@ DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(FsLink *, std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> DirectoryNode::getLink(FsLink *, std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;
@@ -336,7 +336,7 @@ async::result<frg::expected<Error>> DirectoryNode::unlink(std::string name) {
 	co_return frg::expected<Error>{};
 }
 
-smarter::shared_ptr<Link> DirectoryNode::createCgroupDirectory(FsLink *parent, std::string name) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::createCgroupDirectory(FsLink *parent, std::string name) {
 	auto link = directMkdir(parent, name);
 	auto cgroup_dir = static_cast<DirectoryNode*>(link->getTarget().get());
 
@@ -385,7 +385,7 @@ LinkNode::LinkNode()
 
 } // namespace cgroupfs
 
-smarter::shared_ptr<FsLink> getCgroupfs() {
-	static smarter::shared_ptr<FsLink> cgroupfs = cgroupfs::DirectoryNode::createRootDirectory();
+smarter::shared_ptr<FsLink, LinkRc> getCgroupfs() {
+	static smarter::shared_ptr<FsLink, LinkRc> cgroupfs = cgroupfs::DirectoryNode::createRootDirectory();
 	return cgroupfs;
 }

--- a/posix/subsystem/src/cgroupfs.hpp
+++ b/posix/subsystem/src/cgroupfs.hpp
@@ -22,16 +22,16 @@ struct DirectoryNode;
 struct LinkCompare {
 	struct is_transparent { };
 
-	bool operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const;
-	bool operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const;
-	bool operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const;
+	bool operator() (const smarter::shared_ptr<Link, LinkRc> &a, const smarter::shared_ptr<Link, LinkRc> &b) const;
+	bool operator() (const smarter::shared_ptr<Link, LinkRc> &link, const std::string &name) const;
+	bool operator() (const std::string &name, const smarter::shared_ptr<Link, LinkRc> &link) const;
 };
 
 struct RegularFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<RegularFile> file);
 
-	explicit RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
+	explicit RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link);
 
 	void handleClose() override;
 
@@ -58,7 +58,7 @@ struct DirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<DirectoryFile> file);
 
-	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
+	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link);
 
 	void handleClose() override;
 
@@ -73,21 +73,21 @@ private:
 	async::cancellation_event _cancelServe;
 
 	DotEntriesPhase _dots = DotEntriesPhase::dot;
-	std::set<smarter::shared_ptr<Link>, LinkCompare>::iterator _iter;
+	std::set<smarter::shared_ptr<Link, LinkRc>, LinkCompare>::iterator _iter;
 };
 
 struct Link final : FsLink {
 	explicit Link(smarter::shared_ptr<FsNode> target);
 
-	explicit Link(smarter::shared_ptr<FsLink> owner,
+	explicit Link(smarter::shared_ptr<FsLink, LinkRc> owner,
 			std::string name, smarter::shared_ptr<FsNode> target);
 
-	smarter::shared_ptr<FsLink> getParent() override;
+	smarter::shared_ptr<FsLink, LinkRc> getParent() override;
 	std::string getName() override;
 	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
-	smarter::shared_ptr<FsLink> _owner;
+	smarter::shared_ptr<FsLink, LinkRc> _owner;
 	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
 };
@@ -101,7 +101,7 @@ struct RegularNode : FsNode {
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override;
 
 	async::result<Error> chmod(int) override {
@@ -121,7 +121,7 @@ public:
 
 	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 			rename(FsLink *source, FsLink *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
@@ -140,39 +140,39 @@ private:
 struct DirectoryNode final : FsNode {
 	friend struct DirectoryFile;
 
-	static smarter::shared_ptr<Link> createRootDirectory();
+	static smarter::shared_ptr<Link, LinkRc> createRootDirectory();
 
 	DirectoryNode();
 
-	smarter::shared_ptr<Link> directMkregular(FsLink *parent, std::string name,
+	smarter::shared_ptr<Link, LinkRc> directMkregular(FsLink *parent, std::string name,
 			smarter::shared_ptr<RegularNode> regular);
-	smarter::shared_ptr<Link> directMknode(FsLink *parent, std::string name,
+	smarter::shared_ptr<Link, LinkRc> directMknode(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> node);
-	smarter::shared_ptr<Link> directMkdir(FsLink *parent, std::string name);
-	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+	smarter::shared_ptr<Link, LinkRc> directMkdir(FsLink *parent, std::string name);
+	async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	mkdir(FsLink *parent, Process *, std::string name, mode_t mode) override;
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target) override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> getLink(FsLink *parent, std::string name) override;
 	async::result<frg::expected<Error>> unlink(std::string name) override;
 
 	async::result<Error> chmod(int) override {
 		co_return Error::success;
 	}
 
-	smarter::shared_ptr<Link> createCgroupDirectory(FsLink *parent, std::string name);
+	smarter::shared_ptr<Link, LinkRc> createCgroupDirectory(FsLink *parent, std::string name);
 	void createCgroupFiles(FsLink *parent);
 
 private:
-	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
+	std::set<smarter::shared_ptr<Link, LinkRc>, LinkCompare> _entries;
 };
 
 struct ProcsNode final : RegularNode {
@@ -209,4 +209,4 @@ struct LinkNode : FsNode {
 
 } // namespace cgroupfs
 
-smarter::shared_ptr<FsLink> getCgroupfs();
+smarter::shared_ptr<FsLink, LinkRc> getCgroupfs();

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -397,9 +397,10 @@ FutureMaybe<smarter::shared_ptr<FsLink, LinkRc>> mountExternalDevice(helix::Borr
 	HEL_CHECK(pull_node.error());
 
 	managarm::fs::MountResponse resp;
-	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	auto parsed = resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 	recv_resp.reset();
+	assert(parsed);
 	assert(resp.error() == managarm::fs::Errors::SUCCESS);
-	co_return extern_fs::createRoot(lane.dup(), pull_node.descriptor(), device);
+	co_return extern_fs::createRoot(lane.dup(), pull_node.descriptor(), device, resp.caps());
 }
 

--- a/posix/subsystem/src/device.cpp
+++ b/posix/subsystem/src/device.cpp
@@ -23,7 +23,7 @@ UnixDeviceRegistry blockRegistry;
 // UnixDevice
 // --------------------------------------------------------
 
-FutureMaybe<smarter::shared_ptr<FsLink>> UnixDevice::mount(std::string) {
+FutureMaybe<smarter::shared_ptr<FsLink, LinkRc>> UnixDevice::mount(std::string) {
 	// TODO: Return an error.
 	throw std::logic_error("Device cannot be mounted!");
 }
@@ -53,7 +53,7 @@ std::shared_ptr<UnixDevice> UnixDeviceRegistry::get(DeviceId id) {
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 openDevice(Process *process, VfsType type, DeviceId id, std::shared_ptr<MountView> mount,
-	smarter::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
+	smarter::shared_ptr<FsLink, LinkRc> link, SemanticFlags semantic_flags) {
 	if(type == VfsType::charDevice) {
 		auto device = charRegistry.get(id);
 		if(device == nullptr)
@@ -74,8 +74,8 @@ openDevice(Process *process, VfsType type, DeviceId id, std::shared_ptr<MountVie
 // devtmpfs functions.
 // --------------------------------------------------------
 
-smarter::shared_ptr<FsLink> getDevtmpfs() {
-	static smarter::shared_ptr<FsLink> devtmpfs = tmp_fs::createDevTmpFsRoot();
+smarter::shared_ptr<FsLink, LinkRc> getDevtmpfs() {
+	static smarter::shared_ptr<FsLink, LinkRc> devtmpfs = tmp_fs::createDevTmpFsRoot();
 	return devtmpfs;
 }
 
@@ -91,7 +91,7 @@ async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id
 		}else{
 			assert(s > k);
 			auto name = path.substr(k, s - k);
-			smarter::shared_ptr<FsLink> link;
+			smarter::shared_ptr<FsLink, LinkRc> link;
 			while(true) {
 				auto linkResult = co_await dirLink->getTarget()->getLink(dirLink.get(), name);
 				if(linkResult) {
@@ -99,7 +99,7 @@ async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id
 					break;
 				}
 				auto mkdirResult = co_await dirLink->getTarget()->mkdir(dirLink.get(), nullptr, name, 0755);
-				if(auto linkp = std::get_if<smarter::shared_ptr<FsLink>>(&mkdirResult)) {
+				if(auto linkp = std::get_if<smarter::shared_ptr<FsLink, LinkRc>>(&mkdirResult)) {
 					link = std::move(*linkp);
 					break;
 				}
@@ -208,7 +208,7 @@ private:
 
 public:
 	DeviceFile(helix::UniqueLane control, helix::UniqueLane lane,
-			std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+			std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			helix::Mapping status_mapping)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("devicefile"), std::move(mount), std::move(link)},
 			_control{std::move(control)}, _file{std::move(lane)},
@@ -237,7 +237,7 @@ private:
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 openExternalDevice(helix::BorrowedLane lane,
-		std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+		std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite | semanticAppend)){
 		std::cout << "\e[31mposix: openExternalDevice() received illegal arguments:"
@@ -380,7 +380,7 @@ async::result<void> serveServerLane(helix::UniqueDescriptor lane) {
 	}
 }
 
-FutureMaybe<smarter::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lane, std::shared_ptr<UnixDevice> device, std::string fs_type) {
+FutureMaybe<smarter::shared_ptr<FsLink, LinkRc>> mountExternalDevice(helix::BorrowedLane lane, std::shared_ptr<UnixDevice> device, std::string fs_type) {
 	managarm::fs::MountRequest req;
 	req.set_fs_type(fs_type);
 

--- a/posix/subsystem/src/device.hpp
+++ b/posix/subsystem/src/device.hpp
@@ -31,10 +31,10 @@ public:
 	virtual std::string nodePath() = 0;
 
 	virtual async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) = 0;
 
-	virtual FutureMaybe<smarter::shared_ptr<FsLink>> mount(std::string fs_type);
+	virtual FutureMaybe<smarter::shared_ptr<FsLink, LinkRc>> mount(std::string fs_type);
 
 private:
 	VfsType _type;
@@ -73,14 +73,14 @@ extern UnixDeviceRegistry charRegistry;
 extern UnixDeviceRegistry blockRegistry;
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-openDevice(Process *, VfsType type, DeviceId id, std::shared_ptr<MountView> mont, smarter::shared_ptr<FsLink> link,
+openDevice(Process *, VfsType type, DeviceId id, std::shared_ptr<MountView> mont, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags);
 
 // --------------------------------------------------------
 // devtmpfs functions.
 // --------------------------------------------------------
 
-smarter::shared_ptr<FsLink> getDevtmpfs();
+smarter::shared_ptr<FsLink, LinkRc> getDevtmpfs();
 
 async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id);
 
@@ -90,9 +90,9 @@ async::result<void> createDeviceNode(std::string path, VfsType type, DeviceId id
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 openExternalDevice(helix::BorrowedLane lane,
-		std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+		std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags);
 
-FutureMaybe<smarter::shared_ptr<FsLink>> mountExternalDevice(helix::BorrowedLane lane, std::shared_ptr<UnixDevice> device, std::string fs_type);
+FutureMaybe<smarter::shared_ptr<FsLink, LinkRc>> mountExternalDevice(helix::BorrowedLane lane, std::shared_ptr<UnixDevice> device, std::string fs_type);
 
 async::result<void> serveServerLane(helix::UniqueDescriptor lane);

--- a/posix/subsystem/src/devices/full.cpp
+++ b/posix/subsystem/src/devices/full.cpp
@@ -39,7 +39,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	FullFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+	FullFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("full-file"), std::move(mount), std::move(link)} { }
 };
 
@@ -54,7 +54,7 @@ struct FullDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: FullFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/helout.cpp
+++ b/posix/subsystem/src/devices/helout.cpp
@@ -43,7 +43,7 @@ private:
 	}
 
 public:
-	HeloutFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+	HeloutFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("helout"), std::move(mount), std::move(link),
 			File::defaultIsTerminal} { }
 };
@@ -59,7 +59,7 @@ struct HeloutDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: HeloutFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/kmsg.cpp
+++ b/posix/subsystem/src/devices/kmsg.cpp
@@ -145,7 +145,7 @@ public:
 				file, &fileOperations, file->cancelServe_));
 	}
 
-	KmsgFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, helix::UniqueLane lane, bool nonblock)
+	KmsgFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link, helix::UniqueLane lane, bool nonblock)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("kmsg-file"), std::move(mount), std::move(link)},
 		lane_{std::move(lane)}, nonBlock_{nonblock} {}
 };
@@ -161,7 +161,7 @@ struct KmsgDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags flags) override {
 		bool nonblock = flags & semanticNonBlock;
 

--- a/posix/subsystem/src/devices/null.cpp
+++ b/posix/subsystem/src/devices/null.cpp
@@ -42,7 +42,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	NullFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+	NullFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("null-file"), std::move(mount), std::move(link)} { }
 };
 
@@ -57,7 +57,7 @@ struct NullDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: NullFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/random.cpp
+++ b/posix/subsystem/src/devices/random.cpp
@@ -53,7 +53,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	RandomFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+	RandomFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("random-file"), std::move(mount), std::move(link)} { }
 };
 
@@ -68,7 +68,7 @@ struct RandomDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: RandomFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/tty.cpp
+++ b/posix/subsystem/src/devices/tty.cpp
@@ -14,7 +14,7 @@ struct TtyDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags flags) override {
 		if (!process)
 			co_return Error::noBackingDevice;

--- a/posix/subsystem/src/devices/tty0.cpp
+++ b/posix/subsystem/src/devices/tty0.cpp
@@ -15,7 +15,7 @@ struct TTY0Device final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		co_return co_await openDevice(process, VfsType::charDevice, {4, 1}, mount, link, semantic_flags);
 	}

--- a/posix/subsystem/src/devices/ttyn.cpp
+++ b/posix/subsystem/src/devices/ttyn.cpp
@@ -297,7 +297,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	TTYNFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+	TTYNFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("tty1-file"), std::move(mount), std::move(link), File::defaultIsTerminal | File::defaultPipeLikeSeek} {
 		memset(&_activeSettings, 0, sizeof(struct termios));
 		// cflag: Linux also stores a baud rate here.
@@ -336,7 +336,7 @@ struct TTYNDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: TTYNFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/urandom.cpp
+++ b/posix/subsystem/src/devices/urandom.cpp
@@ -60,7 +60,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	UrandomFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+	UrandomFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("urandom-file"), std::move(mount), std::move(link)} { }
 };
 
@@ -75,7 +75,7 @@ struct UrandomDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: UrandomFile open() received illegal arguments:"

--- a/posix/subsystem/src/devices/zero.cpp
+++ b/posix/subsystem/src/devices/zero.cpp
@@ -40,7 +40,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	ZeroFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+	ZeroFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("zero-file"), std::move(mount), std::move(link),
 			defaultMapsAnonymously} { }
 };
@@ -56,7 +56,7 @@ struct ZeroDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: ZeroFile open() received illegal arguments:"

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -45,6 +45,11 @@ struct Superblock final : FsSuperblock {
 	smarter::shared_ptr<FsLink> internalizeLink(FsLink *parent, std::string name,
 			smarter::shared_ptr<Node> target);
 
+	// Called from destructors. The entry may already belong to a newer object with the same key.
+	void forgetStructural(uint64_t id);
+	void forgetPeripheralNode(uint64_t id);
+	void forgetLink(uint64_t ownerId, const std::string &name, uint64_t targetId);
+
 private:
 	helix::UniqueLane _lane;
 	std::map<uint64_t, smarter::weak_ptr<DirectoryNode>> _activeStructural;
@@ -187,10 +192,12 @@ struct Node : FsNode {
 
 public:
 	Node(uint64_t inode, helix::UniqueLane lane, Superblock *sb)
-	: FsNode{sb}, _inode{inode}, _lane{std::move(lane)} { }
+	: FsNode{sb}, _sb{sb}, _inode{inode}, _lane{std::move(lane)} { }
 
 protected:
 	~Node() = default;
+
+	Superblock *_sb;
 
 public:
 	uint64_t getInode() {
@@ -360,6 +367,10 @@ private:
 public:
 	RegularNode(Superblock *sb, uint64_t inode, helix::UniqueLane lane)
 	: Node{inode, std::move(lane), sb} { }
+
+	~RegularNode() {
+		_sb->forgetPeripheralNode(getInode());
+	}
 };
 
 struct SymlinkNode final : Node {
@@ -397,6 +408,10 @@ private:
 public:
 	SymlinkNode(Superblock *sb, uint64_t inode, helix::UniqueLane lane)
 	: Node{inode, std::move(lane), sb} { }
+
+	~SymlinkNode() {
+		_sb->forgetPeripheralNode(getInode());
+	}
 };
 
 struct Link final : FsLink {
@@ -442,23 +457,30 @@ public:
 		_name = std::move(name);
 	}
 
-private:
 	std::string getName() override {
 		assert(_owner);
 		return _name;
 	}
 
-public:
 	// Constructs the root link of the mount, which has neither an owner nor a name.
-	explicit Link(smarter::shared_ptr<FsNode> target)
-	: _target{std::move(target)} { }
+	Link(Superblock *sb, smarter::shared_ptr<FsNode> target)
+	: _sb{sb}, _target{std::move(target)} { }
 
-	Link(smarter::shared_ptr<FsLink> owner, std::string name, smarter::shared_ptr<FsNode> target)
-	: _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
+	Link(Superblock *sb, smarter::shared_ptr<FsLink> owner, std::string name,
+			smarter::shared_ptr<FsNode> target)
+	: _sb{sb}, _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 		assert(_owner);
 	}
 
+	~Link() {
+		// The root link is not interned.
+		if(_owner)
+			_sb->forgetLink(static_cast<Node *>(_owner->getTarget().get())->getInode(),
+					_name, static_cast<Node *>(_target.get())->getInode());
+	}
+
 private:
+	Superblock *_sb;
 	smarter::shared_ptr<FsLink> _owner;
 	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
@@ -880,10 +902,11 @@ private:
 
 public:
 	DirectoryNode(Superblock *sb, uint64_t inode, helix::UniqueLane lane)
-	: Node{inode, std::move(lane), sb}, _sb{sb} { }
+	: Node{inode, std::move(lane), sb} { }
 
-private:
-	Superblock *_sb;
+	~DirectoryNode() {
+		_sb->forgetStructural(getInode());
+	}
 };
 
 Superblock::Superblock(helix::UniqueLane lane, std::shared_ptr<UnixDevice> device)
@@ -960,7 +983,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 }
 
 smarter::shared_ptr<FsLink> Superblock::internalizeRoot(uint64_t id, helix::UniqueLane lane) {
-	return makeFsShared<Link>(internalizeDirectory(id, std::move(lane)));
+	return makeFsShared<Link>(this, internalizeDirectory(id, std::move(lane)));
 }
 
 smarter::shared_ptr<Node> Superblock::internalizeDirectory(uint64_t id, helix::UniqueLane lane) {
@@ -1008,9 +1031,28 @@ smarter::shared_ptr<FsLink> Superblock::internalizeLink(FsLink *parent,
 	if(auto intern = entry->lock(); intern)
 		return intern;
 
-	auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(target));
+	auto link = makeFsShared<Link>(this, parent->sharedFromThis(),
+			std::move(name), std::move(target));
 	*entry = link;
 	return link;
+}
+
+void Superblock::forgetStructural(uint64_t id) {
+	auto it = _activeStructural.find(id);
+	if(it != _activeStructural.end() && !it->second.lock())
+		_activeStructural.erase(it);
+}
+
+void Superblock::forgetPeripheralNode(uint64_t id) {
+	auto it = _activePeripheralNodes.find(id);
+	if(it != _activePeripheralNodes.end() && !it->second.lock())
+		_activePeripheralNodes.erase(it);
+}
+
+void Superblock::forgetLink(uint64_t ownerId, const std::string &name, uint64_t targetId) {
+	auto it = _activeLinks.find({ownerId, name, targetId});
+	if(it != _activeLinks.end() && !it->second.lock())
+		_activeLinks.erase(it);
 }
 
 async::result<frg::expected<Error, FsStats>> Superblock::getFsStats() {

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -491,6 +491,9 @@ private:
 	}
 
 	expected<std::string> readSymlink(FsLink *, Process *) override {
+		if(_cachedTarget)
+			co_return *_cachedTarget;
+
 		managarm::fs::CntRequest req;
 		req.set_req_type(managarm::fs::CntReqType::NODE_READ_SYMLINK);
 
@@ -513,7 +516,12 @@ private:
 		if(resp.error() != managarm::fs::Errors::SUCCESS)
 			co_return resp.error() | toPosixError;
 
-		co_return std::string{static_cast<char *>(recv_target.data()), recv_target.length()};
+		std::string target{static_cast<char *>(recv_target.data()), recv_target.length()};
+		// On client-exclusive mounts, symlink contents cannot change:
+		// there is no way to rewrite a symlink in place, and replacing it creates a new inode.
+		if(_sb->nameCacheEnabled())
+			_cachedTarget = target;
+		co_return target;
 	}
 
 public:
@@ -523,6 +531,9 @@ public:
 	~SymlinkNode() {
 		_sb->forgetPeripheralNode(getInode());
 	}
+
+private:
+	std::optional<std::string> _cachedTarget;
 };
 
 async::result<frg::expected<Error>> Link::obstruct() {

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -685,9 +685,9 @@ private:
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pullNode.error());
 
-			auto child = _sb->internalizeStructural(parent, name,
+			auto child = _sb->internalizePeripheralNode(managarm::fs::FileType::SYMLINK,
 					resp.id(), pullNode.descriptor());
-			co_return child;
+			co_return _sb->internalizeLink(parent, name, std::move(child));
 		} else {
 			co_return resp.error() | toPosixError;
 		}

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -104,6 +104,7 @@ private:
 	size_t _cacheHash = 0;
 	// Hook for the name cache's hash table chain.
 	frg::default_list_hook<Link> _cacheHashHook;
+	frg::default_list_hook<Link> _cacheOwnerHook;
 };
 
 struct Superblock final : FsSuperblock, LinkReclaimer {
@@ -151,9 +152,19 @@ struct Superblock final : FsSuperblock, LinkReclaimer {
 	void nameCacheInsert(Link *link);
 	void nameCacheInvalidate(FsNode *dir, const std::string &name);
 
+	using NameCacheOwnerList = frg::intrusive_list<Link,
+			frg::locate_member<Link, frg::default_list_hook<Link>, &Link::_cacheOwnerHook>>;
+
+	void nameCachePurge(DirectoryNode *dir);
+
+	// Called once the server reports that it removed the directory with the given inode.
+	// There may still be negative links cached for this directory; retireDirectory() removes them.
+	void retireDirectory(uint64_t inode);
+
 private:
 	using NameCacheBucket = frg::intrusive_list<Link,
 			frg::locate_member<Link, frg::default_list_hook<Link>, &Link::_cacheHashHook>>;
+
 	void onReclaim(LinkMetaObjectBase *meta) override;
 	Link *nameCacheFind(FsNode *dir, const std::string &name, size_t hash);
 	void nameCacheUnhash(Link *link);
@@ -1006,6 +1017,7 @@ private:
 			co_return resp.error() | toPosixError;
 
 		invalidateCache(name);
+		_sb->retireDirectory(resp.id());
 		co_return {};
 	}
 
@@ -1066,6 +1078,9 @@ public:
 	void cacheLink(FsLink *parent, const std::string &name, FsLink *link) {
 		if(!_sb->nameCacheEnabled())
 			return;
+		// A lookup that raced the removal of this directory must not revive it.
+		if(_removed)
+			return;
 		// PathResolver never resolves these through the cache.
 		if(name == "." || name == "..")
 			return;
@@ -1096,8 +1111,17 @@ public:
 	: Node{inode, std::move(lane), sb} { }
 
 	~DirectoryNode() {
+		assert(_cacheEntries.empty());
 		_sb->forgetStructural(getInode());
 	}
+
+private:
+	friend struct Superblock;
+
+	// Entries that a directory owns, so that they can be dropped when the directory itself is removed.
+	Superblock::NameCacheOwnerList _cacheEntries;
+	// Set once the server removed the directory, see Superblock::retireDirectory().
+	bool _removed = false;
 };
 
 Superblock::Superblock(helix::UniqueLane lane, std::shared_ptr<UnixDevice> device,
@@ -1178,6 +1202,9 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	_activeLinks.erase({source_node->getInode(), source->getName(), shared_node->getInode()});
 	slink->renameTo(directory->sharedFromThis(), name);
 	_activeLinks[{target_node->getInode(), name, shared_node->getInode()}] = source->sharedFromThis();
+
+	if(resp.id() && resp.file_type() == managarm::fs::FileType::DIRECTORY)
+		retireDirectory(resp.id());
 	co_return source->sharedFromThis();
 }
 
@@ -1292,6 +1319,9 @@ void Superblock::nameCacheInsert(Link *link) {
 	// The link stays alive on its own: the reclaimer holds a reference from construction on.
 	link->_cacheHash = hash;
 	_nameCacheBuckets[hash & (nameCacheBuckets - 1)].push_front(link);
+	// Let the containing directory remember the link such that we can purge it on rmdir().
+	assert(link->ownerNode()->getType() == VfsType::directory);
+	static_cast<DirectoryNode *>(link->ownerNode())->_cacheEntries.push_front(link);
 }
 
 void Superblock::nameCacheInvalidate(FsNode *dir, const std::string &name) {
@@ -1302,6 +1332,8 @@ void Superblock::nameCacheInvalidate(FsNode *dir, const std::string &name) {
 void Superblock::nameCacheUnhash(Link *link) {
 	auto &bucket = _nameCacheBuckets[link->_cacheHash & (nameCacheBuckets - 1)];
 	bucket.erase(bucket.iterator_to(link));
+	auto &owned = static_cast<DirectoryNode *>(link->ownerNode())->_cacheEntries;
+	owned.erase(owned.iterator_to(link));
 }
 
 // Drops an entry from the cache: it cannot be found by name anymore, hence it is only worth
@@ -1313,8 +1345,29 @@ void Superblock::nameCacheEvict(Link *link) {
 
 void Superblock::onReclaim(LinkMetaObjectBase *meta) {
 	auto link = static_cast<LinkMetaObject<Link> *>(meta)->get();
+	// Entries reference the link of the directory that owns them; hence a directory
+	// with cache entries is never reclaimable here.
+	assert(!link->_target || link->_target->getType() != VfsType::directory
+			|| static_cast<DirectoryNode *>(link->_target.get())->_cacheEntries.empty());
 	if(link->_cacheHashHook.in_list)
 		nameCacheUnhash(link);
+}
+
+void Superblock::nameCachePurge(DirectoryNode *dir) {
+	// Evicting an entry removes it from the list, so re-read the list on every step.
+	while(!dir->_cacheEntries.empty())
+		nameCacheEvict(dir->_cacheEntries.front());
+}
+
+void Superblock::retireDirectory(uint64_t inode) {
+	// There is nothing to drop for a directory that we never interned.
+	smarter::shared_ptr<DirectoryNode> dir;
+	if(auto it = _activeStructural.find(inode); it != _activeStructural.end())
+		dir = it->second.lock();
+	if(dir) {
+		dir->_removed = true;
+		nameCachePurge(dir.get());
+	}
 }
 
 async::result<frg::expected<Error, FsStats>> Superblock::getFsStats() {

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -1,8 +1,10 @@
 #include <async/cancellation.hpp>
 #include <sys/epoll.h>
 #include <map>
+#include <vector>
 
 #include <bragi/helpers-std.hpp>
+#include <frg/list.hpp>
 #include <frg/std_compat.hpp>
 #include <protocols/fs/client.hpp>
 #include "common.hpp"
@@ -18,9 +20,82 @@ namespace {
 
 struct Node;
 struct DirectoryNode;
+struct Superblock;
 
-struct Superblock final : FsSuperblock {
-	Superblock(helix::UniqueLane lane, std::shared_ptr<UnixDevice> device);
+// Bounds the number of reclaimable (directory, name) entries that the name cache keeps alive.
+constexpr size_t nameCacheCapacity = 8192;
+// Number of hash buckets; a power of two, sized for a load factor of one at capacity.
+constexpr size_t nameCacheBuckets = 8192;
+
+size_t nameCacheHash(FsNode *dir, const std::string &name) {
+	return std::hash<std::string>{}(name)
+			^ (reinterpret_cast<uintptr_t>(dir) * size_t{0x9e3779b97f4a7c15});
+}
+
+// If a namecache is enabled for a superblock, links double as namecache entries.
+struct Link final : FsLink {
+public:
+	smarter::shared_ptr<FsLink, LinkRc> getParent() override {
+		return _owner;
+	}
+
+	async::result<frg::expected<Error>> obstruct() override;
+
+	// Whether this link was obstructed by a mount; cached path walks must not descend past it.
+	bool isObstructed() {
+		return _obstructed;
+	}
+
+	smarter::shared_ptr<FsNode> getTarget() override {
+		return _target;
+	}
+
+	void renameTo(smarter::shared_ptr<FsLink, LinkRc> owner, std::string name) {
+		assert(_owner); // The root link is never renamed.
+		_owner = std::move(owner);
+		_name = std::move(name);
+	}
+
+	std::string getName() override {
+		assert(_owner);
+		return _name;
+	}
+
+	// Same as getParentNode() but avoids refcount churn.
+	FsNode *ownerNode() {
+		return static_cast<Link *>(_owner.get())->_target.get();
+	}
+
+	// Constructs the root link of the mount, which has neither an owner nor a name.
+	Link(Superblock *sb, smarter::shared_ptr<FsNode> target)
+	: _sb{sb}, _target{std::move(target)} { }
+
+	Link(Superblock *sb, smarter::shared_ptr<FsLink, LinkRc> owner, std::string name,
+			smarter::shared_ptr<FsNode> target)
+	: _sb{sb}, _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
+		assert(_owner);
+	}
+
+	~Link();
+
+private:
+	friend struct Superblock;
+	friend struct DirectoryNode;
+
+	Superblock *_sb;
+	smarter::shared_ptr<FsLink, LinkRc> _owner;
+	std::string _name;
+	smarter::shared_ptr<FsNode> _target;
+	bool _obstructed = false;
+
+	// Name cache state.
+	size_t _cacheHash = 0;
+	// Hook for the name cache's hash table chain.
+	frg::default_list_hook<Link> _cacheHashHook;
+};
+
+struct Superblock final : FsSuperblock, LinkReclaimer {
+	Superblock(helix::UniqueLane lane, std::shared_ptr<UnixDevice> device, uint64_t mountCaps);
 
 	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *process) override;
 
@@ -50,11 +125,35 @@ struct Superblock final : FsSuperblock {
 	void forgetPeripheralNode(uint64_t id);
 	void forgetLink(uint64_t ownerId, const std::string &name, uint64_t targetId);
 
+	// Name caching is only sound if the server cannot change the namespace behind our back.
+	bool nameCacheEnabled() {
+		return _mountCaps & managarm::fs::MountCaps::MC_CLIENT_EXCLUSIVE_NAMESPACE;
+	}
+
+	// Reclaimer that keeps unreferenced links of this mount alive, or null without a name cache.
+	LinkReclaimer *linkReclaimer() {
+		return nameCacheEnabled() ? this : nullptr;
+	}
+
+	std::optional<smarter::shared_ptr<FsLink, LinkRc>> nameCacheLookup(FsNode *dir, const std::string &name);
+	void nameCacheInsert(Link *link);
+	void nameCacheInvalidate(FsNode *dir, const std::string &name);
+
 private:
+	using NameCacheBucket = frg::intrusive_list<Link,
+			frg::locate_member<Link, frg::default_list_hook<Link>, &Link::_cacheHashHook>>;
+	void onReclaim(LinkMetaObjectBase *meta) override;
+	Link *nameCacheFind(FsNode *dir, const std::string &name, size_t hash);
+	void nameCacheUnhash(Link *link);
+	void nameCacheEvict(Link *link);
+
 	helix::UniqueLane _lane;
 	std::map<uint64_t, smarter::weak_ptr<DirectoryNode>> _activeStructural;
 	std::map<uint64_t, smarter::weak_ptr<Node>> _activePeripheralNodes;
 	std::map<std::tuple<uint64_t, std::string, uint64_t>, smarter::weak_ptr<FsLink, LinkRc>> _activeLinks;
+
+	uint64_t _mountCaps;
+	std::vector<NameCacheBucket> _nameCacheBuckets;
 
 	std::shared_ptr<UnixDevice> device_;
 };
@@ -414,77 +513,41 @@ public:
 	}
 };
 
-struct Link final : FsLink {
-public:
-	smarter::shared_ptr<FsLink, LinkRc> getParent() override {
-		return _owner;
-	}
+async::result<frg::expected<Error>> Link::obstruct() {
+	assert(_owner);
+	managarm::fs::ObstructLinkRequest req;
+	req.set_link_name(_name);
 
-	async::result<frg::expected<Error>> obstruct() override {
-		assert(_owner);
-		managarm::fs::ObstructLinkRequest req;
-		req.set_link_name(_name);
+	auto lane = static_cast<Node *>(ownerNode())->getLane();
 
-		auto lane = static_cast<Node *>(_owner->getTarget().get())->getLane();
+	auto [offer, send_req, send_tail, recv_resp] = co_await helix_ng::exchangeMsgs(
+		lane,
+		helix_ng::offer(
+			helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
+			helix_ng::recvInline()
+		)
+	);
+	HEL_CHECK(offer.error());
+	HEL_CHECK(send_req.error());
+	HEL_CHECK(send_tail.error());
+	HEL_CHECK(recv_resp.error());
 
-		auto [offer, send_req, send_tail, recv_resp] = co_await helix_ng::exchangeMsgs(
-			lane,
-			helix_ng::offer(
-				helix_ng::sendBragiHeadTail(req, frg::stl_allocator{}),
-				helix_ng::recvInline()
-			)
-		);
-		HEL_CHECK(offer.error());
-		HEL_CHECK(send_req.error());
-		HEL_CHECK(send_tail.error());
-		HEL_CHECK(recv_resp.error());
+	managarm::fs::SvrResponse resp;
+	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	recv_resp.reset();
+	if(resp.error() != managarm::fs::Errors::SUCCESS)
+		co_return resp.error() | toPosixError;
+	_obstructed = true;
+	co_return frg::success_tag{};
+}
 
-		managarm::fs::SvrResponse resp;
-		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
-		recv_resp.reset();
-		if(resp.error() != managarm::fs::Errors::SUCCESS)
-			co_return resp.error() | toPosixError;
-		co_return frg::success_tag{};
-	}
-
-	smarter::shared_ptr<FsNode> getTarget() override {
-		return _target;
-	}
-
-	void renameTo(smarter::shared_ptr<FsLink, LinkRc> owner, std::string name) {
-		assert(_owner); // The root link is never renamed.
-		_owner = std::move(owner);
-		_name = std::move(name);
-	}
-
-	std::string getName() override {
-		assert(_owner);
-		return _name;
-	}
-
-	// Constructs the root link of the mount, which has neither an owner nor a name.
-	Link(Superblock *sb, smarter::shared_ptr<FsNode> target)
-	: _sb{sb}, _target{std::move(target)} { }
-
-	Link(Superblock *sb, smarter::shared_ptr<FsLink, LinkRc> owner, std::string name,
-			smarter::shared_ptr<FsNode> target)
-	: _sb{sb}, _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
-		assert(_owner);
-	}
-
-	~Link() {
-		// The root link is not interned.
-		if(_owner)
-			_sb->forgetLink(static_cast<Node *>(_owner->getTarget().get())->getInode(),
-					_name, static_cast<Node *>(_target.get())->getInode());
-	}
-
-private:
-	Superblock *_sb;
-	smarter::shared_ptr<FsLink, LinkRc> _owner;
-	std::string _name;
-	smarter::shared_ptr<FsNode> _target;
-};
+Link::~Link() {
+	assert(!_cacheHashHook.in_list);
+	// The root link is not interned.
+	if(_owner)
+		_sb->forgetLink(static_cast<Node *>(ownerNode())->getInode(),
+				_name, static_cast<Node *>(_target.get())->getInode());
+}
 
 struct DirectoryNode final : Node {
 private:
@@ -544,6 +607,48 @@ private:
 
 	async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink, LinkRc>, size_t>>>
 	traverseLinks(FsLink *parent, std::deque<std::string> path) override {
+		// Resolve as many leading components as possible from the name cache.
+		size_t consumed = 0;
+		bool cacheMiss = false;
+		smarter::shared_ptr<FsLink, LinkRc> lastLink;
+		auto dirLink = parent->sharedFromThis();
+		auto dir = smarter::static_pointer_cast<DirectoryNode>(sharedFromThis());
+		while(!path.empty()) {
+			const auto &name = path.front();
+			if(name == "." || name == "..")
+				break; // PathResolver handles these itself once we return.
+			auto cached = dir->lookupCache(name);
+			if(!cached) {
+				cacheMiss = true;
+				break;
+			}
+			lastLink = std::move(*cached);
+			path.pop_front();
+			++consumed;
+			if(path.empty())
+				break;
+			// Mirror the server-side walk: stop at obstructions (mount points) and
+			// at symlinks, fail on other non-directories.
+			if(static_cast<Link *>(lastLink.get())->isObstructed())
+				break;
+			auto type = lastLink->getTarget()->getType();
+			if(type == VfsType::symlink)
+				break;
+			if(type != VfsType::directory)
+				co_return Error::notDirectory;
+			dirLink = lastLink;
+			dir = smarter::static_pointer_cast<DirectoryNode>(lastLink->getTarget());
+		}
+
+		if(consumed && !cacheMiss)
+			co_return std::make_pair(std::move(lastLink), consumed);
+
+		auto remote = FRG_CO_TRY(co_await dir->remoteTraverseLinks(dirLink.get(), std::move(path)));
+		co_return std::make_pair(std::move(remote.first), consumed + remote.second);
+	}
+
+	async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink, LinkRc>, size_t>>>
+	remoteTraverseLinks(FsLink *parent, std::deque<std::string> path) {
 		managarm::fs::NodeTraverseLinksRequest req;
 		for (auto &i : path)
 			req.add_path_segments(i);
@@ -632,6 +737,8 @@ private:
 						pull_node.descriptor());
 				link = _sb->internalizeLink(dirStack.back().get(), path[i], std::move(child));
 			}
+			static_cast<DirectoryNode *>(dirStack.back()->getTarget().get())
+					->cacheLink(dirStack.back().get(), path[i], link.get());
 
 			if (!last)
 				dirStack.push_back(link);
@@ -726,6 +833,9 @@ private:
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 			getLink(FsLink *parent, std::string name) override {
+		if(auto cached = lookupCache(name))
+			co_return std::move(*cached);
+
 		managarm::fs::GetLinkRequest req;
 		req.set_path(name);
 
@@ -748,15 +858,17 @@ private:
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pull_node.error());
 
+			smarter::shared_ptr<FsLink, LinkRc> result;
 			if(resp.file_type() == managarm::fs::FileType::DIRECTORY) {
-				auto child = _sb->internalizeStructural(parent, name,
+				result = _sb->internalizeStructural(parent, name,
 						resp.id(), pull_node.descriptor());
-				co_return child;
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
-				co_return _sb->internalizeLink(parent, name, std::move(child));
+				result = _sb->internalizeLink(parent, name, std::move(child));
 			}
+			cacheLink(parent, name, result.get());
+			co_return result;
 		}else{
 			co_return resp.error() | toPosixError;
 		}
@@ -823,6 +935,7 @@ private:
 		if(resp.error() != managarm::fs::Errors::SUCCESS)
 			co_return resp.error() | toPosixError;
 
+		invalidateCache(name);
 		co_return {};
 	}
 
@@ -849,6 +962,7 @@ private:
 		if(resp.error() != managarm::fs::Errors::SUCCESS)
 			co_return resp.error() | toPosixError;
 
+		invalidateCache(name);
 		co_return {};
 	}
 
@@ -901,6 +1015,27 @@ private:
 	}
 
 public:
+	std::optional<smarter::shared_ptr<FsLink, LinkRc>> lookupCache(const std::string &name) {
+		return _sb->nameCacheLookup(this, name);
+	}
+
+	void cacheLink(FsLink *parent, const std::string &name, FsLink *link) {
+		if(!_sb->nameCacheEnabled())
+			return;
+		// PathResolver never resolves these through the cache.
+		if(name == "." || name == "..")
+			return;
+		auto entry = static_cast<Link *>(link);
+		// Links are interned under, and renamed in place to, the owner and name they are
+		// resolved through, so the cache key always agrees with what the link carries.
+		assert(entry->_owner.get() == parent && entry->_name == name);
+		_sb->nameCacheInsert(entry);
+	}
+
+	void invalidateCache(const std::string &name) {
+		_sb->nameCacheInvalidate(this, name);
+	}
+
 	DirectoryNode(Superblock *sb, uint64_t inode, helix::UniqueLane lane)
 	: Node{inode, std::move(lane), sb} { }
 
@@ -909,8 +1044,13 @@ public:
 	}
 };
 
-Superblock::Superblock(helix::UniqueLane lane, std::shared_ptr<UnixDevice> device)
-: _lane{std::move(lane)}, device_{device} { }
+Superblock::Superblock(helix::UniqueLane lane, std::shared_ptr<UnixDevice> device,
+		uint64_t mountCaps)
+: LinkReclaimer{nameCacheCapacity}, _lane{std::move(lane)}, _mountCaps{mountCaps},
+		device_{device} {
+	if(nameCacheEnabled())
+		_nameCacheBuckets.resize(nameCacheBuckets);
+}
 
 FutureMaybe<smarter::shared_ptr<FsNode>> Superblock::createRegular(Process *process) {
 	managarm::fs::CntRequest req;
@@ -975,7 +1115,10 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	if(resp.error() != managarm::fs::Errors::SUCCESS)
 		co_return resp.error() | toPosixError;
 
-	// _activeLinks is keyed by the owner and name, so the link has to be re-keyed.
+	// Both the name cache and _activeLinks are keyed by the owner and name, so the entries
+	// have to go before the link is renamed.
+	nameCacheInvalidate(source_node, source->getName());
+	nameCacheInvalidate(target_node, name);
 	_activeLinks.erase({source_node->getInode(), source->getName(), shared_node->getInode()});
 	slink->renameTo(directory->sharedFromThis(), name);
 	_activeLinks[{target_node->getInode(), name, shared_node->getInode()}] = source->sharedFromThis();
@@ -983,7 +1126,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 }
 
 smarter::shared_ptr<FsLink, LinkRc> Superblock::internalizeRoot(uint64_t id, helix::UniqueLane lane) {
-	return makeFsShared<Link>(this, internalizeDirectory(id, std::move(lane)));
+	return makeReclaimableLink<Link>(linkReclaimer(), this, internalizeDirectory(id, std::move(lane)));
 }
 
 smarter::shared_ptr<Node> Superblock::internalizeDirectory(uint64_t id, helix::UniqueLane lane) {
@@ -1031,7 +1174,7 @@ smarter::shared_ptr<FsLink, LinkRc> Superblock::internalizeLink(FsLink *parent,
 	if(auto intern = entry->lock(); intern)
 		return intern;
 
-	auto link = makeFsShared<Link>(this, parent->sharedFromThis(),
+	auto link = makeReclaimableLink<Link>(linkReclaimer(), this, parent->sharedFromThis(),
 			std::move(name), std::move(target));
 	*entry = link;
 	return link;
@@ -1053,6 +1196,67 @@ void Superblock::forgetLink(uint64_t ownerId, const std::string &name, uint64_t 
 	auto it = _activeLinks.find({ownerId, name, targetId});
 	if(it != _activeLinks.end() && !it->second.lock())
 		_activeLinks.erase(it);
+}
+
+Link *Superblock::nameCacheFind(FsNode *dir, const std::string &name, size_t hash) {
+	if(_nameCacheBuckets.empty())
+		return nullptr;
+	auto &bucket = _nameCacheBuckets[hash & (nameCacheBuckets - 1)];
+	for(auto it = bucket.begin(); it != bucket.end(); ++it) {
+		Link *link = *it;
+		if(link->_cacheHash == hash && link->ownerNode() == dir && link->_name == name)
+			return link;
+	}
+	return nullptr;
+}
+
+std::optional<smarter::shared_ptr<FsLink, LinkRc>> Superblock::nameCacheLookup(FsNode *dir,
+		const std::string &name) {
+	auto link = nameCacheFind(dir, name, nameCacheHash(dir, name));
+	if(!link)
+		return std::nullopt;
+	touch(link->selfPtr().policy().meta());
+	return link->sharedFromThis();
+}
+
+void Superblock::nameCacheInsert(Link *link) {
+	assert(!_nameCacheBuckets.empty());
+	assert(link->_owner);
+	auto hash = nameCacheHash(link->ownerNode(), link->_name);
+	if(auto present = nameCacheFind(link->ownerNode(), link->_name, hash)) {
+		if(present == link) {
+			touch(link->selfPtr().policy().meta());
+			return;
+		}
+		// The name was re-created and now refers to a different link.
+		nameCacheEvict(present);
+	}
+	// The link stays alive on its own: the reclaimer holds a reference from construction on.
+	link->_cacheHash = hash;
+	_nameCacheBuckets[hash & (nameCacheBuckets - 1)].push_front(link);
+}
+
+void Superblock::nameCacheInvalidate(FsNode *dir, const std::string &name) {
+	if(auto link = nameCacheFind(dir, name, nameCacheHash(dir, name)))
+		nameCacheEvict(link);
+}
+
+void Superblock::nameCacheUnhash(Link *link) {
+	auto &bucket = _nameCacheBuckets[link->_cacheHash & (nameCacheBuckets - 1)];
+	bucket.erase(bucket.iterator_to(link));
+}
+
+// Drops an entry from the cache: it cannot be found by name anymore, hence it is only worth
+// keeping around while something else still references it.
+void Superblock::nameCacheEvict(Link *link) {
+	nameCacheUnhash(link);
+	reclaim(link->selfPtr().policy().meta());
+}
+
+void Superblock::onReclaim(LinkMetaObjectBase *meta) {
+	auto link = static_cast<LinkMetaObject<Link> *>(meta)->get();
+	if(link->_cacheHashHook.in_list)
+		nameCacheUnhash(link);
 }
 
 async::result<frg::expected<Error, FsStats>> Superblock::getFsStats() {
@@ -1097,8 +1301,9 @@ async::result<frg::expected<Error, FsStats>> Superblock::getFsStats() {
 
 } // anonymous namespace
 
-smarter::shared_ptr<FsLink, LinkRc> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device) {
-	auto sb = new Superblock{std::move(sb_lane), device};
+smarter::shared_ptr<FsLink, LinkRc> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane,
+		std::shared_ptr<UnixDevice> device, uint64_t mountCaps) {
+	auto sb = new Superblock{std::move(sb_lane), device, mountCaps};
 	// FIXME: 2 is the ext2fs root inode.
 	return sb->internalizeRoot(2, std::move(lane));
 }

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -24,7 +24,7 @@ struct Superblock final : FsSuperblock {
 
 	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *process) override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 			rename(FsLink *source, FsLink *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
@@ -37,12 +37,12 @@ struct Superblock final : FsSuperblock {
 		return makedev(id.first, id.second);
 	}
 
-	smarter::shared_ptr<FsLink> internalizeRoot(uint64_t id, helix::UniqueLane lane);
-	smarter::shared_ptr<FsLink> internalizeStructural(FsLink *parent, std::string name,
+	smarter::shared_ptr<FsLink, LinkRc> internalizeRoot(uint64_t id, helix::UniqueLane lane);
+	smarter::shared_ptr<FsLink, LinkRc> internalizeStructural(FsLink *parent, std::string name,
 			uint64_t id, helix::UniqueLane lane);
 	smarter::shared_ptr<Node> internalizeDirectory(uint64_t id, helix::UniqueLane lane);
 	smarter::shared_ptr<Node> internalizePeripheralNode(int64_t type, int id, helix::UniqueLane lane);
-	smarter::shared_ptr<FsLink> internalizeLink(FsLink *parent, std::string name,
+	smarter::shared_ptr<FsLink, LinkRc> internalizeLink(FsLink *parent, std::string name,
 			smarter::shared_ptr<Node> target);
 
 	// Called from destructors. The entry may already belong to a newer object with the same key.
@@ -54,7 +54,7 @@ private:
 	helix::UniqueLane _lane;
 	std::map<uint64_t, smarter::weak_ptr<DirectoryNode>> _activeStructural;
 	std::map<uint64_t, smarter::weak_ptr<Node>> _activePeripheralNodes;
-	std::map<std::tuple<uint64_t, std::string, uint64_t>, smarter::weak_ptr<FsLink>> _activeLinks;
+	std::map<std::tuple<uint64_t, std::string, uint64_t>, smarter::weak_ptr<FsLink, LinkRc>> _activeLinks;
 
 	std::shared_ptr<UnixDevice> device_;
 };
@@ -269,7 +269,7 @@ private:
 
 public:
 	OpenFile(helix::UniqueLane control, helix::UniqueLane lane,
-			std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+			std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 	: File{FileKind::unknown, StructName::get("externfs.file"), std::move(mount), std::move(link)},
 			_control{std::move(control)}, _file{std::move(lane)} { }
 
@@ -317,7 +317,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		// Regular files do not support O_NONBLOCK.
 		semantic_flags &= ~semanticNonBlock;
@@ -416,7 +416,7 @@ public:
 
 struct Link final : FsLink {
 public:
-	smarter::shared_ptr<FsLink> getParent() override {
+	smarter::shared_ptr<FsLink, LinkRc> getParent() override {
 		return _owner;
 	}
 
@@ -451,7 +451,7 @@ public:
 		return _target;
 	}
 
-	void renameTo(smarter::shared_ptr<FsLink> owner, std::string name) {
+	void renameTo(smarter::shared_ptr<FsLink, LinkRc> owner, std::string name) {
 		assert(_owner); // The root link is never renamed.
 		_owner = std::move(owner);
 		_name = std::move(name);
@@ -466,7 +466,7 @@ public:
 	Link(Superblock *sb, smarter::shared_ptr<FsNode> target)
 	: _sb{sb}, _target{std::move(target)} { }
 
-	Link(Superblock *sb, smarter::shared_ptr<FsLink> owner, std::string name,
+	Link(Superblock *sb, smarter::shared_ptr<FsLink, LinkRc> owner, std::string name,
 			smarter::shared_ptr<FsNode> target)
 	: _sb{sb}, _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 		assert(_owner);
@@ -481,7 +481,7 @@ public:
 
 private:
 	Superblock *_sb;
-	smarter::shared_ptr<FsLink> _owner;
+	smarter::shared_ptr<FsLink, LinkRc> _owner;
 	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
 };
@@ -497,7 +497,7 @@ private:
 		return true;
 	}
 
-	async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
+	async::result<std::expected<smarter::shared_ptr<FsLink, LinkRc>, Error>>
 	getLinkOrCreate(FsLink *parent, Process *process, std::string name, mode_t mode,
 			bool exclusive) override {
 		assert(this->getType() == VfsType::directory);
@@ -542,7 +542,7 @@ private:
 		}
 	}
 
-	async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>>
+	async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink, LinkRc>, size_t>>>
 	traverseLinks(FsLink *parent, std::deque<std::string> path) override {
 		managarm::fs::NodeTraverseLinksRequest req;
 		for (auto &i : path)
@@ -602,8 +602,8 @@ private:
 
 		// The reply only reports inodes, so we cannot immediately tell which link they correspond to.
 		// We replay the resolution rules to associate each link with the proper parent.
-		smarter::shared_ptr<FsLink> link = nullptr;
-		std::vector<smarter::shared_ptr<FsLink>> dirStack{parent->sharedFromThis()};
+		smarter::shared_ptr<FsLink, LinkRc> link = nullptr;
+		std::vector<smarter::shared_ptr<FsLink, LinkRc>> dirStack{parent->sharedFromThis()};
 		for (size_t i = 0; i < resp.ids().size(); i++) {
 			auto [pull_node] = co_await helix_ng::exchangeMsgs(
 				pull_lane,
@@ -640,7 +640,7 @@ private:
 		co_return std::make_pair(link, resp.links_traversed());
 	}
 
-	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+	async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	mkdir(FsLink *parent, Process *proc, std::string name, mode_t mode) override {
 		auto umask = proc ? proc->fsContext()->getUmask() : 0;
 
@@ -677,7 +677,7 @@ private:
 		}
 	}
 
-	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+	async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	symlink(FsLink *parent, std::string name, std::string path) override {
 		managarm::fs::CntRequest req;
 		req.set_req_type(managarm::fs::CntReqType::NODE_SYMLINK);
@@ -715,7 +715,7 @@ private:
 		}
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(FsLink *parent, std::string name, VfsType type, DeviceId id) override {
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> mkdev(FsLink *parent, std::string name, VfsType type, DeviceId id) override {
 		(void)parent;
 		(void)name;
 		(void)type;
@@ -724,7 +724,7 @@ private:
 		__builtin_unreachable();
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 			getLink(FsLink *parent, std::string name) override {
 		managarm::fs::GetLinkRequest req;
 		req.set_path(name);
@@ -762,7 +762,7 @@ private:
 		}
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target) override {
 		managarm::fs::LinkRequest req;
 		req.set_path(name);
@@ -853,7 +853,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		// Regular files do not support O_NONBLOCK.
 		semantic_flags &= ~semanticNonBlock;
@@ -943,7 +943,7 @@ FutureMaybe<smarter::shared_ptr<FsNode>> Superblock::createRegular(Process *proc
 	}
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 		Superblock::rename(FsLink *source, FsLink *directory, std::string name) {
 
 	managarm::fs::RenameRequest req;
@@ -982,7 +982,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
 	co_return source->sharedFromThis();
 }
 
-smarter::shared_ptr<FsLink> Superblock::internalizeRoot(uint64_t id, helix::UniqueLane lane) {
+smarter::shared_ptr<FsLink, LinkRc> Superblock::internalizeRoot(uint64_t id, helix::UniqueLane lane) {
 	return makeFsShared<Link>(this, internalizeDirectory(id, std::move(lane)));
 }
 
@@ -996,7 +996,7 @@ smarter::shared_ptr<Node> Superblock::internalizeDirectory(uint64_t id, helix::U
 	return node;
 }
 
-smarter::shared_ptr<FsLink> Superblock::internalizeStructural(FsLink *parent,
+smarter::shared_ptr<FsLink, LinkRc> Superblock::internalizeStructural(FsLink *parent,
 		std::string name, uint64_t id, helix::UniqueLane lane) {
 	return internalizeLink(parent, std::move(name),
 			internalizeDirectory(id, std::move(lane)));
@@ -1024,7 +1024,7 @@ smarter::shared_ptr<Node> Superblock::internalizePeripheralNode(int64_t type,
 	return node;
 }
 
-smarter::shared_ptr<FsLink> Superblock::internalizeLink(FsLink *parent,
+smarter::shared_ptr<FsLink, LinkRc> Superblock::internalizeLink(FsLink *parent,
 		std::string name, smarter::shared_ptr<Node> target) {
 	auto parentInode = static_cast<Node *>(parent->getTarget().get())->getInode();
 	auto entry = &_activeLinks[{parentInode, name, target->getInode()}];
@@ -1097,14 +1097,14 @@ async::result<frg::expected<Error, FsStats>> Superblock::getFsStats() {
 
 } // anonymous namespace
 
-smarter::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device) {
+smarter::shared_ptr<FsLink, LinkRc> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device) {
 	auto sb = new Superblock{std::move(sb_lane), device};
 	// FIXME: 2 is the ext2fs root inode.
 	return sb->internalizeRoot(2, std::move(lane));
 }
 
 smarter::shared_ptr<File, FileHandle>
-createFile(helix::UniqueLane lane, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link) {
+createFile(helix::UniqueLane lane, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link) {
 	auto file = smarter::make_shared<OpenFile>(helix::UniqueLane{},
 			std::move(lane), std::move(mount), std::move(link));
 	file->setupWeakFile(file);

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -50,6 +50,12 @@ public:
 		return _target;
 	}
 
+	// A negative link records that a name is known to be absent, so it has no target.
+	// Such links only ever exist as name cache entries.
+	bool isNegative() {
+		return !_target;
+	}
+
 	void renameTo(smarter::shared_ptr<FsLink, LinkRc> owner, std::string name) {
 		assert(_owner); // The root link is never renamed.
 		_owner = std::move(owner);
@@ -69,6 +75,12 @@ public:
 	// Constructs the root link of the mount, which has neither an owner nor a name.
 	Link(Superblock *sb, smarter::shared_ptr<FsNode> target)
 	: _sb{sb}, _target{std::move(target)} { }
+
+	// Constructs a negative link.
+	Link(Superblock *sb, smarter::shared_ptr<FsLink, LinkRc> owner, std::string name)
+	: _sb{sb}, _owner{std::move(owner)}, _name{std::move(name)} {
+		assert(_owner);
+	}
 
 	Link(Superblock *sb, smarter::shared_ptr<FsLink, LinkRc> owner, std::string name,
 			smarter::shared_ptr<FsNode> target)
@@ -543,8 +555,8 @@ async::result<frg::expected<Error>> Link::obstruct() {
 
 Link::~Link() {
 	assert(!_cacheHashHook.in_list);
-	// The root link is not interned.
-	if(_owner)
+	// Neither the root link nor negative links are interned.
+	if(_owner && _target)
 		_sb->forgetLink(static_cast<Node *>(ownerNode())->getInode(),
 				_name, static_cast<Node *>(_target.get())->getInode());
 }
@@ -591,15 +603,17 @@ private:
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pull_node.error());
 
+			smarter::shared_ptr<FsLink, LinkRc> result;
 			if (resp.file_type() == managarm::fs::FileType::DIRECTORY) {
-				auto child = _sb->internalizeStructural(parent, name,
+				result = _sb->internalizeStructural(parent, name,
 						resp.id(), pull_node.descriptor());
-				co_return child;
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
-				co_return _sb->internalizeLink(parent, name, std::move(child));
+				result = _sb->internalizeLink(parent, name, std::move(child));
 			}
+			recacheLink(parent, name, result.get());
+			co_return result;
 		} else {
 			co_return std::unexpected{resp.error() | toPosixError};
 		}
@@ -622,6 +636,10 @@ private:
 				cacheMiss = true;
 				break;
 			}
+			// Negative entry: mirror the server-side walk, where any missing
+			// component fails the entire traversal.
+			if(!*cached)
+				co_return Error::noSuchFile;
 			lastLink = std::move(*cached);
 			path.pop_front();
 			++consumed;
@@ -696,8 +714,12 @@ private:
 			co_return Error::ioError;
 		}
 
-		if(resp.error() != managarm::fs::Errors::SUCCESS)
+		if(resp.error() != managarm::fs::Errors::SUCCESS) {
+			// Only a single-component traversal identifies which name is absent.
+			if(resp.error() == managarm::fs::Errors::FILE_NOT_FOUND && path.size() == 1)
+				cacheLink(parent, path.front(), nullptr);
 			co_return resp.error() | toPosixError;
+		}
 
 		HEL_CHECK(pull_desc.error());
 		helix::UniqueLane pull_lane = pull_desc.descriptor();
@@ -776,9 +798,10 @@ private:
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pullNode.error());
 
-			auto child = _sb->internalizeStructural(parent, name,
+			auto result = _sb->internalizeStructural(parent, name,
 					resp.id(), pullNode.descriptor());
-			co_return child;
+			recacheLink(parent, name, result.get());
+			co_return result;
 		} else {
 			co_return resp.error() | toPosixError;
 		}
@@ -816,7 +839,9 @@ private:
 
 			auto child = _sb->internalizePeripheralNode(managarm::fs::FileType::SYMLINK,
 					resp.id(), pullNode.descriptor());
-			co_return _sb->internalizeLink(parent, name, std::move(child));
+			auto result = _sb->internalizeLink(parent, name, std::move(child));
+			recacheLink(parent, name, result.get());
+			co_return result;
 		} else {
 			co_return resp.error() | toPosixError;
 		}
@@ -833,8 +858,11 @@ private:
 
 	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 			getLink(FsLink *parent, std::string name) override {
-		if(auto cached = lookupCache(name))
+		if(auto cached = lookupCache(name)) {
+			if(!*cached)
+				co_return Error::noSuchFile;
 			co_return std::move(*cached);
+		}
 
 		managarm::fs::GetLinkRequest req;
 		req.set_path(name);
@@ -870,6 +898,8 @@ private:
 			cacheLink(parent, name, result.get());
 			co_return result;
 		}else{
+			if(resp.error() == managarm::fs::Errors::FILE_NOT_FOUND)
+				cacheLink(parent, name, nullptr);
 			co_return resp.error() | toPosixError;
 		}
 	}
@@ -899,15 +929,17 @@ private:
 		if(resp.error() == managarm::fs::Errors::SUCCESS) {
 			HEL_CHECK(pull_node.error());
 
+			smarter::shared_ptr<FsLink, LinkRc> result;
 			if(resp.file_type() == managarm::fs::FileType::DIRECTORY) {
-				auto child = _sb->internalizeStructural(parent, name,
+				result = _sb->internalizeStructural(parent, name,
 						resp.id(), pull_node.descriptor());
-				co_return child;
 			}else{
 				auto child = _sb->internalizePeripheralNode(resp.file_type(), resp.id(),
 						pull_node.descriptor());
-				co_return _sb->internalizeLink(parent, name, std::move(child));
+				result = _sb->internalizeLink(parent, name, std::move(child));
 			}
+			recacheLink(parent, name, result.get());
+			co_return result;
 		}else{
 			co_return resp.error() | toPosixError;
 		}
@@ -1019,12 +1051,19 @@ public:
 		return _sb->nameCacheLookup(this, name);
 	}
 
+	// Passing nullptr for link creates a negative cache entry.
 	void cacheLink(FsLink *parent, const std::string &name, FsLink *link) {
 		if(!_sb->nameCacheEnabled())
 			return;
 		// PathResolver never resolves these through the cache.
 		if(name == "." || name == "..")
 			return;
+		smarter::shared_ptr<Link, LinkRc> negative;
+		if(!link) {
+			negative = makeReclaimableLink<Link>(_sb->linkReclaimer(), _sb,
+					parent->sharedFromThis(), name);
+			link = negative.get();
+		}
 		auto entry = static_cast<Link *>(link);
 		// Links are interned under, and renamed in place to, the owner and name they are
 		// resolved through, so the cache key always agrees with what the link carries.
@@ -1034,6 +1073,12 @@ public:
 
 	void invalidateCache(const std::string &name) {
 		_sb->nameCacheInvalidate(this, name);
+	}
+
+	// Replaces the cache entry for name by a link that we just obtained authoritatively.
+	void recacheLink(FsLink *parent, const std::string &name, FsLink *link) {
+		invalidateCache(name);
+		cacheLink(parent, name, link);
 	}
 
 	DirectoryNode(Superblock *sb, uint64_t inode, helix::UniqueLane lane)
@@ -1216,6 +1261,8 @@ std::optional<smarter::shared_ptr<FsLink, LinkRc>> Superblock::nameCacheLookup(F
 	if(!link)
 		return std::nullopt;
 	touch(link->selfPtr().policy().meta());
+	if(link->isNegative())
+		return smarter::shared_ptr<FsLink, LinkRc>{};
 	return link->sharedFromThis();
 }
 

--- a/posix/subsystem/src/extern_fs.cpp
+++ b/posix/subsystem/src/extern_fs.cpp
@@ -1,5 +1,6 @@
 #include <async/cancellation.hpp>
 #include <sys/epoll.h>
+#include <algorithm>
 #include <map>
 #include <vector>
 
@@ -100,6 +101,10 @@ private:
 	smarter::shared_ptr<FsNode> _target;
 	bool _obstructed = false;
 
+	// Serial of the last rename applied to this link, so that renames whose responses
+	// are processed out of order do not leave the link with an older name.
+	uint64_t _renameSerial = 0;
+
 	// Name cache state.
 	size_t _cacheHash = 0;
 	// Hook for the name cache's hash table chain.
@@ -150,7 +155,15 @@ struct Superblock final : FsSuperblock, LinkReclaimer {
 
 	std::optional<smarter::shared_ptr<FsLink, LinkRc>> nameCacheLookup(FsNode *dir, const std::string &name);
 	void nameCacheInsert(Link *link);
-	void nameCacheInvalidate(FsNode *dir, const std::string &name);
+
+	// Brackets a mutation of a directory entry.
+	// Until endMutation(), lookups of the name bypass the cache and are not cached,
+	// since the server may already have applied the mutation.
+	void beginMutation(DirectoryNode *dir, const std::string &name);
+	// Counterpart of beginMutation(). Always invalidates the cached link.
+	void endMutation(DirectoryNode *dir, const std::string &name);
+	// Counterpart of beginMutation(). Invalidates the cached link unless the server reports serial zero.
+	void endMutation(DirectoryNode *dir, const std::string &name, uint64_t serial);
 
 	using NameCacheOwnerList = frg::intrusive_list<Link,
 			frg::locate_member<Link, frg::default_list_hook<Link>, &Link::_cacheOwnerHook>>;
@@ -166,6 +179,7 @@ private:
 			frg::locate_member<Link, frg::default_list_hook<Link>, &Link::_cacheHashHook>>;
 
 	void onReclaim(LinkMetaObjectBase *meta) override;
+	void popMutation(DirectoryNode *dir, const std::string &name);
 	Link *nameCacheFind(FsNode *dir, const std::string &name, size_t hash);
 	void nameCacheUnhash(Link *link);
 	void nameCacheEvict(Link *link);
@@ -179,6 +193,35 @@ private:
 	std::vector<NameCacheBucket> _nameCacheBuckets;
 
 	std::shared_ptr<UnixDevice> device_;
+};
+
+// Marks a directory entry as being mutated by an in-flight request, see Superblock::beginMutation().
+struct PendingMutation {
+	PendingMutation(Superblock *sb, DirectoryNode *dir, std::string name)
+	: _sb{sb}, _dir{dir}, _name{std::move(name)} {
+		_sb->beginMutation(_dir, _name);
+	}
+
+	PendingMutation(const PendingMutation &) = delete;
+	PendingMutation &operator=(const PendingMutation &) = delete;
+
+	// A mutation that is never completed did not produce a response at all, so the server
+	// may have applied it and the cached entry has to go.
+	~PendingMutation() {
+		if(_dir)
+			_sb->endMutation(_dir, _name);
+	}
+
+	// Mirrors the serial that the server reported, or zero if it did not mutate the directory.
+	void complete(uint64_t serial) {
+		_sb->endMutation(_dir, _name, serial);
+		_dir = nullptr;
+	}
+
+private:
+	Superblock *_sb;
+	DirectoryNode *_dir;
+	std::string _name;
 };
 
 struct Node : FsNode {
@@ -605,6 +648,7 @@ private:
 		req.set_name(name);
 		req.set_uid(process->threadGroup()->uid());
 		req.set_gid(process->threadGroup()->gid());
+		PendingMutation pending{_sb, this, name};
 
 		auto [offer, send_head, send_tail, recv_resp, pull_node] = co_await helix_ng::exchangeMsgs(
 			getLane(),
@@ -634,9 +678,11 @@ private:
 						pull_node.descriptor());
 				result = _sb->internalizeLink(parent, name, std::move(child));
 			}
-			recacheLink(parent, name, result.get());
+			pending.complete(resp.serial());
+			cacheLink(parent, name, result.get(), resp.serial());
 			co_return result;
 		} else {
+			pending.complete(resp.serial());
 			co_return std::unexpected{resp.error() | toPosixError};
 		}
 	}
@@ -739,7 +785,7 @@ private:
 		if(resp.error() != managarm::fs::Errors::SUCCESS) {
 			// Only a single-component traversal identifies which name is absent.
 			if(resp.error() == managarm::fs::Errors::FILE_NOT_FOUND && path.size() == 1)
-				cacheLink(parent, path.front(), nullptr);
+				cacheLink(parent, path.front(), nullptr, resp.serial());
 			co_return resp.error() | toPosixError;
 		}
 
@@ -748,6 +794,7 @@ private:
 
 		assert(resp.links_traversed());
 		assert(resp.links_traversed() <= path.size());
+		assert(resp.serials().size() == resp.ids().size());
 
 		// The reply only reports inodes, so we cannot immediately tell which link they correspond to.
 		// We replay the resolution rules to associate each link with the proper parent.
@@ -782,7 +829,7 @@ private:
 				link = _sb->internalizeLink(dirStack.back().get(), path[i], std::move(child));
 			}
 			static_cast<DirectoryNode *>(dirStack.back()->getTarget().get())
-					->cacheLink(dirStack.back().get(), path[i], link.get());
+					->cacheLink(dirStack.back().get(), path[i], link.get(), resp.serials()[i]);
 
 			if (!last)
 				dirStack.push_back(link);
@@ -800,6 +847,7 @@ private:
 		req.set_mode(mode & ~umask);
 		req.set_uid(proc ? proc->threadGroup()->uid() : 0);
 		req.set_gid(proc ? proc->threadGroup()->gid() : 0);
+		PendingMutation pending{_sb, this, name};
 
 		auto [offer, sendReq, sendTail, recvResp, pullNode] = co_await helix_ng::exchangeMsgs(
 			getLane(),
@@ -822,9 +870,11 @@ private:
 
 			auto result = _sb->internalizeStructural(parent, name,
 					resp.id(), pullNode.descriptor());
-			recacheLink(parent, name, result.get());
+			pending.complete(resp.serial());
+			cacheLink(parent, name, result.get(), resp.serial());
 			co_return result;
 		} else {
+			pending.complete(resp.serial());
 			co_return resp.error() | toPosixError;
 		}
 	}
@@ -835,6 +885,7 @@ private:
 		req.set_req_type(managarm::fs::CntReqType::NODE_SYMLINK);
 		req.set_name_length(name.size());
 		req.set_target_length(path.size());
+		PendingMutation pending{_sb, this, name};
 
 		auto ser = req.SerializeAsString();
 		auto [offer, sendReq, sendName, sendTarget, recvResp, pullNode]
@@ -862,9 +913,11 @@ private:
 			auto child = _sb->internalizePeripheralNode(managarm::fs::FileType::SYMLINK,
 					resp.id(), pullNode.descriptor());
 			auto result = _sb->internalizeLink(parent, name, std::move(child));
-			recacheLink(parent, name, result.get());
+			pending.complete(resp.serial());
+			cacheLink(parent, name, result.get(), resp.serial());
 			co_return result;
 		} else {
+			pending.complete(resp.serial());
 			co_return resp.error() | toPosixError;
 		}
 	}
@@ -917,11 +970,11 @@ private:
 						pull_node.descriptor());
 				result = _sb->internalizeLink(parent, name, std::move(child));
 			}
-			cacheLink(parent, name, result.get());
+			cacheLink(parent, name, result.get(), resp.serial());
 			co_return result;
 		}else{
 			if(resp.error() == managarm::fs::Errors::FILE_NOT_FOUND)
-				cacheLink(parent, name, nullptr);
+				cacheLink(parent, name, nullptr, resp.serial());
 			co_return resp.error() | toPosixError;
 		}
 	}
@@ -931,6 +984,7 @@ private:
 		managarm::fs::LinkRequest req;
 		req.set_path(name);
 		req.set_fd(static_cast<Node *>(target.get())->getInode());
+		PendingMutation pending{_sb, this, name};
 
 		auto [offer, send_req, send_tail, recv_resp, pull_node] = co_await helix_ng::exchangeMsgs(
 			getLane(),
@@ -960,9 +1014,11 @@ private:
 						pull_node.descriptor());
 				result = _sb->internalizeLink(parent, name, std::move(child));
 			}
-			recacheLink(parent, name, result.get());
+			pending.complete(resp.serial());
+			cacheLink(parent, name, result.get(), resp.serial());
 			co_return result;
 		}else{
+			pending.complete(resp.serial());
 			co_return resp.error() | toPosixError;
 		}
 	}
@@ -970,6 +1026,7 @@ private:
 	async::result<frg::expected<Error>> unlink(std::string name) override {
 		managarm::fs::UnlinkRequest req;
 		req.set_path(name);
+		PendingMutation pending{_sb, this, name};
 
 		auto [offer, send_req, send_tail, recv_resp] = co_await helix_ng::exchangeMsgs(
 			getLane(),
@@ -986,16 +1043,17 @@ private:
 		managarm::fs::SvrResponse resp;
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		recv_resp.reset();
+		pending.complete(resp.serial());
 		if(resp.error() != managarm::fs::Errors::SUCCESS)
 			co_return resp.error() | toPosixError;
 
-		invalidateCache(name);
 		co_return {};
 	}
 
 	async::result<frg::expected<Error>> rmdir(std::string name) override {
 		managarm::fs::RmdirRequest req;
 		req.set_path(name);
+		PendingMutation pending{_sb, this, name};
 
 		auto [offer, send_req, send_tail, recv_resp] = co_await helix_ng::exchangeMsgs(
 			getLane(),
@@ -1013,10 +1071,10 @@ private:
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		recv_resp.reset();
 
+		pending.complete(resp.serial());
 		if(resp.error() != managarm::fs::Errors::SUCCESS)
 			co_return resp.error() | toPosixError;
 
-		invalidateCache(name);
 		_sb->retireDirectory(resp.id());
 		co_return {};
 	}
@@ -1071,15 +1129,30 @@ private:
 
 public:
 	std::optional<smarter::shared_ptr<FsLink, LinkRc>> lookupCache(const std::string &name) {
+		// The server may already have applied an in-flight mutation of the name.
+		if(hasPendingMutation(name))
+			return std::nullopt;
 		return _sb->nameCacheLookup(this, name);
 	}
 
+	bool hasPendingMutation(const std::string &name) {
+		return std::find(_pendingMutations.begin(), _pendingMutations.end(), name)
+				!= _pendingMutations.end();
+	}
+
+	// Caches the result of a lookup that the server stamped with serial (see fs.bragi).
 	// Passing nullptr for link creates a negative cache entry.
-	void cacheLink(FsLink *parent, const std::string &name, FsLink *link) {
+	void cacheLink(FsLink *parent, const std::string &name, FsLink *link, uint64_t serial) {
 		if(!_sb->nameCacheEnabled())
 			return;
 		// A lookup that raced the removal of this directory must not revive it.
 		if(_removed)
+			return;
+		// The lookup observed a state older than a mutation that we already mirrored.
+		if(serial < _mutationSerial)
+			return;
+		// The lookup might predate a mutation that the server already applied.
+		if(hasPendingMutation(name))
 			return;
 		// PathResolver never resolves these through the cache.
 		if(name == "." || name == "..")
@@ -1097,14 +1170,9 @@ public:
 		_sb->nameCacheInsert(entry);
 	}
 
-	void invalidateCache(const std::string &name) {
-		_sb->nameCacheInvalidate(this, name);
-	}
-
-	// Replaces the cache entry for name by a link that we just obtained authoritatively.
-	void recacheLink(FsLink *parent, const std::string &name, FsLink *link) {
-		invalidateCache(name);
-		cacheLink(parent, name, link);
+	// Records that a mutation of this directory with the given serial completed.
+	void observeMutation(uint64_t serial) {
+		_mutationSerial = std::max(_mutationSerial, serial);
 	}
 
 	DirectoryNode(Superblock *sb, uint64_t inode, helix::UniqueLane lane)
@@ -1112,6 +1180,7 @@ public:
 
 	~DirectoryNode() {
 		assert(_cacheEntries.empty());
+		assert(_pendingMutations.empty());
 		_sb->forgetStructural(getInode());
 	}
 
@@ -1122,6 +1191,12 @@ private:
 	Superblock::NameCacheOwnerList _cacheEntries;
 	// Set once the server removed the directory, see Superblock::retireDirectory().
 	bool _removed = false;
+	// Highest serial of a mutation of this directory that we have mirrored into the cache.
+	// Lookups stamped with an older serial may have observed the state before it.
+	uint64_t _mutationSerial = 0;
+	// Holds names of link that in-flight mutations of this directory may be changing.
+	// Lookups of them bypass the cache.
+	std::vector<std::string> _pendingMutations;
 };
 
 Superblock::Superblock(helix::UniqueLane lane, std::shared_ptr<UnixDevice> device,
@@ -1168,13 +1243,17 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 
 	managarm::fs::RenameRequest req;
 	Link *slink = static_cast<Link *>(source);
-	Node *source_node = static_cast<Node *>(slink->getParentNode().get());
-	Node *target_node = static_cast<Node *>(directory->getTarget().get());
+	auto oldName = source->getName();
+	// Hold the directories: a concurrent rename of the same link may drop its owner.
+	auto source_node = smarter::static_pointer_cast<DirectoryNode>(slink->getParentNode());
+	auto target_node = smarter::static_pointer_cast<DirectoryNode>(directory->getTarget());
 	smarter::shared_ptr<Node> shared_node = smarter::static_pointer_cast<Node>(source->getTarget());
 	req.set_inode_source(source_node->getInode());
 	req.set_inode_target(target_node->getInode());
-	req.set_old_name(source->getName());
+	req.set_old_name(oldName);
 	req.set_new_name(name);
+	PendingMutation sourcePending{this, source_node.get(), oldName};
+	PendingMutation targetPending{this, target_node.get(), name};
 
 	auto [offer, send_head, send_tail, recv_resp] = co_await helix_ng::exchangeMsgs(
 		_lane,
@@ -1192,16 +1271,23 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	managarm::fs::SvrResponse resp;
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 	recv_resp.reset();
+	// Complete the pending mutations before slink->renameTo()
+	// such that the old name does not persist in the cache.
+	sourcePending.complete(resp.serial());
+	targetPending.complete(resp.serial());
 	if(resp.error() != managarm::fs::Errors::SUCCESS)
 		co_return resp.error() | toPosixError;
+	// A rename of a name onto another name of the same inode changes nothing.
+	if(!resp.serial())
+		co_return source->sharedFromThis();
 
-	// Both the name cache and _activeLinks are keyed by the owner and name, so the entries
-	// have to go before the link is renamed.
-	nameCacheInvalidate(source_node, source->getName());
-	nameCacheInvalidate(target_node, name);
-	_activeLinks.erase({source_node->getInode(), source->getName(), shared_node->getInode()});
-	slink->renameTo(directory->sharedFromThis(), name);
-	_activeLinks[{target_node->getInode(), name, shared_node->getInode()}] = source->sharedFromThis();
+	// Skip the rename if a later one of the same link was mirrored before this one.
+	if(resp.serial() > slink->_renameSerial) {
+		_activeLinks.erase({source_node->getInode(), oldName, shared_node->getInode()});
+		slink->renameTo(directory->sharedFromThis(), name);
+		_activeLinks[{target_node->getInode(), name, shared_node->getInode()}] = source->sharedFromThis();
+		slink->_renameSerial = resp.serial();
+	}
 
 	if(resp.id() && resp.file_type() == managarm::fs::FileType::DIRECTORY)
 		retireDirectory(resp.id());
@@ -1324,9 +1410,31 @@ void Superblock::nameCacheInsert(Link *link) {
 	static_cast<DirectoryNode *>(link->ownerNode())->_cacheEntries.push_front(link);
 }
 
-void Superblock::nameCacheInvalidate(FsNode *dir, const std::string &name) {
+void Superblock::beginMutation(DirectoryNode *dir, const std::string &name) {
+	dir->_pendingMutations.push_back(name);
+}
+
+void Superblock::popMutation(DirectoryNode *dir, const std::string &name) {
+	auto &pending = dir->_pendingMutations;
+	auto it = std::find(pending.begin(), pending.end(), name);
+	assert(it != pending.end());
+	pending.erase(it);
+}
+
+void Superblock::endMutation(DirectoryNode *dir, const std::string &name) {
+	popMutation(dir, name);
 	if(auto link = nameCacheFind(dir, name, nameCacheHash(dir, name)))
 		nameCacheEvict(link);
+}
+
+void Superblock::endMutation(DirectoryNode *dir, const std::string &name, uint64_t serial) {
+	// The server did not mutate the directory, hence the cached entry is still valid.
+	if(!serial) {
+		popMutation(dir, name);
+		return;
+	}
+	endMutation(dir, name);
+	dir->observeMutation(serial);
 }
 
 void Superblock::nameCacheUnhash(Link *link) {

--- a/posix/subsystem/src/extern_fs.hpp
+++ b/posix/subsystem/src/extern_fs.hpp
@@ -5,9 +5,9 @@
 
 namespace extern_fs {
 
-smarter::shared_ptr<FsLink> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device);
+smarter::shared_ptr<FsLink, LinkRc> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device);
 
 smarter::shared_ptr<File, FileHandle>
-createFile(helix::UniqueLane lane, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
+createFile(helix::UniqueLane lane, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link);
 
 } // namespace extern_fs

--- a/posix/subsystem/src/extern_fs.hpp
+++ b/posix/subsystem/src/extern_fs.hpp
@@ -5,7 +5,8 @@
 
 namespace extern_fs {
 
-smarter::shared_ptr<FsLink, LinkRc> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane, std::shared_ptr<UnixDevice> device);
+smarter::shared_ptr<FsLink, LinkRc> createRoot(helix::UniqueLane sb_lane, helix::UniqueLane lane,
+		std::shared_ptr<UnixDevice> device, uint64_t mountCaps);
 
 smarter::shared_ptr<File, FileHandle>
 createFile(helix::UniqueLane lane, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link);

--- a/posix/subsystem/src/fifo.cpp
+++ b/posix/subsystem/src/fifo.cpp
@@ -58,7 +58,7 @@ public:
 				smarter::shared_ptr<File>{file}, &File::fileOperations));
 	}
 
-	OpenFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	OpenFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		bool isReader, bool isWriter, bool nonBlock = false)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("fifo"), mount, link, File::defaultPipeLikeSeek},
 		isReader_{isReader}, isWriter_{isWriter}, nonBlock_{nonBlock} { }
@@ -312,7 +312,7 @@ void unlinkNamedChannel(FsNode *node) {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-openNamedChannel(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, FsNode *node, SemanticFlags flags) {
+openNamedChannel(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link, FsNode *node, SemanticFlags flags) {
 	if (globalChannelMap.find(node) == globalChannelMap.end())
 		co_return nullptr;
 

--- a/posix/subsystem/src/fifo.hpp
+++ b/posix/subsystem/src/fifo.hpp
@@ -8,7 +8,7 @@ namespace fifo {
 void createNamedChannel(FsNode *node);
 void unlinkNamedChannel(FsNode *node);
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-openNamedChannel(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, FsNode *node, SemanticFlags flags);
+openNamedChannel(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link, FsNode *node, SemanticFlags flags);
 
 std::array<smarter::shared_ptr<File, FileHandle>, 2> createPair(bool nonBlock);
 

--- a/posix/subsystem/src/file.hpp
+++ b/posix/subsystem/src/file.hpp
@@ -16,6 +16,7 @@
 #include <sys/socket.h>
 
 #include "common.hpp"
+#include "link-rc.hpp"
 
 struct File;
 struct MountView;
@@ -471,7 +472,7 @@ public:
 	File(FileKind kind, StructName struct_name, DefaultOps default_ops = 0)
 	: kind_{kind}, _structName{struct_name}, _defaultOps{default_ops}, _isOpen{true} { }
 
-	File(FileKind kind, StructName struct_name, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	File(FileKind kind, StructName struct_name, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			DefaultOps default_ops = 0)
 	: _link{std::move(link)}, kind_{kind}, _structName{struct_name}, _mount{std::move(mount)},
 			_defaultOps{default_ops}, _isOpen{true} { }
@@ -519,7 +520,7 @@ public:
 	// This is the link that was used to open the file.
 	// Note that this might not be the only link that can be used
 	// to reach the file's inode.
-	smarter::shared_ptr<FsLink> associatedLink() {
+	smarter::shared_ptr<FsLink, LinkRc> associatedLink() {
 		if(!_link)
 			std::cout << "posix \e[1;34m" << structName()
 					<< "\e[0m: Object does not support associatedLink()" << std::endl;
@@ -623,7 +624,7 @@ public:
 	virtual async::result<protocols::fs::Error> flock(int flags);
 
 protected:
-	const smarter::shared_ptr<FsLink> _link;
+	const smarter::shared_ptr<FsLink, LinkRc> _link;
 
 private:
 	smarter::counter _fileCtr;
@@ -641,7 +642,7 @@ struct FileWithDefaults : File {
 	FileWithDefaults(FileKind kind, StructName struct_name, DefaultOps default_ops = 0)
 	: File{kind, struct_name, default_ops} { }
 
-	FileWithDefaults(FileKind kind, StructName struct_name, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	FileWithDefaults(FileKind kind, StructName struct_name, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			DefaultOps default_ops = 0)
 	: File{kind, struct_name, std::move(mount), std::move(link), default_ops} { }
 
@@ -662,7 +663,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	DummyFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, DefaultOps default_ops = 0)
+	DummyFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link, DefaultOps default_ops = 0)
 	: FileWithDefaults{FileKind::unknown, StructName::get("dummy-file"), std::move(mount), std::move(link), default_ops | defaultPipeLikeSeek} { }
 
 	helix::BorrowedDescriptor getPassthroughLane() override {

--- a/posix/subsystem/src/fs.cpp
+++ b/posix/subsystem/src/fs.cpp
@@ -17,7 +17,7 @@ struct AnonymousSuperblock : FsSuperblock {
 		co_return nullptr;
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	rename(FsLink *, FsLink *, std::string) override {
 		co_return Error::noSuchFile;
 	}
@@ -94,40 +94,40 @@ void FsNode::removeObserver(FsObserver *observer) {
 	_observers.erase(it);
 }
 
-async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
+async::result<std::expected<smarter::shared_ptr<FsLink, LinkRc>, Error>>
 FsNode::getLinkOrCreate(FsLink *, Process *, std::string, mode_t, bool) {
 	std::println("posix: getLink() is not implemented for this FsNode");
 	co_return std::unexpected{Error::illegalOperationTarget};
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::getLink(FsLink *, std::string) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> FsNode::getLink(FsLink *, std::string) {
 	std::cout << "posix: getLink() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::link(FsLink *, std::string, smarter::shared_ptr<FsNode>) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> FsNode::link(FsLink *, std::string, smarter::shared_ptr<FsNode>) {
 	std::cout << "posix: link() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 FsNode::mkdir(FsLink *, Process *, std::string, mode_t) {
 	std::cout << "posix: mkdir() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 FsNode::symlink(FsLink *, std::string, std::string) {
 	std::cout << "posix: symlink() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mkdev(FsLink *, std::string, VfsType, DeviceId) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> FsNode::mkdev(FsLink *, std::string, VfsType, DeviceId) {
 	std::cout << "posix: mkdev() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mkfifo(FsLink *, std::string, mode_t) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> FsNode::mkfifo(FsLink *, std::string, mode_t) {
 	std::cout << "posix: mkfifo() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
@@ -144,7 +144,7 @@ async::result<frg::expected<Error>> FsNode::rmdir(std::string) {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-FsNode::open(Process *, std::shared_ptr<MountView>, smarter::shared_ptr<FsLink>, SemanticFlags) {
+FsNode::open(Process *, std::shared_ptr<MountView>, smarter::shared_ptr<FsLink, LinkRc>, SemanticFlags) {
 	std::cout << "posix: open() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
@@ -161,7 +161,7 @@ bool FsNode::hasTraverseLinks() {
 	return false;
 }
 
-async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>> FsNode::traverseLinks(FsLink *, std::deque<std::string>) {
+async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink, LinkRc>, size_t>>> FsNode::traverseLinks(FsLink *, std::deque<std::string>) {
 	std::cout << "posix: traverseLinks() is not implemented for this FsNode" << std::endl;
 	co_return Error::illegalOperationTarget;
 }
@@ -188,7 +188,7 @@ async::result<Error> FsNode::utimensat(std::optional<timespec> atime, std::optio
 	co_return Error::accessDenied;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FsNode::mksocket(FsLink *, std::string name, mode_t mode, uid_t uid, gid_t gid) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> FsNode::mksocket(FsLink *, std::string name, mode_t mode, uid_t uid, gid_t gid) {
 	(void) name;
 	(void) mode;
 	(void) uid;

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -8,7 +8,6 @@
 
 #include <async/result.hpp>
 #include <core/id-allocator.hpp>
-#include <frg/container_of.hpp>
 #include <hel.h>
 #include <smarter.hpp>
 #include <sys/types.h>
@@ -292,11 +291,11 @@ public:
 	}
 
 	SpecialLink(PrivateTag, VfsType fileType, int mode)
-	: fileType_{fileType}, mode_{mode} { }
+	: node_{makeFsShared<SpecialNode>(fileType, mode)} { }
 
 public:
 	smarter::shared_ptr<FsNode> getTarget() override {
-		return {sharedFromThis(), &embeddedNode_};
+		return node_;
 	}
 
 	smarter::shared_ptr<FsLink> getParent() override {
@@ -314,30 +313,31 @@ public:
 private:
 	// SpecialLinks can never be linked into "real" file systems,
 	// hence the can only ever be one link per node.
-	struct EmbeddedNode final : FsNode {
-		EmbeddedNode() : FsNode(getAnonymousSuperblock()) {}
+	struct SpecialNode final : FsNode {
+		SpecialNode(VfsType fileType, int mode)
+		: FsNode{getAnonymousSuperblock()}, fileType_{fileType}, mode_{mode} { }
 
 		VfsType getType() override {
-			auto node = frg::container_of(this, &SpecialLink::embeddedNode_);
-			return node->fileType_;
+			return fileType_;
 		}
 
 		async::result<frg::expected<Error, FileStats>> getStats() override {
-			auto node = frg::container_of(this, &SpecialLink::embeddedNode_);
 			FileStats stats{};
 			// TODO: Allocate an inode number.
 			stats.inodeNumber = 1;
 			stats.fileSize = 0;
 			stats.numLinks = 1;
-			stats.mode = node->mode_;
+			stats.mode = mode_;
 			stats.uid = 0;
 			stats.gid = 0;
 			// TODO: Linux returns the current time for all timestamps.
 			co_return stats;
 		}
+
+	private:
+		VfsType fileType_;
+		int mode_;
 	};
 
-	VfsType fileType_;
-	int mode_;
-	[[no_unique_address]] EmbeddedNode embeddedNode_;
+	smarter::shared_ptr<SpecialNode> node_;
 };

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -103,6 +103,11 @@ public:
 		return selfPtr_.lock();
 	}
 
+	smarter::borrowed_ptr<FsLink, LinkRc> selfPtr() {
+		assert(selfPtr_);
+		return selfPtr_;
+	}
+
 private:
 	smarter::borrowed_ptr<FsLink, LinkRc> selfPtr_;
 };

--- a/posix/subsystem/src/fs.hpp
+++ b/posix/subsystem/src/fs.hpp
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 
 #include "file.hpp"
+#include "link-rc.hpp"
 
 using DeviceId = std::pair<int, int>;
 
@@ -72,7 +73,7 @@ protected:
 public:
 	// Returns the link of the directory that this link lives in.
 	// Null for the root of a mount and for anonymous links.
-	virtual smarter::shared_ptr<FsLink> getParent() = 0;
+	virtual smarter::shared_ptr<FsLink, LinkRc> getParent() = 0;
 
 	// Name of the link. Empty for the root link.
 	virtual std::string getName() = 0;
@@ -93,17 +94,17 @@ public:
 	virtual std::optional<std::string> getProcFsDescription();
 
 	// Only to be called by makeFsShared().
-	void setupSelfPtr(smarter::borrowed_ptr<FsLink> ptr) {
+	void setupSelfPtr(smarter::borrowed_ptr<FsLink, LinkRc> ptr) {
 		selfPtr_ = ptr;
 	}
 
-	smarter::shared_ptr<FsLink> sharedFromThis() {
+	smarter::shared_ptr<FsLink, LinkRc> sharedFromThis() {
 		assert(selfPtr_);
 		return selfPtr_.lock();
 	}
 
 private:
-	smarter::borrowed_ptr<FsLink> selfPtr_;
+	smarter::borrowed_ptr<FsLink, LinkRc> selfPtr_;
 };
 
 struct FsSuperblock {
@@ -113,7 +114,7 @@ protected:
 public:
 	virtual FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) = 0;
 
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 			rename(FsLink *source, FsLink *directory, std::string name) = 0;
 	virtual async::result<frg::expected<Error, FsStats>> getFsStats() = 0;
 	virtual std::string getFsType() = 0;
@@ -185,30 +186,30 @@ public:
 	virtual void removeObserver(FsObserver *observer);
 
 	//! Get an existing link or create one (directories only).
-	virtual async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
+	virtual async::result<std::expected<smarter::shared_ptr<FsLink, LinkRc>, Error>>
 	getLinkOrCreate(FsLink *parent, Process *, std::string name, mode_t mode,
 			bool exclusive = false);
 
 	//! Resolves a file in a directory (directories only).
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name);
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> getLink(FsLink *parent, std::string name);
 
 	//! Links an existing node to this directory (directories only).
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target);
 
 	//! Creates a new directory (directories only).
-	virtual async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+	virtual async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	mkdir(FsLink *parent, Process *, std::string name, mode_t mode);
 
 	//! Creates a new symlink (directories only).
-	virtual async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+	virtual async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	symlink(FsLink *parent, std::string name, std::string path);
 
 	//! Creates a new device file (directories only).
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(FsLink *parent, std::string name,
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> mkdev(FsLink *parent, std::string name,
 			VfsType type, DeviceId id);
 
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkfifo(FsLink *parent, std::string name, mode_t mode);
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> mkfifo(FsLink *parent, std::string name, mode_t mode);
 
 	virtual async::result<frg::expected<Error>> unlink(std::string name);
 
@@ -217,7 +218,7 @@ public:
 	//! Opens the file (regular files only).
 	// TODO: Move this to the link instead of the inode?
 	virtual async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags);
 
 	// Reads the target of a symlink (symlinks only).
@@ -237,11 +238,11 @@ public:
 	virtual async::result<Error> utimensat(std::optional<timespec> atime, std::optional<timespec> mtime, timespec ctime);
 
 	// Creates an socket
-	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mksocket(FsLink *parent, std::string name, mode_t mode, uid_t uid, gid_t gid);
+	virtual async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> mksocket(FsLink *parent, std::string name, mode_t mode, uid_t uid, gid_t gid);
 
 	// Recursive path traversal
 	virtual bool hasTraverseLinks();
-	virtual async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink>, size_t>>> traverseLinks(FsLink *parent, std::deque<std::string> path);
+	virtual async::result<frg::expected<Error, std::pair<smarter::shared_ptr<FsLink, LinkRc>, size_t>>> traverseLinks(FsLink *parent, std::deque<std::string> path);
 
 	void notifyObservers(uint32_t inotifyEvents, const std::string &name, uint32_t cookie, bool isDir = false);
 
@@ -266,13 +267,28 @@ private:
 	std::unordered_map<FsObserver *, std::shared_ptr<FsObserver>> _observers;
 };
 
+// Allocates an FsLink that the given reclaimer keeps alive while it is unreferenced.
+// Passing a null reclaimer yields an ordinary link that dies with its last reference.
+template<typename T, typename... Args>
+requires std::derived_from<T, FsLink>
+smarter::shared_ptr<T, LinkRc> makeReclaimableLink(LinkReclaimer *reclaimer, Args &&...args) {
+	auto meta = new LinkMetaObject<T>{reclaimer, std::forward<Args>(args)...};
+	auto ptr = smarter::shared_ptr<T, LinkRc>{smarter::adopt_rc, meta->get(), LinkRc{meta}};
+	ptr->setupSelfPtr(ptr);
+	return ptr;
+}
+
 // Allocates an FsLink or FsNode and installs the self-pointer that sharedFromThis() returns.
 template<typename T, typename... Args>
 requires std::derived_from<T, FsLink> || std::derived_from<T, FsNode>
-smarter::shared_ptr<T> makeFsShared(Args &&...args) {
-	auto ptr = smarter::make_shared<T>(std::forward<Args>(args)...);
-	ptr->setupSelfPtr(ptr);
-	return ptr;
+auto makeFsShared(Args &&...args) {
+	if constexpr (std::derived_from<T, FsLink>) {
+		return makeReclaimableLink<T>(nullptr, std::forward<Args>(args)...);
+	}else{
+		auto ptr = smarter::make_shared<T>(std::forward<Args>(args)...);
+		ptr->setupSelfPtr(ptr);
+		return ptr;
+	}
 }
 
 // ----------------------------------------------------------------------------
@@ -286,7 +302,7 @@ private:
 	struct PrivateTag { }; // To tag-dispatch to private methods.
 
 public:
-	static smarter::shared_ptr<SpecialLink> makeSpecialLink(VfsType fileType, int mode) {
+	static smarter::shared_ptr<SpecialLink, LinkRc> makeSpecialLink(VfsType fileType, int mode) {
 		return makeFsShared<SpecialLink>(PrivateTag{}, fileType, mode);
 	}
 
@@ -298,7 +314,7 @@ public:
 		return node_;
 	}
 
-	smarter::shared_ptr<FsLink> getParent() override {
+	smarter::shared_ptr<FsLink, LinkRc> getParent() override {
 		return nullptr;
 	}
 

--- a/posix/subsystem/src/link-rc.cpp
+++ b/posix/subsystem/src/link-rc.cpp
@@ -1,0 +1,73 @@
+#include "link-rc.hpp"
+
+void LinkReclaimer::enlist(LinkMetaObjectBase *meta) {
+	std::unique_lock lock{_mutex};
+	// The link was reclaimed while we were waiting for the mutex, or it is enlisted already
+	// because it was referenced and released again after enlisting.
+	if(meta->reclaimState != LinkMetaObjectBase::ReclaimState::owned)
+		return;
+	meta->reclaimState = LinkMetaObjectBase::ReclaimState::enlisted;
+	_lru.push_front(meta);
+	++_size;
+
+	if(_size > _capacity)
+		trim();
+	runDestructors(lock);
+}
+
+void LinkReclaimer::touch(LinkMetaObjectBase *meta) {
+	std::lock_guard lock{_mutex};
+	if(meta->reclaimState != LinkMetaObjectBase::ReclaimState::enlisted)
+		return;
+	_lru.erase(_lru.iterator_to(meta));
+	_lru.push_front(meta);
+}
+
+void LinkReclaimer::reclaim(LinkMetaObjectBase *meta) {
+	std::unique_lock lock{_mutex};
+	if(meta->reclaimState == LinkMetaObjectBase::ReclaimState::destructing)
+		return;
+	if(meta->reclaimState == LinkMetaObjectBase::ReclaimState::enlisted) {
+		_lru.erase(_lru.iterator_to(meta));
+		--_size;
+		meta->reclaimState = LinkMetaObjectBase::ReclaimState::owned;
+	}
+	tryReclaim(meta);
+	runDestructors(lock);
+}
+
+// Releases our reference, but only if it is the last one. On failure the link is referenced
+// elsewhere and enlist() picks it up again once that reference goes away.
+bool LinkReclaimer::tryReclaim(LinkMetaObjectBase *meta) {
+	unsigned int expected = 1;
+	if(!meta->ctr().raw().compare_exchange_strong(expected, 0,
+			std::memory_order_acq_rel, std::memory_order_relaxed))
+		return false;
+	meta->reclaimState = LinkMetaObjectBase::ReclaimState::destructing;
+	onReclaim(meta);
+	_destructing.push_back(meta);
+	return true;
+}
+
+void LinkReclaimer::trim() {
+	while(_size > _capacity && !_lru.empty()) {
+		auto meta = _lru.pop_back();
+		--_size;
+		meta->reclaimState = LinkMetaObjectBase::ReclaimState::owned;
+		tryReclaim(meta);
+	}
+}
+
+void LinkReclaimer::runDestructors(std::unique_lock<std::mutex> &lock) {
+	// Destructing a link drops its references to other links, which re-enters the reclaimer.
+	if(_runningDestructors)
+		return;
+	_runningDestructors = true;
+	while(!_destructing.empty()) {
+		auto meta = _destructing.pop_front();
+		lock.unlock();
+		meta->finalize();
+		lock.lock();
+	}
+	_runningDestructors = false;
+}

--- a/posix/subsystem/src/link-rc.hpp
+++ b/posix/subsystem/src/link-rc.hpp
@@ -1,0 +1,168 @@
+#pragma once
+
+#include <mutex>
+
+#include <frg/list.hpp>
+#include <frg/manual_box.hpp>
+#include <smarter.hpp>
+
+struct LinkReclaimer;
+
+struct LinkMetaObjectBase : smarter::meta_object_base {
+	LinkMetaObjectBase(void (*finalize)(smarter::meta_object_base *),
+			void (*finalizeWeak)(smarter::meta_object_base *),
+			LinkReclaimer *reclaimer_)
+	: smarter::meta_object_base{finalize, finalizeWeak}, reclaimer{reclaimer_} { }
+
+	// Owner that holds a reference of its own, or null if the link is not reclaimable.
+	// Fixed at construction so that decrement() can read it without synchronization.
+	LinkReclaimer *const reclaimer;
+
+	enum class ReclaimState {
+		// The link is not part of the reclaimer's LRU list.
+		owned,
+		// The link waits in the reclaimer's LRU list.
+		enlisted,
+		// The link was reclaimed and waits to be destructed.
+		destructing
+	};
+
+	// Protected by LinkReclaimer::_mutex.
+	ReclaimState reclaimState = ReclaimState::owned;
+	// Protected by LinkReclaimer::_mutex.
+	frg::default_list_hook<LinkMetaObjectBase> reclaimHook;
+};
+
+// Refcount policy of all FsLinks.
+// Intercepts refcount drops to one such that owners can put cached links into a reclaim list.
+struct LinkRc {
+	LinkRc() = default;
+
+	explicit LinkRc(LinkMetaObjectBase *meta)
+	: _meta{meta} { }
+
+	explicit operator bool() const {
+		return _meta != nullptr;
+	}
+
+	void increment() const {
+		_meta->ctr().increment();
+	}
+
+	void decrement() const;
+
+	bool try_increment() const {
+		return _meta->ctr().increment_if_nonzero();
+	}
+
+	void increment_weak() const {
+		_meta->weak_ctr().increment();
+	}
+
+	void decrement_weak() const {
+		if(_meta->weak_ctr().decrement_and_check_if_zero())
+			_meta->finalize_weak();
+	}
+
+	LinkMetaObjectBase *meta() const {
+		return _meta;
+	}
+
+private:
+	LinkMetaObjectBase *_meta{nullptr};
+};
+
+// Keeps links alive until they are collected from an LRU list.
+// The reclaimer owns one reference per link.
+// That reference is released by a CAS in trim(), it is always that last reference that is released.
+struct LinkReclaimer {
+	LinkReclaimer(size_t capacity)
+	: _capacity{capacity} { }
+
+	// Called by LinkRc once the reclaimer's reference is the only one left.
+	void enlist(LinkMetaObjectBase *meta);
+
+	// Marks a link as recently used.
+	void touch(LinkMetaObjectBase *meta);
+
+	// Reclaims a link right away, e.g. because its owner knows that it is useless.
+	// Links that are still referenced elsewhere are reclaimed once these external references go away.
+	void reclaim(LinkMetaObjectBase *meta);
+
+protected:
+	~LinkReclaimer() = default;
+
+	// Called before a reclaimed link is destructed, i.e. while it is still constructed but
+	// unreferenced. Runs under the reclaimer's mutex.
+	virtual void onReclaim(LinkMetaObjectBase *meta) = 0;
+
+private:
+	using ReclaimList = frg::intrusive_list<LinkMetaObjectBase,
+			frg::locate_member<LinkMetaObjectBase,
+					frg::default_list_hook<LinkMetaObjectBase>,
+					&LinkMetaObjectBase::reclaimHook>>;
+
+	bool tryReclaim(LinkMetaObjectBase *meta);
+	void trim();
+	void runDestructors(std::unique_lock<std::mutex> &lock);
+
+	std::mutex _mutex;
+	ReclaimList _lru;
+	ReclaimList _destructing;
+	// Number of enlisted links, i.e. of the links that the reclaimer is able to reclaim.
+	size_t _size = 0;
+	size_t _capacity;
+	// Whether a thread is already running the deferred destructors.
+	bool _runningDestructors = false;
+};
+
+inline void LinkRc::decrement() const {
+	// Keep the meta object alive across enlist(): the link can be reclaimed concurrently
+	// once we give up our reference below.
+	auto reclaimer = _meta->reclaimer;
+	if(reclaimer)
+		_meta->weak_ctr().increment();
+
+	auto count = _meta->ctr().raw().fetch_sub(1, std::memory_order_acq_rel);
+	assert(count >= 1);
+	if(count == 1) {
+		_meta->finalize();
+	}else if(count == 2 && reclaimer) {
+		reclaimer->enlist(_meta);
+	}
+
+	if(reclaimer && _meta->weak_ctr().decrement_and_check_if_zero())
+		_meta->finalize_weak();
+}
+
+static_assert(smarter::weak_rc_policy<LinkRc>);
+
+template<typename T>
+struct LinkMetaObject : LinkMetaObjectBase {
+	template<typename... Args>
+	LinkMetaObject(LinkReclaimer *reclaimer, Args &&...args)
+	: LinkMetaObjectBase{&finalize_, &finalizeWeak_, reclaimer} {
+		// Reclaimable links are constructed with the reclaimer's reference in place.
+		ctr().setup(smarter::adopt_rc, reclaimer ? 2 : 1);
+		weak_ctr().setup(smarter::adopt_rc, 1);
+		_box.initialize(std::forward<Args>(args)...);
+	}
+
+	T *get() {
+		return _box.get();
+	}
+
+private:
+	static void finalize_(smarter::meta_object_base *base) {
+		auto self = static_cast<LinkMetaObject *>(base);
+		self->_box.destruct();
+		if(base->weak_ctr().decrement_and_check_if_zero())
+			base->finalize_weak();
+	}
+
+	static void finalizeWeak_(smarter::meta_object_base *base) {
+		delete static_cast<LinkMetaObject *>(base);
+	}
+
+	frg::manual_box<T> _box;
+};

--- a/posix/subsystem/src/memfd.hpp
+++ b/posix/subsystem/src/memfd.hpp
@@ -14,7 +14,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	MemoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, bool allowSealing)
+	MemoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link, bool allowSealing)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("memfd-file"), mount, link}, _offset{0} {
 		if(!allowSealing) {
 			_seals = F_SEAL_SEAL;
@@ -71,7 +71,7 @@ private:
 	struct PrivateTag { }; // To tag-dispatch to private methods.
 
 public:
-	static smarter::shared_ptr<MemoryFileLink> makeMemoryFileLink(int mode) {
+	static smarter::shared_ptr<MemoryFileLink, LinkRc> makeMemoryFileLink(int mode) {
 		return makeFsShared<MemoryFileLink>(PrivateTag{}, mode);
 	}
 
@@ -87,7 +87,7 @@ public:
 		return node_;
 	}
 
-	smarter::shared_ptr<FsLink> getParent() override {
+	smarter::shared_ptr<FsLink, LinkRc> getParent() override {
 		return nullptr;
 	}
 

--- a/posix/subsystem/src/memfd.hpp
+++ b/posix/subsystem/src/memfd.hpp
@@ -76,15 +76,15 @@ public:
 	}
 
 	MemoryFileLink(PrivateTag, int mode)
-	: mode_{mode} { }
+	: node_{makeFsShared<MemoryFileNode>(mode)} { }
 
 	void setFile(smarter::shared_ptr<MemoryFile> file) {
-		file_ = std::move(file);
+		node_->setFile(std::move(file));
 	}
 
 public:
 	smarter::shared_ptr<FsNode> getTarget() override {
-		return {sharedFromThis(), &embeddedNode_};
+		return node_;
 	}
 
 	smarter::shared_ptr<FsLink> getParent() override {
@@ -102,28 +102,34 @@ public:
 private:
 	// MemoryFileLink can never be linked into "real" file systems,
 	// hence the can only ever be one link per node.
-	struct EmbeddedNode final : FsNode {
-		EmbeddedNode() : FsNode(getAnonymousSuperblock()) {}
+	struct MemoryFileNode final : FsNode {
+		MemoryFileNode(int mode)
+		: FsNode{getAnonymousSuperblock()}, mode_{mode} { }
+
+		void setFile(smarter::shared_ptr<MemoryFile> file) {
+			file_ = std::move(file);
+		}
 
 		VfsType getType() override {
 			return VfsType::regular;
 		}
 
 		async::result<frg::expected<Error, FileStats>> getStats() override {
-			auto node = frg::container_of(this, &MemoryFileLink::embeddedNode_);
 			FileStats stats{};
 			stats.inodeNumber = 1;
-			stats.fileSize = node->file_->fileSize();
+			stats.fileSize = file_->fileSize();
 			stats.numLinks = 1;
-			stats.mode = node->mode_;
+			stats.mode = mode_;
 			stats.uid = 0;
 			stats.gid = 0;
 			// TODO: Linux returns the current time for all timestamps.
 			co_return stats;
 		}
+
+	private:
+		smarter::shared_ptr<MemoryFile> file_;
+		int mode_;
 	};
 
-	smarter::shared_ptr<MemoryFile> file_;
-	int mode_;
-	[[no_unique_address]] EmbeddedNode embeddedNode_;
+	smarter::shared_ptr<MemoryFileNode> node_;
 };

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -724,7 +724,7 @@ private:
 	std::shared_ptr<FsContext> _fsContext;
 	std::shared_ptr<FileContext> _fileContext;
 
-	smarter::shared_ptr<procfs::Link> procfsTaskLink_;
+	smarter::shared_ptr<procfs::Link, LinkRc> procfsTaskLink_;
 
 	std::shared_ptr<ThreadGroup> tgPointer_;
 	frg::default_list_hook<Process> tgHook_;
@@ -898,11 +898,11 @@ struct ThreadGroup : std::enable_shared_from_this<ThreadGroup> {
 		return _childrenUsage;
 	}
 
-	void setProcfsLink(smarter::shared_ptr<procfs::Link> link) {
+	void setProcfsLink(smarter::shared_ptr<procfs::Link, LinkRc> link) {
 		procfsLink_ = link;
 	}
 
-	smarter::shared_ptr<procfs::Link> procfsLink() const {
+	smarter::shared_ptr<procfs::Link, LinkRc> procfsLink() const {
 		return procfsLink_;
 	}
 
@@ -1046,7 +1046,7 @@ private:
 	> _notifyQueue;
 	async::recurring_event _notifyBell;
 
-	smarter::shared_ptr<procfs::Link> procfsLink_;
+	smarter::shared_ptr<procfs::Link, LinkRc> procfsLink_;
 
 	uint64_t currentSignalSeq_ = 1;
 	// ThreadGroup-wide signal queue for signals with no thread to accept them.

--- a/posix/subsystem/src/procfs.cpp
+++ b/posix/subsystem/src/procfs.cpp
@@ -23,15 +23,15 @@ SuperBlock procfsSuperblock;
 // LinkCompare implementation.
 // ----------------------------------------------------------------------------
 
-bool LinkCompare::operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link, LinkRc> &a, const smarter::shared_ptr<Link, LinkRc> &b) const {
 	return a->getName() < b->getName();
 }
 
-bool LinkCompare::operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link, LinkRc> &link, const std::string &name) const {
 	return link->getName() < name;
 }
 
-bool LinkCompare::operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const {
+bool LinkCompare::operator() (const std::string &name, const smarter::shared_ptr<Link, LinkRc> &link) const {
 	return name < link->getName();
 }
 
@@ -48,7 +48,7 @@ void RegularFile::serve(smarter::shared_ptr<RegularFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-RegularFile::RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+RegularFile::RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("procfs.attr"), std::move(mount), std::move(link)},
 		_cached{false}, _offset{0} { }
 
@@ -139,7 +139,7 @@ void DirectoryFile::serve(smarter::shared_ptr<DirectoryFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("procfs.dir"), std::move(mount), std::move(link)},
 		_node{static_cast<DirectoryNode *>(associatedLink()->getTarget().get())},
 		_iter{_node->_entries.begin()} { }
@@ -178,13 +178,13 @@ helix::BorrowedDescriptor DirectoryFile::getPassthroughLane() {
 Link::Link(smarter::shared_ptr<FsNode> target)
 : _target{std::move(target)} { }
 
-Link::Link(smarter::shared_ptr<FsLink> owner, std::string name, smarter::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsLink, LinkRc> owner, std::string name, smarter::shared_ptr<FsNode> target)
 : _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 	assert(_owner);
 	assert(!_name.empty());
 }
 
-smarter::shared_ptr<FsLink> Link::getParent() {
+smarter::shared_ptr<FsLink, LinkRc> Link::getParent() {
 	return _owner;
 }
 
@@ -257,7 +257,7 @@ async::result<frg::expected<Error, FileStats>> RegularNode::getStatsInternal(Thr
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-RegularNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+RegularNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: procfs RegularNode open() received illegal arguments:"
@@ -278,7 +278,7 @@ FutureMaybe<smarter::shared_ptr<FsNode>> SuperBlock::createRegular(Process *) {
 	co_return nullptr;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 SuperBlock::rename(FsLink *, FsLink *, std::string) {
 	co_return Error::noSuchFile;
 };
@@ -293,7 +293,7 @@ async::result<frg::expected<Error, FsStats>> SuperBlock::getFsStats() {
 // DirectoryNode implementation.
 // ----------------------------------------------------------------------------
 
-smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::createRootDirectory() {
 	auto node = makeFsShared<DirectoryNode>();
 	auto the_node = node.get();
 	auto link = makeFsShared<Link>(std::move(node));
@@ -327,7 +327,7 @@ smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
 DirectoryNode::DirectoryNode()
 : FsNode{&procfsSuperblock} { }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkregular(FsLink *parent, std::string name,
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::directMkregular(FsLink *parent, std::string name,
 		smarter::shared_ptr<RegularNode> regular) {
 	assert(_entries.find(name) == _entries.end());
 	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(regular));
@@ -335,7 +335,7 @@ smarter::shared_ptr<Link> DirectoryNode::directMkregular(FsLink *parent, std::st
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkdir(FsLink *parent, std::string name) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::directMkdir(FsLink *parent, std::string name) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = makeFsShared<DirectoryNode>();
 	auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(node));
@@ -343,14 +343,14 @@ smarter::shared_ptr<Link> DirectoryNode::directMkdir(FsLink *parent, std::string
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMknode(FsLink *parent, std::string name, smarter::shared_ptr<FsNode> node) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::directMknode(FsLink *parent, std::string name, smarter::shared_ptr<FsNode> node) {
 	assert(_entries.find(name) == _entries.end());
 	auto link = makeFsShared<Link>(parent->sharedFromThis(), name, std::move(node));
 	_entries.insert(link);
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::createProcDirectory(FsLink *parent, Process *process) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::createProcDirectory(FsLink *parent, Process *process) {
 	auto link = directMkdir(parent, std::to_string(process->pid()));
 	auto proc_dir = static_cast<DirectoryNode*>(link->getTarget().get());
 
@@ -373,7 +373,7 @@ smarter::shared_ptr<Link> DirectoryNode::createProcDirectory(FsLink *parent, Pro
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::createProcTaskDirectory(FsLink *parent, Process *process) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::createProcTaskDirectory(FsLink *parent, Process *process) {
 	auto pidProcfsLink = process->threadGroup()->procfsLink();
 	// Create /proc/[pid] on demand to minimize observable states of /proc/[pid] being visible
 	// without any /proc/[pid]/task/[tid] attached.
@@ -403,7 +403,7 @@ VfsType DirectoryNode::getType() {
 	return VfsType::directory;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::link(FsLink *, std::string,
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> DirectoryNode::link(FsLink *, std::string,
 		smarter::shared_ptr<FsNode>) {
 	co_return Error::noSuchFile;
 }
@@ -414,7 +414,7 @@ async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: procfs DirectoryNode open() received illegal arguments:"
@@ -430,7 +430,7 @@ DirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(FsLink *, std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> DirectoryNode::getLink(FsLink *, std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;
@@ -1138,7 +1138,7 @@ void FdDirectoryFile::serve(smarter::shared_ptr<FdDirectoryFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-FdDirectoryFile::FdDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, Process *process)
+FdDirectoryFile::FdDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link, Process *process)
 : FileWithDefaults{FileKind::unknown,  StructName::get("procfs.fddir"), std::move(mount), std::move(link)},
 		_process{process->weak_from_this()}, _fileTable{process->fileContext()->fileTable()}, _iter{_fileTable.begin()} {}
 
@@ -1180,7 +1180,7 @@ async::result<frg::expected<Error, FileStats>> FdDirectoryNode::getStats() {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-FdDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+FdDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: procfs FdDirectoryNode open() received illegal arguments:"
@@ -1200,7 +1200,7 @@ FdDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shar
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdDirectoryNode::getLink(FsLink *parent, std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> FdDirectoryNode::getLink(FsLink *parent, std::string name) {
 	auto p = _process.lock();
 	if (!p)
 		co_return Error::noSuchProcess;
@@ -1214,7 +1214,7 @@ async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdDirectoryNode
 	co_return Error::noSuchFile;
 }
 
-SymlinkNode::SymlinkNode(Process* proc, std::shared_ptr<MountView> mount, smarter::weak_ptr<FsLink> link)
+SymlinkNode::SymlinkNode(Process* proc, std::shared_ptr<MountView> mount, smarter::weak_ptr<FsLink, LinkRc> link)
 : _process{proc->weak_from_this()}, _mount{std::move(mount)}, _link{std::move(link)} { }
 
 expected<std::string> SymlinkNode::readSymlink(FsLink *, Process *process) {
@@ -1379,7 +1379,7 @@ async::result<frg::expected<Error, FileStats>> FdInfoDirectoryNode::getStats() {
 }
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-FdInfoDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+FdInfoDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: procfs FdInfoDirectoryNode open() received illegal arguments:"
@@ -1399,7 +1399,7 @@ FdInfoDirectoryNode::open(Process *, std::shared_ptr<MountView> mount, smarter::
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> FdInfoDirectoryNode::getLink(FsLink *parent, std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> FdInfoDirectoryNode::getLink(FsLink *parent, std::string name) {
 	if(!std::all_of(name.begin(), name.end(), isdigit))
 		co_return Error::noSuchFile;
 
@@ -1424,7 +1424,7 @@ void FdInfoDirectoryFile::serve(smarter::shared_ptr<FdInfoDirectoryFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-FdInfoDirectoryFile::FdInfoDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, Process* process)
+FdInfoDirectoryFile::FdInfoDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link, Process* process)
 : FileWithDefaults{FileKind::unknown,  StructName::get("procfs.fdinfodir"), std::move(mount), std::move(link)},
 		_process{process->weak_from_this()}, _fileTable{process->fileContext()->fileTable()}, _iter{_fileTable.begin()} {}
 
@@ -1470,7 +1470,7 @@ async::result<void> FdInfoNode::store(std::string) {
 
 } // namespace procfs
 
-smarter::shared_ptr<FsLink> getProcfs() {
-	static smarter::shared_ptr<FsLink> procfs = procfs::DirectoryNode::createRootDirectory();
+smarter::shared_ptr<FsLink, LinkRc> getProcfs() {
+	static smarter::shared_ptr<FsLink, LinkRc> procfs = procfs::DirectoryNode::createRootDirectory();
 	return procfs;
 }

--- a/posix/subsystem/src/procfs.hpp
+++ b/posix/subsystem/src/procfs.hpp
@@ -23,16 +23,16 @@ struct DirectoryNode;
 struct LinkCompare {
 	struct is_transparent { };
 
-	bool operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const;
-	bool operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const;
-	bool operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const;
+	bool operator() (const smarter::shared_ptr<Link, LinkRc> &a, const smarter::shared_ptr<Link, LinkRc> &b) const;
+	bool operator() (const smarter::shared_ptr<Link, LinkRc> &link, const std::string &name) const;
+	bool operator() (const std::string &name, const smarter::shared_ptr<Link, LinkRc> &link) const;
 };
 
 struct RegularFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<RegularFile> file);
 
-	explicit RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
+	explicit RegularFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link);
 
 	void handleClose() override;
 
@@ -65,7 +65,7 @@ struct DirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<DirectoryFile> file);
 
-	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
+	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link);
 
 	void handleClose() override;
 
@@ -80,22 +80,22 @@ private:
 	async::cancellation_event _cancelServe;
 
 	DotEntriesPhase _dots = DotEntriesPhase::dot;
-	std::set<smarter::shared_ptr<Link>, LinkCompare>::iterator _iter;
+	std::set<smarter::shared_ptr<Link, LinkRc>, LinkCompare>::iterator _iter;
 };
 
 struct Link final : FsLink {
 	explicit Link(smarter::shared_ptr<FsNode> target);
 
-	explicit Link(smarter::shared_ptr<FsLink> owner,
+	explicit Link(smarter::shared_ptr<FsLink, LinkRc> owner,
 			std::string name, smarter::shared_ptr<FsNode> target);
 
-	smarter::shared_ptr<FsLink> getParent() override;
+	smarter::shared_ptr<FsLink, LinkRc> getParent() override;
 	std::string getName() override;
 	smarter::shared_ptr<FsNode> getTarget() override;
 	void unlinkSelf();
 
 private:
-	smarter::shared_ptr<FsLink> _owner;
+	smarter::shared_ptr<FsLink, LinkRc> _owner;
 	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
 };
@@ -109,7 +109,7 @@ struct RegularNode : FsNode {
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override;
 
 protected:
@@ -127,7 +127,7 @@ public:
 
 	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 			rename(FsLink *source, FsLink *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
@@ -146,37 +146,37 @@ private:
 struct DirectoryNode final : FsNode {
 	friend struct DirectoryFile;
 
-	static smarter::shared_ptr<Link> createRootDirectory();
+	static smarter::shared_ptr<Link, LinkRc> createRootDirectory();
 
 	DirectoryNode();
 
-	smarter::shared_ptr<Link> directMkregular(FsLink *parent, std::string name,
+	smarter::shared_ptr<Link, LinkRc> directMkregular(FsLink *parent, std::string name,
 			smarter::shared_ptr<RegularNode> regular);
 
-	smarter::shared_ptr<Link> directMknode(FsLink *parent, std::string name,
+	smarter::shared_ptr<Link, LinkRc> directMknode(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> node);
-	smarter::shared_ptr<Link> directMkdir(FsLink *parent, std::string name);
+	smarter::shared_ptr<Link, LinkRc> directMkdir(FsLink *parent, std::string name);
 
-	smarter::shared_ptr<Link> createProcTaskDirectory(FsLink *parent, Process *process);
+	smarter::shared_ptr<Link, LinkRc> createProcTaskDirectory(FsLink *parent, Process *process);
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target) override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> getLink(FsLink *parent, std::string name) override;
 	async::result<frg::expected<Error>> unlink(std::string name) override;
 
 	Error directUnlink(std::string name);
 
 private:
-	smarter::shared_ptr<Link> createProcDirectory(FsLink *parent, Process *process);
+	smarter::shared_ptr<Link, LinkRc> createProcDirectory(FsLink *parent, Process *process);
 
-	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
+	std::set<smarter::shared_ptr<Link, LinkRc>, LinkCompare> _entries;
 };
 
 struct LinkNode : FsNode {
@@ -362,7 +362,7 @@ struct FdDirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<FdDirectoryFile> file);
 
-	explicit FdDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, Process *process);
+	explicit FdDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link, Process *process);
 
 	void handleClose() override;
 
@@ -400,15 +400,15 @@ public:
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> getLink(FsLink *parent, std::string name) override;
 private:
 	std::weak_ptr<Process> _process;
 };
 
 struct SymlinkNode final : LinkNode {
-	SymlinkNode(Process *, std::shared_ptr<MountView>, smarter::weak_ptr<FsLink>);
+	SymlinkNode(Process *, std::shared_ptr<MountView>, smarter::weak_ptr<FsLink, LinkRc>);
 
 	expected<std::string> readSymlink(FsLink *link, Process *process) override;
 
@@ -416,7 +416,7 @@ struct SymlinkNode final : LinkNode {
 private:
 	std::weak_ptr<Process> _process;
 	std::shared_ptr<MountView> _mount;
-	smarter::weak_ptr<FsLink> _link;
+	smarter::weak_ptr<FsLink, LinkRc> _link;
 };
 
 struct MountsNode final : RegularNode {
@@ -452,9 +452,9 @@ public:
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> getLink(FsLink *parent, std::string name) override;
 private:
 	std::weak_ptr<Process> _process;
 };
@@ -463,7 +463,7 @@ struct FdInfoDirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<FdInfoDirectoryFile> file);
 
-	explicit FdInfoDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, Process* process);
+	explicit FdInfoDirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link, Process* process);
 
 	void handleClose() override;
 
@@ -494,4 +494,4 @@ private:
 
 } // namespace procfs
 
-smarter::shared_ptr<FsLink> getProcfs();
+smarter::shared_ptr<FsLink, LinkRc> getProcfs();

--- a/posix/subsystem/src/pts.cpp
+++ b/posix/subsystem/src/pts.cpp
@@ -34,7 +34,7 @@ bool logAttrs = false;
 
 int nextPtsIndex = 0;
 
-extern smarter::shared_ptr<RootLink> globalRootLink;
+extern smarter::shared_ptr<RootLink, LinkRc> globalRootLink;
 
 //-----------------------------------------------------------------------------
 
@@ -297,7 +297,7 @@ public:
 		co_return nullptr;
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 			rename(FsLink *, FsLink *, std::string) override {
 		co_return Error::noSuchFile;
 	}
@@ -339,7 +339,7 @@ struct MasterDevice final : UnixDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override;
 };
 
@@ -351,7 +351,7 @@ struct SlaveDevice final : UnixDevice, std::enable_shared_from_this<SlaveDevice>
 	}
 
 	async::result<frg::expected<Error, SharedFilePtr>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override;
 
 private:
@@ -373,7 +373,7 @@ public:
 				file, &File::fileOperations, file->cancelServe_));
 	}
 
-	MasterFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	MasterFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			bool nonBlocking);
 
 	async::result<std::expected<size_t, Error>>
@@ -444,7 +444,7 @@ public:
 				file, &File::fileOperations, file->cancelServe_));
 	}
 
-	SlaveFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	SlaveFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			std::shared_ptr<Channel> channel, bool nonBlock, bool read, bool write);
 
 	async::result<std::expected<size_t, Error>>
@@ -509,18 +509,18 @@ private:
 
 struct Link final : FsLink {
 public:
-	explicit Link(smarter::shared_ptr<FsLink> root, std::string name,
+	explicit Link(smarter::shared_ptr<FsLink, LinkRc> root, std::string name,
 			smarter::shared_ptr<DeviceNode> device)
 	: _root{std::move(root)}, _name{std::move(name)}, _device{std::move(device)} { }
 
-	smarter::shared_ptr<FsLink> getParent() override;
+	smarter::shared_ptr<FsLink, LinkRc> getParent() override;
 
 	std::string getName() override;
 
 	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
-	smarter::shared_ptr<FsLink> _root;
+	smarter::shared_ptr<FsLink, LinkRc> _root;
 	std::string _name;
 	smarter::shared_ptr<DeviceNode> _device;
 };
@@ -532,7 +532,7 @@ struct RootLink final : FsLink {
 		return _root.get();
 	}
 
-	smarter::shared_ptr<FsLink> getParent() override {
+	smarter::shared_ptr<FsLink, LinkRc> getParent() override {
 		return nullptr;
 	}
 
@@ -549,14 +549,14 @@ private:
 struct LinkCompare {
 	struct is_transparent { };
 
-	bool operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const {
+	bool operator() (const smarter::shared_ptr<Link, LinkRc> &link, const std::string &name) const {
 		return link->getName() < name;
 	}
-	bool operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const {
+	bool operator() (const std::string &name, const smarter::shared_ptr<Link, LinkRc> &link) const {
 		return name < link->getName();
 	}
 
-	bool operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const {
+	bool operator() (const smarter::shared_ptr<Link, LinkRc> &a, const smarter::shared_ptr<Link, LinkRc> &b) const {
 		return a->getName() < b->getName();
 	}
 };
@@ -584,7 +584,7 @@ public:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *process, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		return openDevice(process, _type, _id, std::move(mount), std::move(link), semantic_flags);
 	}
@@ -628,7 +628,7 @@ public:
 		co_return FileStats{};
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	getLink(FsLink *, std::string name) override {
 		auto it = _entries.find(name);
 		if(it != _entries.end())
@@ -637,7 +637,7 @@ public:
 	}
 
 private:
-	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
+	std::set<smarter::shared_ptr<Link, LinkRc>, LinkCompare> _entries;
 };
 
 async::result<void>
@@ -892,7 +892,7 @@ Channel::commonIoctl(managarm::fs::GenericIoctlRequest req, helix::BorrowedDescr
 //-----------------------------------------------------------------------------
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-MasterDevice::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+MasterDevice::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: pts MasterDevice open() received illegal arguments:"
@@ -909,7 +909,7 @@ MasterDevice::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_
 	co_return File::constructHandle(std::move(file));
 }
 
-MasterFile::MasterFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+MasterFile::MasterFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		bool nonBlocking)
 : FileWithDefaults{FileKind::unknown,  StructName::get("pts.master"), std::move(mount), std::move(link), File::defaultPipeLikeSeek},
 		_channel{std::make_shared<Channel>(nextPtsIndex++)}, _nonBlocking{nonBlocking} {
@@ -1167,7 +1167,7 @@ SlaveDevice::SlaveDevice(std::shared_ptr<Channel> channel)
 }
 
 async::result<frg::expected<Error, SharedFilePtr>>
-SlaveDevice::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+SlaveDevice::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: pts SlaveDevice open() received illegal arguments:"
@@ -1186,7 +1186,7 @@ SlaveDevice::open(Process *, std::shared_ptr<MountView> mount, smarter::shared_p
 	co_return File::constructHandle(std::move(file));
 }
 
-SlaveFile::SlaveFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+SlaveFile::SlaveFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 		std::shared_ptr<Channel> channel, bool nonBlock, bool read, bool write)
 : FileWithDefaults{FileKind::unknown,  StructName::get("pts.slave"), std::move(mount), std::move(link),
 		File::defaultIsTerminal | File::defaultPipeLikeSeek},
@@ -1500,7 +1500,7 @@ async::result<void> SlaveFile::ioctl(Process *, uint32_t, helix_ng::RecvInlineRe
 
 async::result<frg::expected<Error, std::string>>
 SlaveFile::ttyname() {
-	smarter::shared_ptr<FsLink> me = associatedLink();
+	smarter::shared_ptr<FsLink, LinkRc> me = associatedLink();
 	std::string name;
 	if(!isTerminal())
 		co_return Error::notTerminal;
@@ -1525,7 +1525,7 @@ void SlaveFile::handleClose() {
 // Link and RootLink implementation.
 //-----------------------------------------------------------------------------
 
-smarter::shared_ptr<FsLink> Link::getParent() {
+smarter::shared_ptr<FsLink, LinkRc> Link::getParent() {
 	return _root;
 }
 
@@ -1544,7 +1544,7 @@ smarter::shared_ptr<FsNode> RootLink::getTarget() {
 	return _root->sharedFromThis();
 }
 
-smarter::shared_ptr<RootLink> globalRootLink = makeFsShared<RootLink>();
+smarter::shared_ptr<RootLink, LinkRc> globalRootLink = makeFsShared<RootLink>();
 
 } // anonymous namespace
 
@@ -1552,7 +1552,7 @@ std::shared_ptr<UnixDevice> createMasterDevice() {
 	return std::make_shared<MasterDevice>();
 }
 
-smarter::shared_ptr<FsLink> getFsRoot() {
+smarter::shared_ptr<FsLink, LinkRc> getFsRoot() {
 	return globalRootLink;
 }
 

--- a/posix/subsystem/src/pts.hpp
+++ b/posix/subsystem/src/pts.hpp
@@ -6,6 +6,6 @@ namespace pts {
 
 std::shared_ptr<UnixDevice> createMasterDevice();
 
-smarter::shared_ptr<FsLink> getFsRoot();
+smarter::shared_ptr<FsLink, LinkRc> getFsRoot();
 
 } // namespace pts

--- a/posix/subsystem/src/requests/filesystem.cpp
+++ b/posix/subsystem/src/requests/filesystem.cpp
@@ -293,7 +293,7 @@ HandleRequest::operator()(managarm::posix::MkfifoAtRequest &&req,
 
 	ViewPath relative_to;
 	smarter::shared_ptr<File, FileHandle> file;
-	smarter::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink, LinkRc> target_link;
 
 	if (req.fd() == AT_FDCWD) {
 		relative_to = self->fsContext()->getWorkingDirectory();
@@ -725,7 +725,7 @@ HandleRequest::operator()(managarm::posix::UnlinkAtRequest &&req,
 
 	ViewPath relative_to;
 	smarter::shared_ptr<File, FileHandle> file;
-	smarter::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink, LinkRc> target_link;
 
 	if(req.flags() & ~AT_REMOVEDIR) {
 		std::cout << "posix: UNLINKAT flag handling unimplemented with unknown flag: " << req.flags() << std::endl;
@@ -807,7 +807,7 @@ HandleRequest::operator()(managarm::posix::RmdirRequest &&req,
 		co_return std::unexpected(tailRes.error());
 	logBragiRequest(req);
 
-	smarter::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink, LinkRc> target_link;
 
 	PathResolver resolver;
 	resolver.setup(self->fsContext()->getRoot(), self->fsContext()->getWorkingDirectory(),
@@ -865,7 +865,7 @@ HandleRequest::operator()(managarm::posix::FstatAtRequest &&req,
 
 	ViewPath relative_to;
 	smarter::shared_ptr<File, FileHandle> file;
-	smarter::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink, LinkRc> target_link;
 	std::shared_ptr<MountView> target_mount;
 
 	if (req.fd() == AT_FDCWD) {
@@ -1010,7 +1010,7 @@ HandleRequest::operator()(managarm::posix::FstatfsRequest &&req,
 	logRequest(logRequests, self, "FSTATFS");
 
 	smarter::shared_ptr<File, FileHandle> file;
-	smarter::shared_ptr<FsLink> targetLink;
+	smarter::shared_ptr<FsLink, LinkRc> targetLink;
 	managarm::posix::FstatfsResponse resp;
 
 	if(req.fd() >= 0) {
@@ -1098,7 +1098,7 @@ HandleRequest::operator()(managarm::posix::FchmodAtRequest &&req,
 
 	ViewPath relative_to;
 	smarter::shared_ptr<File, FileHandle> file;
-	smarter::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink, LinkRc> target_link;
 
 	if(req.fd() == AT_FDCWD) {
 		relative_to = self->fsContext()->getWorkingDirectory();
@@ -1169,7 +1169,7 @@ HandleRequest::operator()(managarm::posix::FchownAtRequest &&req,
 
 	ViewPath relativeTo;
 	smarter::shared_ptr<File, FileHandle> file;
-	smarter::shared_ptr<FsLink> targetLink;
+	smarter::shared_ptr<FsLink, LinkRc> targetLink;
 
 	if(req.fd() == AT_FDCWD) {
 		relativeTo = self->fsContext()->getWorkingDirectory();
@@ -1370,7 +1370,7 @@ HandleRequest::operator()(managarm::posix::OpenAtRequest &&req,
 
 	ViewPath relative_to;
 	smarter::shared_ptr<File, FileHandle> file;
-	smarter::shared_ptr<FsLink> target_link;
+	smarter::shared_ptr<FsLink, LinkRc> target_link;
 
 	if(req.fd() == AT_FDCWD) {
 		relative_to = self->fsContext()->getWorkingDirectory();

--- a/posix/subsystem/src/subsystem/block.cpp
+++ b/posix/subsystem/src/subsystem/block.cpp
@@ -43,12 +43,12 @@ struct Device final : UnixDevice, drvcore::BlockDevice, std::enable_shared_from_
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
 	}
 
-	FutureMaybe<smarter::shared_ptr<FsLink>> mount(std::string fs_type) override {
+	FutureMaybe<smarter::shared_ptr<FsLink, LinkRc>> mount(std::string fs_type) override {
 		return mountExternalDevice(_lane, shared_from_this(), fs_type);
 	}
 

--- a/posix/subsystem/src/subsystem/drm.cpp
+++ b/posix/subsystem/src/subsystem/drm.cpp
@@ -27,7 +27,7 @@ struct Device final : UnixDevice, drvcore::ClassDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
 	}
@@ -58,7 +58,7 @@ struct RenderDevice final : UnixDevice, drvcore::ClassDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
 	}

--- a/posix/subsystem/src/subsystem/generic.cpp
+++ b/posix/subsystem/src/subsystem/generic.cpp
@@ -24,12 +24,12 @@ struct Device final : UnixDevice, std::enable_shared_from_this<Device> {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
 	}
 
-	FutureMaybe<smarter::shared_ptr<FsLink>> mount(std::string fs_type) override {
+	FutureMaybe<smarter::shared_ptr<FsLink, LinkRc>> mount(std::string fs_type) override {
 		return mountExternalDevice(_lane, shared_from_this(), fs_type);
 	}
 

--- a/posix/subsystem/src/subsystem/input.cpp
+++ b/posix/subsystem/src/subsystem/input.cpp
@@ -48,7 +48,7 @@ struct EventDevice final : UnixDevice, drvcore::ClassDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(_lane, std::move(mount), std::move(link), semantic_flags);
 	}

--- a/posix/subsystem/src/subsystem/sound.cpp
+++ b/posix/subsystem/src/subsystem/sound.cpp
@@ -45,7 +45,7 @@ struct ControlDevice final : UnixDevice, drvcore::ClassDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(lane_, std::move(mount), std::move(link), semantic_flags);
 	}
@@ -81,7 +81,7 @@ struct PcmDevice final : UnixDevice, drvcore::ClassDevice {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		return openExternalDevice(lane_, std::move(mount), std::move(link), semantic_flags);
 	}

--- a/posix/subsystem/src/sysfs.cpp
+++ b/posix/subsystem/src/sysfs.cpp
@@ -22,7 +22,7 @@ FutureMaybe<smarter::shared_ptr<FsNode>> SysfsSuperblock::createRegular(Process 
 	co_return nullptr;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 SysfsSuperblock::rename(FsLink *, FsLink *, std::string) {
 	co_return Error::noSuchFile;
 };
@@ -37,15 +37,15 @@ async::result<frg::expected<Error, FsStats>> SysfsSuperblock::getFsStats() {
 // LinkCompare implementation.
 // ----------------------------------------------------------------------------
 
-bool LinkCompare::operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link, LinkRc> &a, const smarter::shared_ptr<Link, LinkRc> &b) const {
 	return a->getName() < b->getName();
 }
 
-bool LinkCompare::operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const {
+bool LinkCompare::operator() (const smarter::shared_ptr<Link, LinkRc> &link, const std::string &name) const {
 	return link->getName() < name;
 }
 
-bool LinkCompare::operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const {
+bool LinkCompare::operator() (const std::string &name, const smarter::shared_ptr<Link, LinkRc> &link) const {
 	return name < link->getName();
 }
 
@@ -74,7 +74,7 @@ void AttributeFile::serve(smarter::shared_ptr<AttributeFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-AttributeFile::AttributeFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+AttributeFile::AttributeFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("sysfs.attr"), std::move(mount), std::move(link)},
 		_cached{false}, _offset{0} { }
 
@@ -166,7 +166,7 @@ void DirectoryFile::serve(smarter::shared_ptr<DirectoryFile> file) {
 			file, &File::fileOperations, file->_cancelServe));
 }
 
-DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("sysfs.dir"), std::move(mount), std::move(link)},
 		_node{static_cast<DirectoryNode *>(associatedLink()->getTarget().get())},
 		_iter{_node->_entries.begin()} { }
@@ -210,13 +210,13 @@ helix::BorrowedDescriptor DirectoryFile::getPassthroughLane() {
 Link::Link(smarter::shared_ptr<FsNode> target)
 : _target{std::move(target)} { }
 
-Link::Link(smarter::shared_ptr<FsLink> owner, std::string name, smarter::shared_ptr<FsNode> target)
+Link::Link(smarter::shared_ptr<FsLink, LinkRc> owner, std::string name, smarter::shared_ptr<FsNode> target)
 : _owner{std::move(owner)}, _name{std::move(name)}, _target{std::move(target)} {
 	assert(_owner);
 	assert(!_name.empty());
 }
 
-smarter::shared_ptr<FsLink> Link::getParent() {
+smarter::shared_ptr<FsLink, LinkRc> Link::getParent() {
 	return _owner;
 }
 
@@ -265,7 +265,7 @@ async::result<frg::expected<Error, FileStats>> AttributeNode::getStats() {
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 AttributeNode::open(Process *, std::shared_ptr<MountView> mount,
-		smarter::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
+		smarter::shared_ptr<FsLink, LinkRc> link, SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: sysfs AttributeNode open() received illegal arguments:"
 			<< std::bitset<32>(semantic_flags)
@@ -308,7 +308,7 @@ expected<std::string> SymlinkNode::readSymlink(FsLink *link, Process *) {
 	std::string path;
 
 	// Walk from the target to the root to discover the path.
-	for(smarter::shared_ptr<FsLink> ref = object->dirLink(); ref->getParent(); ref = ref->getParent())
+	for(smarter::shared_ptr<FsLink, LinkRc> ref = object->dirLink(); ref->getParent(); ref = ref->getParent())
 		path = path.empty() ? ref->getName() : ref->getName() + "/" + path;
 
 	// Walk from the symlink to the root to discover the number of ../ prefixes.
@@ -322,7 +322,7 @@ expected<std::string> SymlinkNode::readSymlink(FsLink *link, Process *) {
 // DirectoryNode implementation.
 // ----------------------------------------------------------------------------
 
-smarter::shared_ptr<Link> DirectoryNode::createRootDirectory() {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::createRootDirectory() {
 	auto node = makeFsShared<DirectoryNode>();
 	auto link = makeFsShared<Link>(std::move(node));
 	return link;
@@ -333,7 +333,7 @@ DirectoryNode::DirectoryNode()
 	inode_ = static_cast<SysfsSuperblock *>(superblock())->inodeAllocator().allocate();
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkattr(FsLink *parent, Object *object, Attribute *attr) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::directMkattr(FsLink *parent, Object *object, Attribute *attr) {
 	assert(_entries.find(attr->name()) == _entries.end());
 	auto node = makeFsShared<AttributeNode>(object, attr);
 	auto link = makeFsShared<Link>(parent->sharedFromThis(), attr->name(), std::move(node));
@@ -341,7 +341,7 @@ smarter::shared_ptr<Link> DirectoryNode::directMkattr(FsLink *parent, Object *ob
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMklink(FsLink *parent, std::string name, std::weak_ptr<Object> target) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::directMklink(FsLink *parent, std::string name, std::weak_ptr<Object> target) {
 	assert(_entries.find(name) == _entries.end());
 	auto node = makeFsShared<SymlinkNode>(std::move(target));
 	auto link = makeFsShared<Link>(parent->sharedFromThis(), std::move(name), std::move(node));
@@ -349,7 +349,7 @@ smarter::shared_ptr<Link> DirectoryNode::directMklink(FsLink *parent, std::strin
 	return link;
 }
 
-smarter::shared_ptr<Link> DirectoryNode::directMkdir(FsLink *parent, std::string name) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::directMkdir(FsLink *parent, std::string name) {
 	auto preexisting = _entries.find(name);
 	if(preexisting != _entries.end()) {
 		return *preexisting;
@@ -377,7 +377,7 @@ async::result<frg::expected<Error, FileStats>> DirectoryNode::getStats() {
 
 async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
 DirectoryNode::open(Process *, std::shared_ptr<MountView> mount,
-		smarter::shared_ptr<FsLink> link, SemanticFlags semantic_flags) {
+		smarter::shared_ptr<FsLink, LinkRc> link, SemanticFlags semantic_flags) {
 	if(semantic_flags & ~(semanticRead | semanticWrite)){
 		std::cout << "\e[31mposix: sysfs DirectoryNode open() received illegal arguments:"
 			<< std::bitset<32>(semantic_flags)
@@ -392,7 +392,7 @@ DirectoryNode::open(Process *, std::shared_ptr<MountView> mount,
 	co_return File::constructHandle(std::move(file));
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::getLink(FsLink *, std::string name) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> DirectoryNode::getLink(FsLink *, std::string name) {
 	auto it = _entries.find(name);
 	if(it != _entries.end())
 		co_return *it;
@@ -449,8 +449,8 @@ void Object::addObject() {
 
 } // namespace sysfs
 
-smarter::shared_ptr<FsLink> getSysfs() {
-	static smarter::shared_ptr<FsLink> sysfs = sysfs::DirectoryNode::createRootDirectory();
+smarter::shared_ptr<FsLink, LinkRc> getSysfs() {
+	static smarter::shared_ptr<FsLink, LinkRc> sysfs = sysfs::DirectoryNode::createRootDirectory();
 	return sysfs;
 }
 

--- a/posix/subsystem/src/sysfs.hpp
+++ b/posix/subsystem/src/sysfs.hpp
@@ -32,7 +32,7 @@ public:
 
 	FutureMaybe<smarter::shared_ptr<FsNode>> createRegular(Process *) override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 			rename(FsLink *source, FsLink *directory, std::string name) override;
 	async::result<frg::expected<Error, FsStats>> getFsStats() override;
 
@@ -56,16 +56,16 @@ private:
 struct LinkCompare {
 	struct is_transparent { };
 
-	bool operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const;
-	bool operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const;
-	bool operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const;
+	bool operator() (const smarter::shared_ptr<Link, LinkRc> &a, const smarter::shared_ptr<Link, LinkRc> &b) const;
+	bool operator() (const smarter::shared_ptr<Link, LinkRc> &link, const std::string &name) const;
+	bool operator() (const std::string &name, const smarter::shared_ptr<Link, LinkRc> &link) const;
 };
 
 struct AttributeFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<AttributeFile> file);
 
-	explicit AttributeFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
+	explicit AttributeFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link);
 
 	void handleClose() override;
 
@@ -97,7 +97,7 @@ struct DirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<DirectoryFile> file);
 
-	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
+	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link);
 
 	void handleClose() override;
 
@@ -113,21 +113,21 @@ private:
 	async::cancellation_event _cancelServe;
 
 	DotEntriesPhase _dots = DotEntriesPhase::dot;
-	std::set<smarter::shared_ptr<Link>, LinkCompare>::iterator _iter;
+	std::set<smarter::shared_ptr<Link, LinkRc>, LinkCompare>::iterator _iter;
 };
 
 struct Link final : FsLink {
 	explicit Link(smarter::shared_ptr<FsNode> target);
 
-	explicit Link(smarter::shared_ptr<FsLink> owner,
+	explicit Link(smarter::shared_ptr<FsLink, LinkRc> owner,
 			std::string name, smarter::shared_ptr<FsNode> target);
 
-	smarter::shared_ptr<FsLink> getParent() override;
+	smarter::shared_ptr<FsLink, LinkRc> getParent() override;
 	std::string getName() override;
 	smarter::shared_ptr<FsNode> getTarget() override;
 
 private:
-	smarter::shared_ptr<FsLink> _owner;
+	smarter::shared_ptr<FsLink, LinkRc> _owner;
 	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
 };
@@ -143,7 +143,7 @@ struct AttributeNode final : FsNode {
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override;
 
 private:
@@ -170,27 +170,27 @@ private:
 struct DirectoryNode final : FsNode {
 	friend struct DirectoryFile;
 
-	static smarter::shared_ptr<Link> createRootDirectory();
+	static smarter::shared_ptr<Link, LinkRc> createRootDirectory();
 
 	DirectoryNode();
 	~DirectoryNode() {
 		static_cast<SysfsSuperblock *>(superblock())->inodeAllocator().free(inode_);
 	}
 
-	smarter::shared_ptr<Link> directMkattr(FsLink *parent, Object *object, Attribute *attr);
-	smarter::shared_ptr<Link> directMklink(FsLink *parent, std::string name, std::weak_ptr<Object> target);
-	smarter::shared_ptr<Link> directMkdir(FsLink *parent, std::string name);
+	smarter::shared_ptr<Link, LinkRc> directMkattr(FsLink *parent, Object *object, Attribute *attr);
+	smarter::shared_ptr<Link, LinkRc> directMklink(FsLink *parent, std::string name, std::weak_ptr<Object> target);
+	smarter::shared_ptr<Link, LinkRc> directMkdir(FsLink *parent, std::string name);
 
 	VfsType getType() override;
 	async::result<frg::expected<Error, FileStats>> getStats() override;
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override;
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *parent, std::string name) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> getLink(FsLink *parent, std::string name) override;
 
 private:
-	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
+	std::set<smarter::shared_ptr<Link, LinkRc>, LinkCompare> _entries;
 	uint64_t inode_;
 };
 
@@ -240,7 +240,7 @@ struct Object {
 
 	smarter::shared_ptr<DirectoryNode> directoryNode();
 
-	const smarter::shared_ptr<Link> &dirLink() {
+	const smarter::shared_ptr<Link, LinkRc> &dirLink() {
 		return _dirLink;
 	}
 
@@ -257,7 +257,7 @@ private:
 	std::shared_ptr<Object> _parent;
 	std::string _name;
 
-	smarter::shared_ptr<Link> _dirLink;
+	smarter::shared_ptr<Link, LinkRc> _dirLink;
 
 	std::unordered_map<std::string, std::shared_ptr<sysfs::Object>> classDirectories_;
 };
@@ -269,4 +269,4 @@ struct Hierarchy {
 
 } // namespace sysfs
 
-smarter::shared_ptr<FsLink> getSysfs();
+smarter::shared_ptr<FsLink, LinkRc> getSysfs();

--- a/posix/subsystem/src/tmp_fs.cpp
+++ b/posix/subsystem/src/tmp_fs.cpp
@@ -185,7 +185,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> open(Process *process, std::shared_ptr<MountView> mount,
-			smarter::shared_ptr<FsLink> link, SemanticFlags semantic_flags) override {
+			smarter::shared_ptr<FsLink, LinkRc> link, SemanticFlags semantic_flags) override {
 		return openDevice(process, _type, _id, std::move(mount), std::move(link), semantic_flags);
 	}
 
@@ -212,7 +212,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>> open(Process *, std::shared_ptr<MountView> mount,
-			smarter::shared_ptr<FsLink> link, SemanticFlags semantic_flags) override {
+			smarter::shared_ptr<FsLink, LinkRc> link, SemanticFlags semantic_flags) override {
 		co_return co_await fifo::openNamedChannel(mount, link, this, semantic_flags);
 	}
 
@@ -233,13 +233,13 @@ public:
 	explicit Link(smarter::shared_ptr<FsNode> target)
 	: _target(std::move(target)) { }
 
-	explicit Link(smarter::shared_ptr<FsLink> owner, std::string name, smarter::shared_ptr<FsNode> target)
+	explicit Link(smarter::shared_ptr<FsLink, LinkRc> owner, std::string name, smarter::shared_ptr<FsNode> target)
 	: _owner(std::move(owner)), _name(std::move(name)), _target(std::move(target)) {
 		assert(_owner);
 		assert(!_name.empty());
 	}
 
-	smarter::shared_ptr<FsLink> getParent() override {
+	smarter::shared_ptr<FsLink, LinkRc> getParent() override {
 		return _owner;
 	}
 
@@ -253,14 +253,14 @@ public:
 		return _target;
 	}
 
-	void renameTo(smarter::shared_ptr<FsLink> owner, std::string name) {
+	void renameTo(smarter::shared_ptr<FsLink, LinkRc> owner, std::string name) {
 		assert(_owner); // The root link is never renamed.
 		_owner = std::move(owner);
 		_name = std::move(name);
 	}
 
 private:
-	smarter::shared_ptr<FsLink> _owner;
+	smarter::shared_ptr<FsLink, LinkRc> _owner;
 	std::string _name;
 	smarter::shared_ptr<FsNode> _target;
 };
@@ -268,15 +268,15 @@ private:
 struct LinkCompare {
 	struct is_transparent { };
 
-	bool operator() (const smarter::shared_ptr<Link> &link, const std::string &name) const {
+	bool operator() (const smarter::shared_ptr<Link, LinkRc> &link, const std::string &name) const {
 		return link->getName() < name;
 	}
 
-	bool operator() (const std::string &name, const smarter::shared_ptr<Link> &link) const {
+	bool operator() (const std::string &name, const smarter::shared_ptr<Link, LinkRc> &link) const {
 		return name < link->getName();
 	}
 
-	bool operator() (const smarter::shared_ptr<Link> &a, const smarter::shared_ptr<Link> &b) const {
+	bool operator() (const smarter::shared_ptr<Link, LinkRc> &a, const smarter::shared_ptr<Link, LinkRc> &b) const {
 		return a->getName() < b->getName();
 	}
 };
@@ -287,7 +287,7 @@ struct DirectoryFile final : FileWithDefaults {
 public:
 	static void serve(smarter::shared_ptr<DirectoryFile> file);
 
-	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link);
+	explicit DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link);
 
 	void handleClose() override;
 
@@ -304,14 +304,14 @@ private:
 	// The '.' and '..' entries are synthesized before iterating _entries.
 	DotEntriesPhase _dots = DotEntriesPhase::dot;
 
-	std::set<smarter::shared_ptr<Link>, LinkCompare>::iterator _iter;
+	std::set<smarter::shared_ptr<Link, LinkRc>, LinkCompare>::iterator _iter;
 };
 
 struct DirectoryNode final : Node {
 	friend struct Superblock;
 	friend struct DirectoryFile;
 
-	static smarter::shared_ptr<Link> createRootDirectory(Superblock *superblock, int mode, uid_t uid, gid_t gid);
+	static smarter::shared_ptr<Link, LinkRc> createRootDirectory(Superblock *superblock, int mode, uid_t uid, gid_t gid);
 
 private:
 	VfsType getType() override {
@@ -319,7 +319,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		// we silently ignore semanticAppend for directories
 		if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite | semanticAppend)){
@@ -333,18 +333,18 @@ private:
 		co_return File::constructHandle(std::move(file));
 	}
 
-	async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
+	async::result<std::expected<smarter::shared_ptr<FsLink, LinkRc>, Error>>
 	getLinkOrCreate(FsLink *parent, Process *process, std::string name, mode_t mode,
 			bool exclusive) override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> getLink(FsLink *, std::string name) override {
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> getLink(FsLink *, std::string name) override {
 		auto it = _entries.find(name);
 		if(it != _entries.end())
 			co_return *it;
 		co_return Error::noSuchFile;
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> link(FsLink *parent, std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> link(FsLink *parent, std::string name,
 			smarter::shared_ptr<FsNode> target) override {
 		if(!(_entries.find(name) == _entries.end()))
 			co_return Error::alreadyExists;
@@ -354,16 +354,16 @@ private:
 		co_return link;
 	}
 
-	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+	async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	mkdir(FsLink *parent, Process *p, std::string name, mode_t mode) override;
 
-	async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+	async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 	symlink(FsLink *parent, std::string name, std::string path) override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkdev(FsLink *parent, std::string name,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> mkdev(FsLink *parent, std::string name,
 			VfsType type, DeviceId id) override;
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mkfifo(FsLink *parent, std::string name, mode_t mode) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> mkfifo(FsLink *parent, std::string name, mode_t mode) override;
 
 	async::result<frg::expected<Error>> unlink(std::string name) override {
 		auto it = _entries.find(name);
@@ -381,7 +381,7 @@ private:
 		co_return {};
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> mksocket(FsLink *parent, std::string name, mode_t mode, uid_t uid, gid_t gid) override;
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> mksocket(FsLink *parent, std::string name, mode_t mode, uid_t uid, gid_t gid) override;
 
 	async::result<frg::expected<Error>> rmdir(std::string name) override {
 		auto it = _entries.find(name);
@@ -412,7 +412,7 @@ public:
 
 private:
 	// TODO: This creates a circular reference -- fix this.
-	std::set<smarter::shared_ptr<Link>, LinkCompare> _entries;
+	std::set<smarter::shared_ptr<Link, LinkRc>, LinkCompare> _entries;
 };
 
 // TODO: Remove this class in favor of MemoryNode.
@@ -423,7 +423,7 @@ private:
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticRead | semanticWrite)){
 			std::cout << "\e[31mposix: tmp_fs open() received illegal arguments:"
@@ -457,7 +457,7 @@ public:
 				file, &fileOperations, file->_cancelServe));
 	}
 
-	MemoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link, SemanticFlags flags)
+	MemoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link, SemanticFlags flags)
 	: FileWithDefaults{FileKind::unknown,  StructName::get("tmpfs.regular"), std::move(mount), std::move(link)},
 	flags_{flags}, _offset{0} { }
 
@@ -508,7 +508,7 @@ struct MemoryNode final : Node {
 	}
 
 	async::result<frg::expected<Error, smarter::shared_ptr<File, FileHandle>>>
-	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link,
+	open(Process *, std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link,
 			SemanticFlags semantic_flags) override {
 		if(semantic_flags & ~(semanticNonBlock | semanticRead | semanticWrite | semanticAppend)){
 			std::cout << "\e[31mposix: MemoryNode open() received illegal arguments:"
@@ -577,7 +577,7 @@ struct Superblock final : FsSuperblock {
 		co_return std::move(node);
 	}
 
-	async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> rename(FsLink *src_fs_link,
+	async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> rename(FsLink *src_fs_link,
 			FsLink *dest_fs_link, std::string dest_name) override {
 		auto src_link = static_cast<Link *>(src_fs_link);
 
@@ -815,7 +815,7 @@ void DirectoryFile::handleClose() {
 	_cancelServe.cancel();
 }
 
-DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+DirectoryFile::DirectoryFile(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 : FileWithDefaults{FileKind::unknown,  StructName::get("tmpfs.dir"), std::move(mount), std::move(link)},
 		_node{static_cast<DirectoryNode *>(associatedLink()->getTarget().get())},
 		_iter{_node->_entries.begin()} { }
@@ -922,7 +922,7 @@ SocketNode::SocketNode(Superblock *superblock, mode_t mode, uid_t uid, gid_t gid
 // DirectoryNode implementation.
 // ----------------------------------------------------------------------------
 
-smarter::shared_ptr<Link> DirectoryNode::createRootDirectory(Superblock *superblock, int mode, uid_t uid, gid_t gid) {
+smarter::shared_ptr<Link, LinkRc> DirectoryNode::createRootDirectory(Superblock *superblock, int mode, uid_t uid, gid_t gid) {
 	auto node = makeFsShared<DirectoryNode>(superblock, mode, uid, gid);
 	auto link = makeFsShared<Link>(std::move(node));
 	return link;
@@ -936,7 +936,7 @@ DirectoryNode::DirectoryNode(Superblock *superblock, int mode, uid_t uid, gid_t 
 	adjustLinkCount(1);
 }
 
-async::result<std::expected<smarter::shared_ptr<FsLink>, Error>>
+async::result<std::expected<smarter::shared_ptr<FsLink, LinkRc>, Error>>
 DirectoryNode::getLinkOrCreate(FsLink *parent, Process *, std::string name, mode_t mode,
 		bool exclusive) {
 	auto linkResult = co_await getLink(parent, name);
@@ -953,7 +953,7 @@ DirectoryNode::getLinkOrCreate(FsLink *parent, Process *, std::string name, mode
 	co_return link;
 }
 
-async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 DirectoryNode::mkdir(FsLink *parent, Process *proc, std::string name, mode_t mode) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
@@ -971,7 +971,7 @@ DirectoryNode::mkdir(FsLink *parent, Process *proc, std::string name, mode_t mod
 	co_return link;
 }
 
-async::result<std::variant<Error, smarter::shared_ptr<FsLink>>>
+async::result<std::variant<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 DirectoryNode::symlink(FsLink *parent, std::string name, std::string path) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
@@ -982,7 +982,7 @@ DirectoryNode::symlink(FsLink *parent, std::string name, std::string path) {
 	co_return link;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 DirectoryNode::mkdev(FsLink *parent, std::string name, VfsType type, DeviceId id) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
@@ -994,7 +994,7 @@ DirectoryNode::mkdev(FsLink *parent, std::string name, VfsType type, DeviceId id
 	co_return link;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>>
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>>
 DirectoryNode::mkfifo(FsLink *parent, std::string name, mode_t mode) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
@@ -1005,7 +1005,7 @@ DirectoryNode::mkfifo(FsLink *parent, std::string name, mode_t mode) {
 	co_return link;
 }
 
-async::result<frg::expected<Error, smarter::shared_ptr<FsLink>>> DirectoryNode::mksocket(FsLink *parent, std::string name, mode_t mode, uid_t uid, gid_t gid) {
+async::result<frg::expected<Error, smarter::shared_ptr<FsLink, LinkRc>>> DirectoryNode::mksocket(FsLink *parent, std::string name, mode_t mode, uid_t uid, gid_t gid) {
 	if(!(_entries.find(name) == _entries.end()))
 		co_return Error::alreadyExists;
 	auto node = makeFsShared<SocketNode>(static_cast<Superblock *>(superblock()), mode, uid, gid);
@@ -1022,7 +1022,7 @@ smarter::shared_ptr<FsNode> createMemoryNode(std::string path) {
 	return makeFsShared<InheritedNode>(new Superblock{}, std::move(path));
 }
 
-std::expected<smarter::shared_ptr<FsLink>, Error> createRoot(Process *p, std::string options) {
+std::expected<smarter::shared_ptr<FsLink, LinkRc>, Error> createRoot(Process *p, std::string options) {
 	std::optional<uid_t> uid = std::nullopt;
 	std::optional<gid_t> gid = std::nullopt;
 	std::optional<mode_t> mode = std::nullopt;
@@ -1079,7 +1079,7 @@ std::expected<smarter::shared_ptr<FsLink>, Error> createRoot(Process *p, std::st
 	return dir;
 }
 
-smarter::shared_ptr<FsLink> createDevTmpFsRoot() {
+smarter::shared_ptr<FsLink, LinkRc> createDevTmpFsRoot() {
 	return DirectoryNode::createRootDirectory(new Superblock{"devtmpfs"}, 01777, 0, 0);
 }
 

--- a/posix/subsystem/src/tmp_fs.hpp
+++ b/posix/subsystem/src/tmp_fs.hpp
@@ -6,7 +6,7 @@ namespace tmp_fs {
 
 smarter::shared_ptr<FsNode> createMemoryNode(std::string path);
 
-std::expected<smarter::shared_ptr<FsLink>, Error> createRoot(Process *p, std::string options);
-smarter::shared_ptr<FsLink> createDevTmpFsRoot();
+std::expected<smarter::shared_ptr<FsLink, LinkRc>, Error> createRoot(Process *p, std::string options);
+smarter::shared_ptr<FsLink, LinkRc> createDevTmpFsRoot();
 
 } // namespace tmp_fs

--- a/posix/subsystem/src/vfs.cpp
+++ b/posix/subsystem/src/vfs.cpp
@@ -30,7 +30,7 @@ id_allocator<uint64_t> mountIdAllocator;
 // MountView implementation.
 // --------------------------------------------------------
 
-std::shared_ptr<MountView> MountView::createRoot(smarter::shared_ptr<FsLink> origin) {
+std::shared_ptr<MountView> MountView::createRoot(smarter::shared_ptr<FsLink, LinkRc> origin) {
 	return std::make_shared<MountView>(mountIdAllocator.allocate(), nullptr, nullptr, std::move(origin), ViewPath{});
 }
 
@@ -38,15 +38,15 @@ std::shared_ptr<MountView> MountView::getParent() const {
 	return _parent;
 }
 
-smarter::shared_ptr<FsLink> MountView::getAnchor() const {
+smarter::shared_ptr<FsLink, LinkRc> MountView::getAnchor() const {
 	return _anchor;
 }
 
-smarter::shared_ptr<FsLink> MountView::getOrigin() const {
+smarter::shared_ptr<FsLink, LinkRc> MountView::getOrigin() const {
 	return _origin;
 }
 
-async::result<void> MountView::mount(smarter::shared_ptr<FsLink> anchor, smarter::shared_ptr<FsLink> origin, ViewPath deviceLink) {
+async::result<void> MountView::mount(smarter::shared_ptr<FsLink, LinkRc> anchor, smarter::shared_ptr<FsLink, LinkRc> origin, ViewPath deviceLink) {
 	if (anchor) {
 		auto result = co_await anchor->obstruct();
 		(void)result;
@@ -58,7 +58,7 @@ async::result<void> MountView::mount(smarter::shared_ptr<FsLink> anchor, smarter
 	// TODO: check insert return value
 }
 
-std::shared_ptr<MountView> MountView::getMount(smarter::shared_ptr<FsLink> link) const {
+std::shared_ptr<MountView> MountView::getMount(smarter::shared_ptr<FsLink, LinkRc> link) const {
 	auto it = _mounts.find(link);
 	if(it == _mounts.end())
 		return nullptr;
@@ -79,16 +79,16 @@ async::result<void> populateRootView() {
 	co_await tree->getTarget()->mkdir(tree.get(), nullptr, "realfs", 0555);
 
 	// TODO: Check for errors from mkdir().
-	auto dev = std::get<smarter::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir(tree.get(), nullptr, "dev", 0755));
+	auto dev = std::get<smarter::shared_ptr<FsLink, LinkRc>>(co_await tree->getTarget()->mkdir(tree.get(), nullptr, "dev", 0755));
 	co_await rootView->mount(std::move(dev), getDevtmpfs());
 
-	auto sys = std::get<smarter::shared_ptr<FsLink>>(co_await tree->getTarget()->mkdir(tree.get(), nullptr, "sys", 0755));
+	auto sys = std::get<smarter::shared_ptr<FsLink, LinkRc>>(co_await tree->getTarget()->mkdir(tree.get(), nullptr, "sys", 0755));
 	co_await rootView->mount(std::move(sys), getSysfs());
 
 	// Populate the tmpfs from the fs we are running on.
 	std::vector<
 		std::pair<
-			smarter::shared_ptr<FsLink>,
+			smarter::shared_ptr<FsLink, LinkRc>,
 			std::string
 		>
 	> stack;
@@ -157,7 +157,7 @@ async::result<void> populateRootView() {
 
 			if(resp.file_type() == managarm::fs::FileType::DIRECTORY) {
 				// TODO: Check for errors from mkdir().
-				auto link = std::get<smarter::shared_ptr<FsLink>>(
+				auto link = std::get<smarter::shared_ptr<FsLink, LinkRc>>(
 				    co_await item.first->getTarget()->mkdir(item.first.get(), nullptr, resp.path(), 0755)
 				);
 				stack.push_back({link, item.second + "/" + resp.path()});

--- a/posix/subsystem/src/vfs.hpp
+++ b/posix/subsystem/src/vfs.hpp
@@ -40,12 +40,12 @@ inline constexpr ResolveFlags resolveOpenCreate = (1 << 5);
 // If the last component does not exist, resolution fails with ENOENT. Otherwise, it fails with EEXIST.
 inline constexpr ResolveFlags resolveCreatesNonDirectory = (1 << 6);
 
-using ViewPathPair = std::pair<std::shared_ptr<MountView>, smarter::shared_ptr<FsLink>>;
+using ViewPathPair = std::pair<std::shared_ptr<MountView>, smarter::shared_ptr<FsLink, LinkRc>>;
 
 struct ViewPath : public ViewPathPair {
 	ViewPath() = default;
 
-	ViewPath(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink> link)
+	ViewPath(std::shared_ptr<MountView> mount, smarter::shared_ptr<FsLink, LinkRc> link)
 	: ViewPathPair(mount, link) {}
 
 	// smarter::shared_ptr does not compare, hence std::pair's operator== does not apply.
@@ -59,11 +59,11 @@ struct ViewPath : public ViewPathPair {
 //! Represents a virtual view of the file system.
 //! We handle all mount point related logic in this class.
 struct MountView : std::enable_shared_from_this<MountView> {
-	static std::shared_ptr<MountView> createRoot(smarter::shared_ptr<FsLink> origin);
+	static std::shared_ptr<MountView> createRoot(smarter::shared_ptr<FsLink, LinkRc> origin);
 
 	// TODO: This is an implementation detail that could be hidden.
-	explicit MountView(uint64_t mountId, std::shared_ptr<MountView> parent, smarter::shared_ptr<FsLink> anchor,
-			smarter::shared_ptr<FsLink> origin, ViewPath deviceLink)
+	explicit MountView(uint64_t mountId, std::shared_ptr<MountView> parent, smarter::shared_ptr<FsLink, LinkRc> anchor,
+			smarter::shared_ptr<FsLink, LinkRc> origin, ViewPath deviceLink)
 	: mountId_{mountId}, _parent{std::move(parent)}, _anchor{std::move(anchor)}, _origin{std::move(origin)},
 		deviceLink_{std::move(deviceLink)}
 	{ }
@@ -73,24 +73,24 @@ struct MountView : std::enable_shared_from_this<MountView> {
 	}
 
 	std::shared_ptr<MountView> getParent() const;
-	smarter::shared_ptr<FsLink> getAnchor() const;
-	smarter::shared_ptr<FsLink> getOrigin() const;
+	smarter::shared_ptr<FsLink, LinkRc> getAnchor() const;
+	smarter::shared_ptr<FsLink, LinkRc> getOrigin() const;
 	ViewPath getDevice() const {
 		return deviceLink_;
 	}
 
-	async::result<void> mount(smarter::shared_ptr<FsLink> anchor, smarter::shared_ptr<FsLink> origin, ViewPath deviceLink = {});
+	async::result<void> mount(smarter::shared_ptr<FsLink, LinkRc> anchor, smarter::shared_ptr<FsLink, LinkRc> origin, ViewPath deviceLink = {});
 
-	std::shared_ptr<MountView> getMount(smarter::shared_ptr<FsLink> link) const;
+	std::shared_ptr<MountView> getMount(smarter::shared_ptr<FsLink, LinkRc> link) const;
 
 	struct Compare {
 		struct is_transparent { };
 
 		bool operator() (const std::shared_ptr<MountView> &a,
-				const smarter::shared_ptr<FsLink> &b) const {
+				const smarter::shared_ptr<FsLink, LinkRc> &b) const {
 			return a->getAnchor().get() < b.get();
 		}
-		bool operator() (const smarter::shared_ptr<FsLink> &a,
+		bool operator() (const smarter::shared_ptr<FsLink, LinkRc> &a,
 				const std::shared_ptr<MountView> &b) const {
 			return a.get() < b->getAnchor().get();
 		}
@@ -109,8 +109,8 @@ private:
 
 	uint64_t mountId_;
 	std::shared_ptr<MountView> _parent;
-	smarter::shared_ptr<FsLink> _anchor;
-	smarter::shared_ptr<FsLink> _origin;
+	smarter::shared_ptr<FsLink, LinkRc> _anchor;
+	smarter::shared_ptr<FsLink, LinkRc> _origin;
 	ViewPath deviceLink_;
 	std::set<std::shared_ptr<MountView>, Compare> _mounts;
 };
@@ -133,7 +133,7 @@ struct PathResolver {
 		return _currentPath.first;
 	}
 
-	smarter::shared_ptr<FsLink> currentLink() {
+	smarter::shared_ptr<FsLink, LinkRc> currentLink() {
 		return _currentPath.second;
 	}
 

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -70,6 +70,13 @@ consts FileCaps uint32 {
 	FC_POSIX_LANE = 2
 }
 
+consts MountCaps uint64 {
+	// The server never modifies directory entries on its own:
+	// all directory entry mutations originate from requests sent by the client.
+	// Allows the client to cache the directory hierarchy.
+	MC_CLIENT_EXCLUSIVE_NAMESPACE = 1
+}
+
 enum CntReqType {
 	NONE = 0,
 
@@ -940,6 +947,7 @@ tail:
 message MountResponse 52 {
 head(128):
 	Errors error;
+	uint64 caps;
 }
 
 message VtSetModeRequest 53 {

--- a/protocols/fs/fs.bragi
+++ b/protocols/fs/fs.bragi
@@ -250,6 +250,15 @@ head(128):
 		// returned by NODE_GET_LINK
 		tag(18) int64 id;
 
+		// Directory mutation serial that enables client name caches to detect lookup <-> mutation races.
+		// Every mutation of a directory's entries advances a per-superblock counter
+		// (starting at one) and records the new value as that directory's serial.
+		// A lookup reports the current serial of the directory.
+		// A mutation reports the serial that it assigned, or zero if it did not touch any directory.
+		// Note that this also applies to error responses: a request that fails after it
+		// already mutated a directory must still report a serial.
+		tag(98) uint64 serial;
+
 		// returned by FSTAT
 		tag(4) uint64 file_size;
 
@@ -409,8 +418,12 @@ head(128):
 	Errors error;
 	uint64 links_traversed;
 	FileType file_type;
+	// On FILE_NOT_FOUND: serial of the directory in which the lookup failed.
+	uint64 serial;
 tail:
 	int64[] ids;
+	// Serial of the directory that each entry of ids was resolved in.
+	uint64[] serials;
 }
 
 message RecvMsgRequest 6 {
@@ -791,6 +804,7 @@ head(128):
 	Errors error;
 	FileType file_type;
 	int64 id;
+	uint64 serial;
 }
 
 message MkdirRequest 33 {

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -68,15 +68,29 @@ struct FsStats {
 
 using SeekResult = std::variant<Error, int64_t>;
 
-using GetLinkResult = std::tuple<std::shared_ptr<void>, int64_t, FileType>;
+using GetLinkResult = std::tuple<std::shared_ptr<void>, int64_t, FileType, uint64_t>;
 
 using OpenResult = std::pair<helix::UniqueLane, helix::UniqueLane>;
 using AcceptResult = std::pair<helix::UniqueLane, helix::UniqueLane>;
 
-using MkdirResult = std::pair<std::shared_ptr<void>, int64_t>;
-using SymlinkResult = std::pair<std::shared_ptr<void>, int64_t>;
+using MkdirResult = std::tuple<std::shared_ptr<void>, int64_t, uint64_t>;
+using SymlinkResult = std::tuple<std::shared_ptr<void>, int64_t, uint64_t>;
 
-using TraverseLinksResult = frg::expected<Error, std::tuple<std::vector<std::pair<std::shared_ptr<void>, int64_t>>, FileType, size_t>>;
+struct TraversedLink {
+	std::shared_ptr<void> node;
+	int64_t id;
+	// Mutation serial of the directory that the link was resolved in.
+	uint64_t serial;
+};
+
+struct TraverseLinksError {
+	Error error;
+	// Mutation serial of the directory in which the failing lookup ran. Only set for fileNotFound.
+	uint64_t serial = 0;
+};
+
+using TraverseLinksResult = std::expected<std::tuple<std::vector<TraversedLink>, FileType, size_t>,
+		TraverseLinksError>;
 
 struct FileOperations {
 	constexpr FileOperations &withSeekAbs(async::result<SeekResult> (*f)(void *object,
@@ -240,10 +254,11 @@ struct NodeOperations {
 	async::result<std::expected<GetLinkResult, protocols::fs::Error>> (*link)(std::shared_ptr<void> object,
 			std::string name, int64_t ino);
 
-	async::result<std::expected<void, protocols::fs::Error>> (*unlink)(std::shared_ptr<void> object,
+	// unlink() and rmdir() return the mutation serial of the directory.
+	async::result<std::expected<uint64_t, protocols::fs::Error>> (*unlink)(std::shared_ptr<void> object,
 			std::string name);
 
-	async::result<std::expected<void, protocols::fs::Error>> (*rmdir)(std::shared_ptr<void> object,
+	async::result<std::expected<uint64_t, protocols::fs::Error>> (*rmdir)(std::shared_ptr<void> object,
 			std::string name);
 
 	async::result<OpenResult> (*open)(std::shared_ptr<void> object, bool write, bool read, bool append);

--- a/protocols/fs/include/protocols/fs/server.hpp
+++ b/protocols/fs/include/protocols/fs/server.hpp
@@ -75,6 +75,7 @@ using AcceptResult = std::pair<helix::UniqueLane, helix::UniqueLane>;
 
 using MkdirResult = std::tuple<std::shared_ptr<void>, int64_t, uint64_t>;
 using SymlinkResult = std::tuple<std::shared_ptr<void>, int64_t, uint64_t>;
+using RmdirResult = std::tuple<int64_t, uint64_t>;
 
 struct TraversedLink {
 	std::shared_ptr<void> node;
@@ -254,11 +255,11 @@ struct NodeOperations {
 	async::result<std::expected<GetLinkResult, protocols::fs::Error>> (*link)(std::shared_ptr<void> object,
 			std::string name, int64_t ino);
 
-	// unlink() and rmdir() return the mutation serial of the directory.
+	// unlink() returns the mutation serial of the directory.
 	async::result<std::expected<uint64_t, protocols::fs::Error>> (*unlink)(std::shared_ptr<void> object,
 			std::string name);
 
-	async::result<std::expected<uint64_t, protocols::fs::Error>> (*rmdir)(std::shared_ptr<void> object,
+	async::result<std::expected<RmdirResult, protocols::fs::Error>> (*rmdir)(std::shared_ptr<void> object,
 			std::string name);
 
 	async::result<OpenResult> (*open)(std::shared_ptr<void> object, bool write, bool read, bool append);

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -2092,7 +2092,8 @@ struct HandleNodeRequest {
 			co_return {};
 		}
 		resp.set_error(managarm::fs::Errors::SUCCESS);
-		resp.set_serial(result.value());
+		resp.set_id(std::get<0>(result.value()));
+		resp.set_serial(std::get<1>(result.value()));
 
 		auto ser = resp.SerializeAsString();
 		auto [send_resp] = co_await helix_ng::exchangeMsgs(

--- a/protocols/fs/src/server.cpp
+++ b/protocols/fs/src/server.cpp
@@ -1667,6 +1667,7 @@ struct HandleNodeRequest {
 				managarm::fs::SvrResponse resp;
 				resp.set_error(managarm::fs::Errors::SUCCESS);
 				resp.set_id(std::get<1>(result.value()));
+				resp.set_serial(std::get<2>(result.value()));
 
 				auto ser = resp.SerializeAsString();
 				auto [sendResp, pushNode] = co_await helix_ng::exchangeMsgs(
@@ -1795,6 +1796,7 @@ struct HandleNodeRequest {
 			managarm::fs::SvrResponse resp;
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 			resp.set_id(std::get<1>(result.value()));
+			resp.set_serial(std::get<3>(result.value()));
 			switch(std::get<2>(result.value())) {
 			case FileType::directory:
 				resp.set_file_type(managarm::fs::FileType::DIRECTORY);
@@ -1821,6 +1823,7 @@ struct HandleNodeRequest {
 		}else{
 			managarm::fs::SvrResponse resp;
 			resp.set_error(managarm::fs::Errors::FILE_NOT_FOUND);
+			resp.set_serial(std::get<3>(result.value()));
 
 			auto ser = resp.SerializeAsString();
 			auto [send_resp] = co_await helix_ng::exchangeMsgs(
@@ -1848,11 +1851,12 @@ struct HandleNodeRequest {
 
 		if (!result) {
 			managarm::fs::NodeTraverseLinksResponse resp;
-			if (result.error() == protocols::fs::Error::notDirectory) {
+			if (result.error().error == protocols::fs::Error::notDirectory) {
 				resp.set_error(managarm::fs::Errors::NOT_DIRECTORY);
 			} else {
-				assert(result.error() == protocols::fs::Error::fileNotFound);
+				assert(result.error().error == protocols::fs::Error::fileNotFound);
 				resp.set_error(managarm::fs::Errors::FILE_NOT_FOUND);
+				resp.set_serial(result.error().serial);
 			}
 
 			auto [send_resp, send_tail] = co_await helix_ng::exchangeMsgs(
@@ -1889,8 +1893,9 @@ struct HandleNodeRequest {
 		helix::UniqueLane local_push, remote_push;
 		std::tie(local_push, remote_push) = helix::createStream();
 
-		for (auto &[_, id] : nodes) {
-			resp.add_ids(id);
+		for (auto &link : nodes) {
+			resp.add_ids(link.id);
+			resp.add_serials(link.serial);
 		}
 
 		auto [send_resp, send_tail, push_desc] = co_await helix_ng::exchangeMsgs(
@@ -1904,10 +1909,10 @@ struct HandleNodeRequest {
 		HEL_CHECK(push_desc.error());
 		logBragiReply(resp);
 
-		for (auto &[node, _] : nodes) {
+		for (auto &link : nodes) {
 			helix::UniqueLane local_lane, remote_lane;
 			std::tie(local_lane, remote_lane) = helix::createStream();
-			serveNode(std::move(local_lane), std::move(node), node_ops);
+			serveNode(std::move(local_lane), std::move(link.node), node_ops);
 
 			auto [push_node] = co_await helix_ng::exchangeMsgs(
 				local_push,
@@ -1940,6 +1945,7 @@ struct HandleNodeRequest {
 			managarm::fs::SvrResponse resp;
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 			resp.set_id(std::get<1>(result.value()));
+			resp.set_serial(std::get<2>(result.value()));
 
 			auto ser = resp.SerializeAsString();
 			auto [send_resp, push_node] = co_await helix_ng::exchangeMsgs(
@@ -1985,6 +1991,7 @@ struct HandleNodeRequest {
 			managarm::fs::SvrResponse resp;
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 			resp.set_id(std::get<1>(result.value()));
+			resp.set_serial(std::get<3>(result.value()));
 			switch(std::get<2>(result.value())) {
 			case FileType::directory:
 				resp.set_file_type(managarm::fs::FileType::DIRECTORY);
@@ -2048,6 +2055,7 @@ struct HandleNodeRequest {
 			co_return {};
 		}
 		resp.set_error(managarm::fs::Errors::SUCCESS);
+		resp.set_serial(result.value());
 
 		auto ser = resp.SerializeAsString();
 		auto [send_resp] = co_await helix_ng::exchangeMsgs(
@@ -2084,6 +2092,7 @@ struct HandleNodeRequest {
 			co_return {};
 		}
 		resp.set_error(managarm::fs::Errors::SUCCESS);
+		resp.set_serial(result.value());
 
 		auto ser = resp.SerializeAsString();
 		auto [send_resp] = co_await helix_ng::exchangeMsgs(
@@ -2196,6 +2205,7 @@ struct HandleNodeRequest {
 
 			resp.set_error(managarm::fs::Errors::SUCCESS);
 			resp.set_id(std::get<1>(result.value()));
+			resp.set_serial(std::get<3>(result.value()));
 			switch(std::get<2>(result.value())) {
 				case FileType::directory:
 					resp.set_file_type(managarm::fs::FileType::DIRECTORY);

--- a/rust/managarm/src/fs/server.rs
+++ b/rust/managarm/src/fs/server.rs
@@ -747,18 +747,29 @@ async fn handle_traverse_links(
     let result = match node.traverse_links(req.path_segments()).await {
         Ok(result) => result,
         Err(e) => {
-            let resp =
-                bindings::NodeTraverseLinksResponse::new(e, 0, FileType::REGULAR, Vec::new());
+            let resp = bindings::NodeTraverseLinksResponse::new(
+                e,
+                0,
+                FileType::REGULAR,
+                0,
+                Vec::new(),
+                Vec::new(),
+            );
             return send_response_with_tail(&conversation, &resp).await;
         }
     };
 
     let ids: Vec<i64> = result.nodes.iter().map(|&(_, id)| id).collect();
+    // We do not track directory mutation serials. This server never advertises
+    // MC_CLIENT_EXCLUSIVE_NAMESPACE, hence no client caches these lookups.
+    let serials = vec![0; ids.len()];
     let resp = bindings::NodeTraverseLinksResponse::new(
         Error::Success,
         result.links_traversed,
         result.file_type,
+        0,
         ids,
+        serials,
     );
 
     // The node lanes are pushed onto a dedicated lane so that the client can
@@ -918,6 +929,7 @@ async fn handle_get_link_or_create(
     let resp = bindings::GetLinkOrCreateResponse::new(
         Error::IllegalOperationTarget,
         FileType::REGULAR,
+        0,
         0,
     );
     send_response(&conversation, &resp).await


### PR DESCRIPTION
This caches links (i.e., directory entries) on the posix-subsystem side, avoiding round trips for path resolution to the FS server if the path is already cached.