### PR TITLE
thor, posix: Pass ManagarmProcessData size to supercall

### DIFF
--- a/hel/src/passthrough-fd.cpp
+++ b/hel/src/passthrough-fd.cpp
@@ -11,7 +11,11 @@ HelHandle handleForFd(int fd) {
 		return 0;
 
 	posix::ManagarmProcessData data;
-	HEL_CHECK(helSyscall1(kHelCallSuper + posix::superGetProcessData, reinterpret_cast<HelWord>(&data)));
+	HEL_CHECK(helSyscall2(
+		kHelCallSuper + posix::superGetProcessData,
+		reinterpret_cast<HelWord>(&data),
+		sizeof(posix::ManagarmProcessData)
+	));
 
 	return reinterpret_cast<HelHandle *>(data.fileTable)[fd];
 }

--- a/kernel/thor/generic/service.cpp
+++ b/kernel/thor/generic/service.cpp
@@ -1081,8 +1081,10 @@ namespace posix {
 					panicLogger() << "thor: Failed to resume server" << frg::endlog;
 			}else if(interrupt == kIntrSuperCall + ::posix::superGetProcessData) {
 				uintptr_t dataAddr;
+				size_t dataSize;
 				auto readOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					dataAddr = *executor->arg0();
+					dataSize = *executor->arg1();
 				});
 				if(!readOutcome)
 					panicLogger() << "thor: Failed to access server registers" << frg::endlog;
@@ -1095,8 +1097,9 @@ namespace posix {
 					nullptr
 				};
 
+				auto writeSize = frg::min(dataSize, sizeof(::posix::ManagarmProcessData));
 				auto outcome = co_await info.thread->getAddressSpace()->writeSpace(
-						dataAddr, &data, sizeof(::posix::ManagarmProcessData));
+						dataAddr, &data, writeSize);
 				auto writeOutcome = info.thread->accessRegisters([&](Executor *executor) {
 					if(!outcome) {
 						*executor->result0() = kHelErrFault;

--- a/posix/subsystem/src/observations.cpp
+++ b/posix/subsystem/src/observations.cpp
@@ -165,8 +165,9 @@ async::result<void> observeThread(std::shared_ptr<Process> self,
 				std::cout << "posix: GET_PROCESS_DATA supercall" << std::endl;
 			uintptr_t gprs[kHelNumGprs];
 			HEL_CHECK(helLoadRegisters(thread.getHandle(), kHelRegsGeneral, &gprs));
+			auto writeSize = std::min(gprs[kHelRegArg1], sizeof(posix::ManagarmProcessData));
 			auto storeData = co_await helix_ng::writeMemory(thread, gprs[kHelRegArg0],
-					sizeof(posix::ManagarmProcessData), &data);
+					writeSize, &data);
 			HEL_CHECK(storeData.error());
 			gprs[kHelRegError] = kHelErrNone;
 			HEL_CHECK(helStoreRegisters(thread.getHandle(), kHelRegsGeneral, &gprs));

--- a/protocols/mbus/src/client_ng.cpp
+++ b/protocols/mbus/src/client_ng.cpp
@@ -16,8 +16,11 @@ namespace {
 	HelHandle getMbusClientLane() {
 		posix::ManagarmProcessData data;
 
-		HEL_CHECK(helSyscall1(kHelCallSuper + posix::superGetProcessData,
-						reinterpret_cast<HelWord>(&data)));
+		HEL_CHECK(helSyscall2(
+			kHelCallSuper + posix::superGetProcessData,
+			reinterpret_cast<HelWord>(&data),
+			sizeof(posix::ManagarmProcessData)
+		));
 
 		return data.mbusLane;
 	}

--- a/rust/managarm/src/posix.rs
+++ b/rust/managarm/src/posix.rs
@@ -43,9 +43,10 @@ static PROCESS_DATA: LazyLock<ManagarmProcessData> = LazyLock::new(|| {
     // TODO: Create wrapper in `hel`.
     let mut process_data: MaybeUninit<ManagarmProcessData> = MaybeUninit::uninit();
     let result = unsafe {
-        hel_sys::helSyscall1(
+        hel_sys::helSyscall2(
             hel_sys::kHelCallSuper as i32 + PosixSupercall::GetProcessData as i32,
             process_data.as_mut_ptr() as u64,
+            std::mem::size_of::<ManagarmProcessData>() as u64,
         )
     };
 


### PR DESCRIPTION
Forward compatibility change to avoid breaking Managarm <-> mlibc ABI when `ManagarmProcessData` is extended. The mlibc side is already merged as https://github.com/managarm/mlibc/pull/1889