### PR TITLE
hel, thor: Add asynchronous memory mapping and unmapping

### DIFF
--- a/hel/include/hel.h
+++ b/hel/include/hel.h
@@ -785,6 +785,10 @@ static const uint32_t kHelSubmitWritebackFence = 14;
 static const uint32_t kHelSubmitInvalidateMemory = 15;
 //! SQ opcode: populate a space.
 static const uint32_t kHelSubmitPopulateSpace = 16;
+//! SQ opcode: map memory.
+static const uint32_t kHelSubmitMapMemory = 17;
+//! SQ opcode: unmap memory.
+static const uint32_t kHelSubmitUnmapMemory = 18;
 
 //! In-memory kernel/user-space queue.
 struct HelQueue {
@@ -990,6 +994,32 @@ struct HelSqPopulateSpace {
 	size_t length;
 };
 
+//! SQ data for kHelSubmitMapMemory.
+struct HelSqMapMemory {
+	//! Handle to the memory object.
+	HelHandle memoryHandle;
+	//! Handle to the space that the memory is mapped into.
+	HelHandle spaceHandle;
+	//! Address to map at (depending on kHelMap*).
+	void *pointer;
+	//! Offset within the memory object.
+	uintptr_t offset;
+	//! Size of the mapping.
+	size_t size;
+	//! Flags (kHelMap*).
+	uint32_t flags;
+};
+
+//! SQ data for kHelSubmitUnmapMemory.
+struct HelSqUnmapMemory {
+	//! Handle to the space that the mapping is removed from.
+	HelHandle spaceHandle;
+	//! Pointer to the mapping.
+	void *pointer;
+	//! Size of the mapping.
+	size_t size;
+};
+
 struct HelSimpleResult {
 	HelError error;
 	int reserved;
@@ -1036,6 +1066,12 @@ struct HelHandleResult {
 	HelError error;
 	int reserved;
 	HelHandle handle;
+};
+
+struct HelPointerResult {
+	HelError error;
+	int reserved;
+	void *pointer;
 };
 
 struct HelEventResult {

--- a/hel/include/helix/ipc.hpp
+++ b/hel/include/helix/ipc.hpp
@@ -1613,4 +1613,197 @@ inline auto populateSpace(BorrowedDescriptor space, uintptr_t address, size_t le
 	return PopulateSpaceSender{std::move(space), address, length};
 }
 
+// --------------------------------------------------------------------
+// MapMemory
+// --------------------------------------------------------------------
+
+struct MapMemoryResult {
+	HelError error() {
+		assert(valid_);
+		return error_;
+	}
+
+	void *pointer() {
+		assert(valid_);
+		HEL_CHECK(error_);
+		return pointer_;
+	}
+
+	void parse(void *&ptr, const ElementHandle &) {
+		auto result = reinterpret_cast<HelPointerResult *>(ptr);
+		error_ = result->error;
+		pointer_ = result->pointer;
+		ptr = (char *)ptr + sizeof(HelPointerResult);
+		valid_ = true;
+	}
+
+private:
+	bool valid_ = false;
+	HelError error_;
+	void *pointer_;
+};
+
+template <typename Receiver>
+struct MapMemoryOperation : private Context {
+	MapMemoryOperation(BorrowedDescriptor memory, BorrowedDescriptor space, void *pointer,
+			uintptr_t offset, size_t size, uint32_t flags, Receiver r)
+	: memory_{std::move(memory)}, space_{std::move(space)}, pointer_{pointer},
+			offset_{offset}, size_{size}, flags_{flags}, r_{std::move(r)} {}
+
+	void start() {
+		HelSqMapMemory header;
+		header.memoryHandle = memory_.getHandle();
+		header.spaceHandle = space_.getHandle();
+		header.pointer = pointer_;
+		header.offset = offset_;
+		header.size = size_;
+		header.flags = flags_;
+
+		std::array segments{
+			std::as_bytes(std::span{&header, 1})
+		};
+
+		auto context = static_cast<Context *>(this);
+		Dispatcher::global().pushSq(kHelSubmitMapMemory,
+				reinterpret_cast<uintptr_t>(context), segments);
+	}
+
+	MapMemoryOperation(const MapMemoryOperation &) = delete;
+	MapMemoryOperation &operator= (const MapMemoryOperation &) = delete;
+
+private:
+	void complete(ElementHandle element) override {
+		MapMemoryResult result;
+		void *ptr = element.data();
+		result.parse(ptr, element);
+		async::execution::set_value(r_, std::move(result));
+	}
+
+	BorrowedDescriptor memory_;
+	BorrowedDescriptor space_;
+	void *pointer_;
+	uintptr_t offset_;
+	size_t size_;
+	uint32_t flags_;
+	Receiver r_;
+};
+
+struct [[nodiscard]] MapMemorySender {
+	using value_type = MapMemoryResult;
+
+	MapMemorySender(BorrowedDescriptor memory, BorrowedDescriptor space, void *pointer,
+			uintptr_t offset, size_t size, uint32_t flags)
+	: memory_{std::move(memory)}, space_{std::move(space)}, pointer_{pointer},
+			offset_{offset}, size_{size}, flags_{flags} { }
+
+	template<typename Receiver>
+	MapMemoryOperation<Receiver> connect(Receiver receiver) {
+		return {std::move(memory_), std::move(space_), pointer_, offset_, size_, flags_,
+				std::move(receiver)};
+	}
+
+private:
+	BorrowedDescriptor memory_;
+	BorrowedDescriptor space_;
+	void *pointer_;
+	uintptr_t offset_;
+	size_t size_;
+	uint32_t flags_;
+};
+
+inline async::sender_awaiter<MapMemorySender, MapMemoryResult>
+operator co_await (MapMemorySender sender) {
+	return {std::move(sender)};
+}
+
+inline auto mapMemory(BorrowedDescriptor memory, BorrowedDescriptor space, void *pointer,
+		uintptr_t offset, size_t size, uint32_t flags) {
+	return MapMemorySender{std::move(memory), std::move(space), pointer, offset, size, flags};
+}
+
+// --------------------------------------------------------------------
+// UnmapMemory
+// --------------------------------------------------------------------
+
+struct UnmapMemoryResult {
+	HelError error() {
+		assert(valid_);
+		return error_;
+	}
+
+	void parse(void *&ptr, const ElementHandle &) {
+		auto result = reinterpret_cast<HelSimpleResult *>(ptr);
+		error_ = result->error;
+		ptr = (char *)ptr + sizeof(HelSimpleResult);
+		valid_ = true;
+	}
+
+private:
+	bool valid_ = false;
+	HelError error_;
+};
+
+template <typename Receiver>
+struct UnmapMemoryOperation : private Context {
+	UnmapMemoryOperation(BorrowedDescriptor space, void *pointer, size_t size, Receiver r)
+	: space_{std::move(space)}, pointer_{pointer}, size_{size}, r_{std::move(r)} {}
+
+	void start() {
+		HelSqUnmapMemory header;
+		header.spaceHandle = space_.getHandle();
+		header.pointer = pointer_;
+		header.size = size_;
+
+		std::array segments{
+			std::as_bytes(std::span{&header, 1})
+		};
+
+		auto context = static_cast<Context *>(this);
+		Dispatcher::global().pushSq(kHelSubmitUnmapMemory,
+				reinterpret_cast<uintptr_t>(context), segments);
+	}
+
+	UnmapMemoryOperation(const UnmapMemoryOperation &) = delete;
+	UnmapMemoryOperation &operator= (const UnmapMemoryOperation &) = delete;
+
+private:
+	void complete(ElementHandle element) override {
+		UnmapMemoryResult result;
+		void *ptr = element.data();
+		result.parse(ptr, element);
+		async::execution::set_value(r_, std::move(result));
+	}
+
+	BorrowedDescriptor space_;
+	void *pointer_;
+	size_t size_;
+	Receiver r_;
+};
+
+struct [[nodiscard]] UnmapMemorySender {
+	using value_type = UnmapMemoryResult;
+
+	UnmapMemorySender(BorrowedDescriptor space, void *pointer, size_t size)
+	: space_{std::move(space)}, pointer_{pointer}, size_{size} { }
+
+	template<typename Receiver>
+	UnmapMemoryOperation<Receiver> connect(Receiver receiver) {
+		return {std::move(space_), pointer_, size_, std::move(receiver)};
+	}
+
+private:
+	BorrowedDescriptor space_;
+	void *pointer_;
+	size_t size_;
+};
+
+inline async::sender_awaiter<UnmapMemorySender, UnmapMemoryResult>
+operator co_await (UnmapMemorySender sender) {
+	return {std::move(sender)};
+}
+
+inline auto unmapMemory(BorrowedDescriptor space, void *pointer, size_t size) {
+	return UnmapMemorySender{std::move(space), pointer, size};
+}
+
 } // namespace helix_ng

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -1383,6 +1383,41 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 	return kHelErrNone;
 }
 
+
+HelError doSubmitMapMemory(HelHandle memoryHandle, HelHandle spaceHandle,
+		smarter::shared_ptr<IpcQueue> queue, void *pointer, uintptr_t offset, size_t length,
+		uint32_t flags, uintptr_t context) {
+	auto operandsOutcome = resolveMapMemory(memoryHandle, spaceHandle,
+			pointer, offset, length, flags);
+	if(!operandsOutcome)
+		return translateError(operandsOutcome.error());
+
+	if(!queue->validSize(ipcSourceSize(sizeof(HelPointerResult))))
+		return kHelErrQueueTooSmall;
+
+	[](MapMemoryOperands operands, smarter::shared_ptr<IpcQueue> queue,
+			VirtualAddr pointer, uintptr_t offset, size_t length, uintptr_t context,
+			enable_detached_coroutine) -> void {
+		auto mapResult = co_await onExceptionalWq(operands.targetSpace()->map(
+				operands.slice, pointer, offset, length, operands.mapFlags));
+
+		HelPointerResult helResult;
+		if(!mapResult) {
+			helResult = {.error = translateError(mapResult.error()), .reserved = {},
+					.pointer = nullptr};
+		}else{
+			helResult = {.error = kHelErrNone, .reserved = {},
+					.pointer = reinterpret_cast<void *>(mapResult.value())};
+		}
+		QueueSource ipcSource{&helResult, sizeof(HelPointerResult), nullptr};
+		co_await queue->submit(&ipcSource, context);
+	}(std::move(*operandsOutcome), std::move(queue),
+			reinterpret_cast<VirtualAddr>(pointer), offset, length, context,
+			enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
+
+	return kHelErrNone;
+}
+
 HelError doSubmitProtectMemory(HelHandle space_handle, smarter::shared_ptr<IpcQueue> queue,
 		void *pointer, size_t length, uint32_t flags, uintptr_t context) {
 	auto this_thread = getCurrentThread();
@@ -1490,6 +1525,34 @@ HelError helUnmapMemory(HelHandle space_handle, void *pointer, size_t length) {
 	);
 	if(!outcome)
 		return translateError(outcome.error());
+
+	return kHelErrNone;
+}
+
+
+HelError doSubmitUnmapMemory(HelHandle spaceHandle, smarter::shared_ptr<IpcQueue> queue,
+		void *pointer, size_t length, uintptr_t context) {
+	auto operandsOutcome = resolveUnmapMemory(spaceHandle);
+	if(!operandsOutcome)
+		return translateError(operandsOutcome.error());
+
+	if(!queue->validSize(ipcSourceSize(sizeof(HelSimpleResult))))
+		return kHelErrQueueTooSmall;
+
+	[](UnmapMemoryOperands operands, smarter::shared_ptr<IpcQueue> queue,
+			VirtualAddr pointer, size_t length, uintptr_t context,
+			enable_detached_coroutine) -> void {
+		auto outcome = co_await onExceptionalWq(operands.targetSpace()->unmap(pointer, length));
+
+		HelSimpleResult helResult{
+			.error = outcome ? kHelErrNone : translateError(outcome.error()),
+			.reserved = {},
+		};
+		QueueSource ipcSource{&helResult, sizeof(HelSimpleResult), nullptr};
+		co_await queue->submit(&ipcSource, context);
+	}(std::move(*operandsOutcome), std::move(queue),
+			reinterpret_cast<VirtualAddr>(pointer), length, context,
+			enable_detached_coroutine{getCurrentThread()->mainWorkQueue().lock()});
 
 	return kHelErrNone;
 }
@@ -4353,6 +4416,30 @@ void thor::submitFromSq(smarter::shared_ptr<IpcQueue> queue, uint32_t opcode,
 		HelSqPopulateSpace sqData;
 		memcpy(&sqData, sqSpan.data(), sizeof(sqData));
 		error = doSubmitPopulateSpace(sqData.handle, queue, sqData.address, sqData.length, context);
+		break;
+	}
+	case kHelSubmitMapMemory: {
+		if(sqSpan.size() < sizeof(HelSqMapMemory)) {
+			infoLogger() << "Bad length for kHelSubmitMapMemory" << frg::endlog;
+			error = kHelErrBufferTooSmall;
+			break;
+		}
+		HelSqMapMemory sqData;
+		memcpy(&sqData, sqSpan.data(), sizeof(sqData));
+		error = doSubmitMapMemory(sqData.memoryHandle, sqData.spaceHandle, queue,
+				sqData.pointer, sqData.offset, sqData.size, sqData.flags, context);
+		break;
+	}
+	case kHelSubmitUnmapMemory: {
+		if(sqSpan.size() < sizeof(HelSqUnmapMemory)) {
+			infoLogger() << "Bad length for kHelSubmitUnmapMemory" << frg::endlog;
+			error = kHelErrBufferTooSmall;
+			break;
+		}
+		HelSqUnmapMemory sqData;
+		memcpy(&sqData, sqSpan.data(), sizeof(sqData));
+		error = doSubmitUnmapMemory(sqData.spaceHandle, queue,
+				sqData.pointer, sqData.size, context);
 		break;
 	}
 	default:

--- a/kernel/thor/generic/hel.cpp
+++ b/kernel/thor/generic/hel.cpp
@@ -1225,16 +1225,30 @@ HelError helGetRandomBytes(void *buffer, size_t wantedSize, size_t *actualSize) 
 	return kHelErrNone;
 }
 
-HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
-		void *pointer, uintptr_t offset, size_t length, uint32_t flags, void **actualPointer) {
+namespace {
+
+// Descriptors and flags of a mapping operation, as resolved from the syscall arguments.
+struct MapMemoryOperands {
+	smarter::shared_ptr<MemorySlice> slice;
+	smarter::shared_ptr<AddressSpace, BindableHandle> space;
+	smarter::shared_ptr<VirtualSpace> vspace;
+	uint32_t mapFlags;
+
+	VirtualSpace *targetSpace() {
+		return space ? space.get() : vspace.get();
+	}
+};
+
+std::expected<MapMemoryOperands, Error> resolveMapMemory(HelHandle memory_handle,
+		HelHandle space_handle, void *pointer, uintptr_t offset, size_t length, uint32_t flags) {
 	if(length == 0)
-		return kHelErrIllegalArgs;
+		return std::unexpected{Error::illegalArgs};
 	if((uintptr_t)pointer % kPageSize != 0)
-		return kHelErrIllegalArgs;
+		return std::unexpected{Error::illegalArgs};
 	if(offset % kPageSize != 0)
-		return kHelErrIllegalArgs;
+		return std::unexpected{Error::illegalArgs};
 	if(length % kPageSize != 0)
-		return kHelErrIllegalArgs;
+		return std::unexpected{Error::illegalArgs};
 
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
@@ -1306,7 +1320,7 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 		return {};
 	});
 	if(!memoryOutcome)
-		return translateError(memoryOutcome.error());
+		return std::unexpected{memoryOutcome.error()};
 
 	if(space_handle == kHelNullHandle) {
 		space = this_thread->getAddressSpace().lock();
@@ -1336,37 +1350,34 @@ HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
 			return {};
 		});
 		if(!spaceOutcome)
-			return translateError(spaceOutcome.error());
+			return std::unexpected{spaceOutcome.error()};
 	}
 
 	// TODO: check proper alignment
 
-	frg::expected<Error, VirtualAddr> mapResult;
-	if(!isVspace) {
-		if(map_flags & AddressSpace::kMapFixed && !pointer)
-			return kHelErrIllegalArgs; // Non-vspaces aren't allowed to map at NULL
+	if(!isVspace && (map_flags & AddressSpace::kMapFixed) && !pointer)
+		return std::unexpected{Error::illegalArgs}; // Non-vspaces aren't allowed to map at NULL
 
-		mapResult = Thread::asyncBlockCurrent(
-			space->map(slice, (VirtualAddr)pointer, offset, length, map_flags),
-			getCurrentThread()->pagingWorkQueue().get()
-		);
-	} else {
-		mapResult = Thread::asyncBlockCurrent(
-			vspace->map(slice, (VirtualAddr)pointer, offset, length, map_flags),
-			getCurrentThread()->pagingWorkQueue().get()
-		);
-	}
+	return MapMemoryOperands{std::move(slice), std::move(space), std::move(vspace), map_flags};
+}
 
-	if(!mapResult) {
-		assert(mapResult.error() == Error::bufferTooSmall || mapResult.error() == Error::alreadyExists || mapResult.error() == Error::noMemory);
+} // namespace
 
-		if(mapResult.error() == Error::bufferTooSmall)
-			return kHelErrBufferTooSmall;
-		else if(mapResult.error() == Error::noMemory)
-			return kHelErrNoMemory;
-		else if(mapResult.error() == Error::alreadyExists)
-			return kHelErrAlreadyExists;
-	}
+HelError helMapMemory(HelHandle memory_handle, HelHandle space_handle,
+		void *pointer, uintptr_t offset, size_t length, uint32_t flags, void **actualPointer) {
+	auto operandsOutcome = resolveMapMemory(memory_handle, space_handle,
+			pointer, offset, length, flags);
+	if(!operandsOutcome)
+		return translateError(operandsOutcome.error());
+	auto operands = std::move(*operandsOutcome);
+
+	auto mapResult = Thread::asyncBlockCurrent(
+		operands.targetSpace()->map(operands.slice, (VirtualAddr)pointer, offset, length,
+				operands.mapFlags),
+		getCurrentThread()->pagingWorkQueue().get()
+	);
+	if(!mapResult)
+		return translateError(mapResult.error());
 
 	*actualPointer = (void *)mapResult.value();
 	return kHelErrNone;
@@ -1418,7 +1429,19 @@ HelError doSubmitProtectMemory(HelHandle space_handle, smarter::shared_ptr<IpcQu
 	return kHelErrNone;
 }
 
-HelError helUnmapMemory(HelHandle space_handle, void *pointer, size_t length) {
+namespace {
+
+// Descriptors of an unmapping operation, as resolved from the syscall arguments.
+struct UnmapMemoryOperands {
+	smarter::shared_ptr<AddressSpace, BindableHandle> space;
+	smarter::shared_ptr<VirtualSpace> vspace;
+
+	VirtualSpace *targetSpace() {
+		return space ? space.get() : vspace.get();
+	}
+};
+
+std::expected<UnmapMemoryOperands, Error> resolveUnmapMemory(HelHandle space_handle) {
 	auto this_thread = getCurrentThread();
 	auto this_universe = this_thread->getUniverse();
 
@@ -1447,26 +1470,26 @@ HelError helUnmapMemory(HelHandle space_handle, void *pointer, size_t length) {
 			return std::unexpected{Error::badDescriptor};
 		});
 		if(!spaceOutcome)
-			return translateError(spaceOutcome.error());
+			return std::unexpected{spaceOutcome.error()};
 	}
 
-	frg::expected<thor::Error> outcome = Error::illegalArgs;
-	if (space) {
-		outcome = Thread::asyncBlockCurrent(
-			space->unmap((VirtualAddr)pointer, length),
-			getCurrentThread()->pagingWorkQueue().get()
-		);
-	} else {
-		assert(vspace);
-		outcome = Thread::asyncBlockCurrent(
-			vspace->unmap((VirtualAddr)pointer, length),
-			getCurrentThread()->pagingWorkQueue().get()
-		);
-	}
-	if(!outcome) {
-		assert(outcome.error() == Error::illegalArgs);
-		return kHelErrIllegalArgs;
-	}
+	return UnmapMemoryOperands{std::move(space), std::move(vspace)};
+}
+
+} // namespace
+
+HelError helUnmapMemory(HelHandle space_handle, void *pointer, size_t length) {
+	auto operandsOutcome = resolveUnmapMemory(space_handle);
+	if(!operandsOutcome)
+		return translateError(operandsOutcome.error());
+	auto operands = std::move(*operandsOutcome);
+
+	auto outcome = Thread::asyncBlockCurrent(
+		operands.targetSpace()->unmap((VirtualAddr)pointer, length),
+		getCurrentThread()->pagingWorkQueue().get()
+	);
+	if(!outcome)
+		return translateError(outcome.error());
 
 	return kHelErrNone;
 }

--- a/posix/subsystem/src/observations.cpp
+++ b/posix/subsystem/src/observations.cpp
@@ -146,7 +146,7 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 			uintptr_t gprs[kHelNumGprs];
 			HEL_CHECK(helLoadRegisters(thread.getHandle(), kHelRegsGeneral, &gprs));
 
-			self->vmContext()->unmapFile(reinterpret_cast<void *>(gprs[kHelRegArg0]), gprs[kHelRegArg1]);
+			co_await self->vmContext()->unmapFile(reinterpret_cast<void *>(gprs[kHelRegArg0]), gprs[kHelRegArg1]);
 
 			gprs[kHelRegError] = kHelErrNone;
 			gprs[kHelRegOut0] = 0;

--- a/posix/subsystem/src/process.cpp
+++ b/posix/subsystem/src/process.cpp
@@ -84,18 +84,17 @@ async::result<std::shared_ptr<VmContext>> VmContext::clone(std::shared_ptr<VmCon
 			HEL_CHECK(forkResult.error());
 			copyView = forkResult.descriptor();
 
-			void *pointer;
-			HelError error = helMapMemory(copyView.getHandle(), context->_space.getHandle(),
+			auto mapResult = co_await helix_ng::mapMemory(copyView, context->_space,
 					reinterpret_cast<void *>(address),
-					area.effectiveOffset, area.areaSize, area.nativeFlags, &pointer);
-			if(error != kHelErrNone && error != kHelErrAlreadyExists) {
-				HEL_CHECK(error);
+					area.effectiveOffset, area.areaSize, area.nativeFlags);
+			if(mapResult.error() != kHelErrNone && mapResult.error() != kHelErrAlreadyExists) {
+				HEL_CHECK(mapResult.error());
 			}
 		}else{
-			void *pointer;
-			HEL_CHECK(helMapMemory(area.fileView.getHandle(), context->_space.getHandle(),
+			auto mapResult = co_await helix_ng::mapMemory(area.fileView, context->_space,
 					reinterpret_cast<void *>(address),
-					area.offset, area.areaSize, area.nativeFlags, &pointer));
+					area.offset, area.areaSize, area.nativeFlags);
+			HEL_CHECK(mapResult.error());
 		}
 
 		Area copy;
@@ -168,7 +167,7 @@ VmContext::mapFile(uintptr_t hint, helix::UniqueDescriptor memory,
 	// Perform the actual mapping.
 	// POSIX specifies that non-page-size mappings are rounded up and filled with zeros.
 	helix::UniqueDescriptor copyView;
-	void *pointer;
+	void *pointer = nullptr;
 	HelError error;
 	if(copyOnWrite) {
 		HelHandle handle;
@@ -179,13 +178,19 @@ VmContext::mapFile(uintptr_t hint, helix::UniqueDescriptor memory,
 		}
 		copyView = helix::UniqueDescriptor{handle};
 
-		error = helMapMemory(copyView.getHandle(), _space.getHandle(),
+		auto mapResult = co_await helix_ng::mapMemory(copyView, _space,
 				reinterpret_cast<void *>(hint),
-				0, alignedSize, nativeFlags, &pointer);
+				0, alignedSize, nativeFlags);
+		error = mapResult.error();
+		if(!error)
+			pointer = mapResult.pointer();
 	}else{
-		error = helMapMemory(memory.getHandle(), _space.getHandle(),
+		auto mapResult = co_await helix_ng::mapMemory(memory, _space,
 				reinterpret_cast<void *>(hint),
-				offset, alignedSize, nativeFlags, &pointer);
+				offset, alignedSize, nativeFlags);
+		error = mapResult.error();
+		if(!error)
+			pointer = mapResult.pointer();
 	}
 
 	if(error == kHelErrAlreadyExists) {
@@ -240,14 +245,16 @@ async::result<void *> VmContext::remapFile(void *oldPointer,
 
 	// Perform the actual mapping.
 	// POSIX specifies that non-page-size mappings are rounded up and filled with zeros.
-	void *pointer;
-	HEL_CHECK(helMapMemory(memory.getHandle(), _space.getHandle(),
+	auto mapResult = co_await helix_ng::mapMemory(memory, _space,
 			nullptr, it->second.offset, alignedNewSize,
-			it->second.nativeFlags, &pointer));
+			it->second.nativeFlags);
+	HEL_CHECK(mapResult.error());
+	auto pointer = mapResult.pointer();
 //	std::cout << "posix: VM_REMAP returns " << pointer << std::endl;
 
 	// Unmap the old area.
-	HEL_CHECK(helUnmapMemory(_space.getHandle(), oldPointer, alignedOldSize));
+	auto unmapResult = co_await helix_ng::unmapMemory(_space, oldPointer, alignedOldSize);
+	HEL_CHECK(unmapResult.error());
 
 	// Construct the new area from the old one.
 	Area area;
@@ -296,11 +303,12 @@ async::result<void> VmContext::protectFile(void *pointer, size_t size, uint32_t 
 	}
 }
 
-void VmContext::unmapFile(void *pointer, size_t size) {
+async::result<void> VmContext::unmapFile(void *pointer, size_t size) {
 	size_t alignedSize = (size + 0xFFF) & ~size_t(0xFFF);
 	auto address = reinterpret_cast<uintptr_t>(pointer);
 
-	HEL_CHECK(helUnmapMemory(_space.getHandle(), pointer, alignedSize));
+	auto unmapResult = co_await helix_ng::unmapMemory(_space, pointer, alignedSize);
+	HEL_CHECK(unmapResult.error());
 
 	auto [startIt, endIt] = splitAreaOn_(address, alignedSize);
 

--- a/posix/subsystem/src/process.hpp
+++ b/posix/subsystem/src/process.hpp
@@ -54,7 +54,7 @@ struct VmContext {
 
 	async::result<void> protectFile(void *pointer, size_t size, uint32_t protectionFlags);
 
-	void unmapFile(void *pointer, size_t size);
+	async::result<void> unmapFile(void *pointer, size_t size);
 
 private:
 	struct Area {

--- a/posix/subsystem/src/requests/memory.cpp
+++ b/posix/subsystem/src/requests/memory.cpp
@@ -254,7 +254,7 @@ HandleRequest::operator()(managarm::posix::VmUnmapRequest &&req,
 		size = (size + 0xFFF) & ~0xFFF;
 	}
 
-	self->vmContext()->unmapFile(reinterpret_cast<void *>(req.address()), size);
+	co_await self->vmContext()->unmapFile(reinterpret_cast<void *>(req.address()), size);
 
 	managarm::posix::VmUnmapResponse resp;
 	resp.set_error(managarm::posix::Errors::SUCCESS);


### PR DESCRIPTION
Mapping/unmapping asynchronously is avoid blocking the whole process on shootdowns. Use this in posix-subsystem. As a follow up, we will also use it for IOMMU mappings (not in this PR yet).