### PR TITLE
docs: fix broken internal links in the book

### DIFF
--- a/docs/src/building/cbuildrt.md
+++ b/docs/src/building/cbuildrt.md
@@ -8,7 +8,7 @@ This guide shows how to build a managarm distribution from source utilising the 
 To make sure that all build environments work properly, it is recommended to
 setup a build environment with our lightweight containerized build runtime [cbuildrt](https://github.com/managarm/cbuildrt) (see below for instructions).
 It is also possible to build with [Docker](https://www.docker.com/) 
-(see [here](with-docker.md)), or by installing the dependencies manually (see [here](with-manual.md)), but these methods are no longer recommended.
+(see [here](with-docker.md)), or by installing the dependencies manually (see [here](without-containers.md)), but these methods are no longer recommended.
 
 Make sure that you have at least 20 - 30 GiB of free disk space.
 

--- a/docs/src/contributing/commit-messages.md
+++ b/docs/src/contributing/commit-messages.md
@@ -13,14 +13,14 @@ If the intent or implementation are not immediately obvious, the commit should i
 ## Modules
 
 We use modules to describe where in the system the change is made. For the Managarm repo, we use the following modules:
-- `thor`, optionally followed by a subsystem or arch, like `thor/pci` or `thor/x86`. This is used for changes to the main kernel of Managarm, [thor](../design/thoreir/index.md).
-- `eir`, optionally followed by a architecture, like `eir/x86`. This is used for changes to Managarm's prekernel, [eir](../design/thoreir/index.md).
-- `posix`, used for everyting in the [posix emulation layer](../design/posix/index.md).
+- `thor`, optionally followed by a subsystem or arch, like `thor/pci` or `thor/x86`. This is used for changes to the main kernel of Managarm, [thor](../sys-arch/thoreir/index.md).
+- `eir`, optionally followed by a architecture, like `eir/x86`. This is used for changes to Managarm's prekernel, [eir](../sys-arch/thoreir/index.md).
+- `posix`, used for everyting in the [posix emulation layer](../sys-arch/posix/index.md).
 - `docs`, used when updating the documentation, like the one you are reading now!
 - `core/<submodule>`, submodule can be either `drm` or `virtio` at the time of writing. This is used for everything related to the core of the DRM interface or virtio handling.
-- `drivers/<drivername>`, where the driver name is the driver being worked on, like `drivers/libblockfs` for example. This is used for everything [driver](../design/drivers/index.md) related.
-- `hel`, used for everything related to the [hel](../design/hel/index.md) and helix syscall api.
-- `mbus`, used for everything related to [mbus](../design/mbus/index.md).
+- `drivers/<drivername>`, where the driver name is the driver being worked on, like `drivers/libblockfs` for example. This is used for everything [driver](../sys-arch/drivers/index.md) related.
+- `hel`, used for everything related to the [hel](../sys-arch/hel/index.md) and helix syscall api.
+- `mbus`, used for everything related to [mbus](../sys-arch/mbus/index.md).
 - `protocols/<protocol>`, where protocol is the protocol that is being changed. This is used for every protocol change made.
 - `netserver`, used for every change to the network server.
 - `tests`, used when working on the testsuites.

--- a/docs/src/contributing/hwci.md
+++ b/docs/src/contributing/hwci.md
@@ -8,7 +8,7 @@ Managarm has some infrastructure to automate testing of Managarm builds.
 
 To use the hardware CI, you need:
 - Access permissions (see above).
-- A Managarm system root (see [the build instructions](building/index.md)).
+- A Managarm system root (see [the build instructions](../building/index.md)).
 - The base system installed to the system root (`xbstrap install base`).
 - Packages installed that are required the desired device.
     This may include `boot-artifacts` and `vendor-devicetrees` (`xbstrap install boot-artifacts vendor-devicetree`).

--- a/docs/src/contributing/xbstrap.md
+++ b/docs/src/contributing/xbstrap.md
@@ -19,7 +19,7 @@ xbstrap install --rebuild managarm-system
 (and similarly for packages other than `managarm-system`).
 After rebuilding a package, the `make-image` step needs to be invoked again
 to update the disk image
-(see the [section on building Managarm](../building/index.md]) of this handbook):
+(see the [section on building Managarm](../building/index.md) of this handbook):
 ```sh
 xbstrap run make-image
 # Or `xbstrap run make-image qemu` to also run the image in qemu.


### PR DESCRIPTION
- contributing/commit-messages.md pointed at ../design/{thoreir,posix, drivers,hel,mbus}/index.md; there is no docs/src/design, those pages are under sys-arch/.
- contributing/xbstrap.md had a stray ] inside the link target.
- contributing/hwci.md linked building/index.md without ../, so it resolved under contributing/.
- building/cbuildrt.md linked with-manual.md, which does not exist; the page describing manual dependency installation is without-containers.md. This also fixes building/index.md, which is a symlink to cbuildrt.md.

Assisted-by: Claude Code (Claude Opus 5)