### PR TITLE
drivers/{nvme,intel-lil}: Fix contiguous allocations

### DIFF
--- a/drivers/block/nvme/src/controller.hpp
+++ b/drivers/block/nvme/src/controller.hpp
@@ -64,6 +64,10 @@ struct Controller {
 		return pool_;
 	}
 
+	arch::contiguous_pool &contiguousPool() {
+		return contiguousPool_;
+	}
+
 protected:
 	spec::DataTransfer preferredDataTransfer_ = spec::DataTransfer::PRP;
 
@@ -75,6 +79,8 @@ protected:
 
 	arch::dma_realm dmaRealm_;
 	arch::contiguous_pool pool_{&dmaRealm_, {.addressBits = 64, .allocateContigous = false}};
+	// Queues are passed to the controller as a single PRP with kQueuePhysContig.
+	arch::contiguous_pool contiguousPool_{&dmaRealm_, {.addressBits = 64, .allocateContigous = true}};
 
 	std::string serial;
 	std::string model;

--- a/drivers/block/nvme/src/namespace.cpp
+++ b/drivers/block/nvme/src/namespace.cpp
@@ -107,7 +107,7 @@ async::result<void> Namespace::handleIoctl(managarm::fs::GenericIoctlRequest &re
 		cmdBuf.cdw15 = param.cdw15;
 
 		size_t data_size = param.data_len;
-		std::vector<std::byte> data_buf(data_size);
+		arch::dma_buffer data_buf{&controller_->memoryPool(), data_size};
 
 		auto [recv_data] = co_await helix_ng::exchangeMsgs(
 				conversation,
@@ -115,7 +115,7 @@ async::result<void> Namespace::handleIoctl(managarm::fs::GenericIoctlRequest &re
 		);
 		HEL_CHECK(recv_data.error());
 
-		co_await cmd->setupBuffer(controller_, arch::dma_buffer_view{nullptr, data_buf.data(), data_size}, controller_->dataTransferPolicy());
+		co_await cmd->setupBuffer(controller_, data_buf, controller_->dataTransferPolicy());
 
 		auto res = co_await controller_->submitAdminCommand(std::move(cmd));
 

--- a/drivers/block/nvme/src/queue.cpp
+++ b/drivers/block/nvme/src/queue.cpp
@@ -26,11 +26,11 @@ async::result<void> PciExpressQueue::init() {
 	size_t sqSize = ((depth_ << 6) + align - 1) & ~size_t(align - 1);
 	size_t cqSize = ((depth_ * sizeof(spec::CompletionEntry)) + align - 1) & ~size_t(align - 1);
 
-	cq_ = arch::dma_buffer{&controller_->memoryPool(), cqSize};
+	cq_ = arch::dma_buffer{&controller_->contiguousPool(), cqSize};
 	cqes_ = reinterpret_cast<spec::CompletionEntry *>(cq_.data());
 	memset(cqes_, 0, cqSize);
 
-	sq_ = arch::dma_buffer{&controller_->memoryPool(), sqSize};
+	sq_ = arch::dma_buffer{&controller_->contiguousPool(), sqSize};
 	sqCmds_ = sq_.data();
 
 	co_return;

--- a/drivers/gfx/intel-lil/src/gfx.cpp
+++ b/drivers/gfx/intel-lil/src/gfx.cpp
@@ -230,7 +230,7 @@ GfxDevice::createDumb(uint32_t width, uint32_t height, uint32_t bpp) {
 	size_t mappingSize = frg::align_up(size, 0x1000);
 
 	auto gpuVa = _vramAllocator.allocate(size);
-	auto dmaBuffer = arch::dma_buffer{&_pool, size};
+	auto dmaBuffer = arch::dma_buffer{&_pool, mappingSize, 0x1000};
 
 	async::run(dmaSpace_.ensure_mapped(dmaBuffer), helix::currentDispatcher);
 	for (size_t page = 0; page < mappingSize; page += 0x1000) {


### PR DESCRIPTION
Some allocations were turned into erroneously turned into non-contiguous ones when the IOMMU work landed, make them contiguous again.